### PR TITLE
Allow for inconsistent casing of "Fsharp" when detecting

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -105,14 +105,14 @@ type Commands (serialize : Serializer) =
             //.NET Core Sdk preview3+ replace project.json with fsproj
             //Easy way to detect new fsproj is to check the msbuild version of .fsproj
             //  MSBuild version 15 (`ToolsVersion="15.0"`) is the new project format
-            //Post preview5 has (`Sdk="Fsharp.NET.Sdk;Microsoft.NET.Sdk"`), use that
-            //  for checking .NET Core fsproj
+            //Post preview5 has (`Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk"`), use that
+            //  for checking .NET Core fsproj. NB: casing of FSharp may be inconsistent.
             //The `dotnet-compile-fsc.rsp` are created also in `preview3+`, so we can
             //  reuse the same behaviour of `preview2`
             let rec getProjectType (sr:StreamReader) limit =
                 // only preview3-5 uses ToolsVersion='15.0'
                 // post preview5 dropped this, check Sdk field
-                let isNetCore (line:string) = line.Contains("=\"15.0\"") || line.Contains("Fsharp.NET.Sdk")
+                let isNetCore (line:string) = line.Contains("=\"15.0\"") || line.ToLower().Contains("fsharp.net.sdk")
                 if limit = 0 then
                     Unsupported // unsupported project type
                 else


### PR DESCRIPTION
MSBuild 15

Fixes https://github.com/fsharp/vim-fsharp/issues/67