### PR TITLE
Learn new fsproj

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,6 +3,7 @@ source https://www.nuget.org/api/v2/
 
 nuget FSharp.Compiler.Service framework: >= net45
 nuget FSharp.Compiler.Service.ProjectCracker
+nuget Dotnet.ProjInfo
 nuget Mono.Cecil
 nuget NDesk.Options
 nuget Newtonsoft.Json

--- a/paket.lock
+++ b/paket.lock
@@ -1,6 +1,8 @@
 FRAMEWORK: NET45
 NUGET
   remote: https://www.nuget.org/api/v2
+    Dotnet.ProjInfo (0.5)
+      FSharp.Core (>= 4.0.0.1)
     FAKE (4.55)
     FParsec (1.0.2)
     FSharp.Compiler.Service (11.0.6)

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -137,7 +137,7 @@ type Commands (serialize : Serializer) =
                     | NetCoreProjectJson -> checker.TryGetProjectJsonProjectOptions projectFileName
                     | NetCoreSdk -> checker.TryGetCoreProjectOptions projectFileName
                     | Net45 -> checker.TryGetProjectOptions (projectFileName, verbose)
-                    | Unsupported -> Failure (sprintf "File '%s' is not supported" projectFileName)
+                    | Unsupported -> checker.TryGetProjectOptions (projectFileName, verbose)
 
                 match options with
                 | Result.Failure error ->

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -101,7 +101,7 @@ type Commands (serialize : Serializer) =
             state.Projects.[projectFileName] <- project
             project)
 
-        let (|NetCore|Net45|Unsupported|) file =
+        let (|NetCoreProjectJson|NetCoreSdk|Net45|Unsupported|) file =
             //.NET Core Sdk preview3+ replace project.json with fsproj
             //Easy way to detect new fsproj is to check the msbuild version of .fsproj
             //  MSBuild version 15 (`ToolsVersion="15.0"`) is the new project format
@@ -120,9 +120,9 @@ type Commands (serialize : Serializer) =
                     if not <| line.Contains("ToolsVersion") && not <| line.Contains("Sdk=") then
                         getProjectType sr (limit-1)
                     else // both net45 and preview3-5 have 'ToolsVersion', > 5 has 'Sdk'
-                        if isNetCore line then NetCore else Net45
+                        if isNetCore line then NetCoreSdk else Net45
             if not <| File.Exists(projectFileName) then Net45 // no such file is handled downstream
-            elif Path.GetExtension file = ".json" then NetCore // dotnet core preview 2 or earlier
+            elif Path.GetExtension file = ".json" then NetCoreProjectJson // dotnet core preview 2 or earlier
             else
                 use sr = File.OpenText(file)
                 getProjectType sr 3
@@ -134,7 +134,8 @@ type Commands (serialize : Serializer) =
             | None ->
                 let options =
                     match projectFileName with
-                    | NetCore -> checker.TryGetCoreProjectOptions projectFileName
+                    | NetCoreProjectJson -> checker.TryGetProjectJsonProjectOptions projectFileName
+                    | NetCoreSdk -> checker.TryGetCoreProjectOptions projectFileName
                     | Net45 -> checker.TryGetProjectOptions (projectFileName, verbose)
                     | Unsupported -> Failure (sprintf "File '%s' is not supported" projectFileName)
 

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -355,6 +355,19 @@ type FSharpCompilerServiceChecker() =
       with e ->
         Failure e.Message
 
+  member __.TryGetProjectJsonProjectOptions (file : SourceFilePath) : Result<_> =
+    if not (File.Exists file) then
+      Failure (sprintf "File '%s' does not exist" file)
+    else
+      try
+        let po = ProjectCoreCracker.GetProjectOptionsFromResponseFile file
+        let compileFiles = Seq.filter (fun (s:string) -> s.EndsWith(".fs")) po.OtherOptions
+        let outputFile = Seq.tryPick (chooseByPrefix "--out:") po.OtherOptions
+        let references = Seq.choose (chooseByPrefix "-r:") po.OtherOptions
+        Success (po, Seq.toList compileFiles, outputFile, Seq.toList references, Map<string,string>([||]))
+      with e ->
+        Failure e.Message
+
   member __.TryGetCoreProjectOptions (file : SourceFilePath) : Result<_> =
     if not (File.Exists file) then
       Failure (sprintf "File '%s' does not exist" file)

--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -88,6 +88,17 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <ItemGroup>
+        <Reference Include="Dotnet.ProjInfo">
+          <HintPath>..\..\packages\Dotnet.ProjInfo\lib\net45\Dotnet.ProjInfo.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
+      <ItemGroup>
         <Reference Include="FParsec">
           <HintPath>..\..\packages\FParsec\lib\net40-client\FParsec.dll</HintPath>
           <Private>True</Private>

--- a/src/FsAutoComplete.Core/ProjectCoreCracker.fs
+++ b/src/FsAutoComplete.Core/ProjectCoreCracker.fs
@@ -5,7 +5,7 @@ open System.IO
 open Microsoft.FSharp.Compiler.SourceCodeServices
 
 module ProjectCoreCracker =
