### PR TITLE
Confirm .NET Core by the SDK attribute existing

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -112,7 +112,7 @@ type Commands (serialize : Serializer) =
             let rec getProjectType (sr:StreamReader) limit =
                 // only preview3-5 uses ToolsVersion='15.0'
                 // post preview5 dropped this, check Sdk field
-                let isNetCore (line:string) = line.Contains("=\"15.0\"") || line.ToLower().Contains("fsharp.net.sdk")
+                let isNetCore (line:string) = line.Contains("=\"15.0\"") || line.ToLower().Contains("sdk=")
                 if limit = 0 then
                     Unsupported // unsupported project type
                 else


### PR DESCRIPTION
Per advice from @enricosada, the SDK name is changing for RTM. The SDK attribute is the preferred way to check if a project is .NET Core.

Link to comment: https://github.com/ionide/FsAutoComplete/pull/47#issuecomment-278400458