### PR TITLE
add fsdn command

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -10,6 +10,7 @@ nuget Argu ~> 5.2.0
 nuget FSharp.Compiler.Service ~> 28.0
 nuget FSharp.Compiler.Service.ProjectCracker ~> 28.0 framework:net461, condition:net461
 nuget Dotnet.ProjInfo ~> 0.31.0
+nuget FSharp.Data 3.0.1
 nuget ICSharpCode.Decompiler 3.2.0.3856
 nuget Sln ~> 0.3.0
 nuget Mono.Cecil >= 0.10.0-beta7

--- a/paket.lock
+++ b/paket.lock
@@ -6,7 +6,7 @@ NUGET
       FSharp.Core (>= 4.0.0.1) - restriction: || (== net461) (&& (== netcoreapp2.1) (>= net45)) (&& (== netstandard2.0) (>= net45))
       FSharp.Core (>= 4.3.2) - restriction: || (&& (== net461) (< net45) (>= netstandard2.0)) (== netcoreapp2.1) (== netstandard2.0)
       System.Configuration.ConfigurationManager (>= 4.4) - restriction: || (&& (== net461) (< net45) (>= netstandard2.0)) (== netcoreapp2.1) (== netstandard2.0)
-    Dapper (1.60.5)
+    Dapper (1.60.6)
       System.Data.SqlClient (>= 4.4) - restriction: || (&& (== net461) (< net451)) (== netcoreapp2.1) (== netstandard2.0)
       System.Reflection.Emit.Lightweight (>= 4.3) - restriction: || (&& (== net461) (< net451)) (== netcoreapp2.1) (== netstandard2.0)
       System.Reflection.TypeExtensions (>= 4.4) - restriction: || (&& (== net461) (< net451)) (== netcoreapp2.1) (== netstandard2.0)
@@ -36,6 +36,9 @@ NUGET
       FSharp.Core (>= 4.6.2) - restriction: || (== net461) (&& (== netcoreapp2.1) (>= net461)) (&& (== netstandard2.0) (>= net461))
       System.ValueTuple (>= 4.4) - restriction: || (== net461) (&& (== netcoreapp2.1) (>= net461)) (&& (== netstandard2.0) (>= net461))
     FSharp.Core (4.6.2) - redirects: force
+    FSharp.Data (3.0.1)
+      FSharp.Core (>= 4.0.0.1) - restriction: || (== net461) (&& (== netcoreapp2.1) (>= net45)) (&& (== netstandard2.0) (>= net45))
+      FSharp.Core (>= 4.3.4) - restriction: || (&& (== net461) (< net45) (>= netstandard2.0)) (== netcoreapp2.1) (== netstandard2.0)
     FSharpLint.Core (0.10.8)
       Dotnet.ProjInfo (>= 0.31)
       FParsec (>= 1.0.3)

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -109,14 +109,13 @@ type Commands (serialize : Serializer) =
 
         let values = results?values.AsArray()
         
-        let createResult (values) =
-            let v = values
+        let createResult (v: JsonValue) =
             let info2 = v?api?name
             //return a list of strings
             let infonamespace = info2?``namespace``.AsString()
             let infoclass = info2?class_name.AsString()
             let infomethod = info2?id.AsString()
-            let finalresp = infonamespace + infoclass + infomethod
+            let finalresp = infoclass + "." + infomethod
             finalresp 
 
         values
@@ -337,8 +336,7 @@ type Commands (serialize : Serializer) =
         x.MapResultAsync ((fun x -> successToString x |> async.Return), ?failureToString = failureToString)
 
     member x.Fsdn (querystr) = async {
-            printfn "hi! tried to do fsdn from commands"
-            let results = fsdn querystr
+            let results = fsdn querystr 
             return [ Response.fsdn serialize results ]
         }
 

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1,7 +1,4 @@
 namespace FsAutoComplete