-  let GetProjectOptionsFromProjectFile (file : string)  =
+  let GetProjectOptionsFromResponseFile (file : string)  =
     let projDir = Path.GetDirectoryName file
     let rsp =
       Directory.GetFiles(projDir, "dotnet-compile-fsc.rsp", SearchOption.AllDirectories)
@@ -29,3 +29,80 @@ module ProjectCoreCracker =
       OriginalLoadReferences = []
       ExtraProjectInfo = None
     }
+
+  let runProcess (workingDir: string) (exePath: string) (args: string) =
+      let psi = System.Diagnostics.ProcessStartInfo()
+      psi.FileName <- exePath
+      psi.WorkingDirectory <- workingDir 
+      psi.RedirectStandardOutput <- false
+      psi.RedirectStandardError <- false
+      psi.Arguments <- args
+      psi.CreateNoWindow <- true
+      psi.UseShellExecute <- false
+
+      use p = new System.Diagnostics.Process()
+      p.StartInfo <- psi
+      p.Start() |> ignore
+      p.WaitForExit()
+      
+      let exitCode = p.ExitCode
+      exitCode, ()
+
+  let GetProjectOptionsFromProjectFile (file : string) =
+    let rec projInfo file =
+        let projDir = Path.GetDirectoryName file
+
+        let runCmd exePath args = runProcess projDir exePath (args |> String.concat " ")
+
+        let msbuildExec = Dotnet.ProjInfo.Inspect.dotnetMsbuild runCmd
+        let getFscArgs = Dotnet.ProjInfo.Inspect.getFscArgs
+        let getP2PRefs = Dotnet.ProjInfo.Inspect.getP2PRefs
+        let gp () = Dotnet.ProjInfo.Inspect.getProperties ["TargetPath"]
+        let log = ignore
+
+        let results =
+          file
+          |> Dotnet.ProjInfo.Inspect.getProjectInfos log msbuildExec [getFscArgs; getP2PRefs; gp] []
+    
+        // $(TargetPath)
+        let mutable rsp : string list = []
+        let mutable p2p : string list = []
+        let mutable props : (string * string) list = []
+
+        let doResult result =
+          match result with
+          | Choice1Of2 (Dotnet.ProjInfo.Inspect.GetResult.FscArgs x) -> rsp <- x
+          | Choice1Of2 (Dotnet.ProjInfo.Inspect.GetResult.P2PRefs x) -> p2p <- x
+          | Choice1Of2 (Dotnet.ProjInfo.Inspect.GetResult.Properties p) -> props <- p
+          | Choice2Of2 _ -> failwith "errors"
+
+        match results with
+        | Choice1Of2 r -> r |> List.iter doResult
+        | Choice2Of2 r -> failwith "errors"
+
+        //TODO cache projects info of p2p ref
+        let p2pProjects = p2p |> List.map projInfo
+
+        let tar =
+            match props |> Map.ofList |> Map.tryFind "TargetPath" with
+            | Some t -> t
+            | None -> failwith "error, 'TargetPath' property not found"
+
+        let po =
+            {
+                ProjectFileName = file
+                ProjectFileNames = [||]
+                OtherOptions = rsp |> Array.ofList
+                ReferencedProjects = p2pProjects |> Array.ofList
+                IsIncompleteTypeCheckEnvironment = false
+                UseScriptResolutionRules = false
+                LoadTime = DateTime.Now
+                UnresolvedReferences = None;
+                OriginalLoadReferences = []
+                ExtraProjectInfo = None
+            }
+
+        tar, po
+
+    let _, po = projInfo file
+    po

--- a/src/FsAutoComplete.Core/paket.references
+++ b/src/FsAutoComplete.Core/paket.references
@@ -1,3 +1,4 @@
 FSharp.Compiler.Service.ProjectCracker
 FSharp.Compiler.Service
 FSharpLint.Core
+Dotnet.ProjInfo


### PR DESCRIPTION
Status:

- all deps are on nuget.org
- references ok
- p2p project references ok
- `dotnet build` not required
- `dotnet restore` is required, but project parsing will fails normally if not done, so will be retried later, and will work after restore (for vscode that mean no reload window required, just something to retry, like change file)

Example: clean repo -> `code .` -> `dotnet restore` -> F5 -> debug -> profit!

![recf3](https://cloud.githubusercontent.com/assets/147243/24065340/7a80720c-0b6a-11e7-8bc6-fe315b3d62f6.gif)




someone can do testing on osx/ubuntu? /cc @alfonsogarciacaro @haf 

## How to test

- follow [ionide steps to run vscode with dev FSAC](https://github.com/ionide/ionide-vscode-fsharp/blob/master/DEVGUIDE.md#working-with-fsac)
- use the ready to use fsproj projects in https://github.com/enricosada/DotnetNewFsprojTestingSamples

Other than testing on osx, i think is ok for me @Krzysztof-Cieslak 

