### PR TITLE
make paths to binaries optional to aid in error handling for client applications

### DIFF
--- a/src/FsAutoComplete.Core/CommandResponse.fs
+++ b/src/FsAutoComplete.Core/CommandResponse.fs
@@ -213,9 +213,9 @@ module CommandResponse =
 
   type CompilerLocationResponse =
     {
-      Fsc: string
-      Fsi: string
-      MSBuild: string
+      Fsc: string option
+      Fsi: string option
+      MSBuild: string option
     }
 
   type FSharpErrorInfo =

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -466,6 +466,7 @@ module String =
             Some()
         else None
 
+    let split (splitter: char) (s: string) = s.Split([| splitter |], StringSplitOptions.RemoveEmptyEntries) |> List.ofArray
 
 
 type ConcurrentDictionary<'key, 'value> with

--- a/test/FsAutoComplete.Tests/Tests.fs
+++ b/test/FsAutoComplete.Tests/Tests.fs
@@ -40,7 +40,9 @@ let ``should find FSharp.Core`` () =
 [<Test>]
 let ``should find fsc on Windows`` () =
   if not Utils.runningOnMono then
-    Assert.That(Environment.fsc.Contains("Microsoft SDKs"), "fsc.exe resolution failed")
+    Assert.That(Option.isSome Environment.fsc, "should find fsc.exe")
+    let (Some fsc) = Environment.fsc
+    Assert.That(fsc.Contains("Microsoft SDKs"), "fsc.exe resolution failed")
 
 [<Test>]
 let ``should find msbuild on Windows`` () =


### PR DESCRIPTION
as part of https://github.com/ionide/ionide-vscode-fsharp/issues/887 we should be able to tell if the binary was found or not, so send options across the wire if we can't find the things!