### PR TITLE
Improve xml to markdown conversion

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -71,7 +71,7 @@
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
     </PropertyGroup>
-    
+
     <PropertyGroup Condition="'$(PaketPropsVersion)' != '5.174.2' ">
       <PaketRestoreRequired>true</PaketRestoreRequired>
     </PropertyGroup>
@@ -96,7 +96,7 @@
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\$(MSBuildProjectName).paket.references</PaketOriginalReferencesFilePath>
       <!-- paket.references -->
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\paket.references</PaketOriginalReferencesFilePath>
-      
+
       <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
       <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
       <PaketRestoreRequired>true</PaketRestoreRequired>

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -9,9 +9,41 @@ open System.Xml
 open System.Text.RegularExpressions
 open Microsoft.FSharp.Compiler.SourceCodeServices
 
+module Section =
+
+    let inline nl<'T> = Environment.NewLine
+
+    let inline private addSection (name : string) (content : string) =
+        if name <> "" then
+            nl + nl
+            + "**" + name + "**"
+            + nl + nl + content
+        else
+            nl + nl + content
+
+    let fromMap (name : string) (content : Map<string, string>) =
+        if content.Count = 0 then
+            ""
+        else
+            addSection name (content |> Seq.map (fun kv -> "* `" + kv.Key + "`" + ": " + kv.Value) |> String.concat nl)
+
+    let fromOption (name : string) (content : string option) =
+        if content.IsNone then
+            ""
+        else
+            addSection name content.Value
+
+    let fromList (name : string) (content : string seq) =
+        if Seq.length content = 0 then
+            ""
+        else
+            addSection name (content |> String.concat nl)
+
 // TODO: Improve this parser. Is there any other XmlDoc parser available?
-type private XmlDocMember(doc: XmlDocument) =
+type private XmlDocMember(doc: XmlDocument, indentationSize : int, columnOffset : int) =
     let nl = Environment.NewLine
+    /// References used to detect if we should remove meaningless spaces
+    let tabsOffset = String.replicate (columnOffset + indentationSize) " "
     let readContent (node: XmlNode) =
         match node with
         | null -> null
@@ -19,32 +51,45 @@ type private XmlDocMember(doc: XmlDocument) =
             // Many definitions contain references like <paramref name="keyName" /> or <see cref="T:System.IO.IOException">
             // Replace them by the attribute content (keyName and System.IO.Exception in the samples above)
             // Put content in single quotes for possible formatting improvements on editor side.
-            let c = Regex.Replace(node.InnerXml,"""<code.*?>(.*?)<\/code>""", "`$1`")
+            let text = node.InnerXml.Replace("<para>", "\n\n")
+                                    .Replace("</para>", "\n")
+            let c = Regex.Replace(text,"""<code.*?>(.*?)<\/code>""", "`$1`")
             let c = Regex.Replace(c,"""<\w+ \w+="(?:\w:){0,1}(.+?)">.*<\/\w+>""", "`$1`")
             let c = Regex.Replace(c,"""<\w+ \w+="(?:\w:){0,1}(.+?)" />""", "`$1`")
             let tableIndex = c.IndexOf("<table>")
-            if tableIndex > 0 then
-                let start = c.Substring(0, tableIndex)
-                let table = c.Substring(tableIndex)
-                let rows = Regex.Matches(c, "<th>").Count
-                let table =
-                    table.Replace(nl, "")
-                        .Replace("\n", "")
-                        .Replace("<table>", "")
-                        .Replace("</table>", "")
-                        .Replace("<thead>", "")
-                        .Replace("</thead>", (String.replicate rows "| --- "))
-                        .Replace("<tbody>", nl)
-                        .Replace("</tbody>", "")
-                        .Replace("<tr>", "")
-                        .Replace("</tr>", "|" + nl)
-                        .Replace("<th>", "|")
-                        .Replace("</th>", "")
-                        .Replace("<td>", "|")
-                        .Replace("</td>", "")
-                start + nl + nl + nl + nl + table
-            else
-                c
+            let s =
+                if tableIndex > 0 then
+                    let start = c.Substring(0, tableIndex)
+                    let table = c.Substring(tableIndex)
+                    let rows = Regex.Matches(c, "<th>").Count
+                    let table =
+                        table.Replace(nl, "")
+                            .Replace("\n", "")
+                            .Replace("<table>", "")
+                            .Replace("</table>", "")
+                            .Replace("<thead>", "")
+                            .Replace("</thead>", (String.replicate rows "| --- "))
+                            .Replace("<tbody>", nl)
+                            .Replace("</tbody>", "")
+                            .Replace("<tr>", "")
+                            .Replace("</tr>", "|" + nl)
+                            .Replace("<th>", "|")
+                            .Replace("</th>", "")
+                            .Replace("<td>", "|")
+                            .Replace("</td>", "")
+                    start + nl + nl + nl + nl + table
+                else
+                    c
+
+
+            s.Replace("\r\n", "\n").Split('\n')
+            |> Array.map(fun line ->
+                if not (String.IsNullOrWhiteSpace line) && line.StartsWith(tabsOffset) then
+                    line.Substring(columnOffset + indentationSize)
+                else
+                    line
+            )
+            |> String.concat "\n"
 
     let readChildren name (doc: XmlDocument) =
         doc.DocumentElement.GetElementsByTagName name
@@ -52,11 +97,16 @@ type private XmlDocMember(doc: XmlDocument) =
         |> Seq.map (fun node -> node.Attributes.[0].InnerText.Replace("T:",""), readContent node)
         |> Map.ofSeq
 
