### PR TITLE
include symbolcache `runtimeconfig.json` and `deps.json` to .net core binaries

### DIFF
--- a/src/FsAutoComplete/FsAutoComplete.fsproj
+++ b/src/FsAutoComplete/FsAutoComplete.fsproj
@@ -58,5 +58,16 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="CopySymbolCacheJsonToOutputDir"
+          AfterTargets="ComputeFilesToPublish"
+          Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+    <ItemGroup>
+      <ResolvedFileToPublish Include="$(MSBuildProjectDirectory)/../FsAutoComplete.SymbolCache\bin\$(Configuration)\netcoreapp2.1\fsautocomplete.symbolcache.deps.json"
+                             RelativePath="fsautocomplete.symbolcache.deps.json" />
+      <ResolvedFileToPublish Include="$(MSBuildProjectDirectory)/../FsAutoComplete.SymbolCache\bin\$(Configuration)\netcoreapp2.1\fsautocomplete.symbolcache.runtimeconfig.json"
+                             RelativePath="fsautocomplete.symbolcache.runtimeconfig.json" />
+    </ItemGroup>
+  </Target>
+
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
it doesnt bundle the `runtimeconfig.dev.json` because that's just for development

fix https://github.com/fsharp/FsAutoComplete/issues/355