### PR TITLE
fix project parsing of netcore

### DIFF
--- a/src/FsAutoComplete.Core/FscArguments.fs
+++ b/src/FsAutoComplete.Core/FscArguments.fs
@@ -41,7 +41,7 @@ module FscArguments =
         prefix + (v |> makeAbs projDir)
     | None ->
         if isCompileFile s then
-            s |> makeAbs projDir
+            s |> makeAbs projDir |> Path.GetFullPath
         else
             s
 


### PR DESCRIPTION
fix https://github.com/fsharp/FsAutoComplete/issues/254

convert all relative path to full, like `/path/to/../relative/file.fs` -> `/path/relative/file.fs` for the source files paths of the fsc args list