### PR TITLE
format error notes for tooltip/healtext

### DIFF
--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -93,12 +93,13 @@ let private buildFormatComment cmt =
        | _ -> ""
     | _ -> ""
 
-let formatTip (FSharpToolTipText tips) : (string * string) list list = 
+let formatTip (FSharpToolTipText tips) : (string * string) list list =
     tips
     |> List.choose (function
         | FSharpToolTipElement.Single (it, comment) -> Some [it, buildFormatComment comment]
-        | FSharpToolTipElement.Group items -> 
+        | FSharpToolTipElement.Group items ->
             Some (items |> List.map (fun (it, comment) ->  (it, buildFormatComment comment)))
+        | FSharpToolTipElement.CompositionError (error) -> Some [("<Note>", error)]
         | _ -> None)
 
 let extractSignature (FSharpToolTipText tips) =


### PR DESCRIPTION
Currently we don't get nice tooltips for errors that result in the `<Note>` tag that we know and love.  This adds them, so the response we get now looks like:

```
["{"Kind":"helptext","Data":{"Name":"<Note>","Overloads":[[{"Signature":"<Note>","Comment":"The type 'ValueType' is required here and is unavailable. You must add a reference to assembly 'System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'."}]]}}";
 "{"Kind":"completion","Data":[{"Name":"<Note>","ReplacementText":"``<Note>``","Glyph":"Other","GlyphChar":"o"}]}"]
```

This is helpful because as it is in Ionide now you would never get this error aside from the `<Note>` placeholder, no actionable inner content.