### PR TITLE
remove ConcurrentDictionary.ToSeq because is not safe on concurrent collections

### DIFF
--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -368,9 +368,6 @@ type ConcurrentDictionary<'key, 'value> with
         | true, value -> Some value
         | _ -> None
 
-    member x.ToSeq() =
-        x |> Seq.map (fun (KeyValue(k, v)) -> k, v)
-
 type Path with
     static member GetFullPathSafe path =
         try Path.GetFullPath path


### PR DESCRIPTION
use .ToArray() who is thread safe. enumerator was thread safe too, but is not a snapshot in time ( https://msdn.microsoft.com/en-us/library/dd287115(v=vs.110).aspx )
