### PR TITLE
Add BuildTools SKU

### DIFF
--- a/src/FsAutoComplete.Core/Environment.fs
+++ b/src/FsAutoComplete.Core/Environment.fs
@@ -54,7 +54,7 @@ module Environment =
       | Some file -> file
       | None -> tool
 
-  let private vsSkus = ["Community"; "Professional"; "Enterprise"]
+  let private vsSkus = ["Community"; "Professional"; "Enterprise"; "BuildTools"]
   let private vsVersions = ["2017"]
   let cartesian a b =
     [ for a' in a do


### PR DESCRIPTION
The VS Build tools (headless install of MSBuild, NuGet, etc)here: https://visualstudio.microsoft.com/downloads/

Places a subdirectory here:
![image](https://user-images.githubusercontent.com/6309070/44286761-1ed8a300-a21f-11e8-8097-3c20222f0321.png)

With this in place users won't need to install the "full" VS IDE.