### PR TITLE
Update FSharpLint version and add endpoint for F1 Help

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -1,14 +1,14 @@
 FRAMEWORK: NET45
 NUGET
   remote: https://www.nuget.org/api/v2
-    FAKE (4.43)
+    FAKE (4.47.2)
     FParsec (1.0.2)
-    FSharp.Compiler.Service (8.0) - framework: >= net45
+    FSharp.Compiler.Service (8.0)
       System.Collections.Immutable (>= 1.2)
       System.Reflection.Metadata (>= 1.4.1-beta-24227-04)
     FSharp.Compiler.Service.ProjectCracker (8.0)
     FSharp.Core (4.0.0.1) - redirects: on
-    FSharpLint.Core (0.4.10)
+    FSharpLint.Core (0.5.1-beta)
       FParsec (>= 1.0.2)
       FSharp.Compiler.Service (>= 8.0)
       FSharp.Compiler.Service.ProjectCracker (>= 8.0)
@@ -32,10 +32,10 @@ NUGET
     Octokit (0.23)
     Suave (1.1.3)
       FSharp.Core (>= 3.1.2.5)
-    System.Collections.Immutable (1.3.0-preview1-24530-04)
-    System.Reflection.Metadata (1.4.1-preview1-24530-04)
-      System.Collections.Immutable (>= 1.3.0-preview1-24530-04)
+    System.Collections.Immutable (1.3)
+    System.Reflection.Metadata (1.4.1)
+      System.Collections.Immutable (>= 1.3)
 GITHUB
   remote: fsharp/FAKE
-    modules/Octokit/Octokit.fsx (da711ab136889bead398d5ac1a10dc53e60a2c87)
+    modules/Octokit/Octokit.fsx (be6e4b2b513b5f2cd64ec689fe7f1f45c39f4e92)
       Octokit (>= 0.20)

--- a/src/FsAutoComplete.Core/CommandResponse.fs
+++ b/src/FsAutoComplete.Core/CommandResponse.fs
@@ -286,6 +286,9 @@ module CommandResponse =
                       IsFromType = su.IsFromType } ] |> Seq.distinct |> Seq.toList }
     serialize { Kind = "symboluse"; Data = su }
 
