### PR TITLE
ignore FS0213 in the IDE because of FAKE 5

### DIFF
--- a/src/FsAutoComplete.Core/CommandResponse.fs
+++ b/src/FsAutoComplete.Core/CommandResponse.fs
@@ -213,6 +213,9 @@ module CommandResponse =
       Message:string
       Subcategory:string
     }
+    static member IsIgnored(e:Microsoft.FSharp.Compiler.SourceCodeServices.FSharpErrorInfo) =
+        // FST-1027 support in Fake 5
+        e.ErrorNumber = 213 && e.Message.StartsWith "'paket:"
     static member OfFSharpError(e:Microsoft.FSharp.Compiler.SourceCodeServices.FSharpErrorInfo) =
       {
         FileName = e.FileName
@@ -525,9 +528,13 @@ module CommandResponse =
                 }
 
   let errors (serialize : Serializer) (errors: Microsoft.FSharp.Compiler.SourceCodeServices.FSharpErrorInfo[], file: string) =
+    let errors =
+        errors
+        |> Array.filter (FSharpErrorInfo.IsIgnored >> not)
+        |> Array.map FSharpErrorInfo.OfFSharpError
     serialize { Kind = "errors";
                 Data = { File = file
-                         Errors = Array.map FSharpErrorInfo.OfFSharpError errors }}
+                         Errors = errors }}
 
   let colorizations (serialize : Serializer) (colorizations: (Range.range * SemanticClassificationType)[]) =
     // let data = [ for r, k in colorizations do


### PR DESCRIPTION
Honestly I don't think it is the correct thing, as it would be better in the ionide code (maybe even with opt-in or opt-out via config.
However I couldn't find how to do it. Basically I think for this to work we should properly forward the error code :/

Frustrated by inability to figure it out this is my hack to make it work ...

See https://github.com/fsharp/FAKE/pull/1770