### PR TITLE
fix flacky workspaceLoad integration tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    //otherwise take a lot of time to load proj inside
+    //the test directories
+    "omnisharp.autoStart": false
+}

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -698,3 +698,8 @@ type Commands (serialize : Serializer) =
                     let! unused = UnusedOpens.getUnusedOpens(tyRes.GetCheckResults, fun i -> source.[i - 1])
                     return [ Response.unusedOpens serialize (unused |> List.toArray) ]
         } |> x.AsCancellable file
+
+    member __.Quit () =
+        async {
+            return [ Response.info serialize "quitting..." ]
+        }

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -636,7 +636,10 @@ type Commands (serialize : Serializer) =
             // this is to delay the project loading notification (of this thread)
             // after the workspaceload started response returned below in outer async
             // Make test output repeteable, and notification in correct order
-            do! Async.Sleep(TimeSpan.FromMilliseconds(250.0).TotalMilliseconds |> int)
+            match Environment.workspaceLoadDelay() with
+            | delay when delay > TimeSpan.Zero ->
+                do! Async.Sleep(Environment.workspaceLoadDelay().TotalMilliseconds |> int)
+            | _ -> ()
 
             do! Workspace.loadInBackground onLoaded false files
 

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -629,7 +629,10 @@ type Commands (serialize : Serializer) =
                     |> NotificationEvent.Workspace
                     |> notify.Trigger
 
-            // HACK really ugly
+            Response.workspaceLoad serialize false
+            |> NotificationEvent.Workspace
+            |> notify.Trigger
+
             // this is to delay the project loading notification (of this thread)
             // after the workspaceload started response returned below in outer async
             // Make test output repeteable, and notification in correct order

--- a/src/FsAutoComplete.Core/Environment.fs
+++ b/src/FsAutoComplete.Core/Environment.fs
@@ -138,3 +138,11 @@ module Environment =
     |> Array.sortWith (fun x y -> StringComparer.OrdinalIgnoreCase.Compare(x, y))
     |> Array.rev
     |> Array.tryHead
+
+  let workspaceLoadDelay () =
+    match System.Environment.GetEnvironmentVariable("FSAC_WORKSPACELOAD_DELAY") with
+    | delayMs when not (String.IsNullOrWhiteSpace(delayMs)) ->
+        match System.Int32.TryParse(delayMs) with
+        | true, x -> TimeSpan.FromMilliseconds(float x)
+        | false, _ -> TimeSpan.Zero
+    | _ -> TimeSpan.Zero

--- a/src/FsAutoComplete/FsAutoComplete.HttpApiContract.fs
+++ b/src/FsAutoComplete/FsAutoComplete.HttpApiContract.fs
@@ -9,3 +9,4 @@ type PositionRequest = {FileName : string; Line : int; Column : int; Filter : st
 type FileRequest = {FileName : string}
 type WorkspacePeekRequest = {Directory : string; Deep: int; ExcludedDirs: string array}
 type WorkspaceLoadRequest = {Files : string array}
+type QuitRequest() = class end

--- a/src/FsAutoComplete/FsAutoComplete.Stdio.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Stdio.fs
@@ -90,7 +90,7 @@ let main (commands: Commands) (commandQueue: BlockingCollection<Command>) =
           | Error msg -> return commands.Error msg
           | Quit ->
               quit <- true
-              return []
+              return! commands.Quit()
       }
       |> Async.Catch
       |> Async.RunSynchronously

--- a/test/FsAutoComplete.IntegrationTests/Colorizations/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/Colorizations/Runner.fsx
@@ -13,7 +13,7 @@ p.send "colorizations true\n"
 p.parse "Script.fsx"
 p.send "colorizations false\n"
 p.parse "Script.fsx"
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/Colorizations/output.json
+++ b/test/FsAutoComplete.IntegrationTests/Colorizations/output.json
@@ -35,3 +35,7 @@
     "Errors": []
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/CompletionFilter/CompletionFilterRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/CompletionFilter/CompletionFilterRunner.fsx
@@ -18,6 +18,6 @@ p.parse "Script.fsx"
 p.completion "Script.fsx" "X.T" 8 4
 p.completionFilter "Script.fsx" "X.T" 8 4 "StartsWith"
 p.completionFilter "Script.fsx" "X.T" 8 4 "Contains"
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"

