### PR TITLE
Change isOperator in Lexer.fs

### DIFF
--- a/src/FsAutoComplete.Core/Lexer.fs
+++ b/src/FsAutoComplete.Core/Lexer.fs
@@ -47,7 +47,7 @@ module Lexer =
         loop 0L []
 
     let inline private isIdentifier t = t.CharClass = FSharpTokenCharKind.Identifier
-    let inline private isOperator t = t.ColorClass = FSharpTokenColorKind.Operator
+    let inline private isOperator t = t.CharClass = FSharpTokenCharKind.Operator
     let inline private isKeyword t = t.ColorClass = FSharpTokenColorKind.Keyword
 
     let inline private (|GenericTypeParameterPrefix|StaticallyResolvedTypeParameterPrefix|ActivePattern|Other|) ((token: FSharpTokenInfo), (lineStr:string)) =


### PR DESCRIPTION
Found the issue in VSCode 1.17.1 with vscode-ionide-fsharp 3.5.1 on macOS 10.13.

I noticed in vscode-ionide that when creating an operator that begins with `>`, CodeLens wasn't working. That seemed to be true for any length operator beginning with `>`, e.g. `>>=`. If the operator began with `<`, CodeLens would fail only on that character, and then it'd work when a second character was added, e.g. `<` vs. `<*>`.

When CodeLens wasn't working, FSAC was returning `{Kind: "info", Data: "Cannot find ident for tooltip"}` to `signatureData` requests.

The `>` and `<` token info can be found [here](https://github.com/fsharp/FSharp.Compiler.Service/blob/13ecd8d4d080465bce4f49de72e4c13c6005e842/src/fsharp/vs/ServiceLexing.fs#L231). The color was changed from `FSharpTokenColorKind.Operator` to `FSharpTokenColorKind.Punctuation` back in February with [this commit](https://github.com/fsharp/FSharp.Compiler.Service/commit/c8bea744a2838c4c7ba3e67d66b0c2b0a754c225). The isOperator function predates this change, but wasn't updated to go with it.

With this change to `isOperator`, both `<` and `>` will be detected as operators again. However, the `INT32_DOT_DOT` token will also now be recognized as an operator where it wasn't previously by Lexer. Is it intended to not be selected as an operator for the purposes of FSAC?