### PR TITLE
Add find type declaration command

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -50,9 +50,9 @@ Target "BuildRelease" (fun _ ->
   MSBuildRelease "" "Build" ["./FsAutoComplete.sln"]
   |> Log "Build-Output: "
 
-  DotNetCli.Build (fun p ->
-     { p with
-         Project = "FsAutoComplete.netcore.sln" })
+  // DotNetCli.Build (fun p ->
+  //    { p with
+  //        Project = "FsAutoComplete.netcore.sln" })
 )
 
 let integrationTests =
@@ -287,10 +287,10 @@ Target "LocalRelease" (fun _ ->
     )
 
     CleanDirs [ "bin/release_netcore" ]
-    DotNetCli.Publish (fun p ->
-       { p with
-           Output = __SOURCE_DIRECTORY__ </> "bin/release_netcore"
-           Project = "src/FsAutoComplete.netcore" })
+    // DotNetCli.Publish (fun p ->
+    //    { p with
+    //        Output = __SOURCE_DIRECTORY__ </> "bin/release_netcore"
+    //        Project = "src/FsAutoComplete.netcore" })
 )
 
 #load "paket-files/build/fsharp/FAKE/modules/Octokit/Octokit.fsx"

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -315,6 +315,11 @@ type Commands (serialize : Serializer) =
         |> x.SerializeResult (Response.findDeclaration, Response.error)
         |> x.AsCancellable (Path.GetFullPath tyRes.FileName)
 
+    member x.FindTypeDeclaration (tyRes : ParseAndCheckResults) (pos: Pos) lineStr =
+        tyRes.TryFindTypeDeclaration pos lineStr
+        |> x.SerializeResult (Response.findDeclaration, Response.error)
+        |> x.AsCancellable (Path.GetFullPath tyRes.FileName)
+
     member x.Methods (tyRes : ParseAndCheckResults) (pos: Pos) (lines: LineStr[]) =
         tyRes.TryGetMethodOverrides lines pos
         |> x.SerializeResult (Response.methods, Response.error)

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -80,9 +80,8 @@ type ParseAndCheckResults
           | SymbolUse.Property p -> p.FullTypeSafe |> Option.map (fun f -> f.TypeDefinition.DeclarationLocation)
           | _ -> None
         match r with
-        | None -> return Error "No type information for the symbol at this location"
-        | Some r ->
-          return (Ok r)
+        | Some r when File.Exists r.FileName -> return (Ok r)
+        | _ -> return Error "No type information for the symbol at this location"
 
   }
 

--- a/src/FsAutoComplete/CommandInput.fs
+++ b/src/FsAutoComplete/CommandInput.fs
@@ -12,6 +12,7 @@ type PosCommand =
   | ToolTip
   | TypeSig
   | FindDeclaration
+  | FindTypeDeclaration
   | SignatureData
 
 type ParseKind =
@@ -146,6 +147,7 @@ module CommandInput =
              (string "typesig " |> Parser.map (fun _ -> TypeSig)) <|>
              (string "methods " |> Parser.map (fun _ -> Methods)) <|>
              (string "finddecl " |> Parser.map (fun _ -> FindDeclaration)) <|>
+             (string "findtypedecl " |> Parser.map (fun _ -> FindTypeDeclaration)) <|>
              (string "sigdata " |> Parser.map (fun _ -> SignatureData))
 
     let! _ = char '"'

--- a/src/FsAutoComplete/FsAutoComplete.Stdio.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Stdio.fs
@@ -50,6 +50,7 @@ let main (commands: Commands) (commandQueue: BlockingCollection<Command>) =
                             | TypeSig -> commands.Typesig tyRes pos lineStr
                             | SymbolUse -> commands.SymbolUse tyRes pos lineStr
                             | FindDeclaration -> commands.FindDeclaration tyRes pos lineStr
+                            | FindTypeDeclaration -> commands.FindTypeDeclaration tyRes pos lineStr
                             | Methods -> commands.Methods tyRes pos lines
                             | SymbolUseProject -> commands.SymbolUseProject tyRes pos lineStr
                             | SignatureData -> commands.SignatureData tyRes pos lineStr

--- a/src/FsAutoComplete/FsAutoComplete.Suave.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Suave.fs
@@ -135,6 +135,7 @@ let start (commands: Commands) (args: ParseResults<Options.CLIArguments>) =
             path "/symboluse" >=> positionHandler (fun data tyRes lineStr _ -> commands.SymbolUse tyRes { Line = data.Line; Col = data.Column } lineStr)
             path "/signatureData" >=> positionHandler (fun data tyRes lineStr _ -> commands.SignatureData tyRes { Line = data.Line; Col = data.Column } lineStr)
             path "/finddeclaration" >=> positionHandler (fun data tyRes lineStr _ -> commands.FindDeclaration tyRes { Line = data.Line; Col = data.Column } lineStr)
+            path "/findtypedeclaration" >=> positionHandler (fun data tyRes lineStr _ -> commands.FindTypeDeclaration tyRes { Line = data.Line; Col = data.Column } lineStr)
             path "/methods" >=> positionHandler (fun data tyRes _ lines   -> commands.Methods tyRes { Line = data.Line; Col = data.Column } lines)
             path "/help" >=> positionHandler (fun data tyRes line _   -> commands.Help tyRes { Line = data.Line; Col = data.Column } line)
             path "/compilerlocation" >=> fun httpCtx ->
@@ -160,7 +161,7 @@ let start (commands: Commands) (args: ParseResults<Options.CLIArguments>) =
 
 #if SUAVE_2
     let logger = Suave.Logging.LiterateConsoleTarget([| "FsAutoComplete" |], Logging.Info)
-    let serverConfig = 
+    let serverConfig =
         { serverConfig with logger = logger }
 #endif
 


### PR DESCRIPTION
It lets you to find declaration location of the type of the given symbols. Work if type is simple type (class, record, enum, union etc) defined in local workspace. 