### PR TITLE
[WIP] Do not return autocomplete suggestions if in comment

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -111,6 +111,7 @@ type ParseAndCheckResults
   member __.GetExtraColorizations = checkResults.GetExtraColorizationsAlternate()
   member __.GetAST = parseResults.ParseTree
   member __.GetCheckResults = checkResults
+  member __.FileName = parseResults.FileName
 
 type private FileState =
     | Checked

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -2,11 +2,13 @@ namespace FsAutoComplete
 
 open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library
 open System
+open Lexer.Comments
 
 type VolatileFile =
   {
     Touched: DateTime
     Lines: string []
+    Comments: Map<int,LineComment list>
   }
 
 open System.IO

--- a/src/FsAutoComplete.Core/Lexer.fs
+++ b/src/FsAutoComplete.Core/Lexer.fs
@@ -437,11 +437,10 @@ module Lexer =
                     ) []
                 |> List.rev
 
-        let getComments text =
+        let getComments lines =
             let sourceTokenizer = FSharpSourceTokenizer ([], None)
 
-            text
-            |> getLines
+            lines
             |> List.ofArray
             |> Impl.tokenizeText sourceTokenizer
             |> Impl.getComments

--- a/src/FsAutoComplete.Core/Lexer.fs
+++ b/src/FsAutoComplete.Core/Lexer.fs
@@ -283,3 +283,165 @@ module Lexer =
         with e ->
             //LoggingService.LogInfo (sprintf "Getting lex symbols failed with %O" e)
             None