--- a/test/FsAutoComplete.IntegrationTests/CompletionFilter/output.json
+++ b/test/FsAutoComplete.IntegrationTests/CompletionFilter/output.json
@@ -150,3 +150,7 @@
     }
   ]
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/DotNetCore/AppAndLibRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetCore/AppAndLibRunner.fsx
@@ -23,7 +23,7 @@ let doIt () =
     p.project "sample1/c1/c1.fsproj"
     p.parse "sample1/c1/Program.fs"
 
-    p.send "quit\n"
+    p.quit()
     p.finalOutput ()
     |> writeNormalizedOutput outputJson
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetCore/MissingSourceFile.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetCore/MissingSourceFile.fsx
@@ -25,7 +25,7 @@ let doIt () =
     p.project "sample4/c1/c1.fsproj"
     p.parse "sample4/c1/Program.fs"
 
-    p.send "quit\n"
+    p.quit()
     p.finalOutput ()
     |> writeNormalizedOutput outputJson
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetCore/NotRestoredRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetCore/NotRestoredRunner.fsx
@@ -23,7 +23,7 @@ let doIt () =
 
   p.project "sample1/c1/c1.fsproj"
 
-  p.send "quit\n"
+  p.quit()
   p.finalOutput ()
   |> writeNormalizedOutput outputJson
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetCore/WorkspacePeekRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetCore/WorkspacePeekRunner.fsx
@@ -22,7 +22,7 @@ let doIt () =
 
     p.workspacepeek (Path.Combine(__SOURCE_DIRECTORY__, "sample1")) 1
 
-    p.send "quit\n"
+    p.quit()
     p.finalOutput ()
     |> writeNormalizedOutput outputJson
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetCore/appandlib.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetCore/appandlib.json
@@ -119,3 +119,7 @@
     "Errors": []
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/DotNetCore/notrestored.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetCore/notrestored.json
@@ -8,3 +8,7 @@
     }
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/DotNetCore/workspacepeek.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetCore/workspacepeek.json
@@ -44,3 +44,7 @@
     ]
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/DotNetCoreCrossgen/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetCoreCrossgen/Runner.fsx
@@ -22,7 +22,7 @@ let doIt () =
     p.project "sample1/c1/c1.fsproj"
     p.parse "sample1/c1/Program.fs"
 
-    p.send "quit\n"
+    p.quit()
     p.finalOutput ()
     |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetCoreCrossgen/output.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetCoreCrossgen/output.json
@@ -122,3 +122,7 @@
     "Errors": []
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/DotNetCoreCrossgenWithNetFx/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetCoreCrossgenWithNetFx/Runner.fsx
@@ -24,7 +24,7 @@ let doIt () =
     p.project "sample1/c1/c1.fsproj"
     p.parse "sample1/c1/Program.fs"
 
-    p.send "quit\n"
+    p.quit()
     p.finalOutput ()
     |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetCoreCrossgenWithNetFx/output.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetCoreCrossgenWithNetFx/output.json
@@ -58,3 +58,7 @@
     "Errors": []
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/DotNetCoreWithOtherDotnetLang/FSharpOuterRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetCoreWithOtherDotnetLang/FSharpOuterRunner.fsx
@@ -26,7 +26,7 @@ let doIt () =
         p.project "sampleo/c1/c1.fsproj"
         p.parse "sampleo/c1/Program.fs"
 
-        p.send "quit\n"
+        p.quit()
         p.finalOutput ()
         |> writeNormalizedOutput "fsharpouter.json"
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetCoreWithOtherDotnetLang/fsharpouter.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetCoreWithOtherDotnetLang/fsharpouter.json
@@ -119,3 +119,7 @@
     "Errors": []
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/AppAndLibRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/AppAndLibRunner.fsx
@@ -22,7 +22,7 @@ let doIt () =
     p.project "sample1/c1/c1.fsproj"
     p.parse "sample1/c1/Program.fs"
 
-    p.send "quit\n"
+    p.quit()
     p.finalOutput ()
     |> writeNormalizedOutput "appandlib.json"
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/InvalidProjectFileRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/InvalidProjectFileRunner.fsx
@@ -22,7 +22,7 @@ let doIt () =
 
   p.project "sample3/l1/l1.fsproj"
 
-  p.send "quit\n"
+  p.quit()
   p.finalOutput ()
   |> writeNormalizedOutput outputJson
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/MissingSourceFile.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/MissingSourceFile.fsx
@@ -25,7 +25,7 @@ let doIt () =
     p.project "sample4/c1/c1.fsproj"
     p.parse "sample4/c1/Program.fs"
 
