### PR TITLE
Helptext, tooltip structured data

### DIFF
--- a/FsAutoComplete/CommandResponse.fs
+++ b/FsAutoComplete/CommandResponse.fs
@@ -76,6 +76,12 @@ module CommandResponse =
       Framework: string
     }
 
+  type OverloadSignature = 
+    {
+      Signature: string
+      Comment: string
+    }
+
   type OverloadParameter =
     {
       Name : string
@@ -85,7 +91,7 @@ module CommandResponse =
     }
   type Overload =
     {
-      Tip : string
+      Tip : OverloadSignature 
       TypeText : string
       Parameters : OverloadParameter list
       IsStaticArguments : bool
@@ -118,11 +124,7 @@ module CommandResponse =
       Uses: SymbolUseRange list
     }
 
-  type OverloadSignature = 
-    {
-      Signature: string
-      Comment: string
-    }
+
 
   type HelpTextResponse =
     {
@@ -218,7 +220,7 @@ module CommandResponse =
   let error(s: string) = writeJson { Kind = "error"; Data = s }
 
   let helpText(name: string, tip: FSharpToolTipText) =
-    let text = TipFormatter.formatTipAlternative tip |> List.map(fun (n,m) -> {Signature = n; Comment = m} )
+    let text = TipFormatter.formatTip tip |> List.map(fun (n,m) -> {Signature = n; Comment = m} )
     writeJson { Kind = "helptext"; Data = { Name = name; Overloads = text } }
 
   let project(projectFileName, projectFiles, outFileOpt, references, frameworkOpt) =
@@ -264,7 +266,7 @@ module CommandResponse =
                   [ for o in meth.Methods do
                      let tip = TipFormatter.formatTip o.Description
                      yield {
-                       Tip = tip
+                       Tip = {Signature = fst tip.Head; Comment = snd tip.Head } 
                        TypeText = o.TypeText
                        Parameters =
                          [ for p in o.Parameters do
@@ -297,7 +299,7 @@ module CommandResponse =
     writeJson { Kind = "declarations"; Data = decls }
 
   let toolTip(tip) =
-    let text = TipFormatter.formatTipAlternative tip |> List.map(fun (n,m) -> {Signature = n; Comment = m} )
+    let text = TipFormatter.formatTip tip |> List.map(fun (n,m) -> {Signature = n; Comment = m} )
     writeJson { Kind = "tooltip"; Data = text }
 
   let compilerLocation fsc fsi msbuild =

--- a/FsAutoComplete/CommandResponse.fs
+++ b/FsAutoComplete/CommandResponse.fs
@@ -76,7 +76,7 @@ module CommandResponse =
       Framework: string
     }
 
-  type OverloadSignature = 
+  type OverloadSignature =
     {
       Signature: string
       Comment: string
@@ -91,7 +91,7 @@ module CommandResponse =
     }
   type Overload =
     {
-      Tip : OverloadSignature 
+      Tip : OverloadSignature list list
       TypeText : string
       Parameters : OverloadParameter list
       IsStaticArguments : bool
@@ -129,7 +129,7 @@ module CommandResponse =
   type HelpTextResponse =
     {
       Name: string
-      Overloads: OverloadSignature list
+      Overloads: OverloadSignature list list
     }
 
   type CompilerLocationResponse =
@@ -220,8 +220,8 @@ module CommandResponse =
   let error(s: string) = writeJson { Kind = "error"; Data = s }
 
   let helpText(name: string, tip: FSharpToolTipText) =
-    let text = TipFormatter.formatTip tip |> List.map(fun (n,m) -> {Signature = n; Comment = m} )
-    writeJson { Kind = "helptext"; Data = { Name = name; Overloads = text } }
+    let data = TipFormatter.formatTip tip |> List.map(List.map(fun (n,m) -> {Signature = n; Comment = m} ))
+    writeJson { Kind = "helptext"; Data = { Name = name; Overloads = data } }
 
   let project(projectFileName, projectFiles, outFileOpt, references, frameworkOpt) =
     let projectData =
@@ -264,9 +264,9 @@ module CommandResponse =
                  CurrentParameter = commas
                  Overloads =
                   [ for o in meth.Methods do
-                     let tip = TipFormatter.formatTip o.Description
+                     let tip = TipFormatter.formatTip o.Description |> List.map(List.map(fun (n,m) -> {Signature = n; Comment = m} ))
                      yield {
-                       Tip = {Signature = fst tip.Head; Comment = snd tip.Head } 
+                       Tip = tip
                        TypeText = o.TypeText
                        Parameters =
                          [ for p in o.Parameters do
@@ -299,8 +299,8 @@ module CommandResponse =
     writeJson { Kind = "declarations"; Data = decls }
 
   let toolTip(tip) =
-    let text = TipFormatter.formatTip tip |> List.map(fun (n,m) -> {Signature = n; Comment = m} )
-    writeJson { Kind = "tooltip"; Data = text }
+    let data = TipFormatter.formatTip tip |> List.map(List.map(fun (n,m) -> {Signature = n; Comment = m} ))
+    writeJson { Kind = "tooltip"; Data = data }
 
   let compilerLocation fsc fsi msbuild =
     let data = { Fsi = fsi; Fsc = fsc; MSBuild = msbuild }
@@ -308,4 +308,3 @@ module CommandResponse =
 
   let message(kind: string, data: 'a) =
     writeJson { Kind = kind; Data = data }
-

--- a/FsAutoComplete/CommandResponse.fs
+++ b/FsAutoComplete/CommandResponse.fs
@@ -297,7 +297,8 @@ module CommandResponse =
     writeJson { Kind = "declarations"; Data = decls }
 
   let toolTip(tip) =
-    writeJson { Kind = "tooltip"; Data = TipFormatter.formatTip tip }
+    let text = TipFormatter.formatTipAlternative tip |> List.map(fun (n,m) -> {Signature = n; Comment = m} )
+    writeJson { Kind = "tooltip"; Data = text }
 
   let compilerLocation fsc fsi msbuild =
     let data = { Fsi = fsi; Fsc = fsc; MSBuild = msbuild }

--- a/FsAutoComplete/CommandResponse.fs
+++ b/FsAutoComplete/CommandResponse.fs
@@ -118,10 +118,16 @@ module CommandResponse =
       Uses: SymbolUseRange list
     }
 
+  type OverloadSignature = 
+    {
+      Signature: string
+      Comment: string
+    }
+
   type HelpTextResponse =
     {
       Name: string
-      Text: string
+      Overloads: OverloadSignature list
     }
 
   type CompilerLocationResponse =
@@ -212,8 +218,8 @@ module CommandResponse =
   let error(s: string) = writeJson { Kind = "error"; Data = s }
 
   let helpText(name: string, tip: FSharpToolTipText) =
-    let text = TipFormatter.formatTip tip
-    writeJson { Kind = "helptext"; Data = { Name = name; Text = text } }
+    let text = TipFormatter.formatTipAlternative tip |> List.map(fun (n,m) -> {Signature = n; Comment = m} )
+    writeJson { Kind = "helptext"; Data = { Name = name; Overloads = text } }
 
   let project(projectFileName, projectFiles, outFileOpt, references, frameworkOpt) =
     let projectData =

--- a/FsAutoComplete/TipFormatter.fs
+++ b/FsAutoComplete/TipFormatter.fs
@@ -17,6 +17,13 @@ let private buildFormatComment cmt (sb:StringBuilder) =
   // files, but I'm not sure whether these are available on Mono
   | _ -> sb
 
+let private buildFormatCommentAlternative cmt  =
+  match cmt with
+  | FSharpXmlDoc.Text s -> s
+  // For 'XmlCommentSignature' we could get documentation from 'xml'
+  // files, but I'm not sure whether these are available on Mono
+  | _ -> ""
+
 // If 'isSingle' is true (meaning that this is the only tip displayed)
 // then we add first line "Multiple overloads" because MD prints first
 // int in bold (so that no overload is highlighted)
@@ -51,3 +58,16 @@ let private buildFormatTip tip (sb:StringBuilder) =
 /// Format tool-tip that we get from the language service as string
 let formatTip tip =
   (buildFormatTip tip (new StringBuilder())).ToString().Trim('\n', '\r').Replace("\r","")
+
+let formatTipAlternative tip = 
+  match tip with
+  | FSharpToolTipText tips -> tips |> Seq.where (function
+                                                 | FSharpToolTipElement.Single _ | FSharpToolTipElement.Group _ -> true
+                                                 | _ -> false)
+                                   |>  Seq.fold (fun acc t -> match t with
+                                                              | FSharpToolTipElement.Single (it, comment) -> (it, comment |> buildFormatCommentAlternative)::acc
+                                                              | FSharpToolTipElement.Group (items) -> (items |> List.map (fun (it, comment) ->  (it, comment |> buildFormatCommentAlternative) )) @ acc
+                                                              | _ -> acc) []
+
+  
+  

--- a/FsAutoComplete/TipFormatter.fs
+++ b/FsAutoComplete/TipFormatter.fs
@@ -22,9 +22,6 @@ let formatTip tip =
                                                  | FSharpToolTipElement.Single _ | FSharpToolTipElement.Group _ -> true
                                                  | _ -> false)
                                    |>  Seq.fold (fun acc t -> match t with
-                                                              | FSharpToolTipElement.Single (it, comment) -> (it, comment |> buildFormatComment)::acc
-                                                              | FSharpToolTipElement.Group (items) -> (items |> List.map (fun (it, comment) ->  (it, comment |> buildFormatComment) )) @ acc
+                                                              | FSharpToolTipElement.Single (it, comment) -> [(it, comment |> buildFormatComment)]::acc
+                                                              | FSharpToolTipElement.Group (items) -> (items |> List.map (fun (it, comment) ->  (it, comment |> buildFormatComment) )) :: acc
                                                               | _ -> acc) []
-
-  
-  

--- a/FsAutoComplete/TipFormatter.fs
+++ b/FsAutoComplete/TipFormatter.fs
@@ -9,64 +9,21 @@ open Microsoft.FSharp.Compiler.SourceCodeServices
 // --------------------------------------------------------------------------------------
 // Formatting of tool-tip information displayed in F# IntelliSense
 // --------------------------------------------------------------------------------------
-
-let private buildFormatComment cmt (sb:StringBuilder) =
-  match cmt with
-  | FSharpXmlDoc.Text s -> sb.AppendLine(s)
-  // For 'XmlCommentSignature' we could get documentation from 'xml'
-  // files, but I'm not sure whether these are available on Mono
-  | _ -> sb
-
-let private buildFormatCommentAlternative cmt  =
+let private buildFormatComment cmt  =
   match cmt with
   | FSharpXmlDoc.Text s -> s
   // For 'XmlCommentSignature' we could get documentation from 'xml'
   // files, but I'm not sure whether these are available on Mono
   | _ -> ""
 
-// If 'isSingle' is true (meaning that this is the only tip displayed)
-// then we add first line "Multiple overloads" because MD prints first
-// int in bold (so that no overload is highlighted)
-let private buildFormatElement isSingle el (sb:StringBuilder) =
-  match el with
-  | FSharpToolTipElement.None -> sb
-  | FSharpToolTipElement.Single(it, comment) ->
-      sb.AppendLine(it) |> buildFormatComment comment
-  | FSharpToolTipElement.Group(items) ->
-      let items, msg =
-        if items.Length > 10 then
-          (items |> Seq.take 10 |> List.ofSeq),
-            sprintf "   (+%d other overloads)" (items.Length - 10)
-        else items, null
-      if (isSingle && items.Length > 1) then
-        sb.AppendLine("Multiple overloads") |> ignore
-      for (it, comment) in items do
-        sb.AppendLine(it) |> buildFormatComment comment |> ignore
-      if msg <> null then sb.AppendFormat(msg) else sb
-  | FSharpToolTipElement.CompositionError(err) ->
-      sb.Append("Composition error: " + err)
-
-let private buildFormatTip tip (sb:StringBuilder) =
-  match tip with
-  | FSharpToolTipText([single]) -> sb |> buildFormatElement true single
-  | FSharpToolTipText(its) ->
-      sb.AppendLine("Multiple items") |> ignore
-      its |> Seq.mapi (fun i it -> i = 0, it) |> Seq.fold (fun sb (first, item) ->
-        if not first then sb.AppendLine("\n--------------------\n") |> ignore
-        sb |> buildFormatElement false item) sb
-
-/// Format tool-tip that we get from the language service as string
-let formatTip tip =
-  (buildFormatTip tip (new StringBuilder())).ToString().Trim('\n', '\r').Replace("\r","")
-
-let formatTipAlternative tip = 
+let formatTip tip = 
   match tip with
   | FSharpToolTipText tips -> tips |> Seq.where (function
                                                  | FSharpToolTipElement.Single _ | FSharpToolTipElement.Group _ -> true
                                                  | _ -> false)
                                    |>  Seq.fold (fun acc t -> match t with
-                                                              | FSharpToolTipElement.Single (it, comment) -> (it, comment |> buildFormatCommentAlternative)::acc
-                                                              | FSharpToolTipElement.Group (items) -> (items |> List.map (fun (it, comment) ->  (it, comment |> buildFormatCommentAlternative) )) @ acc
+                                                              | FSharpToolTipElement.Single (it, comment) -> (it, comment |> buildFormatComment)::acc
+                                                              | FSharpToolTipElement.Group (items) -> (items |> List.map (fun (it, comment) ->  (it, comment |> buildFormatComment) )) @ acc
                                                               | _ -> acc) []
 
   

--- a/FsAutoComplete/test/integration/CompletionFilter/output.json
+++ b/FsAutoComplete/test/integration/CompletionFilter/output.json
@@ -21,7 +21,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Ticks",
-    "Text": "property System.DateTime.Ticks: int64"
+    "Overloads": [
+      [
+        {
+          "Signature": "property System.DateTime.Ticks: int64",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -238,7 +245,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Ticks",
-    "Text": "property System.DateTime.Ticks: int64"
+    "Overloads": [
+      [
+        {
+          "Signature": "property System.DateTime.Ticks: int64",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -315,7 +329,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Ticks",
-    "Text": "property System.DateTime.Ticks: int64"
+    "Overloads": [
+      [
+        {
+          "Signature": "property System.DateTime.Ticks: int64",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/ErrorTestsJson/output.json
+++ b/FsAutoComplete/test/integration/ErrorTestsJson/output.json
@@ -78,7 +78,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "func",
-    "Text": "val func : x:int -> int"
+    "Overloads": [
+      [
+        {
+          "Signature": "val func : x:int -> int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -95,7 +102,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "func",
-    "Text": "val func : x:int -> int"
+    "Overloads": [
+      [
+        {
+          "Signature": "val func : x:int -> int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/MultiProj/output.json
+++ b/FsAutoComplete/test/integration/MultiProj/output.json
@@ -36,7 +36,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Equals",
-    "Text": "System.Object.Equals(obj: obj) : bool"
+    "Overloads": [
+      [
+        {
+          "Signature": "System.Object.Equals(obj: obj) : bool",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -73,7 +80,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Bar",
-    "Text": "union case FileTwo.Foo.Bar: FileTwo.Foo"
+    "Overloads": [
+      [
+        {
+          "Signature": "union case FileTwo.Foo.Bar: FileTwo.Foo",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -115,7 +129,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "func",
-    "Text": "val func : x:int -> int"
+    "Overloads": [
+      [
+        {
+          "Signature": "val func : x:int -> int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -132,7 +153,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Bar",
-    "Text": "union case FileTwo.Foo.Bar: FileTwo.Foo"
+    "Overloads": [
+      [
+        {
+          "Signature": "union case FileTwo.Foo.Bar: FileTwo.Foo",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -208,7 +236,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Equals",
-    "Text": "System.Object.Equals(obj: obj) : bool"
+    "Overloads": [
+      [
+        {
+          "Signature": "System.Object.Equals(obj: obj) : bool",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -245,7 +280,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Bar",
-    "Text": "union case FileTwo.Foo.Bar: FileTwo.Foo"
+    "Overloads": [
+      [
+        {
+          "Signature": "union case FileTwo.Foo.Bar: FileTwo.Foo",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -287,7 +329,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "func",
-    "Text": "val func : x:int -> int"
+    "Overloads": [
+      [
+        {
+          "Signature": "val func : x:int -> int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -304,7 +353,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Bar",
-    "Text": "union case FileTwo.Foo.Bar: FileTwo.Foo"
+    "Overloads": [
+      [
+        {
+          "Signature": "union case FileTwo.Foo.Bar: FileTwo.Foo",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -362,7 +418,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Equals",
-    "Text": "System.Object.Equals(obj: obj) : bool"
+    "Overloads": [
+      [
+        {
+          "Signature": "System.Object.Equals(obj: obj) : bool",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -399,7 +462,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Bar",
-    "Text": "union case FileTwo.Foo.Bar: FileTwo.Foo"
+    "Overloads": [
+      [
+        {
+          "Signature": "union case FileTwo.Foo.Bar: FileTwo.Foo",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -441,7 +511,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "func",
-    "Text": "val func : x:int -> int"
+    "Overloads": [
+      [
+        {
+          "Signature": "val func : x:int -> int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -458,7 +535,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Bar",
-    "Text": "union case FileTwo.Foo.Bar: FileTwo.Foo"
+    "Overloads": [
+      [
+        {
+          "Signature": "union case FileTwo.Foo.Bar: FileTwo.Foo",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -516,7 +600,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Equals",
-    "Text": "System.Object.Equals(obj: obj) : bool"
+    "Overloads": [
+      [
+        {
+          "Signature": "System.Object.Equals(obj: obj) : bool",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -553,7 +644,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Bar",
-    "Text": "union case FileTwo.Foo.Bar: FileTwo.Foo"
+    "Overloads": [
+      [
+        {
+          "Signature": "union case FileTwo.Foo.Bar: FileTwo.Foo",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -595,7 +693,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "func",
-    "Text": "val func : x:int -> int"
+    "Overloads": [
+      [
+        {
+          "Signature": "val func : x:int -> int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -612,7 +717,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Bar",
-    "Text": "union case FileTwo.Foo.Bar: FileTwo.Foo"
+    "Overloads": [
+      [
+        {
+          "Signature": "union case FileTwo.Foo.Bar: FileTwo.Foo",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/OutOfRange/output.json
+++ b/FsAutoComplete/test/integration/OutOfRange/output.json
@@ -45,7 +45,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "funky",
-    "Text": "val funky : x:int -> int"
+    "Overloads": [
+      [
+        {
+          "Signature": "val funky : x:int -> int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -60,7 +67,14 @@
 }
 {
   "Kind": "tooltip",
-  "Data": "module XA\n\nfrom Script"
+  "Data": [
+    [
+      {
+        "Signature": "module XA\n\nfrom Script",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "info",

--- a/FsAutoComplete/test/integration/ParamCompletion/output.json
+++ b/FsAutoComplete/test/integration/ParamCompletion/output.json
@@ -39,7 +39,14 @@
     "CurrentParameter": 0,
     "Overloads": [
       {
-        "Tip": "new : unit -> FileTwo.NewObjectType",
+        "Tip": [
+          [
+            {
+              "Signature": "new : unit -> FileTwo.NewObjectType",
+              "Comment": ""
+            }
+          ]
+        ],
         "TypeText": ": FileTwo.NewObjectType",
         "Parameters": [],
         "IsStaticArguments": false
@@ -54,7 +61,14 @@
     "CurrentParameter": 0,
     "Overloads": [
       {
-        "Tip": "new : unit -> FileTwo.NewObjectType",
+        "Tip": [
+          [
+            {
+              "Signature": "new : unit -> FileTwo.NewObjectType",
+              "Comment": ""
+            }
+          ]
+        ],
         "TypeText": ": FileTwo.NewObjectType",
         "Parameters": [],
         "IsStaticArguments": false
@@ -69,7 +83,14 @@
     "CurrentParameter": 0,
     "Overloads": [
       {
-        "Tip": "member FileTwo.NewObjectType.Terrific : y:Set<'a> * z:int -> Set<'a> (requires comparison)",
+        "Tip": [
+          [
+            {
+              "Signature": "member FileTwo.NewObjectType.Terrific : y:Set<'a> * z:int -> Set<'a> (requires comparison)",
+              "Comment": ""
+            }
+          ]
+        ],
         "TypeText": ": Set<'a> (requires comparison)",
         "Parameters": [
           {
@@ -88,7 +109,14 @@
         "IsStaticArguments": false
       },
       {
-        "Tip": "member FileTwo.NewObjectType.Terrific : y:int * z:char -> int",
+        "Tip": [
+          [
+            {
+              "Signature": "member FileTwo.NewObjectType.Terrific : y:int * z:char -> int",
+              "Comment": ""
+            }
+          ]
+        ],
         "TypeText": ": int",
         "Parameters": [
           {
@@ -107,7 +135,14 @@
         "IsStaticArguments": false
       },
       {
-        "Tip": "member FileTwo.NewObjectType.Terrific : y:int * z:System.DateTime -> int",
+        "Tip": [
+          [
+            {
+              "Signature": "member FileTwo.NewObjectType.Terrific : y:int * z:System.DateTime -> int",
+              "Comment": ""
+            }
+          ]
+        ],
         "TypeText": ": int",
         "Parameters": [
           {
@@ -135,7 +170,14 @@
     "CurrentParameter": 1,
     "Overloads": [
       {
-        "Tip": "member FileTwo.NewObjectType.Terrific : y:Set<'a> * z:int -> Set<'a> (requires comparison)",
+        "Tip": [
+          [
+            {
+              "Signature": "member FileTwo.NewObjectType.Terrific : y:Set<'a> * z:int -> Set<'a> (requires comparison)",
+              "Comment": ""
+            }
+          ]
+        ],
         "TypeText": ": Set<'a> (requires comparison)",
         "Parameters": [
           {
@@ -154,7 +196,14 @@
         "IsStaticArguments": false
       },
       {
-        "Tip": "member FileTwo.NewObjectType.Terrific : y:int * z:char -> int",
+        "Tip": [
+          [
+            {
+              "Signature": "member FileTwo.NewObjectType.Terrific : y:int * z:char -> int",
+              "Comment": ""
+            }
+          ]
+        ],
         "TypeText": ": int",
         "Parameters": [
           {
@@ -173,7 +222,14 @@
         "IsStaticArguments": false
       },
       {
-        "Tip": "member FileTwo.NewObjectType.Terrific : y:int * z:System.DateTime -> int",
+        "Tip": [
+          [
+            {
+              "Signature": "member FileTwo.NewObjectType.Terrific : y:int * z:System.DateTime -> int",
+              "Comment": ""
+            }
+          ]
+        ],
         "TypeText": ": int",
         "Parameters": [
           {
@@ -201,7 +257,14 @@
     "CurrentParameter": 0,
     "Overloads": [
       {
-        "Tip": "System.DateTime.Parse(s: string) : System.DateTime",
+        "Tip": [
+          [
+            {
+              "Signature": "System.DateTime.Parse(s: string) : System.DateTime",
+              "Comment": ""
+            }
+          ]
+        ],
         "TypeText": ": System.DateTime",
         "Parameters": [
           {
@@ -214,7 +277,14 @@
         "IsStaticArguments": false
       },
       {
-        "Tip": "System.DateTime.Parse(s: string, provider: System.IFormatProvider) : System.DateTime",
+        "Tip": [
+          [
+            {
+              "Signature": "System.DateTime.Parse(s: string, provider: System.IFormatProvider) : System.DateTime",
+              "Comment": ""
+            }
+          ]
+        ],
         "TypeText": ": System.DateTime",
         "Parameters": [
           {
@@ -233,7 +303,14 @@
         "IsStaticArguments": false
       },
       {
-        "Tip": "System.DateTime.Parse(s: string, provider: System.IFormatProvider, styles: System.Globalization.DateTimeStyles) : System.DateTime",
+        "Tip": [
+          [
+            {
+              "Signature": "System.DateTime.Parse(s: string, provider: System.IFormatProvider, styles: System.Globalization.DateTimeStyles) : System.DateTime",
+              "Comment": ""
+            }
+          ]
+        ],
         "TypeText": ": System.DateTime",
         "Parameters": [
           {
@@ -267,7 +344,14 @@
     "CurrentParameter": 0,
     "Overloads": [
       {
-        "Tip": "System.DateTime.Parse(s: string) : System.DateTime",
+        "Tip": [
+          [
+            {
+              "Signature": "System.DateTime.Parse(s: string) : System.DateTime",
+              "Comment": ""
+            }
+          ]
+        ],
         "TypeText": ": System.DateTime",
         "Parameters": [
           {
@@ -280,7 +364,14 @@
         "IsStaticArguments": false
       },
       {
-        "Tip": "System.DateTime.Parse(s: string, provider: System.IFormatProvider) : System.DateTime",
+        "Tip": [
+          [
+            {
+              "Signature": "System.DateTime.Parse(s: string, provider: System.IFormatProvider) : System.DateTime",
+              "Comment": ""
+            }
+          ]
+        ],
         "TypeText": ": System.DateTime",
         "Parameters": [
           {
@@ -299,7 +390,14 @@
         "IsStaticArguments": false
       },
       {
-        "Tip": "System.DateTime.Parse(s: string, provider: System.IFormatProvider, styles: System.Globalization.DateTimeStyles) : System.DateTime",
+        "Tip": [
+          [
+            {
+              "Signature": "System.DateTime.Parse(s: string, provider: System.IFormatProvider, styles: System.Globalization.DateTimeStyles) : System.DateTime",
+              "Comment": ""
+            }
+          ]
+        ],
         "TypeText": ": System.DateTime",
         "Parameters": [
           {

--- a/FsAutoComplete/test/integration/RawIdTest/output.json
+++ b/FsAutoComplete/test/integration/RawIdTest/output.json
@@ -180,7 +180,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Another`Column",
-    "Text": "val Another`Column : int"
+    "Overloads": [
+      [
+        {
+          "Signature": "val Another`Column : int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -217,7 +224,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Another`Column",
-    "Text": "val Another`Column : int"
+    "Overloads": [
+      [
+        {
+          "Signature": "val Another`Column : int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -239,7 +253,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Another`Column",
-    "Text": "property Y.Another`Column: int"
+    "Overloads": [
+      [
+        {
+          "Signature": "property Y.Another`Column: int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -266,7 +287,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Column Two",
-    "Text": "property Y.Column Two: int"
+    "Overloads": [
+      [
+        {
+          "Signature": "property Y.Column Two: int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -293,7 +321,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Another`Column",
-    "Text": "property Y.Another`Column: int"
+    "Overloads": [
+      [
+        {
+          "Signature": "property Y.Another`Column: int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/RobustCommands/completewithoutproject.json
+++ b/FsAutoComplete/test/integration/RobustCommands/completewithoutproject.json
@@ -10,7 +10,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "func",
-    "Text": "val func : x:int -> int"
+    "Overloads": [
+      [
+        {
+          "Signature": "val func : x:int -> int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/SymOpActivePatTooltips/output.json
+++ b/FsAutoComplete/test/integration/SymOpActivePatTooltips/output.json
@@ -12,23 +12,58 @@
 }
 {
   "Kind": "tooltip",
-  "Data": "val ( |<>| ) : x:int -> y:int -> int\n\nFull name: Script.( |<>| )"
+  "Data": [
+    [
+      {
+        "Signature": "val ( |<>| ) : x:int -> y:int -> int\n\nFull name: Script.( |<>| )",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "tooltip",
-  "Data": "val ( |<>| ) : x:int -> y:int -> int\n\nFull name: Script.( |<>| )"
+  "Data": [
+    [
+      {
+        "Signature": "val ( |<>| ) : x:int -> y:int -> int\n\nFull name: Script.( |<>| )",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "tooltip",
-  "Data": "val ( |<>| ) : x:int -> y:int -> int\n\nFull name: Script.( |<>| )"
+  "Data": [
+    [
+      {
+        "Signature": "val ( |<>| ) : x:int -> y:int -> int\n\nFull name: Script.( |<>| )",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "tooltip",
-  "Data": "val ( |<>| ) : x:int -> y:int -> int\n\nFull name: Script.( |<>| )"
+  "Data": [
+    [
+      {
+        "Signature": "val ( |<>| ) : x:int -> y:int -> int\n\nFull name: Script.( |<>| )",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "tooltip",
-  "Data": "val ( |<>| ) : x:int -> y:int -> int\n\nFull name: Script.( |<>| )"
+  "Data": [
+    [
+      {
+        "Signature": "val ( |<>| ) : x:int -> y:int -> int\n\nFull name: Script.( |<>| )",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "info",
@@ -40,23 +75,58 @@
 }
 {
   "Kind": "tooltip",
-  "Data": "val ( |..| ) : x:int -> y:int -> int\n\nFull name: Script.( |..| )"
+  "Data": [
+    [
+      {
+        "Signature": "val ( |..| ) : x:int -> y:int -> int\n\nFull name: Script.( |..| )",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "tooltip",
-  "Data": "val ( |..| ) : x:int -> y:int -> int\n\nFull name: Script.( |..| )"
+  "Data": [
+    [
+      {
+        "Signature": "val ( |..| ) : x:int -> y:int -> int\n\nFull name: Script.( |..| )",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "tooltip",
-  "Data": "val ( |..| ) : x:int -> y:int -> int\n\nFull name: Script.( |..| )"
+  "Data": [
+    [
+      {
+        "Signature": "val ( |..| ) : x:int -> y:int -> int\n\nFull name: Script.( |..| )",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "tooltip",
-  "Data": "val ( |..| ) : x:int -> y:int -> int\n\nFull name: Script.( |..| )"
+  "Data": [
+    [
+      {
+        "Signature": "val ( |..| ) : x:int -> y:int -> int\n\nFull name: Script.( |..| )",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "tooltip",
-  "Data": "val ( |..| ) : x:int -> y:int -> int\n\nFull name: Script.( |..| )"
+  "Data": [
+    [
+      {
+        "Signature": "val ( |..| ) : x:int -> y:int -> int\n\nFull name: Script.( |..| )",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "info",
@@ -64,13 +134,34 @@
 }
 {
   "Kind": "tooltip",
-  "Data": "val ( |Zero|Succ| ) : n:int -> Choice<unit,int>\n\nFull name: Script.( |Zero|Succ| )"
+  "Data": [
+    [
+      {
+        "Signature": "val ( |Zero|Succ| ) : n:int -> Choice<unit,int>\n\nFull name: Script.( |Zero|Succ| )",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "tooltip",
-  "Data": "val ( |Zero|Succ| ) : n:int -> Choice<unit,int>\n\nFull name: Script.( |Zero|Succ| )"
+  "Data": [
+    [
+      {
+        "Signature": "val ( |Zero|Succ| ) : n:int -> Choice<unit,int>\n\nFull name: Script.( |Zero|Succ| )",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "tooltip",
-  "Data": "val ( |Zero|Succ| ) : n:int -> Choice<unit,int>\n\nFull name: Script.( |Zero|Succ| )"
+  "Data": [
+    [
+      {
+        "Signature": "val ( |Zero|Succ| ) : n:int -> Choice<unit,int>\n\nFull name: Script.( |Zero|Succ| )",
+        "Comment": ""
+      }
+    ]
+  ]
 }

--- a/FsAutoComplete/test/integration/Test1Json/output.json
+++ b/FsAutoComplete/test/integration/Test1Json/output.json
@@ -44,7 +44,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "funky",
-    "Text": "val funky : x:int -> int"
+    "Overloads": [
+      [
+        {
+          "Signature": "val funky : x:int -> int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -61,7 +68,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Equals",
-    "Text": "System.Object.Equals(obj: obj) : bool"
+    "Overloads": [
+      [
+        {
+          "Signature": "System.Object.Equals(obj: obj) : bool",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -98,7 +112,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Bar",
-    "Text": "union case FileTwo.Foo.Bar: FileTwo.Foo"
+    "Overloads": [
+      [
+        {
+          "Signature": "union case FileTwo.Foo.Bar: FileTwo.Foo",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -140,7 +161,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "func",
-    "Text": "val func : x:int -> int"
+    "Overloads": [
+      [
+        {
+          "Signature": "val func : x:int -> int",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -157,7 +185,14 @@
   "Kind": "helptext",
   "Data": {
     "Name": "Bar",
-    "Text": "union case FileTwo.Foo.Bar: FileTwo.Foo"
+    "Overloads": [
+      [
+        {
+          "Signature": "union case FileTwo.Foo.Bar: FileTwo.Foo",
+          "Comment": ""
+        }
+      ]
+    ]
   }
 }
 {
@@ -197,19 +232,47 @@
 }
 {
   "Kind": "tooltip",
-  "Data": "val add : x:int -> y:int -> int\n\nFull name: FileTwo.add"
+  "Data": [
+    [
+      {
+        "Signature": "val add : x:int -> y:int -> int\n\nFull name: FileTwo.add",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "tooltip",
-  "Data": "val func : x:int -> int\n\nFull name: Program.X.func"
+  "Data": [
+    [
+      {
+        "Signature": "val func : x:int -> int\n\nFull name: Program.X.func",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "tooltip",
-  "Data": "val testval : FileTwo.NewObjectType\n\nFull name: Program.testval"
+  "Data": [
+    [
+      {
+        "Signature": "val testval : FileTwo.NewObjectType\n\nFull name: Program.testval",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "tooltip",
-  "Data": "val funky : x:int -> int\n\nFull name: Script.XA.funky"
+  "Data": [
+    [
+      {
+        "Signature": "val funky : x:int -> int\n\nFull name: Script.XA.funky",
+        "Comment": ""
+      }
+    ]
+  ]
 }
 {
   "Kind": "finddecl",


### PR DESCRIPTION
Idea is to get rid of tooltip formatting used by HelpTexts, Tooltips and MethodOverloads. IMO, it's better to provide more structured data and allow on client level to format it as it's necessary instead of fixed formatting here in FSAC.

It should allow to implement in editors more VS/XS style tooltips / helptexts allowing user can go through overloads instead of printing all multiple elements in tooltip / helptext.

Marked as [WIP] since tests are not updated, functionality should be working. 
