### PR TITLE
Fix slashes in paths in project file bug

### DIFF
--- a/FsAutoComplete.Core/FsAutoComplete.Core.fs
+++ b/FsAutoComplete.Core/FsAutoComplete.Core.fs
@@ -52,10 +52,9 @@ module Commands =
                 match checker.TryGetProjectOptions(file, verbose) with
                 | Result.Failure s -> [Response.error serialize s],state
                 | Result.Success(po, projectFiles, outFileOpt, references, logMap) ->
-                    let res = Response.project serialize (file, projectFiles, outFileOpt, references, logMap)
-                    let checkOptions =
-                      projectFiles
-                      |> List.fold (fun s f -> Map.add f po s) state.FileCheckOptions
+                    let pf = projectFiles |> List.map Path.GetFullPath
+                    let res = Response.project serialize (file, pf, outFileOpt, references, logMap)
+                    let checkOptions = pf |> List.fold (fun s f -> Map.add f po s) state.FileCheckOptions
                     let loadTimes = Map.add file time state.ProjectLoadTimes
                     let state' =  { state with FileCheckOptions = checkOptions; ProjectLoadTimes = loadTimes }
                     [res], state'


### PR DESCRIPTION
When fsproj file contains backslashes in item definition (i.e. `<Compile Include="code/data.fs" />` ) it doesn't work on windows (working on OSX).

This PR fix this behavior by normalizing paths which we get from project file. 

CC: @tpetricek 