-#if INTERACTIVE
-#r "/home/nikita/.nuget/packages/fsharp.data/3.0.1/lib/net45/FSharp.Data.dll"
-#endif
 
 open System
 open System.IO

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -55,6 +55,7 @@ type CoreResponse =
     | SymbolUseRange of ranges: SymbolCache.SymbolUseRange[]
     | SymbolUseImplementationRange of ranges: SymbolCache.SymbolUseRange[]
     | RangesAtPositions of ranges: range list list
+    | Fsdn of string list
 
 [<RequireQualifiedAccess>]
 type NotificationEvent =
@@ -334,7 +335,7 @@ type Commands (serialize : Serializer) =
 
     member x.Fsdn (querystr) = async {
             let results = fsdn querystr 
-            return [ Response.fsdn serialize results ]
+            return [ CoreResponse.Fsdn results ]
         }
 
     member private x.AsCancellable (filename : SourceFilePath) (action : Async<CoreResponse list>) =

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1,6 +1,6 @@
 namespace FsAutoComplete
 #if INTERACTIVE
-#r "../../../bin/lib/net45/FSharp.Data.dll"
+#r "/home/nikita/.nuget/packages/fsharp.data/3.0.1/lib/net45/FSharp.Data.dll"
 #endif
 
 open System
@@ -105,22 +105,23 @@ type Commands (serialize : Serializer) =
             |> String.concat "&"
 
         let req = Http.RequestString( "https://fsdn.azurewebsites.net/api/search?" + queryString )
-        let info = JsonValue.Parse(req)
+        let results = JsonValue.Parse(req)
 
-        let values = info?values.AsArray()
-        let v = values |> Array.head
-        let d = v?api?name?id.AsString()
+        let values = results?values.AsArray()
+        
+        let createResult (values) =
+            let v = values
+            let info2 = v?api?name
+            //return a list of strings
+            let infonamespace = info2?``namespace``.AsString()
+            let infoclass = info2?class_name.AsString()
+            let infomethod = info2?id.AsString()
+            let finalresp = infonamespace + infoclass + infomethod
+            finalresp 
 
