### PR TITLE
Fix for uncompiled referenced projects

### DIFF
--- a/FsAutoComplete.Core/CommandResponse.fs
+++ b/FsAutoComplete.Core/CommandResponse.fs
@@ -72,7 +72,6 @@ module CommandResponse =
       Files: List<string>
       Output: string
       References: List<string>
-      Framework: string
     }
 
   type OverloadSignature =
@@ -204,13 +203,12 @@ module CommandResponse =
     let data = TipFormatter.formatTip tip |> List.map(List.map(fun (n,m) -> {Signature = n; Comment = m} ))
     serialize { Kind = "helptext"; Data = { HelpTextResponse.Name = name; Overloads = data } }
 
-  let project (serialize : obj -> string) (projectFileName, projectFiles, outFileOpt, references, frameworkOpt) =
+  let project (serialize : obj -> string) (projectFileName, projectFiles, outFileOpt, references) =
     let projectData =
       { Project = projectFileName
         Files = projectFiles
         Output = match outFileOpt with Some x -> x | None -> "null"
-        References = List.sortBy IO.Path.GetFileName references
-        Framework = match frameworkOpt with Some x -> x | None -> "null" }
+        References = List.sortBy IO.Path.GetFileName references }
     serialize { Kind = "project"; Data = projectData }
 
   let completion (serialize : obj -> string) (decls: FSharpDeclarationListItem[]) =

--- a/FsAutoComplete.Core/FsAutoComplete.Core.fs
+++ b/FsAutoComplete.Core/FsAutoComplete.Core.fs
@@ -50,8 +50,8 @@ module Commands =
 
                 match checker.TryGetProjectOptions(file) with
                 | Result.Failure s -> [Response.error serialize s],state
-                | Result.Success(po, projectFiles, outFileOpt, references, frameworkOpt) ->
-                    let res = Response.project serialize (file, projectFiles, outFileOpt, references, frameworkOpt)
+                | Result.Success(po, projectFiles, outFileOpt, references) ->
+                    let res = Response.project serialize (file, projectFiles, outFileOpt, references)
                     let checkOptions =
                       projectFiles
                       |> List.fold (fun s f -> Map.add f po s) state.FileCheckOptions

--- a/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -55,17 +55,6 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
-      <ItemGroup>
-        <Reference Include="FSharp.Compiler.Service">
-          <HintPath>..\packages\FSharp.Compiler.Service\lib\net45\FSharp.Compiler.Service.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
   <ItemGroup>
     <Compile Include="Utils.fs" />
     <Compile Include="Environment.fs" />
@@ -87,4 +76,15 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
   </ItemGroup>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="FSharp.Compiler.Service">
+          <HintPath>..\packages\FSharp.Compiler.Service\lib\net45\FSharp.Compiler.Service.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>

--- a/FsAutoComplete.Suave/FsAutoComplete.Suave.fsproj
+++ b/FsAutoComplete.Suave/FsAutoComplete.Suave.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -87,53 +87,6 @@
         <Reference Include="FSharp.Compiler.Service">
           <HintPath>..\packages\FSharp.Compiler.Service\lib\net45\FSharp.Compiler.Service.dll</HintPath>
           <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="FsPickler">
-          <HintPath>..\packages\FsPickler\lib\net35\FsPickler.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="System.Runtime.Serialization">
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="System.Xml">
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
-      <ItemGroup>
-        <Reference Include="FsPickler">
-          <HintPath>..\packages\FsPickler\lib\net40\FsPickler.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="System.Runtime.Serialization">
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="System.Xml">
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
-      <ItemGroup>
-        <Reference Include="FsPickler">
-          <HintPath>..\packages\FsPickler\lib\net45\FsPickler.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="System.Runtime.Serialization">
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="System.Xml">
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>

--- a/FsAutoComplete.Tests/FsAutoComplete.Tests.fsproj
+++ b/FsAutoComplete.Tests/FsAutoComplete.Tests.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -80,6 +80,8 @@
       <Project>{4e4786f3-4566-44e1-8787-91790007f0f6}</Project>
       <Private>True</Private>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/FsAutoComplete/test/integration/ErrorTestsJson/output.json
