### PR TITLE
Try to make declarations lookup faster

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -152,12 +152,16 @@ type Commands (serialize : Serializer) =
                             [Response.projectError serialize (GenericError (sprintf "expected ExtraProjectInfo after project parsing, was %A" x))]
     }
 
-    member __.Declarations file version = async {
+    member __.Declarations file lines version = async {
         let file = Path.GetFullPath file
         match state.TryGetFileCheckerOptionsWithSource file with
         | Failure s -> return [Response.error serialize s]
         | Success (checkOptions, source) ->
-            let! decls = checker.GetDeclarations(file, source, checkOptions, version)
+            let text = 
+                match lines with
+                | Some l -> String.concat "\n" l
+                | None -> source
+            let! decls = checker.GetDeclarations(file, text, checkOptions, version)
             let decls = decls |> Array.map (fun a -> a,file)
             return [Response.declarations serialize decls]
     }

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -141,7 +141,7 @@ type ParseAndCheckResults
         | Some "StartsWith" -> [| for d in results.Items do if d.Name.StartsWith(residue, StringComparison.InvariantCultureIgnoreCase) then yield d |]
         | Some "Contains" -> [| for d in results.Items do if d.Name.IndexOf(residue, StringComparison.InvariantCultureIgnoreCase) >= 0 then yield d |]
         | _ -> results.Items
-        
+
       let decls = decls |> Array.sortBy (fun d -> d.Name)
       return Some (decls, residue)
     with :? TimeoutException -> return None
@@ -365,22 +365,7 @@ type FSharpCompilerServiceChecker() =
   }
 
   member __.GetDeclarations (fileName, source, options, version) = async {
-    let! parseResult =
-      match checker.TryGetRecentCheckResultsForFile(fileName, options,source), version with
-      | Some (pr, _, v), Some ver when v = ver ->  async {return pr}
-      | _, None -> checker.ParseFileInProject(fileName, source, options)
-      | _ ->
-        async {
-          let! chkd =
-            checker.FileParsed
-            |> Event.filter (fun (fn,_) -> fn = fileName)
-            |> Async.AwaitEvent
-
-          return!
-            match checker.TryGetRecentCheckResultsForFile(fileName,options,source) with
-            | None -> checker.ParseFileInProject(fileName, source, options)
-            | Some (pr,_,_) -> async {return pr}
-        }
+    let! parseResult = checker.ParseFileInProject(fileName, source, options)
     return parseResult.GetNavigationItems().Declarations
   }
 

--- a/src/FsAutoComplete/FsAutoComplete.HttpApiContract.fs
+++ b/src/FsAutoComplete/FsAutoComplete.HttpApiContract.fs
@@ -2,7 +2,7 @@ module FsAutoComplete.HttpApiContract
 
 type ParseRequest = { FileName : string; IsAsync : bool; Lines : string[]; Version : int }
 type ProjectRequest = { FileName : string;}
-type DeclarationsRequest = {FileName : string; Version : int}
+type DeclarationsRequest = {FileName : string; Lines : string[]; Version : int}
 type HelptextRequest = {Symbol : string}
 type CompletionRequest = {FileName : string; SourceLine : string; Line : int; Column : int; Filter : string; IncludeKeywords : bool;}
 type PositionRequest = {FileName : string; Line : int; Column : int; Filter : string}

--- a/src/FsAutoComplete/FsAutoComplete.Stdio.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Stdio.fs
@@ -24,7 +24,7 @@ let main (commands: Commands) (commandQueue: BlockingCollection<Command>) =
 
           | Project (file, verbose) ->
               return! commands.Project file verbose (fun fullPath -> commandQueue.Add(Project (fullPath, verbose)))
-          | Declarations file -> return! commands.Declarations file None
+          | Declarations file -> return! commands.Declarations file None None
           | HelpText sym -> return commands.Helptext sym
           | PosCommand (cmd, file, lineStr, pos, _timeout, filter) ->
               let file = Path.GetFullPath file

--- a/src/FsAutoComplete/FsAutoComplete.Suave.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Suave.fs
@@ -98,7 +98,7 @@ let start (commands: Commands) (args: ParseResults<Options.CLIArguments>) =
             //TODO: Add filewatcher
             path "/parseProjectsInBackground" >=> handler (fun (data : ProjectRequest) -> commands.ParseAndCheckProjectsInBackgroundForFile data.FileName)
             path "/project" >=> handler (fun (data : ProjectRequest) -> commands.Project data.FileName false ignore)
-            path "/declarations" >=> handler (fun (data : DeclarationsRequest) -> commands.Declarations data.FileName (Some data.Version) )
+            path "/declarations" >=> handler (fun (data : DeclarationsRequest) -> commands.Declarations data.FileName (Some data.Lines) (Some data.Version) )
             path "/declarationsProjects" >=> fun httpCtx ->
                 async {
                     let! errors = commands.DeclarationsInProjects ()


### PR DESCRIPTION
Not really sure why  old version of `GetDeclarations` was doing it but it looks like it was waiting for full type check (unless the version of the file was already type checked before). I believe it's unnecessary because `ParseFileInProject` is fast on it's own (and will be even faster with some FCS' PR moving it out of reactor queue).
[And yes, I was author of old version, not really sure what I was thinking back then]

I've also changed HTTP Contact a bit - `declarations` request may pass also the content of the file - it's micro optimization for Ionide's CodeLenses. For CLI version I just pass None, and nothing has changed - file content is loaded from FSAC state. 