+
+    module Comments =
+        open Microsoft.FSharp.Compiler.SourceCodeServices
+
+        type LineCommentInfo =
+            | WholeLine of wraps:bool
+            | Range of left:int * right:int * wraps:bool
+            | Line of left:int * wraps:bool
+
+        type LineComment =
+            { Line : int
+              Comment : LineCommentInfo }
+
+        module Impl =
+            let collectTokens initialState (lineTokenizer:FSharpLineTokenizer) =
+                let rec loop state (currentState,tokens) =
+                    match lineTokenizer.ScanToken state with
+                    | Some tok, nextState ->
+                        loop nextState (nextState,(tok::tokens)) 
+                    | None, nextState ->
+                        nextState,tokens
+        
+                let finalState,tokensRev = loop initialState (0L,[])
+
+                finalState,tokensRev |> List.rev
+
+            let tokenizeText (sourceTokenizer:FSharpSourceTokenizer) sourceCodeLines =
+                let rec loop lines state acc =
+                    match lines with
+                    | line::restLines ->
+                        let (latestState,lineTokens) =
+                            line 
+                            |> sourceTokenizer.CreateLineTokenizer
+                            |> collectTokens state
+                        loop restLines latestState ((line,lineTokens)::acc)
+                    | [] ->
+                        acc
+
+                loop sourceCodeLines 0L []
+                |> List.rev
+                |> List.mapi (fun i (line,tokens) -> i,tokens)
+
+            let aggregateCommentTokens (tokens:FSharpTokenInfo list) = 
+                let rec foldCommentTokens (foldedToken:FSharpTokenInfo) (tokensLeft:FSharpTokenInfo list) =
+                    match tokensLeft with
+                    | [] -> 
+                        foldedToken,tokensLeft
+                    | t::ts ->
+                        let isSameTokenKind = 
+                            t.ColorClass = FSharpTokenColorKind.Comment && t.CharClass = foldedToken.CharClass
+                        if isSameTokenKind then
+                            foldCommentTokens { foldedToken with 
+                                                    RightColumn = t.RightColumn
+                                                    FullMatchedLength = t.RightColumn - foldedToken.LeftColumn + 1 } ts
+                        else
+                            foldedToken,t::ts
+                
+                let rec loop acc (tokensLeft:FSharpTokenInfo list) =
+                    match tokensLeft with
+                    | [] -> 
+                        acc
+                    | t::ts when t.ColorClass <> FSharpTokenColorKind.Comment ->
+                        loop (t::acc) ts
+                    | t::ts ->
+                        let (foldedToken,rest) = foldCommentTokens t ts
+                        loop (foldedToken::acc) rest
+
+                loop [] tokens |> List.rev
+
+            let isComment (token:FSharpTokenInfo) =
+                token.ColorClass = FSharpTokenColorKind.Comment
+
+            let isNotComment = isComment >> not
+
+            let isLineComment (token:FSharpTokenInfo) =
+                token.CharClass = FSharpTokenCharKind.LineComment
+
+            let isRangeComment (token:FSharpTokenInfo) =
+                token.CharClass = FSharpTokenCharKind.Comment
+
+            let getComments (linesTokens:(int*FSharpTokenInfo list) list) =
+                let commentsRanges =
+                    linesTokens
+                    |> List.map (fun (line,tokens) -> 
+                        line,tokens |> aggregateCommentTokens)
+                    |> List.collect (fun (l,toks) ->
+                        match toks with
+                        | [] -> 
+                            [l,None]
+                        | _ -> 
+                            toks |> List.map (fun tok -> l,tok |> Some))
+
+                commentsRanges
+                |> List.fold (fun comments (line,currToken) ->
+                    match currToken, comments |> List.tryHead with
+                    | None, None ->
+                        comments
+                    | None, Some prevComment ->
+                        let updatedComments =
+                            match prevComment.Comment with
+                            | LineCommentInfo.Line (_,true) | LineCommentInfo.WholeLine true | LineCommentInfo.Range (_,_,true) -> 
+                                { prevComment with Comment = LineCommentInfo.WholeLine true }::(comments |> List.skip 1)
+                            | _ -> 
+                                comments
+                        { Line = line; Comment = LineCommentInfo.WholeLine true }::updatedComments
+                    | Some token, None ->
+                        if token |> isNotComment then
+                            comments
+                        else
+                            let comment =
+                                if token |> isLineComment then
+                                    if token.LeftColumn = 0 then { Line = line; Comment = LineCommentInfo.WholeLine false }
+                                    else { Line = line; Comment = LineCommentInfo.Line (token.LeftColumn,false) }
+                                else
+                                    { Line = line; Comment = LineCommentInfo.Range (token.LeftColumn,token.RightColumn,true) }
+                            comment::comments
+                    | Some token, Some prevComment ->
+                        if token |> isRangeComment then
+                            let updatedComments = 
+                                match prevComment.Comment with
+                                | LineCommentInfo.Range (left,_,true) when line <> prevComment.Line ->
+                                    if left = 0 then 
+                                        { prevComment with Comment = LineCommentInfo.WholeLine true }::(comments |> List.skip 1)
+                                    else
+                                        { prevComment with Comment = LineCommentInfo.Line (left,true) }::(comments |> List.skip 1)
+                                | LineCommentInfo.Line (left,true) when line <> prevComment.Line ->
+                                    if left = 0 then 
+                                        { prevComment with Comment = LineCommentInfo.WholeLine true }::(comments |> List.skip 1)
+                                    else
+                                        { prevComment with Comment = LineCommentInfo.Line (left,true) }::(comments |> List.skip 1)
+                                | LineCommentInfo.WholeLine true when line <> prevComment.Line ->
+                                    { prevComment with Comment = LineCommentInfo.WholeLine true }::(comments |> List.skip 1)
+                                | _ -> 
+                                    comments
+                            { Line = line; Comment = LineCommentInfo.Range (token.LeftColumn,token.RightColumn,true) }::updatedComments
+                        elif token |> isNotComment then
+                            match prevComment.Comment with
+                            | LineCommentInfo.Range (left,right,true) ->
+                                { prevComment with Comment = LineCommentInfo.Range (left,right,false) }::(comments |> List.skip 1)
+                            | _ ->
+                                comments
+                        else
+                            if token |> isLineComment then
+                                let comment =
+                                    if token.LeftColumn = 0 then
+                                        { Line = line; Comment = LineCommentInfo.WholeLine false }
+                                    else
+                                        { Line = line; Comment = LineCommentInfo.Line (token.LeftColumn,false) }
+                                comment::comments
+                            else
+                                comments
+                    ) []
+                |> List.rev
+
+        let getComments text =
+            let sourceTokenizer = FSharpSourceTokenizer ([], None)
+
+            text
+            |> getLines
+            |> List.ofArray
+            |> Impl.tokenizeText sourceTokenizer
+            |> Impl.getComments


### PR DESCRIPTION
Hi,

I've taken https://github.com/ionide/ionide-vscode-fsharp/issues/74 for fix and to learn FCS/FSAC, so here is PR. 
Idea is to recognize the comments blocks during file parse and later use this information when request for completion comes. 

I'm not sure I placed things in proper places and/or missed something or did completely wrong, so please let me know, so I can fix that.

Summary of changes:
* Added Comments module to Lexer (the code is the same as in the project I created for this purpose which has tests https://github.com/kirill-gerasimenko/fsc-playground to cover comments parsing)
* During Commands.Parse I get all comments blocks from file lines and add them to the State object
* So State.Files has state information for each parsed file - I extended VolatileFile to hold the map of comments blocks, to be used later on
* Added property FileName to CompilerServiceInterface so I can have file name in the Commands.Completion tyRes parameter (to be able to find comments for the particular line in the State.Files)
* And the last one is the Commands.Completion amendment to check if the requested Pos in file intersects with the comments in the map. 

At the moment Lexer.Comment module is using it's own implementation for tokenizing the line `collectTokens` and `tokenizeText` which I plan to remove in favor of already present in Lexer module. 

I've tested it with Ionide and it's working for me fine. At least I haven't found issues yet :)
