### PR TITLE
add hostPID command line arg, to fix zombie fsac after the client is force closed

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,6 +1,7 @@
 framework: net45
 source https://www.nuget.org/api/v2/
 
+nuget Argu 3.7
 nuget FSharp.Compiler.Service 11.0.9 framework: >= net45
 nuget FSharp.Compiler.Service.ProjectCracker 11.0.9
 nuget Dotnet.ProjInfo 0.7.4

--- a/paket.lock
+++ b/paket.lock
@@ -1,6 +1,7 @@
 FRAMEWORK: NET45
 NUGET
   remote: https://www.nuget.org/api/v2
+    Argu (3.7)
     Dotnet.ProjInfo (0.7.4)
       FSharp.Core (>= 4.0.0.1)
     FAKE (4.61.3)

--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -40,6 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Utils.fs" />
+    <Compile Include="ProcessWatcher.fs" />
     <Compile Include="UntypedAstUtils.fs" />
     <Compile Include="TypedAstUtils.fs" />
     <Compile Include="Extensions.fs" />

--- a/src/FsAutoComplete.Core/ProcessWatcher.fs
+++ b/src/FsAutoComplete.Core/ProcessWatcher.fs
@@ -1,0 +1,33 @@
+namespace FsAutoComplete
+
+open System.Diagnostics
+open System
+
+module ProcessWatcher =
+
+  type private OnExitMessage =
+    | Watch of Process * (Process -> unit)
+
+  let private watcher = new MailboxProcessor<OnExitMessage>(fun inbox ->
+    let rec loop underWatch =
+        async {
+            let! message = inbox.TryReceive(System.TimeSpan.FromSeconds(0.5).TotalMilliseconds |> int)
+            let next =
+                match message with
+                | Some (Watch (proc, a)) ->
+                    (proc, a) :: underWatch
+                | None ->
+                    let exited, alive = underWatch |> List.partition (fun (p, _) -> p.HasExited)
+                    exited |> List.iter (fun (p,a) -> a p)
+                    alive
+            do! loop next
+        }
+    loop [] )
+
+  let watch proc onExitCallback =
+    if Utils.runningOnMono then
+        watcher.Start()
+        watcher.Post (OnExitMessage.Watch(proc, onExitCallback))
+    else
+        proc.EnableRaisingEvents <- true
+        proc.Exited |> Event.add (fun _ -> onExitCallback proc)

--- a/src/FsAutoComplete.Suave/FsAutoComplete.Suave.fsproj
+++ b/src/FsAutoComplete.Suave/FsAutoComplete.Suave.fsproj
@@ -81,6 +81,17 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
       <ItemGroup>
+        <Reference Include="Argu">
+          <HintPath>..\..\packages\Argu\lib\net40\Argu.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
+      <ItemGroup>
         <Reference Include="FSharp.Compiler.Service">
           <HintPath>..\..\packages\FSharp.Compiler.Service\lib\net45\FSharp.Compiler.Service.dll</HintPath>
           <Private>True</Private>

--- a/src/FsAutoComplete.Suave/paket.references
+++ b/src/FsAutoComplete.Suave/paket.references
@@ -3,3 +3,4 @@ FSharp.Compiler.Service
 FSharp.Compiler.Service.ProjectCracker
 Newtonsoft.Json
 FSharp.Core
+Argu

--- a/src/FsAutoComplete/CommandInput.fs
+++ b/src/FsAutoComplete/CommandInput.fs
@@ -28,6 +28,7 @@ type Command =
   | Project of string * bool
   | Colorization of bool
   | CompilerLocation
+  | Started
   | Quit
 
 module CommandInput =

--- a/src/FsAutoComplete/Options.fs
+++ b/src/FsAutoComplete/Options.fs
@@ -85,4 +85,11 @@ module Options =
       "wait-for-debugger", "wait for a debugger to attach to the process",
         fun _ -> Debug.waitForDebugger := true
 
+      "hostPID=", "Host process ID",
+        fun s -> try
+                   Debug.hostPID := Some (int s)
+                 with
+                   | e -> printfn "Bad Host process ID '%s' expected int: %s" s e.Message
+                          exit 1
+
     ]

