### PR TITLE
Debugger opt

### DIFF
--- a/src/FsAutoComplete/Debug.fs
+++ b/src/FsAutoComplete/Debug.fs
@@ -5,6 +5,7 @@ namespace FsAutoComplete
 
 module Debug =
 
+  let waitForDebugger = ref false
   let verbose = ref false
   let categories : Ref<Option<Set<string>>> =
     ref None
@@ -48,6 +49,11 @@ module Debug =
       fprintfn !output fmt
     else
       Format<_>.Instance
+
+  let checkIfWaitForDebugger () =
+    if !waitForDebugger then
+      while not(System.Diagnostics.Debugger.IsAttached) do
+        System.Threading.Thread.Sleep(100)
 
   let inline flush () =
     if !verbose then

--- a/src/FsAutoComplete/Options.fs
+++ b/src/FsAutoComplete/Options.fs
@@ -82,4 +82,7 @@ module Options =
         fun _ -> printfn "%s" Version.string;
                  p.WriteOptionDescriptions(stdout);
                  exit 0
+      "wait-for-debugger", "wait for a debugger to attach to the process",
+        fun _ -> Debug.waitForDebugger := true
+
     ]

--- a/src/FsAutoComplete/Program.fs
+++ b/src/FsAutoComplete/Program.fs
@@ -90,6 +90,7 @@ module internal Main =
       printfn "Unrecognised arguments: %s" (String.concat "," extra)
       1
     else
+      Debug.checkIfWaitForDebugger()
       try
         async {
           while true do

--- a/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
+++ b/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
@@ -23,6 +23,8 @@ type FsAutoCompleteWrapper() =
     p.StartInfo.RedirectStandardInput  <- true
     p.StartInfo.UseShellExecute <- false
     p.StartInfo.EnvironmentVariables.Add("FCS_ToolTipSpinWaitTime", "10000")
+    if Environment.GetEnvironmentVariable("FSAC_TESTSUITE_WAITDEBUGGER") = "1" then
+      p.StartInfo.Arguments <- "--wait-for-debugger"
     p.Start () |> ignore
 
   member x.project (s: string) : unit =


### PR DESCRIPTION
add new command line option `--wait-for-debugger` to stop waiting a debugger at beginning of program.

useful in test suite in combination with env `FSAC_TESTSUITE_WAITDEBUGGER`, when `1` will pass that args, so is possibile to attach a debugger, after running an `fsi Runner.fsx`.
