### PR TITLE
Defer to locally-packaged FSharp.Core for scripts

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -43,7 +43,8 @@ Target "BuildDebug" (fun _ ->
   DotNetCli.Build (fun p ->
      { p with
          Configuration = "Debug"
-         Project = "FsAutoComplete.netcore.sln" })
+         Project = "FsAutoComplete.netcore.sln"
+         AdditionalArgs = [ "/p:SourceLinkCreate=true" ]  })
 )
 
 Target "BuildRelease" (fun _ ->
@@ -302,13 +303,15 @@ Target "LocalRelease" (fun _ ->
        { p with
            Output = __SOURCE_DIRECTORY__ </> "bin/release"
            Runtime = "win-x64"
-           Project = "src/FsAutoComplete" })
+           Project = "src/FsAutoComplete"
+           AdditionalArgs = [ "/p:SourceLinkCreate=true" ]  })
 
     CleanDirs [ "bin/release_netcore" ]
     DotNetCli.Publish (fun p ->
        { p with
            Output = __SOURCE_DIRECTORY__ </> "bin/release_netcore"
-           Project = "src/FsAutoComplete.netcore" })
+           Project = "src/FsAutoComplete.netcore"
+           AdditionalArgs = [ "/p:SourceLinkCreate=true" ]  })
 )
 
 #load "paket-files/build/fsharp/FAKE/modules/Octokit/Octokit.fsx"

--- a/paket.lock
+++ b/paket.lock
@@ -7,7 +7,7 @@ NUGET
       FSharp.Core (>= 4.0.0.1)
     FParsec (1.0.3)
       FSharp.Core (>= 4.0.0.1)
-    FSharp.Core (4.5.1) - redirects: force
+    FSharp.Core (4.5.2) - redirects: force
     FSharpLint.Core (0.9.0-beta)
       FParsec (>= 1.0.3)
       FSharp.Compiler.Service (>= 14.0.2)

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -425,12 +425,7 @@ module FSharpCompilerServiceCheckerHelper =
   let isFSharpCore (s : string) = s.EndsWith "FSharp.Core.dll"
 
   let ensureCorrectFSharpCore (options: string[]) =
-    [| match Environment.fsharpCoreOpt with
-       | Some path -> yield (sprintf "-r:%s" path)
-       | None ->
-          match options |> Array.tryFind isFSharpCore with
-          | Some ref -> yield ref
-          | None -> ()
+    [| yield sprintf "-r:%s" Environment.fsharpCore
        //ensure single FSharp.Core ref
        yield! options |> Array.filter (not << isFSharpCore) |]
 

--- a/src/FsAutoComplete.Core/Environment.fs
+++ b/src/FsAutoComplete.Core/Environment.fs
@@ -113,23 +113,9 @@ module Environment =
       // if running on windows, non-mono we can't yet send paths to the netcore version of fsc.exe so use the one from full-framework
       Option.getOrElse "" fsharpInstallationPath </> "fsc.exe"
 
-  let fsharpCoreOpt =
-#if SCRIPT_REFS_FROM_MSBUILD
-    if not(System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) then
-      None
-#else
-    if Utils.runningOnMono then
-      let mscorlibDir = Path.GetDirectoryName typeof<obj>.Assembly.Location
-      if List.forall File.Exists (List.map (combinePaths mscorlibDir) ["FSharp.Core.dll"; "FSharp.Core.optdata"; "FSharp.Core.sigdata"]) then
-        Some (mscorlibDir </> "FSharp.Core.dll")
-      else
-        None
-#endif
-    else
-      let referenceAssembliesPath =
-        programFilesX86 </> @"Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\"
-      let fsharpCoreVersions = ["4.4.1.0"; "4.4.0.0"; "4.3.1.0"; "4.3.0.0"]
-      tryFindFile (List.map (combinePaths referenceAssembliesPath) fsharpCoreVersions) "FSharp.Core.dll"
+  let fsharpCore =
+    let dir = Path.GetDirectoryName <| System.Reflection.Assembly.GetExecutingAssembly().Location
+    dir </> "FSharp.Core.dll"
 
 #if SCRIPT_REFS_FROM_MSBUILD
 #else

--- a/src/FsAutoComplete.Core/State.fs
+++ b/src/FsAutoComplete.Core/State.fs
@@ -70,8 +70,7 @@ type State =
     lst
 
   static member private FileWithoutProjectOptions(file) =
-    let opts=
-        defaultArg (Environment.fsharpCoreOpt  |> Option.map (fun path -> [| yield sprintf "-r:%s" path; yield "--noframework" |] )) [|"--noframework"|]
+    let opts = [| yield sprintf "-r:%s" Environment.fsharpCore; yield "--noframework" |]
 
     { ProjectId = Some (file + ".fsproj")
       ProjectFileName = file + ".fsproj"

--- a/test/FsAutoComplete.Tests/Tests.fs
+++ b/test/FsAutoComplete.Tests/Tests.fs
@@ -34,10 +34,6 @@ let ``normalCracking`` () =
      CollectionAssert.AreEqual (["Third"], idents, "idents")
 
 [<Test>]
-let ``should find FSharp.Core`` () =
-  Assert.That(Option.isSome Environment.fsharpCoreOpt, "FSharp.Core.dll resolution failed")
-
-[<Test>]
 let ``should find fsc on Windows`` () =
   if not Utils.runningOnMono then
     Assert.That(Environment.fsc.Contains("Microsoft SDKs"), "fsc.exe resolution failed")


### PR DESCRIPTION
Fixes (hopefully) #309 