-
+    let readRemarks (doc : XmlDocument) =
+        doc.DocumentElement.GetElementsByTagName "remarks"
+        |> Seq.cast<XmlNode>
+        |> Seq.map (fun node -> readContent node )
 
     let summary = readContent doc.DocumentElement.ChildNodes.[0]
     let pars = readChildren "param" doc
+    let remarks = readRemarks doc
     let exceptions = readChildren "exception" doc
+    let typeParams = readChildren "typeparam" doc
 
     let returns =
         doc.DocumentElement.GetElementsByTagName "returns"
@@ -72,36 +122,47 @@ type private XmlDocMember(doc: XmlDocument) =
                 (exceptions |> Seq.map (fun kv -> "\t" + "`" + kv.Key + "`" + ": " + kv.Value) |> String.concat nl))
 
     member __.ToEnhancedString() =
-        summary + nl + nl +
-        (if pars.Count = 0 then ""
-         else "**Parameters**" + nl +
-                (pars |> Seq.map (fun kv -> "* `" + kv.Key + "`" + ": " + kv.Value) |> String.concat nl)) +
-        (if exceptions.Count = 0 then ""
-         else nl + nl + "**Exceptions**" + nl +
-                (exceptions |> Seq.map (fun kv -> "* `" + kv.Key + "`" + ": " + kv.Value) |> String.concat nl)) +
-        (if returns.IsNone then "" else nl + nl + "**Returns**" + nl + nl + returns.Value )
+        "**Description**" + nl + nl
+        + summary
+        + Section.fromList "" remarks
+        + Section.fromMap "Type parameters" typeParams
+        + Section.fromMap "Parameters" pars
+        + Section.fromOption "Returns" returns
+        + Section.fromMap "Exceptions" exceptions
 
-
-let rec private readXmlDoc (reader: XmlReader) (acc: Map<string,XmlDocMember>) =
+let rec private readXmlDoc (reader: XmlReader) (indentationSize : int) (acc: Map<string,XmlDocMember>) =
   let acc' =
     match reader.Read() with
-    | false -> None
+    | false -> indentationSize, None
+    // Assembly is the first node in the XML and is at least always indended by 1 "tab"
+    // So we used it as a reference to detect the tabs sizes
+    // This is needed because `netstandard.xml` use 2 spaces tabs
+    // Where when building a C# classlib, the xml file use 4 spaces size for example
+    | true when reader.Name = "assembly" && reader.NodeType = XmlNodeType.Element ->
+        let xli : IXmlLineInfo = (box reader) :?> IXmlLineInfo
+        // - 2 : allow us to detect the position before the < char
+        xli.LinePosition - 2, Some acc
     | true when reader.Name = "member" && reader.NodeType = XmlNodeType.Element ->
       try
+        // We detect the member LinePosition so we can calculate the meaningless spaces later
+        let xli : IXmlLineInfo = (box reader) :?> IXmlLineInfo
         let key = reader.GetAttribute("name")
         use subReader = reader.ReadSubtree()
         let doc = XmlDocument()
         doc.Load(subReader)
-        acc |> Map.add key (XmlDocMember doc) |> Some
+        // - 3 : allow us to detect the last indentation position
+        // This isn't intuitive but from my tests this is what works
+        indentationSize, acc |> Map.add key (XmlDocMember(doc, indentationSize, xli.LinePosition - 3)) |> Some
       with
       | ex ->
         printfn "%s" ex.Message
         printfn "%s" ex.StackTrace
-        Some acc
-    | _ -> Some acc
+        indentationSize, Some acc
+    | _ -> indentationSize, Some acc
+
   match acc' with
-  | None -> acc
-  | Some acc' -> readXmlDoc reader acc'
+  | _, None -> acc
+  | indentationSize, Some acc' -> readXmlDoc reader indentationSize acc'
 
 let private getXmlDoc =
   let xmlDocCache = Collections.Concurrent.ConcurrentDictionary<string, Map<string, XmlDocMember>>()
@@ -134,7 +195,7 @@ let private getXmlDoc =
                 cnt
           use stringReader = new StringReader(cnt)
           use reader = XmlReader.Create stringReader
-          let xmlDoc = readXmlDoc reader Map.empty
+          let xmlDoc = readXmlDoc reader 0 Map.empty
           xmlDocCache.AddOrUpdate(xmlFile, xmlDoc, fun _ _ -> xmlDoc) |> ignore
           Some xmlDoc
         with ex ->


### PR DESCRIPTION
We detect the indentation size and position in order to remove meaningless spaces.

We also add support for the same tags as in Ionide formatting process.

Added tag:
- remarks
- typeparam

With all the changes proposed in this PR, we now have the same display between a comments declared inside the user code and one from an `*.xml` file.

We are also able to correctly convert xml to markdown format. (Related: https://github.com/fsharp/FsAutoComplete/issues/300)

I also added a `Section` module in order to make it easier to improve readibily of the return tooltip content.

Preview:

When hovering `c.ComplexeDoc()` we see `!:System.ArgumentNullException1` instead of `System.ArgumentNullException1` this is "normal". Because this exception do not exist, `dotnet build` add `!:` in the `*.xml` file. We can ignore this difference

I tried to add comments where it make sense and I am open to discuss the implementation as this isn't obvious at first.

![2018-07-31 13 01 11](https://user-images.githubusercontent.com/4760796/43456353-7cbae532-94c3-11e8-8e54-9c079ff0f2e0.gif)

cc @Krzysztof-Cieslak (pinging you because this PR is based on your branch)