### PR TITLE
add the same non-windows msbuild check that we do for fsc and fsi

### DIFF
--- a/src/FsAutoComplete.Core/Environment.fs
+++ b/src/FsAutoComplete.Core/Environment.fs
@@ -66,7 +66,7 @@ module Environment =
     |> List.map (fun (version, sku) -> programFilesX86 </> "Microsoft Visual Studio" </> version </> sku) 
 
   let msbuild =
-      if Utils.runningOnMono then "msbuild" // we're way past 5.0 now, time to get updated
+      if Utils.runningOnMono || not Utils.isWindows then "msbuild" // we're way past 5.0 now, time to get updated
       else
         let legacyPaths =
             [ programFilesX86 </> @"\MSBuild\14.0\Bin"


### PR DESCRIPTION
One more, I somehow missed msbuild:

before(dotnet):
```
➜  release_netcore git:(417ecd0) ✗ dotnet fsautocomplete.dll
compilerlocation
{"Kind":"compilerlocation","Data":{"Fsc":"fsharpc","Fsi":"fsharpi","MSBuild":"MSBuild.exe"}}
```
before(mono):
```
➜  release_netcore git:(417ecd0) ✗ cd ../release
➜  release git:(417ecd0) ✗ mono fsautocomplete.exe
compilerlocation
{"Kind":"compilerlocation","Data":{"Fsc":"fsharpc","Fsi":"fsharpi","MSBuild":"msbuild"}}
```

after(dotnet):
```
➜  FsAutoComplete.netcore git:(fix-netcore-msbuild-path) dotnet run
compilerlocation
{"Kind":"compilerlocation","Data":{"Fsc":"fsharpc","Fsi":"fsharpi","MSBuild":"msbuild"}}
```

after(mono):
```
➜  net461 git:(fix-netcore-msbuild-path) mono fsautocomplete.exe
pilerlocation
{"Kind":"compilerlocation","Data":{"Fsc":"fsharpc","Fsi":"fsharpi","MSBuild":"msbuild"}}
```
