### PR TITLE
[WIP] fix tests suite

### DIFF
--- a/test/FsAutoComplete.IntegrationTests/SymbolUse/output.json
+++ b/test/FsAutoComplete.IntegrationTests/SymbolUse/output.json
@@ -45,7 +45,7 @@
         "StartColumn": 5,
         "EndColumn": 12,
         "Severity": "Error",
-        "Message": "The value, namespace, type or module 'console' is not defined. Maybe you want one of the following:\n   Consts\n   Control",
+        "Message": "The value, namespace, type or module 'console' is not defined. Maybe you want one of the following:\n   Control",
         "Subcategory": "typecheck"
       }
     ]


### PR DESCRIPTION
on tests of the integration test suite fails

```
diff --git a/test/FsAutoComplete.IntegrationTests/SymbolUse/output.json b/test/FsAutoComplete.IntegrationTests/SymbolUse/output.json
index 71292c4..f7c0428 100644
--- a/test/FsAutoComplete.IntegrationTests/SymbolUse/output.json
+++ b/test/FsAutoComplete.IntegrationTests/SymbolUse/output.json
@@ -45,7 +45,7 @@
         "StartColumn": 5,
         "EndColumn": 12,
         "Severity": "Error",
-        "Message": "The value, namespace, type or module 'console' is not defined. Maybe you want one of the following:\n   Control",
+        "Message": "The value, namespace, type or module 'console' is not defined. Maybe you want one of the following:\n   Consts\n   Control",
         "Subcategory": "typecheck"
       }
     ]
Running build failed.
Error:
System.Exception: Integration tests failed:
```