+++ b/FsAutoComplete/test/integration/ErrorTestsJson/output.json
@@ -12,8 +12,7 @@
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/FindDeclarations/output.json
+++ b/FsAutoComplete/test/integration/FindDeclarations/output.json
@@ -12,8 +12,7 @@
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/MultiProj/output.json
+++ b/FsAutoComplete/test/integration/MultiProj/output.json
@@ -12,8 +12,7 @@
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }
 {
@@ -212,8 +211,7 @@
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/MultipleUnsavedFiles/output.json
+++ b/FsAutoComplete/test/integration/MultipleUnsavedFiles/output.json
@@ -12,8 +12,7 @@
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/NoFSharpCoreReference/output.json
+++ b/FsAutoComplete/test/integration/NoFSharpCoreReference/output.json
@@ -12,7 +12,6 @@
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }

--- a/FsAutoComplete/test/integration/OutOfRange/output.json
+++ b/FsAutoComplete/test/integration/OutOfRange/output.json
@@ -19,16 +19,6 @@
       "FileName": "<absolute path removed>/test/integration/OutOfRange/Script.fsx",
       "StartLine": 6,
       "EndLine": 6,
-      "StartColumn": 15,
-      "EndColumn": 16,
-      "Severity": "Error",
-      "Message": "Missing qualification after '.'",
-      "Subcategory": "parse"
-    },
-    {
-      "FileName": "<absolute path removed>/test/integration/OutOfRange/Script.fsx",
-      "StartLine": 6,
-      "EndLine": 6,
       "StartColumn": 13,
       "EndColumn": 15,
       "Severity": "Error",

--- a/FsAutoComplete/test/integration/ParamCompletion/output.json
+++ b/FsAutoComplete/test/integration/ParamCompletion/output.json
@@ -12,8 +12,7 @@
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/ProjectReload/output.json
+++ b/FsAutoComplete/test/integration/ProjectReload/output.json
@@ -11,8 +11,7 @@
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }
 {
@@ -28,7 +27,6 @@
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }

