### PR TITLE
add vscode debug conf

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core mode http (debug)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build_debug_netcore",
+            "program": "${workspaceFolder}/src/FsAutoComplete.netcore/bin/Debug/netcoreapp2.0/fsautocomplete.dll",
+            "args": ["--mode", "http"],
+            "cwd": "${workspaceFolder}",
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,6 +11,12 @@
                 "kind": "build",
                 "isDefault": true
             }
+        },
+        {
+            "taskName": "build_debug_netcore",
+            "type": "shell",
+            "command": "dotnet build src/FsAutoComplete.netcore",
+            "group": "build"
         }
     ]
 }


### PR DESCRIPTION
New configuration:

- `NET Core mode http (debug)` to start .net core fsac in http mode

usefull to pass additional arguments too