### PR TITLE
Read XmlDoc comments

### DIFF
--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -75,6 +75,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -3,17 +3,53 @@
 // --------------------------------------------------------------------------------------
 module FsAutoComplete.TipFormatter
 
+open System.IO
+open System.Xml
 open System.Text
+open System.Text.RegularExpressions
 open Microsoft.FSharp.Compiler.SourceCodeServices
+
+// TODO: Improve this parser. Is there any other XmlDoc parser available?
+type private XmlDoc(doc: XmlDocument) =
+  let nl = System.Environment.NewLine
+  let readContent (node: XmlNode) =
+    Regex.Replace(node.InnerXml,"""<\w+ \w+="(?:\w:){0,1}(.+?)" />""", "$1")
+  let readChildren name (doc: XmlDocument) =
+    doc.DocumentElement.GetElementsByTagName name
+    |> Seq.cast<XmlNode>
+    |> Seq.map (fun node -> node.Attributes.[0].InnerText.Replace("T:",""), readContent node)
+    |> Map.ofSeq
+  member val Summary = readContent doc.DocumentElement.ChildNodes.[0]
+  member val Params = readChildren "param" doc
+  member val Exceptions = readChildren "exception" doc
+  override x.ToString() =
+    x.Summary + nl + nl +
+    (x.Params |> Seq.map (fun kv -> kv.Key + ": " + kv.Value) |> String.concat nl) + nl + nl +
+    "Exceptions:" + nl +
+    (x.Exceptions |> Seq.map (fun kv -> "\t" + kv.Key + ": " + kv.Value) |> String.concat nl)
+    
 
 // --------------------------------------------------------------------------------------
 // Formatting of tool-tip information displayed in F# IntelliSense
 // --------------------------------------------------------------------------------------
-let private buildFormatComment cmt  =
+let private buildFormatComment cmt =
   match cmt with
   | FSharpXmlDoc.Text s -> s
-  // For 'XmlCommentSignature' we could get documentation from 'xml'
-  // files, but I'm not sure whether these are available on Mono
+  | FSharpXmlDoc.XmlDocFileSignature(dllFile, memberName) when
+    File.Exists(Path.ChangeExtension(dllFile, ".xml")) ->
+    let rec findComment name (reader: XmlReader) =
+      match reader.Read() with
+      | false -> ""
+      | true when reader.GetAttribute("name") = name ->
+        use subReader = reader.ReadSubtree()
+        let doc = XmlDocument()
+        doc.Load(subReader)
+        XmlDoc doc |> string
+      | _ -> findComment name reader
+    try
+      use reader = Path.ChangeExtension(dllFile, ".xml") |> XmlReader.Create
+      findComment memberName reader
+    with _ -> ""
   | _ -> ""
 
 let formatTip tip = 


### PR DESCRIPTION
WIP: Add XmlDoc reading functionality. I'm worried this can pose performance issues when there are many requests coming, so I would like to discuss with you the best way to avoid this. Currently I'm thinking of two possibilities:
- Cache XmlDoc the same way as Visual Studio does. But this will increase the memory requirements considerably.
- Restrict reading XML to specific cases. Again, two options come to mind:
  - A command flag: but this can make the API more cumbersome
  - A timeout threshold: for example when the timeout is set to half or one second (autocomplete, tooltip...) the XML file is not read to prevent consuming the time allowed.

Please have a look and tell me what you think. Thanks!
