### PR TITLE
bump Dotnet.ProjInfo

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,7 +3,7 @@ source https://www.nuget.org/api/v2/
 
 nuget FSharp.Compiler.Service 11.0.9 framework: >= net45
 nuget FSharp.Compiler.Service.ProjectCracker 11.0.9
-nuget Dotnet.ProjInfo
+nuget Dotnet.ProjInfo 0.6.0
 nuget Mono.Cecil
 nuget NDesk.Options
 nuget Newtonsoft.Json

--- a/paket.lock
+++ b/paket.lock
@@ -1,7 +1,7 @@
 FRAMEWORK: NET45
 NUGET
   remote: https://www.nuget.org/api/v2
-    Dotnet.ProjInfo (0.5)
+    Dotnet.ProjInfo (0.6)
       FSharp.Core (>= 4.0.0.1)
     FAKE (4.55)
     FParsec (1.0.2)


### PR DESCRIPTION
fix https://github.com/fsharp/FsAutoComplete/issues/152
fix issue with project references (ref https://github.com/enricosada/dotnet-proj-info/issues/1 )

/cc @forki @alfonsogarciacaro for fable (this will remove the need for current workaround with env var for elmish)

To test with vscode:

- `build LocalRelease`
- copy `bin\release` files in `C:\Users\%USERNAME%\.vscode\extensions\Ionide.Ionide-fsharp-2.25.2\bin`

@rneatherway i tested locally, seems ok, but i didnt check vim/emacs (i'll try next time to setup also these).
And i'll try to help to add some smoke tests in this repo next week

@Krzysztof-Cieslak after this pr and #157 are merged is possibile to have another release of ionide for fable? /cc @alfonsogarciacaro 
