### PR TITLE
Fix for vscode ionide issue - abstract member and member override signatures

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -171,7 +171,13 @@ type ParseAndCheckResults
                 symbol.CurriedParameterGroups
                 |> Seq.map (Seq.map (fun p -> p.DisplayName, p.Type.Format symboluse.DisplayContext) >> Seq.toList )
                 |> Seq.toList
-              return Ok(typ, parms)
+              // Abstract members and abstract member overrides with one () parameter seem have a list with an empty list
+              // as parameters.
+              match parms with
+              | [ [] ] when symbol.IsMember && (not symbol.IsPropertyGetterMethod) -> 
+                return Ok(typ, [ [ ("unit", "unit") ] ])
+              | _ -> 
+                return Ok(typ, parms)
           | _ ->
             return (ResultOrString.Error "Not a member, function or value" )
     }

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -162,12 +162,16 @@ type ParseAndCheckResults
           let fsym = symboluse.Symbol
           match fsym with
           | :? FSharpMemberOrFunctionOrValue as symbol ->
-            let parms =
-              symbol.CurriedParameterGroups
-              |> Seq.map (Seq.map (fun p -> p.DisplayName, p.Type.Format symboluse.DisplayContext) >> Seq.toList )
-              |> Seq.toList
+
             let typ = symbol.ReturnParameter.Type.Format symboluse.DisplayContext
-            return Ok(typ, parms)
+            if symbol.IsPropertyGetterMethod then
+                return Ok(typ, [])
+            else
+              let parms =
+                symbol.CurriedParameterGroups
+                |> Seq.map (Seq.map (fun p -> p.DisplayName, p.Type.Format symboluse.DisplayContext) >> Seq.toList )
+                |> Seq.toList
+              return Ok(typ, parms)
           | _ ->
             return (ResultOrString.Error "Not a member, function or value" )
     }

--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -195,9 +195,11 @@ module SignatureFormatter =
             if isDelegate then retType
             else modifiers ++ functionName + ":" ++ retType
 
-        | [[]] ->
+        | [[]] ->         
             if isDelegate then retType
-            elif func.IsConstructor then modifiers + ": unit -> " ++ retType //A ctor with () parameters seems to be a list with an empty list
+            //A ctor with () parameters seems to be a list with an empty list.
+            // Also abstract members and abstract member overrides with one () parameter seem to be a list with an empty list.
+            elif func.IsConstructor || (func.IsMember && (not func.IsPropertyGetterMethod)) then modifiers + ": unit -> " ++ retType
             else modifiers ++ functionName + ":" ++ retType //Value members seems to be a list with an empty list
         | [[p]] when  maybeGetter && formatParameter p = "unit" -> //Member or property with only getter
             modifiers ++ functionName + ":" ++ retType


### PR DESCRIPTION
This is a fix for this downstream issue:
https://github.com/ionide/ionide-vscode-fsharp/issues/814
It fixes the signatures for both the hover signature and the code lens signature.
Its a bit hacky unfortunately though. The issue is because FCS seems to return a list containing one empty list for the curried parameter groups for abstract members and abstract member overrides where there is only one unit parameter.
Fix in action shown below:
<img width="619" alt="abstract-member-signature-fix" src="https://user-images.githubusercontent.com/13556648/40277659-a1fb80fe-5c1a-11e8-9343-8e0f4a0a09c9.png">

<img width="639" alt="abstract-member-sig-fix-2" src="https://user-images.githubusercontent.com/13556648/40277648-60def452-5c1a-11e8-95e4-5067f8ed75dd.png">

The issue didn't arise where there is more then one parameter and one of the parameters is unit.
<img width="483" alt="abstract-member-sig-fix-3" src="https://user-images.githubusercontent.com/13556648/40277651-76568548-5c1a-11e8-98ed-5cfc6b5d0e62.png">

