### PR TITLE
Add structured signature command

### DIFF
--- a/src/FsAutoComplete.Core/CommandResponse.fs
+++ b/src/FsAutoComplete.Core/CommandResponse.fs
@@ -424,8 +424,8 @@ module CommandResponse =
       qualfies
       |> List.map (fun (name, q) ->
         {
-          Name = name
-          Qualifier = q
+          QualifySymbol.Name = name
+          QualifySymbol.Qualifier = q
         })
       |> List.toArray
 

--- a/src/FsAutoComplete.Core/CommandResponse.fs
+++ b/src/FsAutoComplete.Core/CommandResponse.fs
@@ -262,7 +262,15 @@ module CommandResponse =
     Position : Pos
   }
 
+  type Parameter = {
+    Name : string
+    Type : string
+  }
 
+  type SignatureData = {
+    OutputType : string
+    Parameters : Parameter list list
+  }
 
   let info (serialize : Serializer) (s: string) = serialize { Kind = "info"; Data = s }
 
@@ -291,7 +299,7 @@ module CommandResponse =
   let projectError (serialize : Serializer) errorDetails =
     match errorDetails with
     | GenericError errorMessage -> error serialize errorMessage //compatibility with old api
-    | ProjectNotRestored project -> errorG serialize (ErrorData.ProjectNotRestored { Project = project }) "Project not restored" 
+    | ProjectNotRestored project -> errorG serialize (ErrorData.ProjectNotRestored { Project = project }) "Project not restored"
 
   let completion (serialize : Serializer) (decls: FSharpDeclarationListItem[]) includeKeywords =
       serialize {  Kind = "completion"
@@ -321,6 +329,12 @@ module CommandResponse =
                       IsFromPattern = su.IsFromPattern
                       IsFromType = su.IsFromType } ] |> Seq.distinct |> Seq.toList }
     serialize { Kind = "symboluse"; Data = su }
+
+  let signatureData (serialize : Serializer) ((typ, parms) : string * ((string * string) list list) ) =
+    let pms =
+      parms
+      |> List.map (List.map (fun (n, t) -> { Name= n; Type = t }))
+    serialize { Kind = "signatureData"; Data = { Parameters = pms; OutputType = typ } }
 
   let help (serialize : Serializer) (data : string) =
     serialize { Kind = "help"; Data = data }

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -225,6 +225,9 @@ type Commands (serialize : Serializer) =
     member x.SymbolUse (tyRes : ParseAndCheckResults) (pos: Pos) lineStr =
         tyRes.TryGetSymbolUse pos lineStr |> x.SerializeResult Response.symbolUse
 
+    member x.SignatureData (tyRes : ParseAndCheckResults) (pos: Pos) lineStr =
+        tyRes.TryGetSignatureData pos lineStr |> x.SerializeResult Response.signatureData
+
     member x.Help (tyRes : ParseAndCheckResults) (pos: Pos) lineStr =
         tyRes.TryGetF1Help pos lineStr |> x.SerializeResult Response.help
 

--- a/src/FsAutoComplete.Suave/FsAutoComplete.Suave.fs
+++ b/src/FsAutoComplete.Suave/FsAutoComplete.Suave.fs
@@ -147,6 +147,7 @@ let main argv =
             path "/signature" >=> positionHandler (fun data tyRes lineStr _ -> commands.Typesig tyRes { Line = data.Line; Col = data.Column } lineStr)
             path "/symboluseproject" >=> positionHandler (fun data tyRes lineStr _ -> commands.SymbolUseProject tyRes { Line = data.Line; Col = data.Column } lineStr)
             path "/symboluse" >=> positionHandler (fun data tyRes lineStr _ -> commands.SymbolUse tyRes { Line = data.Line; Col = data.Column } lineStr)
+            path "/signatureData" >=> positionHandler (fun data tyRes lineStr _ -> commands.SignatureData tyRes { Line = data.Line; Col = data.Column } lineStr)
             path "/finddeclaration" >=> positionHandler (fun data tyRes lineStr _ -> commands.FindDeclarations tyRes { Line = data.Line; Col = data.Column } lineStr)
             path "/methods" >=> positionHandler (fun data tyRes _ lines   -> commands.Methods tyRes { Line = data.Line; Col = data.Column } lines)
             path "/help" >=> positionHandler (fun data tyRes line _   -> commands.Help tyRes { Line = data.Line; Col = data.Column } line)

--- a/src/FsAutoComplete/CommandInput.fs
+++ b/src/FsAutoComplete/CommandInput.fs
@@ -8,10 +8,11 @@ type PosCommand =
   | Completion
   | Methods
   | SymbolUse
-  | SymbolUseProject 
+  | SymbolUseProject
   | ToolTip
   | TypeSig
   | FindDeclaration
+  | SignatureData
 
 type ParseKind =
   | Normal
