### PR TITLE
Fix System.ValueTuple.dll assembly binding error while typechecking FSX files

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -13,6 +13,7 @@ nuget FSharpLint.Core 0.9.0-beta
 nuget FSharp.Core redirects:force
 nuget System.Collections.Immutable < 1.4
 nuget OptimizedPriorityQueue
+nuget System.ValueTuple redirects:force // workaround for older version of net framework.
 
 group Netcore
   source https://www.nuget.org/api/v2/

--- a/paket.lock
+++ b/paket.lock
@@ -16,7 +16,11 @@ NUGET
       FParsec (>= 1.0.3)
       FSharp.Compiler.Service (>= 14.0.2)
       FSharp.Compiler.Service.ProjectCracker (>= 14.0.2)
+    Microsoft.NETCore.Platforms (2.0.1) - redirects: force
     Mono.Cecil (0.9.6.4)
+    NETStandard.Library (2.0.1) - redirects: force
+      Microsoft.NETCore.Platforms (>= 1.1)
+      System.Runtime.InteropServices.RuntimeInformation (>= 4.3)
     Newtonsoft.Json (10.0.3)
     OptimizedPriorityQueue (4.1.1)
     Sln (0.3)
@@ -25,6 +29,9 @@ NUGET
     System.Collections.Immutable (1.3.1)
     System.Reflection.Metadata (1.4.2)
       System.Collections.Immutable (>= 1.3.1)
+    System.Runtime.InteropServices.RuntimeInformation (4.3) - redirects: force
+    System.ValueTuple (4.4) - redirects: force
+      NETStandard.Library (>= 1.6.1)
 
 GROUP Build
 GENERATE-LOAD-SCRIPTS: ON

--- a/src/FsAutoComplete/App.config
+++ b/src/FsAutoComplete/App.config
@@ -11,4 +11,14 @@
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.1.0" />
   </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.2.0" />
+  </dependentAssembly>
 </assemblyBinding></runtime></configuration>

--- a/src/FsAutoComplete/FsAutoComplete.fsproj
+++ b/src/FsAutoComplete/FsAutoComplete.fsproj
@@ -170,5 +170,28 @@
       </ItemGroup>
     </When>
   </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
+      <ItemGroup>
+        <Reference Include="System.Runtime.InteropServices.RuntimeInformation">
+          <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
+      <ItemGroup>
+        <Reference Include="System.ValueTuple">
+          <HintPath>..\..\packages\System.ValueTuple\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <Import Project="..\..\packages\FSharp.Compiler.Service.ProjectCracker\build\$(__paket__FSharp_Compiler_Service_ProjectCracker_targets).targets" Condition="Exists('..\..\packages\FSharp.Compiler.Service.ProjectCracker\build\$(__paket__FSharp_Compiler_Service_ProjectCracker_targets).targets')" Label="Paket" />
+  <Import Project="..\..\packages\NETStandard.Library\build\NETStandard.Library.targets" Condition="Exists('..\..\packages\NETStandard.Library\build\NETStandard.Library.targets')" Label="Paket" />
 </Project>

--- a/src/FsAutoComplete/paket.references
+++ b/src/FsAutoComplete/paket.references
@@ -1,3 +1,4 @@
+System.ValueTuple
 FSharp.Compiler.Service
 FSharp.Compiler.Service.ProjectCracker
 Argu


### PR DESCRIPTION
Attempted to fix inability to load System.ValueTuple.dll. See https://github.com/ionide/ionide-vscode-fsharp/issues/683. Not sure if this is the right™ way to fix the problem, but a top-level nuget dependency on `System.ValueTuple` (w/t assembly binding redirects) was added to non-core FSAC. This forces System.ValueTuple.dll to be deployed along with the rest of the FSAC binaries, which will make the assembly binding exception magically disappear. Note: this change has not been tested on mono/mac.

This issue seems to affect windows machines (at least) running fsac on the full .net framework. While loading fsx files, fsautocomplete will throw an exception along the lines of: `System.IO.FileNotFoundException: Could not load file or assembly 'System.ValueTuple, Version=4.0.1.1` (see stack trace below.)

Ultimately, i think the main issue may be the .net framework version that FSAC is targeting (net45). System.ValueTuple.dll *I think* is a net61+ library. Bumping FSAC up to net61 *may* eliminate the need to add System.ValueTuple as a top-level dependency.

```
System.IO.FileNotFoundException: Could not load file or assembly 'System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The system cannot find the file specified.\r\nFile name: 'System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'\r\n   at Microsoft.FSharp.Compiler.CompileOps.GetDefaultSystemValueTupleReference()\r\n   at Microsoft.FSharp.Compiler.CompileOps.DefaultReferencesForScriptsAndOutOfProjectSources@1805.GenerateNext(IEnumerable`1& next)\r\n   at Microsoft.FSharp.Core.CompilerServices.GeneratedSequenceBase`1.MoveNextImpl()\r\n   at Microsoft.FSharp.Collections.SeqModule.ToList[T](IEnumerable`1 source)\r\n   at Microsoft.FSharp.Compiler.CompileOps.BasicReferencesForScriptLoadClosure(Boolean useFsiAuxLib, Boolean assumeDotNetFramework)\r\n   at Microsoft.FSharp.Compiler.CompileOps.ScriptPreprocessClosure.CreateScriptSourceTcConfig[a](Resolver legacyReferenceResolver, String defaultFSharpBinariesDir, String filename, CodeContext codeContext, Boolean useSimpleResolution, Boolean useFsiAuxLib, FSharpOption`1 basicReferences, FSharpFunc`2 applyCommandLineArgs, Boolean assumeDotNetFramework)\r\n   at Microsoft.FSharp.Compiler.CompileOps.ScriptPreprocessClosure.GetFullClosureOfScriptSource(CompilationThreadToken ctok, Resolver legacyReferenceResolver, String defaultFSharpBinariesDir, String filename, String source, CodeContext codeContext, Boolean useSimpleResolution, Boolean useFsiAuxLib, LexResourceManager lexResourceManager, FSharpFunc`2 applyCommmandLineArgs, Boolean assumeDotNetFramework)\r\n   at Microsoft.FSharp.Compiler.CompileOps.LoadClosure.ComputeClosureOfSourceText(CompilationThreadToken ctok, Resolver legacyReferenceResolver, String defaultFSharpBinariesDir, String filename, String source, CodeContext implicitDefines, Boolean useSimpleResolution, Boolean useFsiAuxLib, LexResourceManager lexResourceManager, FSharpFunc`2 applyCompilerOptions, Boolean assumeDotNetFramework)\r\n   at <StartupCode$FSharp-Compiler-Service>.$Service.GetProjectOptionsFromScript@2728-2.Invoke(ErrorScope _arg30)\r\n   at Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CancellableBuilder.Using[c,d](c resource, FSharpFunc`2 e)\r\n   at Microsoft.FSharp.Compiler.AbstractIL.Internal.Library.CancellableModule.delay@751.Invoke(CancellationToken ct)\r\n   at <StartupCode$FSharp-Compiler-Service>.$Reactor.EnqueueAndAwaitOpAsync@174-2.Invoke(CompilationThreadToken ctok)\r\n\r\nWRN: Assembly binding logging is turned OFF.\r\nTo enable assembly bind failure logging, set the registry value [HKLM\\Software\\Microsoft\\Fusion!EnableLog] (DWORD) to 1.\r\nNote: There is some performance penalty associated with assembly bind failure logging.\r\nTo turn this feature off, remove the registry value [HKLM\\Software\\Microsoft\\Fusion!EnableLog].\r\n
``` 