### PR TITLE
Fix Symboluseproject

### DIFF
--- a/src/FsAutoComplete/CommandInput.fs
+++ b/src/FsAutoComplete/CommandInput.fs
@@ -102,7 +102,7 @@ module CommandInput =
   let completionTipOrDecl = parser {
     let! f = (string "completion " |> Parser.map (fun _ -> Completion)) <|>
              (string "symboluse " |> Parser.map (fun _ -> SymbolUse)) <|>
-             (string "symboluseproject " |> Parser.map (fun _ -> SymbolUse)) <|>
+             (string "symboluseproject " |> Parser.map (fun _ -> SymbolUseProject)) <|>
              (string "tooltip " |> Parser.map (fun _ -> ToolTip)) <|>
              (string "typesig " |> Parser.map (fun _ -> TypeSig)) <|>
              (string "methods " |> Parser.map (fun _ -> Methods)) <|>

--- a/src/FsAutoComplete/Options.fs
+++ b/src/FsAutoComplete/Options.fs
@@ -25,19 +25,19 @@ module Options =
         Optional 'sync' is used to force the parse to occur
         synchronously for testing purposes. Not intended for
         use in production.
-    completion ""<filename>"" <line> <col> [timeout] [filter=(StartsWith|Contains)]
+    completion ""<filename>"" ""<lineStr>"" <line> <col> [timeout] [filter=(StartsWith|Contains)]
       - trigger completion request for the specified location
         optionally filter in the specified manner
     helptext <candidate>
       - fetch type signature for specified completion candidate
         (from last completion request). Only use in JSON mode.
-    symboluse ""<filename>"" <line> <col> [timeout]
+    symboluse ""<filename>"" ""<lineStr>"" <line> <col> [timeout]
       - find all uses of the symbol for the specified location
-    tooltip ""<filename>"" <line> <col> [timeout]
+    tooltip ""<filename>"" ""<lineStr>"" <line> <col> [timeout]
       - get tool tip for the specified location
-    finddecl ""<filename>"" <line> <col> [timeout]
+    finddecl ""<filename>"" ""<lineStr>"" <line> <col> [timeout]
       - find the point of declaration of the symbol at specified location
-    methods ""<filename>"" <line> <col> [timeout]
+    methods ""<filename>"" ""<lineStr>"" <line> <col> [timeout]
       - find the method signatures at specified location
     project ""<filename>""
       - associates the current session with the specified project

--- a/src/FsAutoComplete/Options.fs
+++ b/src/FsAutoComplete/Options.fs
@@ -33,6 +33,8 @@ module Options =
         (from last completion request). Only use in JSON mode.
     symboluse ""<filename>"" ""<lineStr>"" <line> <col> [timeout]
       - find all uses of the symbol for the specified location
+    symboluseproject ""<filename>"" ""<lineStr>"" <line> <col> [timeout]
+      - find all uses of the symbol for the specified location across whole project
     tooltip ""<filename>"" ""<lineStr>"" <line> <col> [timeout]
       - get tool tip for the specified location
     finddecl ""<filename>"" ""<lineStr>"" <line> <col> [timeout]

--- a/src/FsAutoComplete/Options.fs
+++ b/src/FsAutoComplete/Options.fs
@@ -37,6 +37,8 @@ module Options =
       - find all uses of the symbol for the specified location across whole project
     tooltip ""<filename>"" ""<lineStr>"" <line> <col> [timeout]
       - get tool tip for the specified location
+    typesig ""<filename>"" ""<lineStr>"" <line> <col> [timeout]
+      - get type signature for the specified location
     finddecl ""<filename>"" ""<lineStr>"" <line> <col> [timeout]
       - find the point of declaration of the symbol at specified location
     methods ""<filename>"" ""<lineStr>"" <line> <col> [timeout]


### PR DESCRIPTION
The wrong function (SymbolUse instead of SymbolUseProject) was used when
handling "symboluseproject" commands.

It was only correctly dispatched in the Suave backend. Most likely nobody noticed it because it's not yet implemented in the Emacs backend https://github.com/fsharp/emacs-fsharp-mode/issues/64

Also fix some (outdated) command line documentation.