--- a/FsAutoComplete/test/integration/RawIdTest/output.json
+++ b/FsAutoComplete/test/integration/RawIdTest/output.json
@@ -37,36 +37,6 @@
     },
     {
       "FileName": "<absolute path removed>/test/integration/RawIdTest/Test-Module.fsx",
-      "StartLine": 11,
-      "EndLine": 11,
-      "StartColumn": 3,
-      "EndColumn": 4,
-      "Severity": "Error",
-      "Message": "Unexpected reserved keyword in implementation file",
-      "Subcategory": "parse"
-    },
-    {
-      "FileName": "<absolute path removed>/test/integration/RawIdTest/Test-Module.fsx",
-      "StartLine": 11,
-      "EndLine": 11,
-      "StartColumn": 2,
-      "EndColumn": 3,
-      "Severity": "Error",
-      "Message": "Missing qualification after '.'",
-      "Subcategory": "parse"
-    },
-    {
-      "FileName": "<absolute path removed>/test/integration/RawIdTest/Test-Module.fsx",
-      "StartLine": 9,
-      "EndLine": 9,
-      "StartColumn": 2,
-      "EndColumn": 3,
-      "Severity": "Error",
-      "Message": "Missing qualification after '.'",
-      "Subcategory": "parse"
-    },
-    {
-      "FileName": "<absolute path removed>/test/integration/RawIdTest/Test-Module.fsx",
       "StartLine": 9,
       "EndLine": 9,
       "StartColumn": 1,
@@ -122,36 +92,6 @@
       "EndColumn": 4,
       "Severity": "Error",
       "Message": "Unexpected reserved keyword in implementation file",
-      "Subcategory": "parse"
-    },
-    {
-      "FileName": "<absolute path removed>/test/integration/RawIdTest/Test-Class.fsx",
-      "StartLine": 11,
-      "EndLine": 11,
-      "StartColumn": 3,
-      "EndColumn": 4,
-      "Severity": "Error",
-      "Message": "Unexpected reserved keyword in implementation file",
-      "Subcategory": "parse"
-    },
-    {
-      "FileName": "<absolute path removed>/test/integration/RawIdTest/Test-Class.fsx",
-      "StartLine": 11,
-      "EndLine": 11,
-      "StartColumn": 2,
-      "EndColumn": 3,
-      "Severity": "Error",
-      "Message": "Missing qualification after '.'",
-      "Subcategory": "parse"
-    },
-    {
-      "FileName": "<absolute path removed>/test/integration/RawIdTest/Test-Class.fsx",
-      "StartLine": 9,
-      "EndLine": 9,
-      "StartColumn": 2,
-      "EndColumn": 3,
-      "Severity": "Error",
-      "Message": "Missing qualification after '.'",
       "Subcategory": "parse"
     },
     {

--- a/FsAutoComplete/test/integration/RobustCommands/completebadposition.json
+++ b/FsAutoComplete/test/integration/RobustCommands/completebadposition.json
@@ -12,8 +12,7 @@
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/RobustCommands/completenosuchfile.json
+++ b/FsAutoComplete/test/integration/RobustCommands/completenosuchfile.json
@@ -12,8 +12,7 @@
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/RobustCommands/parsenosuchfile.json
+++ b/FsAutoComplete/test/integration/RobustCommands/parsenosuchfile.json
@@ -12,8 +12,7 @@
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/SymbolUse/output.json
+++ b/FsAutoComplete/test/integration/SymbolUse/output.json
@@ -12,8 +12,7 @@
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/Test1Json/output.json
+++ b/FsAutoComplete/test/integration/Test1Json/output.json
@@ -12,8 +12,7 @@
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }
 {

--- a/FsAutoComplete/test/integration/TestHelpers.fsx
+++ b/FsAutoComplete/test/integration/TestHelpers.fsx
@@ -20,7 +20,7 @@ type FsAutoCompleteWrapper() =
     p.StartInfo.RedirectStandardError  <- true
     p.StartInfo.RedirectStandardInput  <- true
     p.StartInfo.UseShellExecute <- false
-    p.StartInfo.EnvironmentVariables.Add("mFSharp_ToolTipSpinWaitTime", "10000")
+    p.StartInfo.EnvironmentVariables.Add("FCS_ToolTipSpinWaitTime", "10000")
     p.Start () |> ignore
 
   member x.project (s: string) : unit =

--- a/FsAutoComplete/test/integration/UncompiledReferencedProjects/MultiProject1.fs
+++ b/FsAutoComplete/test/integration/UncompiledReferencedProjects/MultiProject1.fs
@@ -1,0 +1,5 @@
+
+module MultiProject1
+open Project1A
+open Project1B
+let p = (Project1A.x1, Project1B.b)

--- a/FsAutoComplete/test/integration/UncompiledReferencedProjects/MultiProject1.fsproj
+++ b/FsAutoComplete/test/integration/UncompiledReferencedProjects/MultiProject1.fsproj
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{116cc2f9-f987-4b3d-915a-34cac04a73da}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MultiProject1</RootNamespace>
+    <AssemblyName>MultiProject1</AssemblyName>
+    <Name>MultiProject1</Name>
+    <UsePartialTypes>False</UsePartialTypes>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <Tailcalls>False</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Debug\MultiProject1.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <Tailcalls>True</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Release\MultiProject1.XML</DocumentationFile>
+    <DebugSymbols>False</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MultiProject1.fs" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <ProjectReference Include="Project1A.fsproj">
+      <Name>Project1A</Name>
+      <Project>{116cc2f9-f987-4b3d-915a-34cac04a73da}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="Project1B.fsproj">
+      <Name>Project1A</Name>
+      <Project>{116cc2f9-f987-4b3d-915a-34cac04a73db}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+	     Other similar extension points exist, see Microsoft.Common.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/FsAutoComplete/test/integration/UncompiledReferencedProjects/Project1A.fs
+++ b/FsAutoComplete/test/integration/UncompiledReferencedProjects/Project1A.fs
@@ -1,0 +1,5 @@
+
+type C() = 
+    static member M(arg1: int, arg2: int, ?arg3 : int) = arg1 + arg2 + defaultArg arg3 4
+let x1 = C.M(arg1 = 3, arg2 = 4, arg3 = 5)
+let x2 = C.M(arg1 = 3, arg2 = 4, ?arg3 = Some 5)

--- a/FsAutoComplete/test/integration/UncompiledReferencedProjects/Project1A.fsproj
+++ b/FsAutoComplete/test/integration/UncompiledReferencedProjects/Project1A.fsproj
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{116cc2f9-f987-4b3d-915a-34cac04a73da}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Project1A</RootNamespace>
+    <AssemblyName>Project1A</AssemblyName>
+    <Name>Project1A</Name>
+    <UsePartialTypes>False</UsePartialTypes>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <Tailcalls>False</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Debug\Project1A.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <Tailcalls>True</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Release\Project1A.XML</DocumentationFile>
+    <DebugSymbols>False</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Project1A.fs" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+	     Other similar extension points exist, see Microsoft.Common.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/FsAutoComplete/test/integration/UncompiledReferencedProjects/Project1B.fs
+++ b/FsAutoComplete/test/integration/UncompiledReferencedProjects/Project1B.fs
@@ -1,0 +1,7 @@
+module Project1B
+type A = B of xxx: int * yyy : int
+let b = B(xxx=1, yyy=2)
+let x = 
+    match b with
+    // does not find usage here
+    | B (xxx = a; yyy = b) -> ()

--- a/FsAutoComplete/test/integration/UncompiledReferencedProjects/Project1B.fsproj
+++ b/FsAutoComplete/test/integration/UncompiledReferencedProjects/Project1B.fsproj
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{116cc2f9-f987-4b3d-915a-34cac04a73db}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Project1B</RootNamespace>
+    <AssemblyName>Project1B</AssemblyName>
+    <Name>Project1B</Name>
+    <UsePartialTypes>False</UsePartialTypes>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <Tailcalls>False</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Debug\Project1B.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <Tailcalls>True</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Release\Project1B.XML</DocumentationFile>
+    <DebugSymbols>False</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Project1B.fs" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+	     Other similar extension points exist, see Microsoft.Common.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/FsAutoComplete/test/integration/UncompiledReferencedProjects/Runner.fsx
+++ b/FsAutoComplete/test/integration/UncompiledReferencedProjects/Runner.fsx
@@ -1,0 +1,19 @@
+#load "../TestHelpers.fsx"
+open TestHelpers
+open System.IO
+open System
+
+Environment.CurrentDirectory <- __SOURCE_DIRECTORY__
+File.Delete "output.json"
+
+let p = new FsAutoCompleteWrapper()
+
+p.project "MultiProject1.fsproj"
+p.parse "MultiProject1.fs"
+p.tooltip "MultiProject1.fs" 5 20
+p.tooltip "MultiProject1.fs" 5 34
+
+p.send "quit\n"
+p.finalOutput ()
+|> writeNormalizedOutput "output.json"
+

--- a/FsAutoComplete/test/integration/UncompiledReferencedProjects/output.json
+++ b/FsAutoComplete/test/integration/UncompiledReferencedProjects/output.json
@@ -1,0 +1,115 @@
+{
+  "Kind": "project",
+  "Data": {
+    "Project": "<absolute path removed>/test/integration/UncompiledReferencedProjects/MultiProject1.fsproj",
+    "Files": [
+      "<absolute path removed>/test/integration/UncompiledReferencedProjects/MultiProject1.fs"
+    ],
+    "Output": "<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug/MultiProject1.exe",
+    "References": [
+      "<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug//Project1A.dll",
+      "<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug//Project1B.exe",
+      "<absolute path removed>/System.Core.dll",
+      "<absolute path removed>/System.dll",
+      "<absolute path removed>/mscorlib.dll"
+    ],
+    "Framework": "v4.0"
+  }
+}
+{
+  "Kind": "info",
+  "Data": "Synchronous parsing started"
+}
+{
+  "Kind": "errors",
+  "Data": [
+    {
+      "FileName": "startup",
+      "StartLine": 1,
+      "EndLine": 1,
+      "StartColumn": 1,
+      "EndColumn": 81,
+      "Severity": "Error",
+      "Message": "Unable to find the file '<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug//Project1B.exe' in any of\n /Library/Frameworks/Mono.framework/Versions/4.0.2/lib/mono/4.0\n /Users/robnea/dev/FsAutoComplete/FsAutoComplete/test/integration/UncompiledReferencedProjects\n /Library/Frameworks/Mono.framework/Versions/4.0.2/lib/mono/gac/FSharp.Core/4.3.0.0__b03f5f7f11d50a3a",
+      "Subcategory": "typecheck"
+    },
+    {
+      "FileName": "startup",
+      "StartLine": 1,
+      "EndLine": 1,
+      "StartColumn": 1,
+      "EndColumn": 81,
+      "Severity": "Error",
+      "Message": "Unable to find the file '<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug//Project1A.dll' in any of\n /Library/Frameworks/Mono.framework/Versions/4.0.2/lib/mono/4.0\n /Users/robnea/dev/FsAutoComplete/FsAutoComplete/test/integration/UncompiledReferencedProjects\n /Library/Frameworks/Mono.framework/Versions/4.0.2/lib/mono/gac/FSharp.Core/4.3.0.0__b03f5f7f11d50a3a",
+      "Subcategory": "typecheck"
+    },
+    {
+      "FileName": "startup",
+      "StartLine": 1,
+      "EndLine": 1,
+      "StartColumn": 1,
+      "EndColumn": 81,
+      "Severity": "Error",
+      "Message": "Assembly reference '<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug//Project1A.dll' was not found or is invalid",
+      "Subcategory": "parameter"
+    },
+    {
+      "FileName": "startup",
+      "StartLine": 1,
+      "EndLine": 1,
+      "StartColumn": 1,
+      "EndColumn": 81,
+      "Severity": "Error",
+      "Message": "Assembly reference '<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug//Project1B.exe' was not found or is invalid",
+      "Subcategory": "parameter"
+    },
+    {
+      "FileName": "<absolute path removed>/test/integration/UncompiledReferencedProjects/MultiProject1.fs",
+      "StartLine": 3,
+      "EndLine": 3,
+      "StartColumn": 6,
+      "EndColumn": 15,
+      "Severity": "Error",
+      "Message": "The namespace or module 'Project1A' is not defined",
+      "Subcategory": "typecheck"
+    },
+    {
+      "FileName": "<absolute path removed>/test/integration/UncompiledReferencedProjects/MultiProject1.fs",
+      "StartLine": 4,
+      "EndLine": 4,
+      "StartColumn": 6,
+      "EndColumn": 15,
+      "Severity": "Error",
+      "Message": "The namespace or module 'Project1B' is not defined",
+      "Subcategory": "typecheck"
+    },
+    {
+      "FileName": "<absolute path removed>/test/integration/UncompiledReferencedProjects/MultiProject1.fs",
+      "StartLine": 5,
+      "EndLine": 5,
+      "StartColumn": 10,
+      "EndColumn": 19,
+      "Severity": "Error",
+      "Message": "The namespace or module 'Project1A' is not defined",
+      "Subcategory": "typecheck"
+    },
+    {
+      "FileName": "<absolute path removed>/test/integration/UncompiledReferencedProjects/MultiProject1.fs",
+      "StartLine": 5,
+      "EndLine": 5,
+      "StartColumn": 24,
+      "EndColumn": 33,
+      "Severity": "Error",
+      "Message": "The namespace or module 'Project1B' is not defined",
+      "Subcategory": "typecheck"
+    }
+  ]
+}
+{
+  "Kind": "info",
+  "Data": "No tooltip information"
+}
+{
+  "Kind": "info",
+  "Data": "No tooltip information"
+}

--- a/FsAutoComplete/test/integration/UncompiledReferencedProjects/output.json
+++ b/FsAutoComplete/test/integration/UncompiledReferencedProjects/output.json
@@ -7,13 +7,12 @@
     ],
     "Output": "<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug/MultiProject1.exe",
     "References": [
-      "<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug//Project1A.dll",
-      "<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug//Project1B.exe",
+      "<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug/Project1A.dll",
+      "<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug/Project1B.exe",
       "<absolute path removed>/System.Core.dll",
       "<absolute path removed>/System.dll",
       "<absolute path removed>/mscorlib.dll"
-    ],
-    "Framework": "v4.0"
+    ]
   }
 }
 {
@@ -22,94 +21,27 @@
 }
 {
   "Kind": "errors",
+  "Data": []
+}
+{
+  "Kind": "tooltip",
   "Data": [
-    {
-      "FileName": "startup",
-      "StartLine": 1,
-      "EndLine": 1,
-      "StartColumn": 1,
-      "EndColumn": 81,
-      "Severity": "Error",
-      "Message": "Unable to find the file '<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug//Project1B.exe' in any of\n /Library/Frameworks/Mono.framework/Versions/4.0.2/lib/mono/4.0\n /Users/robnea/dev/FsAutoComplete/FsAutoComplete/test/integration/UncompiledReferencedProjects\n /Library/Frameworks/Mono.framework/Versions/4.0.2/lib/mono/gac/FSharp.Core/4.3.0.0__b03f5f7f11d50a3a",
-      "Subcategory": "typecheck"
-    },
-    {
-      "FileName": "startup",
-      "StartLine": 1,
-      "EndLine": 1,
-      "StartColumn": 1,
-      "EndColumn": 81,
-      "Severity": "Error",
-      "Message": "Unable to find the file '<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug//Project1A.dll' in any of\n /Library/Frameworks/Mono.framework/Versions/4.0.2/lib/mono/4.0\n /Users/robnea/dev/FsAutoComplete/FsAutoComplete/test/integration/UncompiledReferencedProjects\n /Library/Frameworks/Mono.framework/Versions/4.0.2/lib/mono/gac/FSharp.Core/4.3.0.0__b03f5f7f11d50a3a",
-      "Subcategory": "typecheck"
-    },
-    {
-      "FileName": "startup",
-      "StartLine": 1,
-      "EndLine": 1,
-      "StartColumn": 1,
-      "EndColumn": 81,
-      "Severity": "Error",
-      "Message": "Assembly reference '<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug//Project1A.dll' was not found or is invalid",
-      "Subcategory": "parameter"
-    },
-    {
-      "FileName": "startup",
-      "StartLine": 1,
-      "EndLine": 1,
-      "StartColumn": 1,
-      "EndColumn": 81,
-      "Severity": "Error",
-      "Message": "Assembly reference '<absolute path removed>/test/integration/UncompiledReferencedProjects/bin/Debug//Project1B.exe' was not found or is invalid",
-      "Subcategory": "parameter"
-    },
-    {
-      "FileName": "<absolute path removed>/test/integration/UncompiledReferencedProjects/MultiProject1.fs",
-      "StartLine": 3,
-      "EndLine": 3,
-      "StartColumn": 6,
-      "EndColumn": 15,
-      "Severity": "Error",
-      "Message": "The namespace or module 'Project1A' is not defined",
-      "Subcategory": "typecheck"
-    },
-    {
-      "FileName": "<absolute path removed>/test/integration/UncompiledReferencedProjects/MultiProject1.fs",
-      "StartLine": 4,
-      "EndLine": 4,
-      "StartColumn": 6,
-      "EndColumn": 15,
-      "Severity": "Error",
-      "Message": "The namespace or module 'Project1B' is not defined",
-      "Subcategory": "typecheck"
-    },
-    {
-      "FileName": "<absolute path removed>/test/integration/UncompiledReferencedProjects/MultiProject1.fs",
-      "StartLine": 5,
-      "EndLine": 5,
-      "StartColumn": 10,
-      "EndColumn": 19,
-      "Severity": "Error",
-      "Message": "The namespace or module 'Project1A' is not defined",
-      "Subcategory": "typecheck"
-    },
-    {
-      "FileName": "<absolute path removed>/test/integration/UncompiledReferencedProjects/MultiProject1.fs",
-      "StartLine": 5,
-      "EndLine": 5,
-      "StartColumn": 24,
-      "EndColumn": 33,
-      "Severity": "Error",
-      "Message": "The namespace or module 'Project1B' is not defined",
-      "Subcategory": "typecheck"
-    }
+    [
+      {
+        "Signature": "val x1 : int\n\nFull name: Project1A.x1",
+        "Comment": ""
+      }
+    ]
   ]
 }
 {
-  "Kind": "info",
-  "Data": "No tooltip information"
-}
-{
-  "Kind": "info",
-  "Data": "No tooltip information"
+  "Kind": "tooltip",
+  "Data": [
+    [
+      {
+        "Signature": "val b : A\n\nFull name: Project1B.b",
+        "Comment": ""
+      }
+    ]
+  ]
 }

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,6 +1,6 @@
 source https://www.nuget.org/api/v2/
 
