### PR TITLE
Completion glyphs ( Bump to version 0.15.0)

### DIFF
--- a/FSharp.AutoComplete/Program.fs
+++ b/FSharp.AutoComplete/Program.fs
@@ -284,8 +284,8 @@ module internal CompletionUtils =
       0x0008,  ("Interface", "I")
       0x000e,  ("Module", "N") (* module *)
       0x000f,  ("Namespace", "N")
-      0x000c,  ("Method", "m")
-      0x000d,  ("Extension Method", "m") (* method2 ? *)
+      0x000c,  ("Method", "M")
+      0x000d,  ("Extension Method", "M") (* method2 ? *)
       0x00011, ("Property", "P")
       0x0005,  ("Event", "e")
       0x0007,  ("Field", "F") (* fieldblue ? *)
@@ -523,7 +523,7 @@ module internal Main =
                   match state.OutputMode with
                   | Text ->
                       printAgent.WriteLine "DATA: completion"
-                      for d in decls.Items do printAgent.WriteLine(sprintf "%s" d.Name)
+                      for d in decls.Items do printAgent.WriteLine(d.Name)
                       printAgent.WriteLine "<<EOF>>"
                       main state
                   | Json ->

--- a/FSharp.AutoComplete/Program.fs
+++ b/FSharp.AutoComplete/Program.fs
@@ -51,7 +51,8 @@ type Location =
 type CompletionResponse = 
   {
     Name: string
-    Glyph: int
+    Glyph: string
+    GlyphChar: string
   }
 
 type ProjectResponse =
@@ -273,6 +274,48 @@ module internal CommandInput =
       let cmds = compilerlocation <|> outputmode <|> helptext <|> help <|> declarations <|> parse <|> project <|> completionTipOrDecl <|> quit <|> error
       reader |> Parsing.getFirst cmds
 
+module internal CompletionUtils =
+  let map =
+    [ 0x0000,  ("Class", "C")
+      0x0003,  ("Enum", "E")
+      0x00012, ("Struct", "S")
+      0x00018, ("Struct", "S") (* value type *)
+      0x0002,  ("Delegate", "D")
+      0x0008,  ("Interface", "I")
+      0x000e,  ("Module", "N") (* module *)
+      0x000f,  ("Namespace", "N")
+      0x000c,  ("Method", "m")
+      0x000d,  ("Extension Method", "m") (* method2 ? *)
+      0x00011, ("Property", "P")
+      0x0005,  ("Event", "e")
+      0x0007,  ("Field", "F") (* fieldblue ? *)
+      0x0020,  ("Field", "F") (* fieldyellow ? *)
+      0x0001,  ("Field", "F") (* const *)
+      0x0004,  ("Property", "P") (* enummember *)
+      0x0006,  ("Exception", "X") (* exception *)
+      0x0009,  ("Text File Icon", "t") (* TextLine *)
+      0x000a,  ("Regular File", "R") (* Script *)
+      0x000b,  ("Script", "s") (* Script2 *)
+      0x0010,  ("Tip of the day", "t") (* Formula *);
+      0x00013, ("Class", "C") (* Template *)
+      0x00014, ("Class", "C") (* Typedef *)
+      0x00015, ("Type", "T") (* Type *)
+      0x00016, ("Type", "T") (* Union *)
+      0x00017, ("Field", "F") (* Variable *)
+      0x00019, ("Class", "C") (* Intrinsic *)
+      0x0001f, ("Other", "o") (* error *)
+      0x00021, ("Other", "o") (* Misc1 *)
+      0x0022,  ("Other", "o") (* Misc2 *)
+      0x00023, ("Other", "o") (* Misc3 *) ] |> Map.ofSeq
+
+  /// Translates icon code that we get from F# language service into a MonoDevelop icon
+  let getIcon glyph =
+    match map.TryFind (glyph / 6), map.TryFind (glyph % 6) with
+    | Some(s), _ -> s // Is the second number good for anything?
+    | _, _ -> ("", "")
+
+
+
 // --------------------------------------------------------------------------------------
 // Main application command-line loop
 // --------------------------------------------------------------------------------------
@@ -480,7 +523,7 @@ module internal Main =
                   match state.OutputMode with
                   | Text ->
                       printAgent.WriteLine "DATA: completion"
-                      for d in decls.Items do printAgent.WriteLine(sprintf "%s:%d" d.Name d.Glyph)
+                      for d in decls.Items do printAgent.WriteLine(sprintf "%s" d.Name)
                       printAgent.WriteLine "<<EOF>>"
                       main state
                   | Json ->
@@ -494,7 +537,9 @@ module internal Main =
                                   prAsJson { Kind = "helptext"; Data = helptext }
 
                       prAsJson { Kind = "completion"
-                                 Data = [ for d in decls.Items do yield { Name = d.Name; Glyph = d.Glyph } ] }
+                                 Data = [ for d in decls.Items do 
+                                            let (glyph, glyphChar) = CompletionUtils.getIcon d.Glyph
+                                            yield { Name = d.Name; Glyph = glyph; GlyphChar = glyphChar } ] }
 
                       let helptext =
                         Seq.fold (fun m (d: FSharpDeclarationListItem) -> Map.add d.Name d.DescriptionText m) Map.empty decls.Items

--- a/FSharp.AutoComplete/Program.fs
+++ b/FSharp.AutoComplete/Program.fs
@@ -48,6 +48,12 @@ type Location =
     Column: int
   }
 
