### PR TITLE
add rollForwardOnNoCandidateFx runtime setting to allow to run on .net core runtime > 2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 * upgrade to `FSharpLint.Core` v0.10.8
 * include symbolcache `runtimeconfig.json` and `deps.json` to .net core binaries
 * add `default.win32manifest` to .net core binaries
+* fix to allow run with only .NET Core Runtime 3 installed (previously v2.x was required) [#364](https://github.com/fsharp/FsAutoComplete/issues/364)
 
 #### 0.37.0 - 28.02.2019
 

--- a/src/FsAutoComplete.SymbolCache/runtimeconfig.template.json
+++ b/src/FsAutoComplete.SymbolCache/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForwardOnNoCandidateFx": 2
+}

--- a/src/FsAutoComplete/runtimeconfig.template.json
+++ b/src/FsAutoComplete/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
fix https://github.com/fsharp/FsAutoComplete/issues/364