-    p.send "quit\n"
+    p.quit()
     p.finalOutput ()
     |> writeNormalizedOutput missingfsJson
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/NotRestoredRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/NotRestoredRunner.fsx
@@ -23,7 +23,7 @@ let doIt () =
 
   p.project "sample1/c1/c1.fsproj"
 
-  p.send "quit\n"
+  p.quit()
   p.finalOutput ()
   |> writeNormalizedOutput outputJson
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/SignatureFile.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/SignatureFile.fsx
@@ -23,7 +23,7 @@ let doIt () =
     p.parse "sample2/l1/Module1.fsi"
     p.parse "sample2/l1/Module1.fs"
 
-    p.send "quit\n"
+    p.quit()
     p.finalOutput ()
     |> writeNormalizedOutput "signfile.json"
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/WorkspaceLoadRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/WorkspaceLoadRunner.fsx
@@ -27,7 +27,7 @@ let doIt () =
     let expectedNotificationCount = 7
     p.awaitNotification (fun (o) -> o.Contains("""{"Status":"finished"}""")) expectedNotificationCount
 
-    p.send "quit\n"
+    p.quit()
     p.finalOutput ()
     |> writeNormalizedOutput outputJson
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/WorkspaceLoadRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/WorkspaceLoadRunner.fsx
@@ -24,7 +24,8 @@ let doIt () =
 
     p.workspaceload [ (Path.Combine(__SOURCE_DIRECTORY__, "sample1/c1/c1.fsproj")); (Path.Combine(__SOURCE_DIRECTORY__, "sample1/l1/l1.fsproj")) ]
 
-    p.awaitNotification (fun (o) -> o.Contains("""{"Status":"finished"}""")) 6
+    let expectedNotificationCount = 7
+    p.awaitNotification (fun (o) -> o.Contains("""{"Status":"finished"}""")) expectedNotificationCount
 
     p.send "quit\n"
     p.finalOutput ()

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/WorkspacePeekRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/WorkspacePeekRunner.fsx
@@ -22,7 +22,7 @@ let doIt () =
 
     p.workspacepeek (Path.Combine(__SOURCE_DIRECTORY__, "sample1")) 1
 
-    p.send "quit\n"
+    p.quit()
     p.finalOutput ()
     |> writeNormalizedOutput outputJson
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/appandlib.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/appandlib.json
@@ -187,3 +187,7 @@
     "Errors": []
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/invalidprojectfile.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/invalidprojectfile.json
@@ -8,3 +8,7 @@
     }
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/notrestored.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/notrestored.json
@@ -8,3 +8,7 @@
     }
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/workspaceload.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/workspaceload.json
@@ -5,6 +5,12 @@
   }
 }
 {
+  "Kind": "workspaceLoad",
+  "Data": {
+    "Status": "started"
+  }
+}
+{
   "Kind": "projectLoading",
   "Data": {
     "Project": "<absolute path removed>/FsAutoComplete.IntegrationTests/DotNetSdk2.0/sample1/c1/c1.fsproj"

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/workspaceload.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/workspaceload.json
@@ -300,3 +300,7 @@
     "Status": "finished"
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/workspacepeek.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0/workspacepeek.json
@@ -44,3 +44,7 @@
     ]
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0Crossgen/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0Crossgen/Runner.fsx
@@ -22,7 +22,7 @@ let doIt () =
     p.project "sample1/c1/c1.fsproj"
     p.parse "sample1/c1/Program.fs"
 
-    p.send "quit\n"
+    p.quit()
     p.finalOutput ()
     |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0Crossgen/output.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0Crossgen/output.json
@@ -190,3 +190,7 @@
     "Errors": []
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0CrossgenWithNetFx/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0CrossgenWithNetFx/Runner.fsx
@@ -24,7 +24,7 @@ let doIt () =
     p.project "sample1/c1/c1.fsproj"
     p.parse "sample1/c1/Program.fs"
 
-    p.send "quit\n"
+    p.quit()
     p.finalOutput ()
     |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0CrossgenWithNetFx/output.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0CrossgenWithNetFx/output.json
@@ -59,3 +59,7 @@
     "Errors": []
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0WithOtherDotnetLang/FSharpOuterRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0WithOtherDotnetLang/FSharpOuterRunner.fsx
@@ -26,7 +26,7 @@ let doIt () =
       p.project "sampleo/c1/c1.fsproj"
       p.parse "sampleo/c1/Program.fs"
 
-      p.send "quit\n"
+      p.quit()
       p.finalOutput ()
       |> writeNormalizedOutput "fsharpouter.json"
 

--- a/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0WithOtherDotnetLang/fsharpouter.json
+++ b/test/FsAutoComplete.IntegrationTests/DotNetSdk2.0WithOtherDotnetLang/fsharpouter.json
@@ -187,3 +187,7 @@
     "Errors": []
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/ErrorTestsJson/ErrorsRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/ErrorTestsJson/ErrorsRunner.fsx
@@ -14,7 +14,7 @@ p.parse "Program.fs"
 p.parse "Script.fsx"
 p.completion "Program.fs" "let val2 = X.func 2" 6 14
 p.completion "Script.fsx" "let val2 = X.func 2" 6 14
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/ErrorTestsJson/output.json
+++ b/test/FsAutoComplete.IntegrationTests/ErrorTestsJson/output.json
@@ -142,3 +142,7 @@
     }
   ]
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/FindDeclarations/FindDeclRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/FindDeclarations/FindDeclRunner.fsx
@@ -22,6 +22,6 @@ p.finddeclaration "Program.fs" "let val3 = testval.Terrific val2" 8 20
 p.finddeclaration "Program.fs" "    printfn \\\"Hello %d\\\" val2" 14 26
 p.finddeclaration "Program.fs" "let val4 : FileTwo.NewObjectType = testval" 10 20
 p.finddeclaration "Script.fsx" "let val99 = XA.funky 21" 6 17
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"