+  let help (serialize : Serializer) (data : string) =
+    serialize { Kind = "help"; Data = data }
+
   let methods (serialize : Serializer) (meth: FSharpMethodGroup, commas: int) =
       serialize {  Kind = "method"
                    Data = {  Name = meth.MethodName
@@ -382,4 +385,4 @@ module CommandResponse =
       Word = word
     }
 
-    serialize { Kind = "namespaces"; Data = data} 
+    serialize { Kind = "namespaces"; Data = data}

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -200,6 +200,9 @@ type Commands (serialize : Serializer) =
     member x.SymbolUse (tyRes : ParseAndCheckResults) (pos: Pos) lineStr =
         tyRes.TryGetSymbolUse pos lineStr |> x.SerializeResult Response.symbolUse
 
+    member x.Help (tyRes : ParseAndCheckResults) (pos: Pos) lineStr =
+        tyRes.TryGetF1Help pos lineStr |> x.SerializeResult Response.help
+
     member x.SymbolUseProject (tyRes : ParseAndCheckResults) (pos: Pos) lineStr =
         let fn = tyRes.FileName
         tyRes.TryGetSymbolUse pos lineStr |> x.SerializeResultAsync (fun _ (sym, usages) ->

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -261,15 +261,6 @@ type Commands (serialize : Serializer) =
     }
 
     member __.GetNamespaceSuggestions (tyRes : ParseAndCheckResults) (pos: Pos) (line: LineStr) = async {
-        let! entitiesRes = tyRes.GetAllEntities ()
-        let symbol = Lexer.getSymbol pos.Line pos.Col line SymbolLookupKind.Fuzzy [||]
-
-        match symbol with
-        | None -> return [Response.info serialize "Symbol at position not found"]
-        | Some sym ->
-        match entitiesRes with
-        | None -> return [Response.info serialize "Something went wrong"]
-        | Some entities ->
         match tyRes.GetAST with
         | None -> return [Response.info serialize "Parsed Tree not avaliable"]
         | Some parsedTree ->
@@ -279,6 +270,16 @@ type Commands (serialize : Serializer) =
         match ParsedInput.getEntityKind parsedTree pos with
         | None -> return [Response.info serialize "EntityKind not found"]
         | Some entityKind ->
+
+        let symbol = Lexer.getSymbol pos.Line pos.Col line SymbolLookupKind.Fuzzy [||]
+        match symbol with
+        | None -> return [Response.info serialize "Symbol at position not found"]
+        | Some sym ->
+
+        let! entitiesRes = tyRes.GetAllEntities ()
+        match entitiesRes with
+        | None -> return [Response.info serialize "Something went wrong"]
+        | Some entities ->
             let isAttribute = entityKind = EntityKind.Attribute
             let entities =
                 entities |> List.filter (fun e ->

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -94,6 +94,17 @@ type ParseAndCheckResults
         let! symboluses = checkResults.GetUsesOfSymbolInFile symboluse.Symbol
         return Success (symboluse, symboluses) }
 
+  member __.TryGetF1Help (pos: Pos) (lineStr: LineStr) =
+    async {
+        match Parsing.findLongIdents(pos.Col - 1, lineStr) with
+        | None -> return (Failure "No ident at this location")
+        | Some(colu, identIsland) ->
+
+        let! help = checkResults.GetF1KeywordAlternate(pos.Line, colu, lineStr, identIsland)
+        match help with
+        | None -> return (Failure "No symbol information found")
+        | Some hlp -> return Success hlp}
+
   member __.TryGetCompletions (pos: Pos) (lineStr: LineStr) filter = async {
     let longName, residue = Parsing.findLongIdentsAndResidue(pos.Col - 1, lineStr)
     try

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -161,7 +161,7 @@ type FSharpCompilerServiceChecker() =
   let checker =
     FSharpChecker.Create(
       projectCacheSize = 200,
-      keepAllBackgroundResolutions = true,
+      keepAllBackgroundResolutions = false,
       keepAssemblyContents = true)
 
   let files = ConcurrentDictionary<string, Version * FileState>()
@@ -245,10 +245,9 @@ type FSharpCompilerServiceChecker() =
     return { rawOptions with OtherOptions = opts }
   }
 
-  member __.ParseAndCheckAllProjectsInBackground (options : FSharpProjectOptions seq) =
-    options
-    |> Seq.distinctBy(fun v -> v.ProjectFileName)
-    |> Seq.iter (checker.CheckProjectInBackground)
+  member __.CheckProjectsInBackgroundForFile (file,options : seq<string * FSharpProjectOptions>) =
+    defaultArg (getDependingProjects file options) []
+    |> List.iter (checker.CheckProjectInBackground)
 
   member __.ParseProjectsForFile(file, options : seq<string * FSharpProjectOptions> ) =
     let project = options |> Seq.tryFind (fun (k,_) -> k = file)

--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Name>FsAutoComplete.Core</Name>
@@ -109,16 +109,6 @@
         </Reference>
         <Reference Include="FSharp.Compiler.Service">
           <HintPath>..\..\packages\FSharp.Compiler.Service\lib\net45\FSharp.Compiler.Service.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="FSharp.Compiler.Service.MSBuild.v12">
-          <HintPath>..\..\packages\FSharp.Compiler.Service\lib\net45\stock\FSharp.Compiler.Service.MSBuild.v12.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="FSharp.Compiler.Service">
-          <HintPath>..\..\packages\FSharp.Compiler.Service\lib\net45\stock\FSharp.Compiler.Service.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/src/FsAutoComplete.Core/paket.references
+++ b/src/FsAutoComplete.Core/paket.references
@@ -1,2 +1,3 @@
-FSharpLint.Core
 FSharp.Compiler.Service.ProjectCracker
+FSharp.Compiler.Service
+FSharpLint.Core

--- a/src/FsAutoComplete.Suave/AssemblyInfo.fs
+++ b/src/FsAutoComplete.Suave/AssemblyInfo.fs
@@ -13,6 +13,5 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FsAutoComplete.Suave"
     let [<Literal>] AssemblyProduct = "FsAutoComplete.Suave"
     let [<Literal>] AssemblyDescription = "A Suave web server for interfacing with FSharp.Compiler.Service over a HTTP."
-
     let [<Literal>] AssemblyVersion = "0.30.2"
     let [<Literal>] AssemblyFileVersion = "0.30.2"

--- a/src/FsAutoComplete.Suave/FsAutoComplete.Suave.fs
+++ b/src/FsAutoComplete.Suave/FsAutoComplete.Suave.fs
@@ -151,6 +151,8 @@ let main argv =
             path "/symboluse" >=> positionHandler (fun data tyRes lineStr _ -> commands.SymbolUse tyRes { Line = data.Line; Col = data.Column } lineStr)
             path "/finddeclaration" >=> positionHandler (fun data tyRes lineStr _ -> commands.FindDeclarations tyRes { Line = data.Line; Col = data.Column } lineStr)
             path "/methods" >=> positionHandler (fun data tyRes _ lines   -> commands.Methods tyRes { Line = data.Line; Col = data.Column } lines)
+            path "/help" >=> positionHandler (fun data tyRes line _   -> commands.Help tyRes { Line = data.Line; Col = data.Column } line)
+
             path "/compilerlocation" >=> fun httpCtx ->
                 async {
                     let res = commands.CompilerLocation() |> List.toArray |> Json.toJson

--- a/src/FsAutoComplete.Suave/FsAutoComplete.Suave.fs
+++ b/src/FsAutoComplete.Suave/FsAutoComplete.Suave.fs
@@ -110,7 +110,7 @@ let main argv =
 
     let app =
         choose [
-            path "/notify" >=> handShake echo
+            // path "/notify" >=> handShake echo
             path "/parse" >=> handler (fun (data : ParseRequest) -> commands.Parse data.FileName data.Lines data.Version)
             path "/parseProjects" >=> handler (fun (data : ProjectRequest) -> commands.ParseProjectsForFile data.FileName)
             //TODO: Add filewatcher

--- a/src/FsAutoComplete.Suave/FsAutoComplete.Suave.fsproj
+++ b/src/FsAutoComplete.Suave/FsAutoComplete.Suave.fsproj
@@ -98,16 +98,6 @@
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
-        <Reference Include="FSharp.Compiler.Service.MSBuild.v12">
-          <HintPath>..\..\packages\FSharp.Compiler.Service\lib\net45\stock\FSharp.Compiler.Service.MSBuild.v12.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="FSharp.Compiler.Service">
-          <HintPath>..\..\packages\FSharp.Compiler.Service\lib\net45\stock\FSharp.Compiler.Service.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
       </ItemGroup>
     </When>
   </Choose>

--- a/src/FsAutoComplete.Suave/JsonSerializer.fs
+++ b/src/FsAutoComplete.Suave/JsonSerializer.fs
@@ -2,6 +2,8 @@ namespace FsAutoComplete
 
 module JsonSerializer =
 
+    open System
+    open Microsoft.FSharp.Reflection
     open Newtonsoft.Json
     open Newtonsoft.Json.Converters
     open Microsoft.FSharp.Compiler
@@ -48,10 +50,35 @@ module JsonSerializer =
       override x.CanRead = false
       override x.CanWrite = true
 
+    type OptionConverter() =
+      inherit JsonConverter()
+
+      override x.CanConvert(t) =
+        t.IsGenericType && t.GetGenericTypeDefinition() = typedefof<option<_>>
+
+      override x.WriteJson(writer, value, serializer) =
+        let value =
+          if isNull value then null
+          else
+            let _,fields = FSharpValue.GetUnionFields(value, value.GetType())
+            fields.[0]
+        serializer.Serialize(writer, value)
+
+      override x.ReadJson(reader, t, existingValue, serializer) =
+          let innerType = t.GetGenericArguments().[0]
+          let innerType =
+            if innerType.IsValueType then (typedefof<Nullable<_>>).MakeGenericType([|innerType|])
+            else innerType
+          let value = serializer.Deserialize(reader, innerType)
+          let cases = FSharpType.GetUnionCases(t)
+          if isNull value then FSharpValue.MakeUnion(cases.[0], [||])
+          else FSharpValue.MakeUnion(cases.[1], [|value|])
+
     let private jsonConverters =
       [|
-       new FSharpErrorSeverityConverter() :> JsonConverter;
+       new FSharpErrorSeverityConverter() :> JsonConverter
        new RangeConverter() :> JsonConverter
+       new OptionConverter() :> JsonConverter
       |]
 
     let internal writeJson(o: obj) = JsonConvert.SerializeObject(o, jsonConverters)

--- a/src/FsAutoComplete/FsAutoComplete.fsproj
+++ b/src/FsAutoComplete/FsAutoComplete.fsproj
@@ -101,16 +101,6 @@
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
-        <Reference Include="FSharp.Compiler.Service.MSBuild.v12">
-          <HintPath>..\..\packages\FSharp.Compiler.Service\lib\net45\stock\FSharp.Compiler.Service.MSBuild.v12.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="FSharp.Compiler.Service">
-          <HintPath>..\..\packages\FSharp.Compiler.Service\lib\net45\stock\FSharp.Compiler.Service.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
       </ItemGroup>
     </When>
   </Choose>

--- a/test/FsAutoComplete.IntegrationTests/Linter/output.json
+++ b/test/FsAutoComplete.IntegrationTests/Linter/output.json
@@ -13,24 +13,54 @@
   "Kind": "lint",
   "Data": [
     {
-      "Info": "`not (a=b)` might be able to be refactored into `a<>b`.",
+      "Info": "`not (a = b)` might be able to be refactored into `a <> b`.",
       "Range": {
         "StartColumn": 17,
         "StartLine": 1,
         "EndColumn": 26,
         "EndLine": 1
       },
-      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n"
+      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n",
+      "Fix": {
+        "Case": "Some",
+        "Fields": [
+          {
+            "FromText": "not (a=b)",
+            "FromRange": {
+              "StartColumn": 17,
+              "StartLine": 1,
+              "EndColumn": 26,
+              "EndLine": 1
+            },
+            "ToText": "a <> b"
+          }
+        ]
+      }
     },
     {
-      "Info": "`not (a<>b)` might be able to be refactored into `a=b`.",
+      "Info": "`not (a <> b)` might be able to be refactored into `a = b`.",
       "Range": {
         "StartColumn": 17,
         "StartLine": 2,
         "EndColumn": 27,
         "EndLine": 2
       },
-      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n"
+      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n",
+      "Fix": {
+        "Case": "Some",
+        "Fields": [
+          {
+            "FromText": "not (a<>b)",
+            "FromRange": {
+              "StartColumn": 17,
+              "StartLine": 2,
+              "EndColumn": 27,
+              "EndLine": 2
+            },
+            "ToText": "a = b"
+          }
+        ]
+      }
     },
     {
       "Info": "`fun x -> x` might be able to be refactored into `id`.",
@@ -40,7 +70,22 @@
         "EndColumn": 23,
         "EndLine": 3
       },
-      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n"
+      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n",
+      "Fix": {
+        "Case": "Some",
+        "Fields": [
+          {
+            "FromText": "fun a -> a",
+            "FromRange": {
+              "StartColumn": 13,
+              "StartLine": 3,
+              "EndColumn": 23,
+              "EndLine": 3
+            },
+            "ToText": "id"
+          }
+        ]
+      }
     },
     {
       "Info": "`not true` might be able to be refactored into `false`.",
@@ -50,7 +95,22 @@
         "EndColumn": 21,
         "EndLine": 4
       },
-      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n"
+      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n",
+      "Fix": {
+        "Case": "Some",
+        "Fields": [
+          {
+            "FromText": "not true",
+            "FromRange": {
+              "StartColumn": 13,
+              "StartLine": 4,
+              "EndColumn": 21,
+              "EndLine": 4
+            },
+            "ToText": "false"
+          }
+        ]
+      }
     },
     {
       "Info": "`not false` might be able to be refactored into `true`.",
@@ -60,27 +120,58 @@
         "EndColumn": 22,
         "EndLine": 5
       },
-      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n"
+      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n",
+      "Fix": {
+        "Case": "Some",
+        "Fields": [
+          {
+            "FromText": "not false",
+            "FromRange": {
+              "StartColumn": 13,
+              "StartLine": 5,
+              "EndColumn": 22,
+              "EndLine": 5
+            },
+            "ToText": "true"
+          }
+        ]
+      }
     },
     {
-      "Info": "`a<>true` might be able to be refactored into `not a`.",
+      "Info": "`a <> true` might be able to be refactored into `not a`.",
       "Range": {
         "StartColumn": 15,
         "StartLine": 7,
         "EndColumn": 22,
         "EndLine": 7
       },
-      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n"
+      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n",
+      "Fix": {
+        "Case": "Some",
+        "Fields": [
+          {
+            "FromText": "a<>true",
+            "FromRange": {
+              "StartColumn": 15,
+              "StartLine": 7,
+              "EndColumn": 22,
+              "EndLine": 7
+            },
+            "ToText": "not a"
+          }
+        ]
+      }
     },
     {
-      "Info": "`x=null`; suggestion: Consider using pattern matching, or if you're using F# 4 then `isNull`.",
+      "Info": "`x = null`; suggestion: Consider using pattern matching, or if you're using F# 4 then `isNull`.",
       "Range": {
         "StartColumn": 15,
         "StartLine": 8,
         "EndColumn": 21,
         "EndLine": 8
       },
-      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n"
+      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n",
+      "Fix": null
     },
     {
       "Info": "`List.head (List.sort x)` might be able to be refactored into `List.min x`.",
@@ -90,7 +181,22 @@
         "EndColumn": 38,
         "EndLine": 9
       },
-      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n"
+      "Input": "let test1 a b = not (a=b)\nlet test2 a b = not (a<>b)\nlet test3 = fun a -> a\nlet test4 = not true\nlet test5 = not false\nlet test6 = List.fold ( + ) 0\nlet test7 a = a<>true\nlet test8 a = a=null\nlet test9 a = List.head (List.sort a) \n",
+      "Fix": {
+        "Case": "Some",
+        "Fields": [
+          {
+            "FromText": "List.head (List.sort a)",
+            "FromRange": {
+              "StartColumn": 15,
+              "StartLine": 9,
+              "EndColumn": 38,
+              "EndLine": 9
+            },
+            "ToText": "List.min a"
+          }
+        ]
+      }
     }
   ]
 }

--- a/test/FsAutoComplete.Tests/FsAutoComplete.Tests.fsproj
+++ b/test/FsAutoComplete.Tests/FsAutoComplete.Tests.fsproj
@@ -92,16 +92,6 @@
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
-        <Reference Include="FSharp.Compiler.Service.MSBuild.v12">
-          <HintPath>..\..\packages\FSharp.Compiler.Service\lib\net45\stock\FSharp.Compiler.Service.MSBuild.v12.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="FSharp.Compiler.Service">
-          <HintPath>..\..\packages\FSharp.Compiler.Service\lib\net45\stock\FSharp.Compiler.Service.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
       </ItemGroup>
     </When>
   </Choose>


### PR DESCRIPTION
New FSharpLint version include fixes suggestion which can be used to provide some refactorings in editor

Exposing `GetF1KeywordAlternate` as an endpoint lets query MSDN documentation, similarly to VS' F1. 