### PR TITLE
Improve tooltip text format

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -71,7 +71,10 @@
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
     </PropertyGroup>
-
+    
+    <PropertyGroup Condition="'$(PaketPropsVersion)' != '5.174.2' ">
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+    </PropertyGroup>
 
     <!-- Do a global restore if required -->
     <Exec Command='$(PaketBootStrapperCommand)' Condition="Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
@@ -132,11 +135,11 @@
     <Error Condition=" '$(DoAllResolvedFilesExist)' != 'true' AND '$(ResolveNuGetPackages)' != 'False' " Text="One Paket file '@(PaketResolvedFilePaths)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
 
     <!-- Step 4 forward all msbuild properties (PackageReference, DotNetCliToolReference) to msbuild -->
-    <ReadLinesFromFile Condition="'@(PaketResolvedFilePaths)' != ''" File="%(PaketResolvedFilePaths.Identity)" ><!--Condition="Exists('%(PaketResolvedFilePaths.Identity)')"-->
+    <ReadLinesFromFile Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketResolvedFilePaths)' != ''" File="%(PaketResolvedFilePaths.Identity)" >
       <Output TaskParameter="Lines" ItemName="PaketReferencesFileLines"/>
     </ReadLinesFromFile>
 
-    <ItemGroup Condition=" '@(PaketReferencesFileLines)' != '' " >
+    <ItemGroup Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketReferencesFileLines)' != '' " >
       <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
         <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -11,31 +11,38 @@ open Microsoft.FSharp.Compiler.SourceCodeServices
 
 // TODO: Improve this parser. Is there any other XmlDoc parser available?
 type private XmlDocMember(doc: XmlDocument) =
-  let nl = Environment.NewLine
-  let readContent (node: XmlNode) =
-    match node with
-    | null -> null
-    | _ ->
-        // Many definitions contain references like <paramref name="keyName" /> or <see cref="T:System.IO.IOException">
-        // Replace them by the attribute content (keyName and System.IO.Exception in the samples above)
-        // Put content in single quotes for possible formatting improvements on editor side.
-        Regex.Replace(node.InnerXml,"""<\w+ \w+="(?:\w:){0,1}(.+?)" />""", "`$1`")
-  let readChildren name (doc: XmlDocument) =
-    doc.DocumentElement.GetElementsByTagName name
-    |> Seq.cast<XmlNode>
-    |> Seq.map (fun node -> node.Attributes.[0].InnerText.Replace("T:",""), readContent node)
-    |> Map.ofSeq
-  let summary = readContent doc.DocumentElement.ChildNodes.[0]
-  let pars = readChildren "param" doc
-  let exceptions = readChildren "exception" doc
-  override x.ToString() =
-    summary + nl + nl +
-    (if pars.Count = 0 then ""
-     else "**Parameters**" + nl +
-            (pars |> Seq.map (fun kv -> "  * `" + kv.Key + "`" + ": " + kv.Value) |> String.concat nl)) +
-    (if exceptions.Count = 0 then ""
-     else nl + nl + "**Exceptions**" + nl +
-            (exceptions |> Seq.map (fun kv -> "  * `" + kv.Key + "`" + ": " + kv.Value) |> String.concat nl))
+    let nl = Environment.NewLine
+    let readContent (node: XmlNode) =
+        match node with
+        | null -> null
+        | _ ->
+            // Many definitions contain references like <paramref name="keyName" /> or <see cref="T:System.IO.IOException">
+            // Replace them by the attribute content (keyName and System.IO.Exception in the samples above)
+            // Put content in single quotes for possible formatting improvements on editor side.
+            Regex.Replace(node.InnerXml,"""<\w+ \w+="(?:\w:){0,1}(.+?)" />""", "`$1`")
+    let readChildren name (doc: XmlDocument) =
+        doc.DocumentElement.GetElementsByTagName name
+        |> Seq.cast<XmlNode>
+        |> Seq.map (fun node -> node.Attributes.[0].InnerText.Replace("T:",""), readContent node)
+        |> Map.ofSeq
+    let summary = readContent doc.DocumentElement.ChildNodes.[0]
+    let pars = readChildren "param" doc
+    let exceptions = readChildren "exception" doc
+    override x.ToString() =
+        summary + nl + nl +
+        (pars |> Seq.map (fun kv -> "`" + kv.Key + "`" + ": " + kv.Value) |> String.concat nl) +
+        (if exceptions.Count = 0 then ""
+         else nl + nl + "Exceptions:" + nl +
+                (exceptions |> Seq.map (fun kv -> "\t" + "`" + kv.Key + "`" + ": " + kv.Value) |> String.concat nl))
+
+    member __.ToEnhancedString() =
+        summary + nl + nl +
+        (if pars.Count = 0 then ""
+         else "**Parameters**" + nl +
+                (pars |> Seq.map (fun kv -> "* `" + kv.Key + "`" + ": " + kv.Value) |> String.concat nl)) +
+        (if exceptions.Count = 0 then ""
+         else nl + nl + "**Exceptions**" + nl +
+                (exceptions |> Seq.map (fun kv -> "* `" + kv.Key + "`" + ": " + kv.Value) |> String.concat nl))
 
 let rec private readXmlDoc (reader: XmlReader) (acc: Map<string,XmlDocMember>) =
   let acc' =