--- a/src/FsAutoComplete/Program.fs
+++ b/src/FsAutoComplete/Program.fs
@@ -22,6 +22,8 @@ module internal Main =
     while not quit do
       async {
           match commandQueue.Take() with
+          | Started ->
+              return [ Response.info writeJson (sprintf "Started (PID=%i)" (System.Diagnostics.Process.GetCurrentProcess().Id)) ]
           | Parse (file, kind, lines) ->
               let! res = commands.Parse file lines 0
               //Hack for tests
@@ -94,6 +96,9 @@ module internal Main =
       Debug.zombieCheckWithHostPID (fun () -> commandQueue.Add(Command.Quit))
       try
         async {
+          if !Debug.verbose then
+            commandQueue.Add(Command.Started)
+
           while true do
             commandQueue.Add (CommandInput.parseCommand(Console.ReadLine()))
         }

--- a/src/FsAutoComplete/Program.fs
+++ b/src/FsAutoComplete/Program.fs
@@ -91,6 +91,7 @@ module internal Main =
       1
     else
       Debug.checkIfWaitForDebugger()
+      Debug.zombieCheckWithHostPID (fun () -> commandQueue.Add(Command.Quit))
       try
         async {
           while true do

--- a/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
+++ b/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
@@ -15,9 +15,7 @@ type FsAutoCompleteWrapper() =
   let cachedOutput = new Text.StringBuilder()
 
   do
-    p.StartInfo.FileName <-
-      IO.Path.Combine(__SOURCE_DIRECTORY__,
-                      "../../src/FsAutoComplete/bin/Debug/fsautocomplete.exe")
+    p.StartInfo.FileName <- FsAutoCompleteWrapper.ExePath ()
     p.StartInfo.RedirectStandardOutput <- true
     p.StartInfo.RedirectStandardError  <- true
     p.StartInfo.RedirectStandardInput  <- true
@@ -26,6 +24,10 @@ type FsAutoCompleteWrapper() =
     if Environment.GetEnvironmentVariable("FSAC_TESTSUITE_WAITDEBUGGER") = "1" then
       p.StartInfo.Arguments <- "--wait-for-debugger"
     p.Start () |> ignore
+
+  static member ExePath () =
+      IO.Path.Combine(__SOURCE_DIRECTORY__,
+                      "../../src/FsAutoComplete/bin/Debug/fsautocomplete.exe")
 
   member x.project (s: string) : unit =
     fprintf p.StandardInput "project \"%s\"\n" s

--- a/test/FsAutoComplete.IntegrationTests/ZombieSlayer/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/ZombieSlayer/Runner.fsx
@@ -91,7 +91,7 @@ let run () =
         | _ -> ()
         )
 
-    let exited = p.WaitForExit(TimeSpan.FromSeconds(5.0).TotalMilliseconds |> int)
+    let exited = p.WaitForExit(TimeSpan.FromSeconds(30.0).TotalMilliseconds |> int)
 
     // check fsac shouldnt be alive
     match exited, fsacProc with

--- a/test/FsAutoComplete.IntegrationTests/ZombieSlayer/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/ZombieSlayer/Runner.fsx
@@ -68,7 +68,7 @@ let run () =
     let start =
         let isWindows = Environment.OSVersion.Platform = PlatformID.Win32NT
         if isWindows then
-            startWrapper __SOURCE_DIRECTORY__ "powershell.exe" (sprintf """-ExecutionPolicy Bypass -File runfsac.ps1 "%s" """ fsacExePath)
+            startWrapper __SOURCE_DIRECTORY__ "powershell.exe" (sprintf """-NonInteractive -ExecutionPolicy Bypass -File runfsac.ps1 "%s" """ fsacExePath)
         else
             startWrapper __SOURCE_DIRECTORY__ "sh" (sprintf """./runfsac.sh "%s" """ fsacExePath)
 

--- a/test/FsAutoComplete.IntegrationTests/ZombieSlayer/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/ZombieSlayer/Runner.fsx
@@ -1,0 +1,125 @@
+#load "../TestHelpers.fsx"
+open TestHelpers
+open System.IO
+open System
+open System.Diagnostics
+
+Environment.CurrentDirectory <- __SOURCE_DIRECTORY__
+File.Delete "output.json"
+
+let startWrapper (workingDir: string) (exePath: string) (args: string) f =
+    printfn "Running '%s %s' in working dir '%s'" exePath args workingDir
+    let psi = ProcessStartInfo()
+    psi.FileName <- exePath
+    psi.WorkingDirectory <- workingDir
+    psi.RedirectStandardOutput <- true
+    psi.RedirectStandardError <- true
+    psi.Arguments <- args
+    psi.CreateNoWindow <- true
+    psi.UseShellExecute <- false
+
+    let p = new Process()
+    p.StartInfo <- psi
+
+    p.OutputDataReceived
+    |> Event.map (fun ea -> ea.Data)
+    |> Event.filter (not << isNull)
+    |> Event.add (fun s ->
+        printfn "%s" s
+        f (p, s))
+
+    p.ErrorDataReceived
+    |> Event.add (fun ea ->  printfn "%s" (ea.Data))
+
+    p.Start() |> ignore
+    p.BeginOutputReadLine()
+    p.BeginErrorReadLine()
+    p
+
+
+let rec retry (times, sleepTime: TimeSpan) f = async {
+    if times < 0 then
+        return false
+    elif f () then
+        return true
+    else
+        do! Async.Sleep (sleepTime.TotalMilliseconds |> int)
+        return! retry (times - 1, sleepTime) f
+    }
+
+let testOutput = Text.StringBuilder()
+let log s =
+    printfn "%s" s
+    testOutput.Append(s + "\n") |> ignore
+
+/// parse the started info message who contains the PID
+let (|FSACStartedMsg|_|) (s: string) =
+    let startedInfoMessage = """{"Kind":"info","Data":"Started (PID="""
+    let startedInfoMessageEnd = """)"}"""
+    if s.Contains(startedInfoMessage) then
+        s.Replace(startedInfoMessage, "").Replace(startedInfoMessageEnd, "").Trim()
+        |> int
+        |> Some
+    else
+        None
+
+let run () =
+    let fsacExePath = FsAutoCompleteWrapper.ExePath ()
+    let start =
+        let isWindows = Environment.OSVersion.Platform = PlatformID.Win32NT
+        if isWindows then
+            startWrapper __SOURCE_DIRECTORY__ "powershell.exe" (sprintf """-ExecutionPolicy Bypass -File runfsac.ps1 "%s" """ fsacExePath)
+        else
+            startWrapper __SOURCE_DIRECTORY__ "sh" (sprintf """./runfsac.sh "%s" """ fsacExePath)
+
+    let mutable fsacProc : Process option = None
+
+    use p = start (fun (hostProc, s) ->
+        match s with
+        | FSACStartedMsg fsacPID ->
+            log "FSAC started"
+            let fsac = Process.GetProcessById fsacPID
+            fsacProc <- Some fsac
+
+            log "FSAC process found by PID"
+
+            // let's kill the host process
+            printfn "killing host (PID=%i)" hostProc.Id
+            log "killing host"
+            hostProc.Kill()
+            log "killed host"
+        | _ -> ()
+        )
+
+    let exited = p.WaitForExit(TimeSpan.FromSeconds(5.0).TotalMilliseconds |> int)
+
+    // check fsac shouldnt be alive
+    match exited, fsacProc with
+    | false, Some fsacProc ->
+        log "timeout out, with fsac running"
+    | false, None ->
+        log "timeout out, fsac not started"
+    | true, None ->
+        log "unexpected, exited without fsac process"
+    | true, Some fsacProc ->
+        log "waiting FSAC to quit"
+        let fsacExited =
+            retry (5, TimeSpan.FromSeconds(0.5)) (fun () ->
+                printfn "checking..."
+                let e = fsacProc.HasExited
+                e)
+            |> Async.RunSynchronously
+
+        log (sprintf "FSAC exited: %s" (fsacExited.ToString()))
+
+    // cleanup test, if needed
+    match fsacProc with
+    | Some proc when not (proc.HasExited) ->
+        printfn "cleanup test..."
+        try proc.Kill(); proc.Dispose() with _ -> ()
+    | _ -> ()
+
+run ()
+
+testOutput.ToString()
+|> writeNormalizedOutput "output.json"

--- a/test/FsAutoComplete.IntegrationTests/ZombieSlayer/output.json
+++ b/test/FsAutoComplete.IntegrationTests/ZombieSlayer/output.json
@@ -1,0 +1,6 @@
+FSAC started
+FSAC process found by PID
+killing host
+killed host
+waiting FSAC to quit
+FSAC exited: True

--- a/test/FsAutoComplete.IntegrationTests/ZombieSlayer/runfsac.ps1
+++ b/test/FsAutoComplete.IntegrationTests/ZombieSlayer/runfsac.ps1
@@ -1,0 +1,7 @@
+param (
+  [string] $FsacExePath
+)
+
+Write-Host "Host process: $pid"
+Write-Host "$FsacExePath --hostPID=$pid --verbose"
+& "$FsacExePath" @("--verbose", "--hostPID=$pid")

--- a/test/FsAutoComplete.IntegrationTests/ZombieSlayer/runfsac.sh
+++ b/test/FsAutoComplete.IntegrationTests/ZombieSlayer/runfsac.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -x
+echo Host process: $$
+
+# read _
+$1 --verbose --hostPID=$$

--- a/test/FsAutoComplete.IntegrationTests/ZombieSlayer/runfsac.sh
+++ b/test/FsAutoComplete.IntegrationTests/ZombieSlayer/runfsac.sh
@@ -2,4 +2,4 @@
 echo Host process: $$
 
 # read _
-$1 --verbose --hostPID=$$
+mono $1 --verbose --hostPID=$$


### PR DESCRIPTION
add `--hostPID` command line arg (optional)
used to pass the host process id, when that process exit then fsac will quit too

Pratically, client will pass its PID as `--hostPID=123`, and when that process die, also fsac will quit.
This should remove issues with zombie process.
in stdio will use the `Quit` command, and `exit` function on suave

ref https://github.com/fsharp/vim-fsharp/issues/94#issuecomment-314874375
ref https://github.com/ionide/ionide-vscode-fsharp/issues/374

- [x] stdio
- [x] suave
