### PR TITLE
fix lsp test run

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -233,7 +233,7 @@ Target "IntegrationTestHttpModeNetCore" (fun _ ->
 
 Target "LspTest" (fun _ ->
   DotNetCli.Restore (fun r -> {r with WorkingDir = "./test/FsAutoComplete.Tests.Lsp/TestCases/"})
-  DotNetCli.RunCommand id "run -p \"./test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj\""
+  DotNetCli.RunCommand id "run -c Release --no-build -p \"./test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj\""
 )
 
 Target "ReleaseArchive" (fun _ ->


### PR DESCRIPTION
The `dotnet run` configuration was not specified, and by default is Debug.
So that `dotnet run` was rebuilding everything (time consuming, Release was already built) and the tests where run on Debug.

Now it run on Release without rebuild