@@ -87,19 +94,23 @@ let private getXmlDoc =
 // --------------------------------------------------------------------------------------
 // Formatting of tool-tip information displayed in F# IntelliSense
 // --------------------------------------------------------------------------------------
-let private buildFormatComment cmt =
+let private buildFormatComment cmt (isEnhanced : bool) =
     match cmt with
     | FSharpXmlDoc.Text s -> s
     | FSharpXmlDoc.XmlDocFileSignature(dllFile, memberName) ->
        match getXmlDoc dllFile with
-       | Some doc when doc.ContainsKey memberName -> string doc.[memberName]
+       | Some doc when doc.ContainsKey memberName ->
+            if isEnhanced then
+                doc.[memberName].ToEnhancedString()
+            else
+                string doc.[memberName]
        | _ -> ""
     | _ -> ""
 
 let private formatGenericParamInfo cmt =
   let m = Regex.Match(cmt, """(.*) is (.*)""")
   if m.Success then
-    sprintf "  * `%s` is `%s`" m.Groups.[1].Value m.Groups.[2].Value
+    sprintf "* `%s` is `%s`" m.Groups.[1].Value m.Groups.[2].Value
   else
     cmt
 
@@ -109,7 +120,7 @@ let formatTip (FSharpToolTipText tips) : (string * string) list list =
     |> List.choose (function
         | FSharpToolTipElement.Group items ->
             let getRemarks (it : FSharpToolTipElementData<string>) = defaultArg (it.Remarks |> Option.map (fun n -> if String.IsNullOrWhiteSpace n then n else "\n\n" + n)) ""
-            Some (items |> List.map (fun (it) ->  (it.MainDescription + getRemarks it, buildFormatComment it.XmlDoc)))
+            Some (items |> List.map (fun (it) ->  (it.MainDescription + getRemarks it, buildFormatComment it.XmlDoc false)))
         | FSharpToolTipElement.CompositionError (error) -> Some [("<Note>", error)]
         | _ -> None)
 
