### PR TITLE
Fix zoombie fsac process after exit vim-fsharp

### DIFF
--- a/src/FsAutoComplete/CommandInput.fs
+++ b/src/FsAutoComplete/CommandInput.fs
@@ -74,9 +74,9 @@ module CommandInput =
 
   /// Read multi-line input as a list of strings
   let rec readInput input =
-    let str = Console.ReadLine()
-    if str = "<<EOF>>" then List.rev input
-    else readInput (str::input)
+    match Console.ReadLine() with
+    | null | "<<EOF>>" -> List.rev input
+    | str -> readInput (str::input)
 
   // Parse 'parse "<filename>" [sync]' command
   let parse =


### PR DESCRIPTION
On windows, if user quit vim while sending file content in parse command, fsac isn't get killed. Because `Console.ReadLine` then always returns null, fsac consumes all avalable RAM.