-nuget FSharp.Compiler.Service 1.4.0.1 framework: >= net45
+nuget FSharp.Compiler.Service framework: >= net45
 nuget Mono.Cecil
 nuget NDesk.Options
 nuget Newtonsoft.Json

--- a/paket.lock
+++ b/paket.lock
@@ -1,13 +1,12 @@
 NUGET
   remote: https://nuget.org/api/v2
   specs:
-    FAKE (4.4.4)
-    FSharp.Compiler.Service (1.4.0.1) - framework: >= net45
+    FAKE (4.7.2)
+    FSharp.Compiler.Service (1.4.2.1) - framework: >= net45
     FSharp.Core (4.0.0.1)
-    FsPickler (1.4.0)
     Microsoft.Bcl (1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
-    Microsoft.Bcl.Build (1.0.21)
+    Microsoft.Bcl.Build (1.0.21) - import_targets: false
     Microsoft.Net.Http (2.2.29)
       Microsoft.Bcl (>= 1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
@@ -18,6 +17,5 @@ NUGET
     NUnit.Runners (2.6.4)
     Octokit (0.16.0)
       Microsoft.Net.Http
-    Suave (0.31.2)
+    Suave (0.32.1)
       FSharp.Core (>= 3.1.2.5)
-      FsPickler (>= 1.2.5)


### PR DESCRIPTION
Updating to latest FCS required. Many tests changed.

Backwards-incompatible: Framework removed in project response, as it is a bit awkward to get. @Krzysztof-Cieslak @kjnilsson any issue with that?