--- a/test/FsAutoComplete.IntegrationTests/FindDeclarations/output.json
+++ b/test/FsAutoComplete.IntegrationTests/FindDeclarations/output.json
@@ -97,3 +97,7 @@
     "Column": 7
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/Linter/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/Linter/Runner.fsx
@@ -10,6 +10,6 @@ let p = new FsAutoCompleteWrapper()
 
 p.parse "Script.fsx"
 p.lint "Script.fsx"
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"

--- a/test/FsAutoComplete.IntegrationTests/Linter/output.json
+++ b/test/FsAutoComplete.IntegrationTests/Linter/output.json
@@ -165,3 +165,7 @@
     }
   ]
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/LinterWithOptions/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/LinterWithOptions/Runner.fsx
@@ -10,6 +10,6 @@ let p = new FsAutoCompleteWrapper()
 
 p.parse "Script.fsx"
 p.lint "Script.fsx"
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"

--- a/test/FsAutoComplete.IntegrationTests/LinterWithOptions/output.json
+++ b/test/FsAutoComplete.IntegrationTests/LinterWithOptions/output.json
@@ -13,3 +13,7 @@
   "Kind": "lint",
   "Data": []
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/MultiProj/MultiProjRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/MultiProj/MultiProjRunner.fsx
@@ -38,7 +38,7 @@ p.completion "Proj2/Program.fs" "let testval = FileTwo.NewObjectType()" 4 23
 p.completion "Proj2/Program.fs" "let val2 = X.func 2" 6 14
 p.completion "Proj2/Program.fs" "let val4 : FileTwo.NewObjectType = testval" 10 20
 
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/MultiProj/WorkspacePeekRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/MultiProj/WorkspacePeekRunner.fsx
@@ -10,7 +10,7 @@ let p = new FsAutoCompleteWrapper()
 
 p.workspacepeek __SOURCE_DIRECTORY__ 2
 
-p.send "quit\n"
+p.quit()
 
 p.finalOutput ()
 |> writeNormalizedOutput "workspacepeek.json"

