### PR TITLE
make tool paths returned for the netcore host in line with full-framework

### DIFF
--- a/src/FsAutoComplete.Core/Environment.fs
+++ b/src/FsAutoComplete.Core/Environment.fs
@@ -66,13 +66,7 @@ module Environment =
     |> List.map (fun (version, sku) -> programFilesX86 </> "Microsoft Visual Studio" </> version </> sku) 
 
   let msbuild =
-#if SCRIPT_REFS_FROM_MSBUILD
-      if not(RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) then
-        //well, depends on mono version, but like this is mono >= 5.2 (msbuild on mono 5.0 sort of works)
-        "msbuild"
-#else
-      if Utils.runningOnMono then "xbuild" // mono <= 5.0
-#endif
+      if Utils.runningOnMono then "msbuild" // we're way past 5.0 now, time to get updated
       else
         let legacyPaths =
             [ programFilesX86 </> @"\MSBuild\14.0\Bin"
@@ -107,13 +101,16 @@ module Environment =
     |> List.tryFind Directory.Exists
 
   let fsi =
-    if Utils.runningOnMono then "fsharpi"
+    // on netcore on non-windows we just deflect to fsharpi as usual
+    if Utils.runningOnMono || not Utils.isWindows then "fsharpi"
     else
+      // if running on windows, non-mono we can't yet send paths to the netcore version of fsi.exe so use the one from full-framework
       Option.getOrElse "" fsharpInstallationPath </> "fsi.exe"
 
   let fsc =
-    if Utils.runningOnMono then "fsharpc"
+    if Utils.runningOnMono || not Utils.isWindows then "fsharpc"
     else
+      // if running on windows, non-mono we can't yet send paths to the netcore version of fsc.exe so use the one from full-framework
       Option.getOrElse "" fsharpInstallationPath </> "fsc.exe"
 
   let fsharpCoreOpt =

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -40,6 +40,56 @@ let isAScript fileName =
     let ext = Path.GetExtension fileName
     [".fsx";".fsscript";".sketchfs"] |> List.exists ((=) ext)
 
+/// Determines if the current system is an Unix system.
+/// See http://www.mono-project.com/docs/faq/technical/#how-to-detect-the-execution-platform
+let isUnix =
+#if NETSTANDARD1_6
+    System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+        System.Runtime.InteropServices.OSPlatform.Linux) ||
+    System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+        System.Runtime.InteropServices.OSPlatform.OSX)
+#else
+    int System.Environment.OSVersion.Platform |> fun p -> (p = 4) || (p = 6) || (p = 128)
+#endif
+
+/// Determines if the current system is a MacOs system
+let isMacOS =
+#if NETSTANDARD1_6
+    System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+        System.Runtime.InteropServices.OSPlatform.OSX)
+#else
+    (System.Environment.OSVersion.Platform = PlatformID.MacOSX) ||
+        // osascript is the AppleScript interpreter on OS X
+        File.Exists "/usr/bin/osascript"
+#endif
+
+/// Determines if the current system is a Linux system
+let isLinux =
+#if NETSTANDARD1_6
+    System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+        System.Runtime.InteropServices.OSPlatform.Linux)
+#else
+    isUnix && not isMacOS
+#endif
+
+/// Determines if the current system is a Windows system
+let isWindows =
+#if NETSTANDARD1_6
+    System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+        System.Runtime.InteropServices.OSPlatform.Windows)
+#else
+    match System.Environment.OSVersion.Platform with
+    | PlatformID.Win32NT | PlatformID.Win32S | PlatformID.Win32Windows | PlatformID.WinCE -> true
+    | _ -> false
+#endif
+
+let runningOnNetCore =
+#if NETSTANDARD1_6
+    true
+#else
+    false
+#endif
+
 let runningOnMono =
   try not << isNull <| Type.GetType "Mono.Runtime"
   with _ -> false


### PR DESCRIPTION
even though FSAC is running on netcore, the tools it returns back should probably be full-framework compatible until we get to a spot where tooling can _tell_ fsac where compilers/corelibs are.

This makes it so that non-windows, netcore users of FSAC get the same compiler binaries returned as non-windows, mono users of FSAC. This enables ionide to trust the responses received from FSAC instead of having to probe on its own.

Before (mono):
```
➜  bin git:(master) ✗ mono fsautocomplete.exe
compilerlocation
{"Kind":"compilerlocation","Data":{"Fsc":"fsharpc","Fsi":"fsharpi","MSBuild":"xbuild"}}
```

Before(netcore):
```
➜  bin_netcore git:(master) ✗ dotnet fsautocomplete.dll
compilerlocation
{"Kind":"compilerlocation","Data":{"Fsc":"fsc.exe","Fsi":"fsi.exe","MSBuild":"msbuild"}}
```

After(mono):
```
➜  bin git:(master) ✗ mono fsautocomplete.exe
compilerlocation
{"Kind":"compilerlocation","Data":{"Fsc":"fsharpc","Fsi":"fsharpi","MSBuild":"msbuild"}}
```

After(netcore):
```
➜  netcoreapp2.0 git:(netcore_binary_paths) ✗ dotnet fsautocomplete.dll
compilerlocation
{"Kind":"compilerlocation","Data":{"Fsc":"fsc.exe","Fsi":"fsharpi","MSBuild":"msbuild"}}
```