-        let info2 = v?api?name
-        //return a list of strings
-
-        let infonamespace = info2?``namespace``.AsString()
-        let infoclass = info2?class_name.AsString()
-        let infomethod = info2?id.AsString()
-        let finalresp = infonamespace + infoclass + infomethod
-
-        [ finalresp ]
-
+        values
+        |> Array.map createResult
+        |> Array.toList    
 
     let workspaceReady = Event<unit>()
 

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -338,7 +338,8 @@ type Commands (serialize : Serializer) =
 
     member x.Fsdn (querystr) = async {
             printfn "hi! tried to do fsdn from commands"
-            return fsdn querystr
+            let results = fsdn querystr
+            return [ Response.fsdn serialize results ]
         }
 
     member private x.AsCancellable (filename : SourceFilePath) (action : Async<CoreResponse list>) =

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -335,9 +335,9 @@ type Commands (serialize : Serializer) =
     member private x.MapResult (successToString: 'a -> CoreResponse, ?failureToString: string -> CoreResponse) =
         x.MapResultAsync ((fun x -> successToString x |> async.Return), ?failureToString = failureToString)
 
-    member x.Fsdn () = async {
+    member x.Fsdn (querystr) = async {
             printfn "hi! tried to do fsdn from commands"
-            return fsdn "int -> int"
+            return fsdn querystr
         }
 
     member private x.AsCancellable (filename : SourceFilePath) (action : Async<CoreResponse list>) =

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1,4 +1,5 @@
 namespace FsAutoComplete
+#r "../../../bin/lib/net45/FSharp.Data.dll"
 
 open System
 open System.IO
@@ -12,6 +13,7 @@ open Utils
 open System.Reflection
 open FSharp.Compiler.Range
 open FSharp.Analyzers
+open FSharp.Data
 
 [<RequireQualifiedAccess>]
 type CoreResponse =
@@ -81,6 +83,16 @@ type Commands (serialize : Serializer) =
     let mutable isWorkspaceReady = false
 
     let notify = Event<NotificationEvent>()
+
+    let fsdn (querystr:string) = 
+        Http.RequestString( "https://fsdn.azurewebsites.net/api/search",query=querystr, httpMethod="GET" )
+        let resp = req.GetResponse()
+        let info = JsonValue.Parse(resp)
+        let infonamespace = info?namespace.AsString()
+        let infoclass = info?class_name.AsString()
+        let infomethod = info?name.AsString()
+        let finalresp = infonamespace + infoclass + infomethod
+        Console.WriteLine(finalresp)
 
     let workspaceReady = Event<unit>()
 

--- a/src/FsAutoComplete.Core/paket.references
+++ b/src/FsAutoComplete.Core/paket.references
@@ -8,3 +8,4 @@ OptimizedPriorityQueue
 ICSharpCode.Decompiler
 FSharp.Analyzers.SDK
 Microsoft.SourceLink.GitHub
+FSharp.Data

--- a/src/FsAutoComplete/CommandInput.fs
+++ b/src/FsAutoComplete/CommandInput.fs
@@ -40,7 +40,7 @@ type Command =
   | RegisterAnalyzer of string
   | Started
   | Quit
-  | Fsdn
+  | Fsdn of string
 
 module CommandInput =
   /// Parse 'quit' command
@@ -166,8 +166,11 @@ module CommandInput =
       return WorkspaceLoad (files |> Array.ofList) }
 
   let fsdn = parser {
-      let! _ = string "fsdn"
-      return Fsdn
+      let! _ = string "fsdn "
+      let! _ = char '"'
+      let! querystr = some (sat ((<>) '"')) |> Parser.map String.OfSeq
+      let! _ = char '"'
+      return (Fsdn querystr)
       }
 
   // Parse 'completion "<filename>" "<linestr>" <line> <col> [timeout]' command

--- a/src/FsAutoComplete/CommandInput.fs
+++ b/src/FsAutoComplete/CommandInput.fs
@@ -40,6 +40,7 @@ type Command =
   | RegisterAnalyzer of string
   | Started
   | Quit
+  | Fsdn
 
 module CommandInput =
   /// Parse 'quit' command
@@ -164,6 +165,11 @@ module CommandInput =
       let! files = many parseFilename
       return WorkspaceLoad (files |> Array.ofList) }
 
