### PR TITLE
Fix SymbolUse

### DIFF
--- a/FsAutoComplete/CommandResponse.fs
+++ b/FsAutoComplete/CommandResponse.fs
@@ -219,22 +219,25 @@ module CommandResponse =
                    yield { Name = d.Name; Glyph = glyph; GlyphChar = glyphChar } ] }
 
   let symbolUse(symboluses: FSharpSymbolUse[]) =
-    let su =
-      { Name = symboluses.[0].Symbol.DisplayName
-        Uses =
-          [ for su in symboluses do
-              yield { StartLine = su.RangeAlternate.StartLine
-                      StartColumn = su.RangeAlternate.StartColumn + 1
-                      EndLine = su.RangeAlternate.EndLine
-                      EndColumn = su.RangeAlternate.EndColumn + 1
-                      Filename = su.FileName
-                      IsFromDefinition = su.IsFromDefinition
-                      IsFromAttribute = su.IsFromAttribute
-                      IsFromComputationExpression = su.IsFromComputationExpression
-                      IsFromDispatchSlotImplementation = su.IsFromDispatchSlotImplementation
-                      IsFromPattern = su.IsFromPattern
-                      IsFromType = su.IsFromType } ] }
-    writeJson { Kind = "symboluse"; Data = su }
+    if symboluses.Length = 0 then
+      info "No symbol uses found"
+    else
+      let su =
+        { Name = symboluses.[0].Symbol.DisplayName
+          Uses =
+            [ for su in symboluses do
+                yield { StartLine = su.RangeAlternate.StartLine
+                        StartColumn = su.RangeAlternate.StartColumn + 1
+                        EndLine = su.RangeAlternate.EndLine
+                        EndColumn = su.RangeAlternate.EndColumn + 1
+                        Filename = su.FileName
+                        IsFromDefinition = su.IsFromDefinition
+                        IsFromAttribute = su.IsFromAttribute
+                        IsFromComputationExpression = su.IsFromComputationExpression
+                        IsFromDispatchSlotImplementation = su.IsFromDispatchSlotImplementation
+                        IsFromPattern = su.IsFromPattern
+                        IsFromType = su.IsFromType } ] }
+      writeJson { Kind = "symboluse"; Data = su }
 
   let methods(meth: FSharpMethodGroup, commas: int) =
     writeJson
@@ -277,4 +280,3 @@ module CommandResponse =
 
   let message(kind: string, data: 'a) =
     writeJson { Kind = kind; Data = data }
-


### PR DESCRIPTION
Fix for SymbolUse problem I've got while testing new release in Atom editor and reported in F# Foundation Slack channel:

```
Unhandled Exception:
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at FsAutoComplete.CommandResponse.symbolUse(FSharpSymbolUse[] symboluses)
   at FsAutoComplete.Main.main(State state)
   at FsAutoComplete.Main.entry(String[] args) 
```

The problem was in line 223 where it was assumed that there is at least one element in SymbolUse array.
I've decided to return info response if array is empty - we can easily change it if You think that other reaction should be better.