@@ -120,9 +131,9 @@ let formatTipEnhanced (FSharpToolTipText tips) (signature : string) (footer : st
             Some (items |> List.map (fun i ->
                 let comment =
                     if i.TypeMapping.IsEmpty then
-                      buildFormatComment i.XmlDoc
+                      buildFormatComment i.XmlDoc true
                     else
-                      buildFormatComment i.XmlDoc
+                      buildFormatComment i.XmlDoc true
                       + "\n\n**Generic parameters**\n\n"
                       + (i.TypeMapping |> List.map formatGenericParamInfo |> String.concat "\n")
 

--- a/src/FsAutoComplete/AssemblyInfo.fs
+++ b/src/FsAutoComplete/AssemblyInfo.fs
@@ -7,7 +7,7 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("A command line tool for interfacing with FSharp.Compiler.Service over a pipe.")>]
 [<assembly: AssemblyVersionAttribute("0.34.0")>]
 [<assembly: AssemblyFileVersionAttribute("0.34.0")>]
-[<assembly: AssemblyMetadataAttribute("githash","6e212faa0d8db46926a57d0b3a94d3970ef0211f")>]
+[<assembly: AssemblyMetadataAttribute("githash","ae4759a7fd15c12c3f41a4bd7c84d5ebfaf10cbf")>]
 do ()
 
 module internal AssemblyVersionInformation =
@@ -16,4 +16,4 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyDescription = "A command line tool for interfacing with FSharp.Compiler.Service over a pipe."
     let [<Literal>] AssemblyVersion = "0.34.0"
     let [<Literal>] AssemblyFileVersion = "0.34.0"
-    let [<Literal>] AssemblyMetadata_githash = "6e212faa0d8db46926a57d0b3a94d3970ef0211f"
+    let [<Literal>] AssemblyMetadata_githash = "ae4759a7fd15c12c3f41a4bd7c84d5ebfaf10cbf"

--- a/src/FsAutoComplete/AssemblyInfo.fs
+++ b/src/FsAutoComplete/AssemblyInfo.fs
@@ -7,7 +7,7 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("A command line tool for interfacing with FSharp.Compiler.Service over a pipe.")>]
 [<assembly: AssemblyVersionAttribute("0.34.0")>]
 [<assembly: AssemblyFileVersionAttribute("0.34.0")>]
-[<assembly: AssemblyMetadataAttribute("githash","d397eb6f6734c833d66b5c6e48eb032f4d2d320a")>]
+[<assembly: AssemblyMetadataAttribute("githash","6e212faa0d8db46926a57d0b3a94d3970ef0211f")>]
 do ()
 
 module internal AssemblyVersionInformation =
@@ -16,4 +16,4 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyDescription = "A command line tool for interfacing with FSharp.Compiler.Service over a pipe."
     let [<Literal>] AssemblyVersion = "0.34.0"
     let [<Literal>] AssemblyFileVersion = "0.34.0"
-    let [<Literal>] AssemblyMetadata_githash = "d397eb6f6734c833d66b5c6e48eb032f4d2d320a"
+    let [<Literal>] AssemblyMetadata_githash = "6e212faa0d8db46926a57d0b3a94d3970ef0211f"


### PR DESCRIPTION
This PR is related to my current work to make the tooltip in Ionide consistant:
 
- https://github.com/ionide/ionide-vscode-fsharp/issues/852
- https://github.com/ionide/ionide-vscode-fsharp/pull/855

### Introduction

The new text generated for the tooltip is now using Markdown synthax. I know that FSAC is used by others project that Ionide so we need to ask if this is the good choice.

Also, I add some section header in the output so it's easier to read and more consistant. Before this PR, the tooltip where already containing some markdown synthax like ``` `source code format` ```

If having the section in Markdown format is a problem we can still replace `**Parameters**` by `Parameters:` and replace it from Ionide side but it would need an extra step.

## Changes

In order to compare before and after, I will use `List.find` to get the tooltip info.

**Source code**

```fs
/// <summary>Returns the first element for which the given function returns True.
/// Raises <c>KeyNotFoundException</c> if no such element exists.</summary>
/// <param name="predicate">The function to test the input elements.</param>
/// <param name="list">The input list.</param>
/// <exception cref="System.Collections.Generic.KeyNotFoundException">Thrown if the predicate evaluates to false for
/// all the elements of the list.</exception>
/// <returns>The first element that satisfies the predicate.</returns>
[<CompiledName("Find")>]
val find: predicate:('T -> bool) -> list:'T list -> 'T
```

### Text generated by FSAC:

**Before**

```markdown
Returns the first element for which the given function returns True.
 Raises <c>KeyNotFoundException</c> if no such element exists.

`list`: The input list.
`predicate`: The function to test the input elements.

Exceptions:
	`System.Collections.Generic.KeyNotFoundException`: Thrown if the predicate evaluates to false for
 all the elements of the list.

Generic parameters:
`'T` is `'b`
```

**Now**

```markdown
Returns the first element for which the given function returns True.
 Raises <c>KeyNotFoundException</c> if no such element exists.

**Parameters**
  * `list`: The input list.
  * `predicate`: The function to test the input elements.

**Exceptions**
  * `System.Collections.Generic.KeyNotFoundException`: Thrown if the predicate evaluates to false for
 all the elements of the list.

**Generic parameters**
  * `'T` is `'b`
```

### Preview from Ionide

**Before**
![2018-07-21 10 59 51](https://user-images.githubusercontent.com/4760796/43034102-30c7565a-8cd6-11e8-9db3-f98a12a5a2bf.gif)

**Now**
![2018-07-20 23 17 05](https://user-images.githubusercontent.com/4760796/43034107-3a47895c-8cd6-11e8-992f-4dbec2380d4c.gif)

The new preview use the same section as docs comment in markdown style or XML style written by user.