+  let fsdn = parser {
+      let! _ = string "fsdn"
+      return Fsdn
+      }
+
   // Parse 'completion "<filename>" "<linestr>" <line> <col> [timeout]' command
   let completionTipOrDecl = parser {
     let! f = (string "completion " |> Parser.map (fun _ -> Completion)) <|>
@@ -222,7 +228,7 @@ module CommandInput =
     | null -> Quit
     | input ->
       let reader = Parsing.createForwardStringReader input 0
-      let cmds = compilerlocation <|> helptext <|> declarations <|> lint <|> registerAnalyzer <|> unusedDeclarations <|> simplifiedNames <|> unusedOpens <|> parse <|> project <|> completionTipOrDecl <|> quit <|> colorizations <|> workspacePeek <|> workspaceLoad <|> error
+      let cmds = compilerlocation <|> helptext <|> declarations <|> lint <|> registerAnalyzer <|> unusedDeclarations <|> simplifiedNames <|> unusedOpens <|> parse <|> project <|> completionTipOrDecl <|> quit <|> colorizations <|> workspacePeek <|> workspaceLoad <|> fsdn <|> error
       let cmd = reader |> Parsing.getFirst cmds
       match cmd with
       | Parse (filename,kind,_) ->

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -404,6 +404,11 @@ module CommandResponse =
     { File: string
       Messages: AnalyzerMsg list}
 
+  type FsdnResponse = {
+    Functions: string list
+  }
+
+
   let info (serialize : Serializer) (s: string) = serialize { Kind = "info"; Data = s }
 
   let errorG (serialize : Serializer) (errorData: ErrorData) message =
@@ -582,6 +587,10 @@ module CommandResponse =
 
   let help (serialize : Serializer) (data : string) =
     serialize { Kind = "help"; Data = data }
+
+  let fsdn (serialize : Serializer) (functions : string list) =
+    let data = { FsdnResponse.Functions = functions }
+    serialize { Kind = "fsdn"; Data = data }
 
   let methods (serialize : Serializer) (meth: FSharpMethodGroup, commas: int) =
       serialize {  Kind = "method"

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -861,3 +861,4 @@ module CommandResponse =
     | CoreResponse.InterfaceStub(generatedCode, insertPosition) ->
       interfaceStub s generatedCode insertPosition
     | CoreResponse.RangesAtPositions(ranges) -> rangesAtPosition s ranges
+    | CoreResponse.Fsdn(functions) -> fsdn s functions

--- a/src/FsAutoComplete/FsAutoComplete.HttpApiContract.fs
+++ b/src/FsAutoComplete/FsAutoComplete.HttpApiContract.fs
@@ -13,4 +13,5 @@ type FileRequest = {FileName : string}
 type WorkspacePeekRequest = {Directory : string; Deep: int; ExcludedDirs: string array}
 type WorkspaceLoadRequest = {Files : string array; DisableInMemoryProjectReferences: bool}
 type DocumentationForSymbolReuqest = {XmlSig: string; Assembly: string}
+type FsdnRequest = {Signature : string}
 type QuitRequest() = class end

--- a/src/FsAutoComplete/FsAutoComplete.Stdio.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Stdio.fs
@@ -95,6 +95,7 @@ let main (commands: Commands) (commandQueue: BlockingCollection<Command>) =
           | WorkspacePeek (dir, deep, excludeDir) -> return! commands.WorkspacePeek dir deep (excludeDir |> List.ofArray)
           | WorkspaceLoad files -> return! commands.WorkspaceLoad (fun fullPath -> commandQueue.Add(Project (fullPath, false))) (files |> List.ofArray) false
           | Error msg -> return commands.Error msg
+          | Fsdn -> return! commands.Fsdn ()
           | Quit ->
               quit <- true
               return! commands.Quit()

--- a/src/FsAutoComplete/FsAutoComplete.Stdio.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Stdio.fs
@@ -95,7 +95,7 @@ let main (commands: Commands) (commandQueue: BlockingCollection<Command>) =
           | WorkspacePeek (dir, deep, excludeDir) -> return! commands.WorkspacePeek dir deep (excludeDir |> List.ofArray)
           | WorkspaceLoad files -> return! commands.WorkspaceLoad (fun fullPath -> commandQueue.Add(Project (fullPath, false))) (files |> List.ofArray) false
           | Error msg -> return commands.Error msg
-          | Fsdn -> return! commands.Fsdn ()
+          | Fsdn querystr -> return! commands.Fsdn (querystr)
           | Quit ->
               quit <- true
               return! commands.Quit()

--- a/src/FsAutoComplete/FsAutoComplete.Suave.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Suave.fs
@@ -149,6 +149,7 @@ let start (commands: Commands) (args: ParseResults<Options.CLIArguments>) =
                     return! Response.response HttpCode.HTTP_200 res httpCtx
                 }
             path "/helptext" >=> handler (fun (data : HelptextRequest) -> commands.Helptext data.Symbol |> async.Return)
+            path "/fsdn" >=> handler (fun (data : FsdnRequest) -> commands.Fsdn data.Signature )
             path "/completion" >=> handler (fun (data : CompletionRequest) -> async {
                 let file = Path.GetFullPath data.FileName
                 match commands.TryGetFileCheckerOptionsWithLines file with


### PR DESCRIPTION
I have created a "fsdn" command which makes an http get request to https://fsdn.azurewebsites.net/api/search and parses the response. The code is still 'work in progress'. 
@enricosada let me know if you have any suggestions.

fix #362 

TODO

- [X] add stdio command `fsdn` with query as argument
- [x] return all query results
- [x] return json
- [x] add http command `/fsdn` with query as argument

