### PR TITLE
Optimize GetDeclarations

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -147,12 +147,12 @@ type Commands (serialize : Serializer) =
                     [response]
     }
 
-    member __.Declarations file = async {
+    member __.Declarations file version = async {
         let file = Path.GetFullPath file
         match state.TryGetFileCheckerOptionsWithSource file with
         | Failure s -> return [Response.error serialize s]
         | Success (checkOptions, source) ->
-            let! decls = checker.GetDeclarations(file, source, checkOptions)
+            let! decls = checker.GetDeclarations(file, source, checkOptions, version)
             let decls = decls |> Array.map (fun a -> a,file)
             return [Response.declarations serialize decls]
     }

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -101,27 +101,30 @@ type Commands (serialize : Serializer) =
             project)
 
         let (|NetCore|Net45|Unsupported|) file =
-            //.NET Core Sdk preview3 replace project.json with fsproj
+            //.NET Core Sdk preview3+ replace project.json with fsproj
             //Easy way to detect new fsproj is to check the msbuild version of .fsproj
             //  MSBuild version 15 (`ToolsVersion="15.0"`) is the new project format
-            //The `dotnet-compile-fsc.rsp` are created also in `preview3`, so we can
+            //Post preview5 has (`Sdk="Fsharp.NET.Sdk;Microsoft.NET.Sdk"`), use that
+            //  for checking .NET Core fsproj
+            //The `dotnet-compile-fsc.rsp` are created also in `preview3+`, so we can
             //  reuse the same behaviour of `preview2`
-            let rec findToolsVersion (sr:StreamReader) limit =
-                // only preview3+ uses ToolsVersion='15.0'
-                let isPreview3 (toolsVersion:string) = toolsVersion.Contains("=\"15.0\"")
+            let rec getProjectType (sr:StreamReader) limit =
+                // only preview3-5 uses ToolsVersion='15.0'
+                // post preview5 dropped this, check Sdk field
+                let isNetCore (line:string) = line.Contains("=\"15.0\"") || line.Contains("Fsharp.NET.Sdk")
                 if limit = 0 then
                     Unsupported // unsupported project type
                 else
                     let line = sr.ReadLine()
-                    if not <| line.Contains("ToolsVersion") then
-                        findToolsVersion sr (limit-1)
-                    else // both net45 and preview3+ have 'ToolsVersion'
-                        if isPreview3 line then NetCore else Net45
+                    if not <| line.Contains("ToolsVersion") && not <| line.Contains("Sdk=") then
+                        getProjectType sr (limit-1)
+                    else // both net45 and preview3-5 have 'ToolsVersion', > 5 has 'Sdk'
+                        if isNetCore line then NetCore else Net45
             if not <| File.Exists(projectFileName) then Net45 // no such file is handled downstream
             elif Path.GetExtension file = ".json" then NetCore // dotnet core preview 2 or earlier
             else
                 use sr = File.OpenText(file)
-                findToolsVersion sr 3
+                getProjectType sr 3
 
 
         return

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -377,6 +377,7 @@ type FSharpCompilerServiceChecker() =
     let! parseResult =
       match checker.TryGetRecentCheckResultsForFile(fileName, options,source), version with
       | Some (pr, _, v), Some ver when v = ver ->  async {return pr}
+      | _, None -> checker.ParseFileInProject(fileName, source, options)
       | _ ->
         async {
           let! chkd =

--- a/src/FsAutoComplete.Suave/FsAutoComplete.Suave.fs
+++ b/src/FsAutoComplete.Suave/FsAutoComplete.Suave.fs
@@ -19,7 +19,7 @@ open FsAutoComplete.JsonSerializer
 module Contract =
     type ParseRequest = { FileName : string; IsAsync : bool; Lines : string[]; Version : int }
     type ProjectRequest = { FileName : string;}
-    type DeclarationsRequest = {FileName : string}
+    type DeclarationsRequest = {FileName : string; Version : int}
     type HelptextRequest = {Symbol : string}
     type CompletionRequest = {FileName : string; SourceLine : string; Line : int; Column : int; Filter : string; IncludeKeywords : bool;}
     type PositionRequest = {FileName : string; Line : int; Column : int; Filter : string}
@@ -116,7 +116,7 @@ let main argv =
             //TODO: Add filewatcher
             path "/parseProjectsInBackground" >=> handler (fun (data : ProjectRequest) -> commands.ParseAndCheckProjectsInBackgroundForFile data.FileName)
             path "/project" >=> handler (fun (data : ProjectRequest) -> commands.Project data.FileName false ignore)
-            path "/declarations" >=> handler (fun (data : DeclarationsRequest) -> commands.Declarations data.FileName)
+            path "/declarations" >=> handler (fun (data : DeclarationsRequest) -> commands.Declarations data.FileName (Some data.Version) )
             path "/declarationsProjects" >=> fun httpCtx ->
                 async {
                     let! errors = commands.DeclarationsInProjects ()

--- a/src/FsAutoComplete/Program.fs
+++ b/src/FsAutoComplete/Program.fs
@@ -32,7 +32,7 @@ module internal Main =
 
           | Project (file, verbose) ->
               return! commands.Project file verbose (fun fullPath -> commandQueue.Add(Project (fullPath, verbose)))
-          | Declarations file -> return! commands.Declarations file
+          | Declarations file -> return! commands.Declarations file None
           | HelpText sym -> return commands.Helptext sym
           | PosCommand (cmd, file, lineStr, pos, _timeout, filter) ->
               let file = Path.GetFullPath file


### PR DESCRIPTION
1. Add version parameter to `GetDeclarations` function
2. If provided version is same as version returned by `TryGetFileCheckerOptionsWithSource ` use those parse results
3. If that's not the case wait for `FileParsed` event for given file and call  `TryGetFileCheckerOptionsWithSource ` again
4. Fallback to `ParseFileInProject` only if something is wrong (should be never)

In VSCode `GetDeclarations` is used in 2 places:
1. Editor is idle, file is not edited (so it was parsed either when open, or on last edit) and users asks for symbols in this file - version of the file has not changed so `TryGetFileCheckerOptionsWithSource ` will return valid result
2. It's used to find positions where CodeLenses should be displayed in file - in such case `GetDeclarations` is invoked in more or less (editor controls it) at same time as `parse` request - there are 2 options:
    * `parse` is completed before `declarations` is send (`TryGetFileCheckerOptionsWithSource ` will return valid result) 
    *  parse is not completed (`TryGetFileCheckerOptionsWithSource ` returned older version number) but we know file'll be parse soon as it's parsed "in parallel" - so instead of starting own parsing, we just wait for this parallel request to be finished and use `TryGetFileCheckerOptionsWithSource `