+type CompletionResponse = 
+  {
+    Name: string
+    Glyph: int
+  }
+
 type ProjectResponse =
   {
     Project: string
@@ -474,7 +480,7 @@ module internal Main =
                   match state.OutputMode with
                   | Text ->
                       printAgent.WriteLine "DATA: completion"
-                      for d in decls.Items do printAgent.WriteLine(d.Name)
+                      for d in decls.Items do printAgent.WriteLine(sprintf "%s:%d" d.Name d.Glyph)
                       printAgent.WriteLine "<<EOF>>"
                       main state
                   | Json ->
@@ -488,7 +494,7 @@ module internal Main =
                                   prAsJson { Kind = "helptext"; Data = helptext }
 
                       prAsJson { Kind = "completion"
-                                 Data = [ for d in decls.Items do yield d.Name ] }
+                                 Data = [ for d in decls.Items do yield { Name = d.Name; Glyph = d.Glyph } ] }
 
                       let helptext =
                         Seq.fold (fun m (d: FSharpDeclarationListItem) -> Map.add d.Name d.DescriptionText m) Map.empty decls.Items

--- a/FSharp.AutoComplete/test/integration/ErrorTestsJson/output.json
+++ b/FSharp.AutoComplete/test/integration/ErrorTestsJson/output.json
@@ -4,6 +4,6 @@
 {"Kind":"INFO","Data":"Synchronous parsing started"}
 {"Kind":"errors","Data":[{"StartLine":7,"StartLineAlternate":8,"EndLine":7,"EndLineAlternate":8,"StartColumn":12,"EndColumn":19,"Severity":"Error","Message":"The value or constructor 'unnamed' is not defined","Subcategory":"typecheck","FileName":"<absolute path removed>/test/integration/ErrorTestsJson/Script.fsx"}]}
 {"Kind":"helptext","Data":{"func":"val func : x:int -> int"}}
-{"Kind":"completion","Data":["func"]}
+{"Kind":"completion","Data":[{"Name":"func","Glyph":"Method","GlyphChar":"m"}]}
 {"Kind":"helptext","Data":{"func":"val func : x:int -> int"}}
-{"Kind":"completion","Data":["func"]}
+{"Kind":"completion","Data":[{"Name":"func","Glyph":"Method","GlyphChar":"m"}]}

--- a/FSharp.AutoComplete/test/integration/Test1Json/output.json
+++ b/FSharp.AutoComplete/test/integration/Test1Json/output.json
@@ -6,15 +6,15 @@
 {"Kind":"INFO","Data":"Synchronous parsing started"}
 {"Kind":"errors","Data":[]}
 {"Kind":"helptext","Data":{"funky":"val funky : x:int -> int"}}
-{"Kind":"completion","Data":["funky"]}
+{"Kind":"completion","Data":[{"Name":"funky","Glyph":"Method","GlyphChar":"m"}]}
 {"Kind":"helptext","Data":{"Equals":"System.Object.Equals(obj: obj) : bool"}}
-{"Kind":"completion","Data":["Equals","GetHashCode","GetType","Terrific","ToString"]}
+{"Kind":"completion","Data":[{"Name":"Equals","Glyph":"Method","GlyphChar":"m"},{"Name":"GetHashCode","Glyph":"Method","GlyphChar":"m"},{"Name":"GetType","Glyph":"Method","GlyphChar":"m"},{"Name":"Terrific","Glyph":"Method","GlyphChar":"m"},{"Name":"ToString","Glyph":"Method","GlyphChar":"m"}]}
 {"Kind":"helptext","Data":{"Bar":"union case FileTwo.Foo.Bar: FileTwo.Foo"}}
-{"Kind":"completion","Data":["Bar","Foo","NewObjectType","Qux","add","addition"]}
+{"Kind":"completion","Data":[{"Name":"Bar","Glyph":"Property","GlyphChar":"P"},{"Name":"Foo","Glyph":"Type","GlyphChar":"T"},{"Name":"NewObjectType","Glyph":"Class","GlyphChar":"C"},{"Name":"Qux","Glyph":"Property","GlyphChar":"P"},{"Name":"add","Glyph":"Method","GlyphChar":"m"},{"Name":"addition","Glyph":"Method","GlyphChar":"m"}]}
 {"Kind":"helptext","Data":{"func":"val func : x:int -> int"}}
-{"Kind":"completion","Data":["func"]}
+{"Kind":"completion","Data":[{"Name":"func","Glyph":"Method","GlyphChar":"m"}]}
 {"Kind":"helptext","Data":{"Bar":"union case FileTwo.Foo.Bar: FileTwo.Foo"}}
-{"Kind":"completion","Data":["Bar","Foo","NewObjectType","Qux","add","addition"]}
+{"Kind":"completion","Data":[{"Name":"Bar","Glyph":"Property","GlyphChar":"P"},{"Name":"Foo","Glyph":"Type","GlyphChar":"T"},{"Name":"NewObjectType","Glyph":"Class","GlyphChar":"C"},{"Name":"Qux","Glyph":"Property","GlyphChar":"P"},{"Name":"add","Glyph":"Method","GlyphChar":"m"},{"Name":"addition","Glyph":"Method","GlyphChar":"m"}]}
 {"Kind":"tooltip","Data":"val add : x:int -> y:int -> int\n\nFull name: FileTwo.add"}
 {"Kind":"tooltip","Data":"val func : x:int -> int\n\nFull name: Program.X.func"}
 {"Kind":"tooltip","Data":"val testval : FileTwo.NewObjectType\n\nFull name: Program.testval"}


### PR DESCRIPTION
As discussed in https://github.com/fsharp/fsharpbinding/issues/1010 :
- I've updated Completion API to get also glyph number ( we can consider translating it too meaningful string)
- I've committed updated test results.

Also: 
- I've fixed `paket.references` file naming in `FSharp.AutoComplete` project
- I've removed `build.fsx` reference from `FSharp.AutoComplete.fsproj`
- I've added `build.fsx`, `paket.lock` and `readme.md` files to `sln` (I think it's standard way of managing solutions with Paket and FAKE)