@@ -106,7 +107,9 @@ module CommandInput =
              (string "tooltip " |> Parser.map (fun _ -> ToolTip)) <|>
              (string "typesig " |> Parser.map (fun _ -> TypeSig)) <|>
              (string "methods " |> Parser.map (fun _ -> Methods)) <|>
-             (string "finddecl " |> Parser.map (fun _ -> FindDeclaration))
+             (string "finddecl " |> Parser.map (fun _ -> FindDeclaration)) <|>
+             (string "sigdata " |> Parser.map (fun _ -> SignatureData))
+
     let! _ = char '"'
     let! filename = some (sat ((<>) '"')) |> Parser.map String.OfSeq
     let! _ = char '"'
@@ -152,7 +155,7 @@ module CommandInput =
     | null -> Quit
     | input ->
       let reader = Parsing.createForwardStringReader input 0
-      let cmds = compilerlocation <|> helptext <|> declarations <|> lint <|> parse <|> project <|> completionTipOrDecl <|> quit <|> colorizations <|> error 
+      let cmds = compilerlocation <|> helptext <|> declarations <|> lint <|> parse <|> project <|> completionTipOrDecl <|> quit <|> colorizations <|> error
       let cmd = reader |> Parsing.getFirst cmds
       match cmd with
       | Parse (filename,kind,_) ->

--- a/src/FsAutoComplete/Program.fs
+++ b/src/FsAutoComplete/Program.fs
@@ -60,7 +60,7 @@ module internal Main =
                             | FindDeclaration -> commands.FindDeclarations tyRes pos lineStr
                             | Methods -> commands.Methods tyRes pos lines
                             | SymbolUseProject -> commands.SymbolUseProject tyRes pos lineStr
-
+                            | SignatureData -> commands.SignatureData tyRes pos lineStr
           | CompilerLocation -> return commands.CompilerLocation()
           | Colorization enabled -> commands.Colorization enabled; return []
           | Lint filename -> return! commands.Lint filename

--- a/test/FsAutoComplete.IntegrationTests/ProjectCache/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/ProjectCache/Runner.fsx
@@ -8,27 +8,29 @@ open System
  * A few completions, files and script.
  *)
 
+if Environment.OSVersion.Platform = PlatformID.Win32NT then
+    ()
+else
+    Environment.CurrentDirectory <- __SOURCE_DIRECTORY__
+    let cacheFile = Path.Combine("obj", "fsac.cache")
+    File.Delete "output.json"
+    if File.Exists cacheFile then File.Delete cacheFile
 
-Environment.CurrentDirectory <- __SOURCE_DIRECTORY__
-let cacheFile = Path.Combine("obj", "fsac.cache")
-File.Delete "output.json"
-if File.Exists cacheFile then File.Delete cacheFile
 
+    let p = new FsAutoCompleteWrapper()
 
-let p = new FsAutoCompleteWrapper()
+    p.project "Test1.fsproj"
+    p.waitForLine()
+    Threading.Thread.Sleep 2000
+    let msg1, time1 = if File.Exists cacheFile then "cache exists\n", File.GetLastWriteTimeUtc cacheFile else "cache doesn't exist\n", DateTime.MinValue
 
-p.project "Test1.fsproj"
-p.waitForLine()
-Threading.Thread.Sleep 2000
-let msg1, time1 = if File.Exists cacheFile then "cache exists\n", File.GetLastWriteTimeUtc cacheFile else "cache doesn't exist\n", DateTime.MinValue
+    File.WriteAllBytes("Test1.fsproj", File.ReadAllBytes "Test1.fsproj")
+    Threading.Thread.Sleep 2000
+    let time2 = if File.Exists cacheFile then File.GetLastWriteTimeUtc cacheFile else DateTime.MinValue
+    let msg2 = if time1 < time2 then "cache updated" else "cache not updated"
 
-File.WriteAllBytes("Test1.fsproj", File.ReadAllBytes "Test1.fsproj")
-Threading.Thread.Sleep 2000
-let time2 = if File.Exists cacheFile then File.GetLastWriteTimeUtc cacheFile else DateTime.MinValue
-let msg2 = if time1 < time2 then "cache updated" else "cache not updated"
-
-p.send "quit\n"
-p.finalOutput ()
-|> writeNormalizedOutput "output.json"
-File.AppendAllText("output.json", msg1)
-File.AppendAllText("output.json", msg2)
+    p.send "quit\n"
+    p.finalOutput ()
+    |> writeNormalizedOutput "output.json"
+    File.AppendAllText("output.json", msg1)
+    File.AppendAllText("output.json", msg2)


### PR DESCRIPTION
It adds command (both to Suave, and CLI versions) that returns structured information about symbol signature - output type and curried list of input parameters (giving name  and type of the parameter) .

Right now I'm using it for automatic comment generation, but it also could be used for things like CodeLenses (at the moment, I'm using tooltips + string manipulation for it which is super error prone)