--- a/test/FsAutoComplete.IntegrationTests/MultiProj/output.json
+++ b/test/FsAutoComplete.IntegrationTests/MultiProj/output.json
@@ -878,3 +878,7 @@
     }
   ]
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/MultiProj/workspacepeek.json
+++ b/test/FsAutoComplete.IntegrationTests/MultiProj/workspacepeek.json
@@ -70,3 +70,7 @@
     ]
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/MultipleUnsavedFiles/multunsavedRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/MultipleUnsavedFiles/multunsavedRunner.fsx
@@ -22,6 +22,6 @@ module FileTwo
 let addTwo2 x y = x + y
 """
 p.parse "Program.fs"
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"

--- a/test/FsAutoComplete.IntegrationTests/MultipleUnsavedFiles/output.json
+++ b/test/FsAutoComplete.IntegrationTests/MultipleUnsavedFiles/output.json
@@ -79,3 +79,7 @@
     ]
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/NoFSharpCoreReference/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/NoFSharpCoreReference/Runner.fsx
@@ -15,7 +15,7 @@ let p = new FsAutoCompleteWrapper()
 
 
 p.project "Test1.fsproj"
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/NoFSharpCoreReference/output.json
+++ b/test/FsAutoComplete.IntegrationTests/NoFSharpCoreReference/output.json
@@ -24,3 +24,7 @@
     "AdditionalInfo": {}
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/OldSdk/InvalidProjectFileRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/OldSdk/InvalidProjectFileRunner.fsx
@@ -23,7 +23,7 @@ let doIt () =
   p.project "sample3/l1/Test1.fsproj"
   p.parse "sample3/l1/Module1.fs"
 
-  p.send "quit\n"
+  p.quit()
   p.finalOutput ()
   |> writeNormalizedOutputWith normalizedOutputRemoveToolsList invalidprojectfileJson
 

--- a/test/FsAutoComplete.IntegrationTests/OldSdk/MissingSourceFile.fsx
+++ b/test/FsAutoComplete.IntegrationTests/OldSdk/MissingSourceFile.fsx
@@ -13,7 +13,7 @@ let doIt () =
   p.project "sample4/l1/Test1.fsproj"
   p.parse "sample4/l1/Module1.fs"
 
-  p.send "quit\n"
+  p.quit()
   p.finalOutput ()
   |> writeNormalizedOutput outputJson
 

--- a/test/FsAutoComplete.IntegrationTests/OldSdk/SignatureFile.fsx
+++ b/test/FsAutoComplete.IntegrationTests/OldSdk/SignatureFile.fsx
@@ -13,7 +13,7 @@ let doIt () =
   p.parse "sample2/l1/Module1.fsi"
   p.parse "sample2/l1/Module1.fs"
 
-  p.send "quit\n"
+  p.quit()
   p.finalOutput ()
   |> writeNormalizedOutput "signfile.json"
 

--- a/test/FsAutoComplete.IntegrationTests/OldSdk/invalidprojectfile.json
+++ b/test/FsAutoComplete.IntegrationTests/OldSdk/invalidprojectfile.json
@@ -19,3 +19,7 @@
     "Errors": []
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/OldSdk/invalidprojectfile.netcore.json
+++ b/test/FsAutoComplete.IntegrationTests/OldSdk/invalidprojectfile.netcore.json
@@ -19,3 +19,7 @@
     "Errors": []
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/OutOfRange/OutOfRangeRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/OutOfRange/OutOfRangeRunner.fsx
@@ -25,7 +25,7 @@ p.finddeclaration "Script.fsx" "let val99 = XA." 6 15
 p.finddeclaration "Script.fsx" "let val99 = XA." 6 16
 p.finddeclaration "Script.fsx" "let val99 = XA." 6 17
 
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/OutOfRange/output.json
+++ b/test/FsAutoComplete.IntegrationTests/OutOfRange/output.json
@@ -143,3 +143,7 @@
     "AdditionalData": {}
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/ParamCompletion/ParamCompletionRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/ParamCompletion/ParamCompletionRunner.fsx
@@ -24,6 +24,6 @@ p.methods "Program.fs" "let val3 = testval.Terrific(val2, 'c')" 13 30
 p.methods "Program.fs" "let val3 = testval.Terrific(val2, 'c')" 13 35
 p.methods "Program.fs" "let val4 = MyDateTime.Parse(\\\"hello\\\")" 15 34
 p.methods "Program.fs" "          \\\"hello\\\"" 19 3
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"

--- a/test/FsAutoComplete.IntegrationTests/ParamCompletion/output.json
+++ b/test/FsAutoComplete.IntegrationTests/ParamCompletion/output.json
@@ -426,3 +426,7 @@
     ]
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/ProjectCache/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/ProjectCache/Runner.fsx
@@ -27,7 +27,7 @@ Threading.Thread.Sleep 2000
 let time2 = if File.Exists cacheFile then File.GetLastWriteTimeUtc cacheFile else DateTime.MinValue
 let msg2 = if time1 < time2 then "cache updated" else "cache not updated"
 
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"
 File.AppendAllText("output.json", msg1)

--- a/test/FsAutoComplete.IntegrationTests/ProjectReload/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/ProjectReload/Runner.fsx
@@ -18,7 +18,7 @@ p.waitForLine()
 Threading.Thread.Sleep 2000
 File.WriteAllBytes("Test1.fsproj", File.ReadAllBytes "Test1.fsproj")
 Threading.Thread.Sleep 2000
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/ProjectReload/output.json
+++ b/test/FsAutoComplete.IntegrationTests/ProjectReload/output.json
@@ -48,3 +48,7 @@
     "AdditionalInfo": {}
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/RawIdTest/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/RawIdTest/Runner.fsx
@@ -23,7 +23,7 @@ p.completion "Test-Module.fsx" "X." 9 3
 p.completion "Test-Class.fsx" "Y." 9 3
 // p.completion "Test-Class.fsx" "Y.``Column T" 11 13
 // p.completion "Test-Class.fsx" "Y.``Another`C" 13 14
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/RawIdTest/output.json
+++ b/test/FsAutoComplete.IntegrationTests/RawIdTest/output.json
@@ -264,3 +264,7 @@
     }
   ]
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/RobustCommands/CompleteBadPositionRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/RobustCommands/CompleteBadPositionRunner.fsx
@@ -12,7 +12,7 @@ p.project "Project/Test1.fsproj"
 p.parse "Project/Program.fs"
 p.completion "Project/Program.fs" "whatever" 50 1
 p.completion "Project/Program.fs" "module X =" 1 100
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "completebadposition.json"
 

--- a/test/FsAutoComplete.IntegrationTests/RobustCommands/CompleteNoSuchFileRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/RobustCommands/CompleteNoSuchFileRunner.fsx
@@ -10,7 +10,7 @@ let p = new FsAutoCompleteWrapper()
 
 p.project "Project/Test1.fsproj"
 p.completion "NoSuchFile.fs" "whatever" 1 1
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "completenosuchfile.json"
 

--- a/test/FsAutoComplete.IntegrationTests/RobustCommands/CompleteWithoutProjectRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/RobustCommands/CompleteWithoutProjectRunner.fsx
@@ -12,7 +12,7 @@ p.parse "Project/Script.fsx"
 p.completion "Project/Script.fsx" "let val2 = X.func 2" 6 14
 p.parse "Project/Program.fs"
 p.completion "Project/Program.fs" "let testval = FileTwo.NewObjectType()" 4 23
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "completewithoutproject.json"
 

--- a/test/FsAutoComplete.IntegrationTests/RobustCommands/NoSuchCommandRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/RobustCommands/NoSuchCommandRunner.fsx
@@ -9,7 +9,7 @@ File.Delete "nosuchcommand.json"
 let p = new FsAutoCompleteWrapper()
 
 p.send "BadCommand\n"
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "nosuchcommand.json"
 

--- a/test/FsAutoComplete.IntegrationTests/RobustCommands/NoSuchProjectRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/RobustCommands/NoSuchProjectRunner.fsx
@@ -9,7 +9,7 @@ File.Delete "nosuchproject.json"
 let p = new FsAutoCompleteWrapper()
 
 p.project "NoSuchProject.fsproj"
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "nosuchproject.json"
 

--- a/test/FsAutoComplete.IntegrationTests/RobustCommands/ParseNoSuchFileRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/RobustCommands/ParseNoSuchFileRunner.fsx
@@ -10,7 +10,7 @@ let p = new FsAutoCompleteWrapper()
 
 p.project "Project/Test1.fsproj"
 p.parseContent "NoSuchFile.fs" "Bla bla bla"
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "parsenosuchfile.json"
 

--- a/test/FsAutoComplete.IntegrationTests/RobustCommands/completebadposition.json
+++ b/test/FsAutoComplete.IntegrationTests/RobustCommands/completebadposition.json
@@ -51,3 +51,7 @@
     "AdditionalData": {}
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/RobustCommands/completenosuchfile.json
+++ b/test/FsAutoComplete.IntegrationTests/RobustCommands/completenosuchfile.json
@@ -32,3 +32,7 @@
     "AdditionalData": {}
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/RobustCommands/completewithoutproject.json
+++ b/test/FsAutoComplete.IntegrationTests/RobustCommands/completewithoutproject.json
@@ -72,3 +72,7 @@
   "Kind": "completion",
   "Data": []
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/RobustCommands/nosuchcommand.json
+++ b/test/FsAutoComplete.IntegrationTests/RobustCommands/nosuchcommand.json
@@ -6,3 +6,7 @@
     "AdditionalData": {}
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/RobustCommands/nosuchproject.json
+++ b/test/FsAutoComplete.IntegrationTests/RobustCommands/nosuchproject.json
@@ -8,3 +8,7 @@
     }
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/RobustCommands/parsenosuchfile.json
+++ b/test/FsAutoComplete.IntegrationTests/RobustCommands/parsenosuchfile.json
@@ -46,3 +46,7 @@
     ]
   }
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/SymOpActivePatTooltips/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/SymOpActivePatTooltips/Runner.fsx
@@ -31,7 +31,7 @@ p.tooltip "Script.fsx" "let val99 = 1 |<>| 1 |..| 1" 6 27
 p.tooltip "Script.fsx" "let (|Zero|Succ|) n = if n = 0 then Zero else Succ(n-1)" 8 7
 p.tooltip "Script.fsx" "let (|Zero|Succ|) n = if n = 0 then Zero else Succ(n-1)" 8 11
 p.tooltip "Script.fsx" "let (|Zero|Succ|) n = if n = 0 then Zero else Succ(n-1)" 8 16
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/SymOpActivePatTooltips/output.json
+++ b/test/FsAutoComplete.IntegrationTests/SymOpActivePatTooltips/output.json
@@ -181,3 +181,7 @@
     ]
   ]
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/SymbolUse/SymbolUseRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/SymbolUse/SymbolUseRunner.fsx
@@ -26,7 +26,7 @@ p.symboluse "Program.fs" "let shadowed = " 12 13 //shadowed end
 p.symboluse "Script.fsx" "    console.undefinedsymbol 3" 6 17 // no uses due to compile error
 
 Threading.Thread.Sleep(1000)
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/SymbolUse/output.json
+++ b/test/FsAutoComplete.IntegrationTests/SymbolUse/output.json
@@ -199,3 +199,7 @@
   "Kind": "info",
   "Data": "No symbol information found"
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/Test1Json/Test1JsonRunner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/Test1Json/Test1JsonRunner.fsx
@@ -32,7 +32,7 @@ p.finddeclaration "Script.fsx" "let val99 = XA.funky 21" 6 16
 p.declarations "Program.fs"
 p.declarations "FileTwo.fs"
 p.declarations "Script.fsx"
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/Test1Json/output.json
+++ b/test/FsAutoComplete.IntegrationTests/Test1Json/output.json
@@ -816,3 +816,7 @@
     }
   ]
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
+++ b/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
@@ -213,7 +213,7 @@ type FsAutoCompleteWrapperHttp() =
 
   let port = 8089
 
-  let notifyCts = CancellationTokenSource()
+  let notifyCts = new CancellationTokenSource()
 
   do
     configureFSACArgs p.StartInfo
@@ -264,7 +264,7 @@ type FsAutoCompleteWrapperHttp() =
     |> Hopac.run
     |> crazyness
 
-  let allResp = System.Collections.Concurrent.BlockingCollection<string> ()
+  let allResp = new System.Collections.Concurrent.BlockingCollection<string> ()
 
   let recordRequest action requestId r =
     doRequest action requestId r

--- a/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
+++ b/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
@@ -377,7 +377,9 @@ type FsAutoCompleteWrapperHttp() =
       else
         let count = allResp.Count
         if count >= upTo then
-          printfn "timeout %i vs %i" count upTo
+          let msg = sprintf "timeout %i vs %i" count upTo
+          printfn "%s" msg
+          allResp.Add(msg)
           return ()
         else
           printfn "not yet %i vs %i" count upTo

--- a/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
+++ b/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
@@ -67,6 +67,7 @@ let configureFSACArgs (startInfo: ProcessStartInfo) =
     startInfo.RedirectStandardInput  <- true
     startInfo.UseShellExecute <- false
     startInfo.EnvironmentVariables.Add("FCS_ToolTipSpinWaitTime", "10000")
+    startInfo.EnvironmentVariables.Add("FSAC_WORKSPACELOAD_DELAY", "1000")
     match testConfig.Runtime with
     | FSACRuntime.NETCoreFDD _ ->
         startInfo.Arguments <- fsacExePath ()

--- a/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
+++ b/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
@@ -67,7 +67,7 @@ let configureFSACArgs (startInfo: ProcessStartInfo) =
     startInfo.RedirectStandardInput  <- true
     startInfo.UseShellExecute <- false
     startInfo.EnvironmentVariables.Add("FCS_ToolTipSpinWaitTime", "10000")
-    startInfo.EnvironmentVariables.Add("FSAC_WORKSPACELOAD_DELAY", "1000")
+    startInfo.EnvironmentVariables.Add("FSAC_WORKSPACELOAD_DELAY", "2000")
     match testConfig.Runtime with
     | FSACRuntime.NETCoreFDD _ ->
         startInfo.Arguments <- fsacExePath ()

--- a/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
+++ b/test/FsAutoComplete.IntegrationTests/TestHelpers.fsx
@@ -135,6 +135,9 @@ type FsAutoCompleteWrapperStdio() =
   member x.workspaceload (projects: string list): unit =
     fprintf p.StandardInput "workspaceload %s\n" (projects |> List.map (sprintf "\"%s\"") |> String.concat " ")
 
+  member x.quit (): unit =
+    x.send "quit\n"
+
   member x.notify () : unit =
     ()
 
@@ -353,6 +356,10 @@ type FsAutoCompleteWrapperHttp() =
   member x.workspaceload (projects: string list): unit =
     { WorkspaceLoadRequest.Files = projects |> Array.ofList }
     |> recordRequest "workspaceLoad" (makeRequestId())
+
+  member x.quit (): unit =
+    new QuitRequest()
+    |> recordRequest "quit" (makeRequestId())
 
   member x.notify () : unit =
     listenWs (fun s -> allResp.Add(s)) port "notifyWorkspace" (notifyCts.Token)

--- a/test/FsAutoComplete.IntegrationTests/Tooltips/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/Tooltips/Runner.fsx
@@ -36,7 +36,7 @@ p.tooltip "Script.fsx" "   | Even -> 1" 54 8
 // p.tooltip "Script.fsx" "let cbfdg = Array.append" 58 15
 
 
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/Tooltips/output.json
+++ b/test/FsAutoComplete.IntegrationTests/Tooltips/output.json
@@ -201,3 +201,7 @@
     ]
   ]
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/TypeSig/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/TypeSig/Runner.fsx
@@ -18,7 +18,7 @@ p.typesig "Script.fsx" "  let funky x = x + 1" 4 10
 p.typesig "Script.fsx" "module CommandResponse =" 8 19
 p.typesig "Script.fsx" "  type ResponseMsg<'T> =" 10 14
 p.typesig "Script.fsx" "  let funky x = x + 1" 4 10
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/TypeSig/output.json
+++ b/test/FsAutoComplete.IntegrationTests/TypeSig/output.json
@@ -25,3 +25,7 @@
   "Kind": "typesig",
   "Data": "val funky : x:int -> int"
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}

--- a/test/FsAutoComplete.IntegrationTests/UncompiledReferencedProjects/Runner.fsx
+++ b/test/FsAutoComplete.IntegrationTests/UncompiledReferencedProjects/Runner.fsx
@@ -13,7 +13,7 @@ p.parse "MultiProject1.fs"
 p.tooltip "MultiProject1.fs" "let p = (Project1A.x1, Project1B.b)" 5 20
 p.tooltip "MultiProject1.fs" "let p = (Project1A.x1, Project1B.b)" 5 34
 
-p.send "quit\n"
+p.quit()
 p.finalOutput ()
 |> writeNormalizedOutput "output.json"
 

--- a/test/FsAutoComplete.IntegrationTests/UncompiledReferencedProjects/output.json
+++ b/test/FsAutoComplete.IntegrationTests/UncompiledReferencedProjects/output.json
@@ -62,3 +62,7 @@
     ]
   ]
 }
+{
+  "Kind": "info",
+  "Data": "quitting..."
+}


### PR DESCRIPTION
workspaceLoad integration test fails from time to time.

that's because sometimes the notification of `project loading` arrive before the response of the `workspaceLoad` command

added `worksapceLoad started` notifiication too, so clients can ignore the command response, and just use notiification to see the progress

added `quit` command to http mode.
now the quit command send a info message `quitting...` as reply

missing:

- [x] a "started" notification miss
- [x] a "finished" notification miss

