### PR TITLE
Set minimum threads to 8 for Mono 4.2.1

### DIFF
--- a/FsAutoComplete.Suave/FsAutoComplete.Suave.fs
+++ b/FsAutoComplete.Suave/FsAutoComplete.Suave.fs
@@ -37,6 +37,7 @@ module internal Utils =
 
 [<EntryPoint>]
 let main argv =
+    System.Threading.ThreadPool.SetMinThreads(8, 8) |> ignore
     let state = ref FsAutoComplete.State.Initial
     let checker = new FSharpCompilerServiceChecker()
 

--- a/FsAutoComplete/Program.fs
+++ b/FsAutoComplete/Program.fs
@@ -110,6 +110,7 @@ module internal Main =
 
   [<EntryPoint>]
   let entry args =
+    System.Threading.ThreadPool.SetMinThreads(8, 8) |> ignore
     Console.InputEncoding <- Text.Encoding.UTF8
     Console.OutputEncoding <- new Text.UTF8Encoding(false, false)
     let extra = Options.p.Parse args


### PR DESCRIPTION
This was causing deadlocks on Mono as the default
number of threads was insufficient. The library function

```
System.Threading.ThreadPool.SetMinThreads
```

also did not work.

This has been worked around in Emacs by setting the
environment variable MONO_THREADS_PER_CPU to 8:

```
https://github.com/fsharp/emacs-fsharp-mode/pull/46
```

This has been reported and fixed in Mono:

```
https://bugzilla.xamarin.com/show_bug.cgi?id=37288
```

So now the call to `SetMinThreads` should be sufficient.

Fixes #88.
