### PR TITLE
Make completion string comparisons case-insensitive

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -92,8 +92,8 @@ type ParseAndCheckResults(parseResults: FSharpParseFileResults,
       
       let decls =
         match filter with
-        | Some "StartsWith" -> [| for d in results.Items do if d.Name.StartsWith residue then yield d |]
-        | Some "Contains" -> [| for d in results.Items do if d.Name.Contains residue then yield d |]
+        | Some "StartsWith" -> [| for d in results.Items do if d.Name.StartsWith(residue, StringComparison.InvariantCultureIgnoreCase) then yield d |]
+        | Some "Contains" -> [| for d in results.Items do if d.Name.IndexOf(residue, StringComparison.InvariantCultureIgnoreCase) >= 0 then yield d |]
         | _ -> results.Items
       return Some (decls, residue)
     with :? TimeoutException -> return None

--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fs
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fs
@@ -97,7 +97,7 @@ module Commands =
                     // This allows it to be displayed immediately in the editor.
                     let firstMatchOpt =
                       Array.sortBy declName decls
-                      |> Array.tryFind (fun d -> (declName d).StartsWith residue)
+                      |> Array.tryFind (fun d -> (declName d).StartsWith(residue, StringComparison.InvariantCultureIgnoreCase))
                     let res = match firstMatchOpt with
                                 | None -> [Response.completion serialize (decls)]
                                 | Some d ->

--- a/test/FsAutoComplete.IntegrationTests/CompletionFilter/output.json
+++ b/test/FsAutoComplete.IntegrationTests/CompletionFilter/output.json
@@ -109,6 +109,12 @@
   "Kind": "completion",
   "Data": [
     {
+      "Name": "Convert",
+      "ReplacementText": "Convert",
+      "Glyph": "Method",
+      "GlyphChar": "M"
+    },
+    {
       "Name": "GoodTime",
       "ReplacementText": "GoodTime",
       "Glyph": "Method",


### PR DESCRIPTION
I just noticed that now emacs has added the StartsWith filter that completions were case sensitive.

This PR makes them case insensitive. 
