### PR TITLE
Made getter property signatures consistent.

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -162,12 +162,16 @@ type ParseAndCheckResults
           let fsym = symboluse.Symbol
           match fsym with
           | :? FSharpMemberOrFunctionOrValue as symbol ->
-            let parms =
-              symbol.CurriedParameterGroups
-              |> Seq.map (Seq.map (fun p -> p.DisplayName, p.Type.Format symboluse.DisplayContext) >> Seq.toList )
-              |> Seq.toList
+
             let typ = symbol.ReturnParameter.Type.Format symboluse.DisplayContext
-            return Ok(typ, parms)
+            if symbol.IsPropertyGetterMethod then
+                return Ok(typ, [])
+            else
+              let parms =
+                symbol.CurriedParameterGroups
+                |> Seq.map (Seq.map (fun p -> p.DisplayName, p.Type.Format symboluse.DisplayContext) >> Seq.toList )
+                |> Seq.toList
+              return Ok(typ, parms)
           | _ ->
             return (ResultOrString.Error "Not a member, function or value" )
     }


### PR DESCRIPTION
Made getter property signature from /signatureData consistent with that which is returned from /signature.

This PR is to fix an issue raised with ionide: https://github.com/ionide/ionide-vscode-fsharp/issues/789

The signature on hover in vscode ionide uses the FSAC /signature endpoint and gets displayed with just the return type in the case of a getter property on a class. However, code lens uses /signatureData FSAC endpoint which includes a unit parameter in the signature of a getter property. So code lens and the type signature when hovering are out inconsistent.

This PR fixes this issue but, if I have made the change in the wrong place, I am can change this fix.
Thanks.