### PR TITLE
 Refactor debug logging

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -94,12 +94,9 @@ type Commands (serialize : Serializer) =
         async {
             try
                 let opt = state.BackgroundProjects.First
-                // printfn "1. BACKGROUND QUEUE: %A" (state.BackgroundProjects |> Seq.map (fun n -> n.ProjectFileName))
-                // printfn "BACKGROUND CHECKER - PARSING STARTED: %s" (opt.ProjectFileName)
                 checker.CheckProjectInBackground opt
             with
             | _ ->
-                // printfn "BACKGROUND CHECKER - NO PROJECTS"
                 ()
         } |> Async.Start
 
@@ -212,7 +209,7 @@ type Commands (serialize : Serializer) =
                     // is raised, who can be ignored
                     ()
                 | ex ->
-                    printfn "Failed to parse file '%s' exn %A" file ex
+                    Debug.print "[Commands] Failed to parse file '%s' exn %A" file ex
             ) }
 
     let calculateNamespaceInser (decl : FSharpDeclarationListItem) (pos : pos) getLine =
@@ -386,7 +383,6 @@ type Commands (serialize : Serializer) =
         | Some (p, projs) ->
             state.EnqueueProjectForBackgroundParsing(p, 0)
             projs |> Seq.iter (fun p -> state.EnqueueProjectForBackgroundParsing (p,1))
-            // printfn "3. BACKGROUND QUEUE: %A" (state.BackgroundProjects |> Seq.map (fun n -> n.ProjectFileName))
         | None -> ()
         return [CoreResponse.Errors ([||], "") ]
     }
@@ -416,7 +412,6 @@ type Commands (serialize : Serializer) =
 
     member x.Project projectFileName verbose onChange = async {
         let projectFileName = Path.GetFullPath projectFileName
-        //printfn "project path: %s" projectFileName
         let project =
             match state.Projects.TryFind projectFileName with
             | Some prj -> prj
@@ -424,7 +419,6 @@ type Commands (serialize : Serializer) =
                 let proj = new Project(projectFileName, onChange)
                 state.Projects.[projectFileName] <- proj
                 proj
-        //printfn "project:\n%A" project
         let projResponse =
             match project.Response with
             | Some response ->
@@ -437,7 +431,6 @@ type Commands (serialize : Serializer) =
                 | Result.Error error ->
                     project.Response <- None
                     Result.Error error
-        //printfn "Project response: %A" projResponse
         return
             match projResponse with
             | Result.Ok (projectFileName, response) ->

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -48,14 +48,10 @@ type ParseAndCheckResults
     let lineStr = lines.[line - 1]
     match Parsing.findLongIdentsAtGetMethodsTrigger(col - 1, lineStr) with
     | None ->
-      let e = DateTime.Now
-      //printfn "[Debug] TryGetMethodOverrides took %fms" (e-s).TotalMilliseconds
       return ResultOrString.Error "Could not find ident at this location"
     | Some identIsland ->
 
     let! meth = checkResults.GetMethods(line, col, lineStr, Some identIsland)
-    let e = DateTime.Now
-    //printfn "[Debug] TryGetMethodOverrides took %fms" (e-s).TotalMilliseconds
     return Ok(meth, commas) }
 
   member __.TryFindDeclaration (pos: pos) (lineStr: LineStr) = async {
@@ -68,34 +64,23 @@ type ParseAndCheckResults
 
       match declarations with
       | FSharpFindDeclResult.DeclNotFound _ ->
-        let e = DateTime.Now
-        //printfn "[Debug] TryFindDeclaration took %fms" (e-s).TotalMilliseconds
         return ResultOrString.Error "Could not find declaration"
       | FSharpFindDeclResult.DeclFound range ->
-        let e = DateTime.Now
-        //printfn "[Debug] TryFindDeclaration took %fms" (e-s).TotalMilliseconds
         return Ok (FindDeclarationResult.Range range)
       | FSharpFindDeclResult.ExternalDecl (assembly, externalSym) ->
-        let e = DateTime.Now
-        //printfn "[Debug] TryFindDeclaration took %fms" (e-s).TotalMilliseconds
         return Decompiler.tryFindExternalDeclaration checkResults (assembly, externalSym)
                 |> Option.map (fun extDec -> ResultOrString.Ok (FindDeclarationResult.ExternalDeclaration extDec))
                 |> Option.getOrElse (ResultOrString.Error "External declaration not resolved")
     }
 
   member __.TryFindTypeDeclaration (pos: pos) (lineStr: LineStr) = async {
-    let s = DateTime.Now
     match Parsing.findLongIdents(pos.Column - 1, lineStr) with
     | None ->
-      let e = DateTime.Now
-      //printfn "[Debug] TryFindTypeDeclaration took %fms" (e-s).TotalMilliseconds
       return Error "Cannot find ident at this location"
     | Some(col,identIsland) ->
       let! symbol = checkResults.GetSymbolUseAtLocation(pos.Line, col, lineStr, identIsland)
       match symbol with
       | None ->
-        let e = DateTime.Now
-        //printfn "[Debug] TryFindTypeDeclaration took %fms" (e-s).TotalMilliseconds
         return Error "Cannot find symbol at this locaion"
       | Some sym ->
         let r =
@@ -109,18 +94,13 @@ type ParseAndCheckResults
           | _ -> None
         match r with
         | Some r when File.Exists r.FileName ->
-          let e = DateTime.Now
-          //printfn "[Debug] TryFindTypeDeclaration took %fms" (e-s).TotalMilliseconds
           return (Ok r)
         | _ ->
-          let e = DateTime.Now
-          //printfn "[Debug] TryFindTypeDeclaration took %fms" (e-s).TotalMilliseconds
           return Error "No type information for the symbol at this location"
 
   }
 
   member __.TryGetToolTip (pos: pos) (lineStr: LineStr) = async {
-    let s = DateTime.Now
     match Parsing.findLongIdents(pos.Column - 1, lineStr) with
     | None -> return ResultOrString.Error "Cannot find ident for tooltip"
     | Some(col,identIsland) ->
@@ -136,25 +116,16 @@ type ParseAndCheckResults
                |> Option.map (fun desc -> FSharpToolTipText [FSharpToolTipElement.Single(ident, FSharpXmlDoc.Text desc)])
                |> function
                | Some tip ->
-                let e = DateTime.Now
-                //printfn "[Debug] TryGetToolTip took %fms" (e-s).TotalMilliseconds
                 Ok tip
                | None ->
-                let e = DateTime.Now
-                //printfn "[Debug] TryGetToolTip took %fms" (e-s).TotalMilliseconds
                 ResultOrString.Error "No tooltip information"
             | _ ->
-              let e = DateTime.Now
-              //printfn "[Debug] TryGetToolTip took %fms" (e-s).TotalMilliseconds
               ResultOrString.Error "No tooltip information"
         | _ ->
-          let e = DateTime.Now
-          //printfn "[Debug] TryGetToolTip took %fms" (e-s).TotalMilliseconds
           Ok(tip)
   }
 
   member __.TryGetToolTipEnhanced (pos: pos) (lineStr: LineStr) = async {
-    let s = DateTime.Now
     match Parsing.findLongIdents(pos.Column - 1, lineStr) with
     | None -> return Error "Cannot find ident for tooltip"
     | Some(col,identIsland) ->
@@ -171,36 +142,22 @@ type ParseAndCheckResults
                            |> Option.map (fun desc -> FSharpToolTipText [FSharpToolTipElement.Single(ident, FSharpXmlDoc.Text desc)])
              match keyword with
              | Some tip ->
-              let e = DateTime.Now
-              //printfn "[Debug] TryGetToolTipEnhanced took %fms" (e-s).TotalMilliseconds
               return Ok (tip, ident, "", None)
              | None ->
-              let e = DateTime.Now
-              //printfn "[Debug] TryGetToolTipEnhanced took %fms" (e-s).TotalMilliseconds
               return Error "No tooltip information"
           | _ ->
-            let e = DateTime.Now
-            //printfn "[Debug] TryGetToolTipEnhanced took %fms" (e-s).TotalMilliseconds
             return Error "No tooltip information"
       | _ ->
       match symbol with
       | None ->
-        let e = DateTime.Now
-        //printfn "[Debug] TryGetToolTipEnhanced took %fms" (e-s).TotalMilliseconds
         return Error "No tooltip information"
       | Some symbol ->
 
         match SignatureFormatter.getTooltipDetailsFromSymbolUse symbol with
         | None ->
-          let e = DateTime.Now
-          //printfn "[Debug] TryGetToolTipEnhanced took %fms" (e-s).TotalMilliseconds
           return Error "No tooltip information"
         | Some (signature, footer) ->
-            let e = DateTime.Now
             let typeDoc = getTypeIfConstructor symbol.Symbol |> Option.map (fun n -> n.XmlDocSig)
-
-
-            //printfn "[Debug] TryGetToolTipEnhanced took %fms" (e-s).TotalMilliseconds
             return Ok (tip, signature, footer, typeDoc)
   }
 
@@ -299,42 +256,30 @@ type ParseAndCheckResults
 
   member __.TryGetSymbolUse (pos: pos) (lineStr: LineStr) =
     async {
-        let s = DateTime.Now
         match Parsing.findLongIdents(pos.Column - 1, lineStr) with
         | None ->
-          let e = DateTime.Now
-          //printfn "[Debug] TryGetSymbolUse took %fms" (e-s).TotalMilliseconds
           return (ResultOrString.Error "No ident at this location")
         | Some(colu, identIsland) ->
 
         let! symboluse = checkResults.GetSymbolUseAtLocation(pos.Line, colu, lineStr, identIsland)
         match symboluse with
         | None ->
-          let e = DateTime.Now
-          //printfn "[Debug] TryGetSymbolUse took %fms" (e-s).TotalMilliseconds
           return (ResultOrString.Error "No symbol information found")
         | Some symboluse ->
 
         let! symboluses = checkResults.GetUsesOfSymbolInFile symboluse.Symbol
-        let e = DateTime.Now
-        //printfn "[Debug] TryGetSymbolUse took %fms" (e-s).TotalMilliseconds
         return Ok (symboluse, symboluses) }
 
   member __.TryGetSignatureData (pos: pos) (lineStr: LineStr) =
     async {
-        let s = DateTime.Now
         match Parsing.findLongIdents(pos.Column - 1, lineStr) with
         | None ->
-          let e = DateTime.Now
-          //printfn "[Debug] TryGetSignatureData took %fms" (e-s).TotalMilliseconds
           return (ResultOrString.Error "No ident at this location")
         | Some(colu, identIsland) ->
 
         let! symboluse = checkResults.GetSymbolUseAtLocation(pos.Line, colu, lineStr, identIsland)
         match symboluse with
         | None ->
-          let e = DateTime.Now
-          //printfn "[Debug] TryGetSignatureData took %fms" (e-s).TotalMilliseconds
           return (ResultOrString.Error "No symbol information found")
         | Some symboluse ->
           let fsym = symboluse.Symbol
@@ -343,8 +288,6 @@ type ParseAndCheckResults
 
             let typ = symbol.ReturnParameter.Type.Format symboluse.DisplayContext
             if symbol.IsPropertyGetterMethod then
-                let e = DateTime.Now
-                //printfn "[Debug] TryGetSignatureData took %fms" (e-s).TotalMilliseconds
                 return Ok(typ, [])
             else
               let parms =
@@ -355,16 +298,10 @@ type ParseAndCheckResults
               // as parameters.
               match parms with
               | [ [] ] when symbol.IsMember && (not symbol.IsPropertyGetterMethod) ->
-                let e = DateTime.Now
-                //printfn "[Debug] TryGetSignatureData took %fms" (e-s).TotalMilliseconds
                 return Ok(typ, [ [ ("unit", "unit") ] ])
               | _ ->
-                let e = DateTime.Now
-                //printfn "[Debug] TryGetSignatureData took %fms" (e-s).TotalMilliseconds
                 return Ok(typ, parms)
           | _ ->
-            let e = DateTime.Now
-            //printfn "[Debug] TryGetSignatureData took %fms" (e-s).TotalMilliseconds
             return (ResultOrString.Error "Not a member, function or value" )
     }
 
@@ -381,7 +318,6 @@ type ParseAndCheckResults
 
   member __.TryGetCompletions (pos: pos) (lineStr: LineStr) filter (getAllSymbols : unit -> AssemblySymbol list) = async {
     try
-      let s = DateTime.Now
       let longName = FSharp.Compiler.QuickParse.GetPartialLongNameEx(lineStr, pos.Column - 2)
       let residue = longName.PartialIdent
 
@@ -429,15 +365,12 @@ type ParseAndCheckResults
 
 
       let shouldKeywords = decls.Length > 0 && not results.IsForType && not results.IsError && List.isEmpty longName.QualifyingIdents
-      let e = DateTime.Now
-      //printfn "[Debug] TryGetCompletions took %fms" (e-s).TotalMilliseconds
       return Some (decls, residue, shouldKeywords)
     with :? TimeoutException -> return None
   }
 
   member __.GetAllEntities (publicOnly: bool) : AssemblySymbol list =
       try
-        let s = DateTime.Now
         let res = [
           yield! AssemblyContentProvider.getAssemblySignatureContent AssemblyContentType.Full checkResults.PartialAssemblySignature
           let ctx = checkResults.ProjectContext
@@ -454,8 +387,6 @@ type ParseAndCheckResults
             let content = AssemblyContentProvider.getAssemblyContent entityCache.Locking contentType fileName signatures
             yield! content
         ]
-        let e = DateTime.Now
-        //printfn "[Debug] GetAllEntities took %fms" (e-s).TotalMilliseconds
         res
       with
       | _ -> []
@@ -536,6 +467,11 @@ type FSharpCompilerServiceChecker() =
   let clearProjectReferecnes (opts: FSharpProjectOptions) =
     if disableInMemoryProjectReferences then {opts with ReferencedProjects = [||]} else opts
 
+  let logDebug fmt =
+
+    if Debug.verbose then Debug.print "[FSharpChecker] Current Queue Length: %d" checker.CurrentQueueLength
+    Debug.print fmt
+
   member __.DisableInMemoryProjectReferences
     with get() = disableInMemoryProjectReferences
     and set(value) = disableInMemoryProjectReferences <- value
@@ -585,9 +521,12 @@ type FSharpCompilerServiceChecker() =
   }
 
 
-  member __.CheckProjectInBackground = checker.CheckProjectInBackground
+  member __.CheckProjectInBackground (fpo: FSharpProjectOptions) =
+    logDebug "[Checker] CheckProjectInBackground - %s" fpo.ProjectFileName
+    checker.CheckProjectInBackground fpo
 
   member __.GetBackgroundCheckResultsForFileInProject(fn, opt) =
+    logDebug "[Checker] GetBackgroundCheckResultsForFileInProject - %s" fn
     let opt = clearProjectReferecnes opt
     checker.GetBackgroundCheckResultsForFileInProject(fn, opt)
     |> Async.map (fun (pr,cr) ->  ParseAndCheckResults (pr, cr, entityCache))
@@ -598,11 +537,13 @@ type FSharpCompilerServiceChecker() =
   member __.ProjectChecked =
     checker.ProjectChecked
 
-  member __.ParseFile =
-    checker.ParseFile
+  member __.ParseFile(fn, source, fpo) =
+    logDebug "[Checker] ParseFile - %s" fn
+    checker.ParseFile(fn, source, fpo)
 
   member __.ParseAndCheckFileInProject(filePath, version, source, options) =
     async {
+      logDebug "[Checker] ParseAndCheckFileInProject - %s" filePath
       let options = clearProjectReferecnes options
       let fixedFilePath = fixFileName filePath
       let! res = Async.Catch (checker.ParseAndCheckFileInProject (fixedFilePath, version, source, options, null))
@@ -619,6 +560,7 @@ type FSharpCompilerServiceChecker() =
 
   member __.ParseAndCheckFileInProject'(filePath, version, source, options) =
     async {
+      logDebug "[Checker] ParseAndCheckFileInProject2 - %s" filePath
       let options = clearProjectReferecnes options
       let fixedFilePath = fixFileName filePath
       let! res = Async.Catch (checker.ParseAndCheckFileInProject (fixedFilePath, version, source, options, null))
@@ -632,11 +574,13 @@ type FSharpCompilerServiceChecker() =
     }
 
   member __.TryGetRecentCheckResultsForFile(file, options, ?source) =
+    logDebug "[Checker] TryGetRecentCheckResultsForFile - %s" file
     let options = clearProjectReferecnes options
     checker.TryGetRecentCheckResultsForFile(file, options, ?source=source)
     |> Option.map (fun (pr, cr, _) -> ParseAndCheckResults (pr, cr, entityCache))
 
   member x.GetUsesOfSymbol (file, options : (SourceFilePath * FSharpProjectOptions) seq, symbol : FSharpSymbol) = async {
+    logDebug "[Checker] GetUsesOfSymbol - %s" file
     let projects = x.GetDependingProjects file options
     return!
       match projects with
@@ -654,6 +598,7 @@ type FSharpCompilerServiceChecker() =
   }
 
   member __.GetDeclarations (fileName, source, options, version) = async {
+    logDebug "[Checker] GetDeclarations - %s" fileName
     let! parseResult = checker.ParseFile(fileName, source, options)
     return parseResult.GetNavigationItems().Declarations
   }

--- a/src/FsAutoComplete.Core/Debug.fs
+++ b/src/FsAutoComplete.Core/Debug.fs
@@ -52,16 +52,7 @@ module Debug =
     while not(System.Diagnostics.Debugger.IsAttached) do
       System.Threading.Thread.Sleep(100)
 
-  let zombieCheckWithHostPID quit pid =
-    try
-      let hostProcess = System.Diagnostics.Process.GetProcessById(pid)
-      ProcessWatcher.watch hostProcess (fun _ -> quit ())
-    with
-    | e ->
-      printfn "Host process ID %i not found: %s" pid e.Message
-      // If the process dies before we get here then request shutdown
-      // immediately
-      quit ()
+
 
   let inline flush () =
     if verbose then

--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Debug.fs" />
     <Compile Include="Utils.fs" />
     <Compile Include="ProcessWatcher.fs" />
     <Compile Include="UntypedAstUtils.fs" />

--- a/src/FsAutoComplete.Core/Lexer.fs
+++ b/src/FsAutoComplete.Core/Lexer.fs
@@ -128,7 +128,6 @@ module Lexer =
             | SymbolLookupKind.ByLongIdent ->
                 tokens |> List.filter (fun x -> x.Token.LeftColumn <= col)
 
-        //printfn "Filtered tokens: %+A" tokensUnderCursor
         match lookupKind with
         | SymbolLookupKind.ByLongIdent ->
             // Try to find start column of the long identifiers

--- a/src/FsAutoComplete.Core/ProcessWatcher.fs
+++ b/src/FsAutoComplete.Core/ProcessWatcher.fs
@@ -38,7 +38,7 @@ module ProcessWatcher =
       watch hostProcess (fun _ -> quit ())
     with
     | e ->
-      printfn "Host process ID %i not found: %s" pid e.Message
+      Debug.print "[Process Watcher] Host process ID %i not found: %s" pid e.Message
       // If the process dies before we get here then request shutdown
       // immediately
       quit ()

--- a/src/FsAutoComplete.Core/ProcessWatcher.fs
+++ b/src/FsAutoComplete.Core/ProcessWatcher.fs
@@ -31,3 +31,14 @@ module ProcessWatcher =
     else
         proc.EnableRaisingEvents <- true
         proc.Exited |> Event.add (fun _ -> onExitCallback proc)
+
+  let zombieCheckWithHostPID quit pid =
+    try
+      let hostProcess = System.Diagnostics.Process.GetProcessById(pid)
+      watch hostProcess (fun _ -> quit ())
+    with
+    | e ->
+      printfn "Host process ID %i not found: %s" pid e.Message
+      // If the process dies before we get here then request shutdown
+      // immediately
+      quit ()

--- a/src/FsAutoComplete.Core/ProjectCrackerVerbose.fs
+++ b/src/FsAutoComplete.Core/ProjectCrackerVerbose.fs
@@ -42,14 +42,12 @@ module ProjectCrackerVerbose =
                     Utils.Convert DateTime.Now opts
                 else
                     raise e
-          //printfn "from cracker: %A" p
           match p.SourceFiles, p.OtherOptions, logMap |> Map.isEmpty with
           | [| |], [| |], false ->
             //HACK project cracker has failed
             //  ref https://github.com/fsharp/FSharp.Compiler.Service/issues/804
             //  the ProjectCracker.GetProjectOptionsFromProjectFileLogged doesnt throw, just return an
             //  uninitalized FSharpProjectOptions and some log, who contains the exception
-            printfn "MAP: %A" logMap
             let logs =
                 logMap
                 |> Map.toArray

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -170,8 +170,6 @@ let rec private readXmlDoc (reader: XmlReader) (indentationSize : int) (acc: Map
         indentationSize, acc |> Map.add key (XmlDocMember(doc, indentationSize, xli.LinePosition - 3)) |> Some
       with
       | ex ->
-        // printfn "%s" ex.Message
-        // printfn "%s" ex.StackTrace
         indentationSize, Some acc
     | _ -> indentationSize, Some acc
 
@@ -221,8 +219,6 @@ let private getXmlDoc dllFile =
           xmlDocCache.AddOrUpdate(xmlFile, xmlDoc, fun _ _ -> xmlDoc) |> ignore
           Some xmlDoc
         with ex ->
-        //   printfn "%s" ex.Message
-        //   printfn "%s" ex.StackTrace
           None  // TODO: Remove the empty map from cache to try again in the next request?
 
 // --------------------------------------------------------------------------------------

--- a/src/FsAutoComplete.Core/UnionPatternMatchCaseGenerator.fs
+++ b/src/FsAutoComplete.Core/UnionPatternMatchCaseGenerator.fs
@@ -33,7 +33,6 @@ type private Context = {
 }
 
 let private clauseIsCandidateForCodeGen (cursorPos: pos) (clause: SynMatchClause) =
-    //printfn "Checking pos (%+A) inside clause (%+A)..." cursorPos clause
     let rec patIsCandidate (pat: SynPat) =
         match pat with
         | SynPat.Paren(innerPat, _)

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -557,8 +557,6 @@ let runProcess (log: string -> unit) (workingDir: string) (exePath: string) (arg
 
     p.ErrorDataReceived.Add(fun ea -> log (ea.Data))
 
-    // printfn "running: %s %s" psi.FileName psi.Arguments
-
     p.Start() |> ignore
     p.BeginOutputReadLine()
     p.BeginErrorReadLine()

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -217,7 +217,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
 
 
     override __.Initialize(p) = async {
-        // Debug.print "Initialize"
+        Debug.print "[LSP call] Initialize"
         clientCapabilities <- p.Capabilities
         glyphToCompletionKind <- glyphToCompletionKindGenerator clientCapabilities
         glyphToSymbolKind <- glyphToSymbolKindGenerator clientCapabilities
@@ -321,10 +321,12 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     override __.Initialized(p) = async {
+        Debug.print "[LSP call] Initialized"
         return ()
     }
 
     override __.TextDocumentDidOpen(p) = async {
+        Debug.print "[LSP call] TextDocumentDidOpen"
         commands.FileStateWaiting <- true
         if not commands.IsWorkspaceReady then
             do! commands.WorkspaceReady |> Async.AwaitEvent
@@ -345,12 +347,14 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     override __.TextDocumentDidChange(p) = async {
+        Debug.print "[LSP call] TextDocumentDidChange"
         commands.FileStateWaiting <- true
         parseFileDebuncer.Bounce p
     }
 
     //TODO: Investigate if this should be done at all
     override __.TextDocumentDidSave(p) = async {
+        Debug.print "[LSP call] TextDocumentDidSave"
         if not commands.IsWorkspaceReady then
             Debug.print "[LSP] DidSave - Workspace not ready"
         elif config.MinimizeBackgroundParsing then
@@ -363,7 +367,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     override __.TextDocumentCompletion(p) = async {
-
+        Debug.print "[LSP call] TextDocumentCompletion"
         // Sublime-lsp doesn't like when we answer null so we answer an empty list instead
         let noCompletion = success (Some { IsIncomplete = true; Items = [||] })
         let doc = p.TextDocument
@@ -456,6 +460,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     override __.CompletionItemResolve(ci) = async {
+        Debug.print "[LSP call] CompletionItemResolve"
         let res = commands.Helptext ci.InsertText.Value
         let res =
             match res.[0] with
@@ -474,6 +479,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     override x.TextDocumentSignatureHelp(p) =
+        Debug.print "[LSP call] TextDocumentSignatureHelp"
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {
                 let! res = commands.Methods tyRes  pos lines
@@ -514,6 +520,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         )
 
     override x.TextDocumentHover(p) =
+        Debug.print "[LSP call] TextDocumentHover"
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {
                 let! res = commands.ToolTip tyRes pos lineStr
@@ -567,6 +574,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             })
 
     override x.TextDocumentRename(p) =
+        Debug.print "[LSP call] TextDocumentRename"
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {
                 let! res = commands.SymbolUseProject tyRes pos lineStr
@@ -624,6 +632,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             })
 
     override x.TextDocumentDefinition(p) =
+        Debug.print "[LSP call] TextDocumentDefinition"
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {
                 //TODO: Add #load reference
@@ -642,6 +651,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             })
 
     override x.TextDocumentTypeDefinition(p) =
+        Debug.print "[LSP call] TextDocumentTypeDefinition"
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {
                 let! res = commands.FindTypeDeclaration tyRes pos lineStr
@@ -659,6 +669,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             })
 
     override x.TextDocumentReferences(p) =
+        Debug.print "[LSP call] TextDocumentRefrences"
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {
                 let! res = commands.SymbolUseProject tyRes pos lineStr
@@ -681,6 +692,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             })
 
     override x.TextDocumentDocumentHighlight(p) =
+        Debug.print "[LSP call] TextDocumentDocumentHighlight"
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {
                 let! res = commands.SymbolUse tyRes pos lineStr
@@ -702,6 +714,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             })
 
     override x.TextDocumentImplementation(p) =
+        Debug.print "[LSP call] TextDocumentImplementation"
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {
                 let! res = commands.SymbolImplementationProject tyRes pos lineStr
@@ -727,6 +740,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
 
 
     override __.TextDocumentDocumentSymbol(p) = async {
+        Debug.print "[LSP call] TextDocumentDocumentSymbol"
         let fn = p.TextDocument.GetFilePath()
         if not fileInit then
             do! fileInited.Publish |> Async.AwaitEvent
@@ -747,6 +761,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     override __.WorkspaceSymbol(p) = async {
+        Debug.print "[LSP call] WorkspaceSymbol"
         let! res = commands.DeclarationsInProjects ()
         let res =
             match res.[0] with
@@ -1026,6 +1041,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             async.Return []
 
     override x.TextDocumentCodeAction(p) =
+        Debug.print "[LSP call] TextDocumentCodeAction"
         let fn = p.TextDocument.GetFilePath()
         match commands.TryGetFileCheckerOptionsWithLines fn with
         | ResultOrString.Error s ->
@@ -1057,6 +1073,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         }
 
     override __.TextDocumentCodeLens(p) = async {
+        Debug.print "[LSP call] TextDocumentCodeLens"
         let fn = p.TextDocument.GetFilePath()
         if commands.FileStateWaiting then
             do! commands.FileStateSet.Publish |> Async.AwaitEvent
@@ -1088,6 +1105,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     override __.CodeLensResolve(p) =
+        Debug.print "[LSP call] CodeLensResolve"
         let handler f (arg: CodeLens) =
             async {
                 if not workspaceInit then
@@ -1215,6 +1233,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         ) p
 
     override __.WorkspaceDidChangeWatchedFiles(p) = async {
+        Debug.print "[LSP call] WorkspaceDidChangeWatchedFiles"
         p.Changes
         |> Array.iter (fun c ->
             if c.Type = FileChangeType.Deleted then
@@ -1231,6 +1250,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     override __.WorkspaceDidChangeConfiguration(p) = async {
+        Debug.print "[LSP call] WorkspaceDidChangeConfiguration"
         let dto =
             p.Settings
             |> Server.deserialize<FSharpConfigRequest>
@@ -1240,6 +1260,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     member x.FSharpSignature(p: TextDocumentPositionParams) =
+        Debug.print "[LSP call] FSharpSignature"
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {
                 let! res = commands.Typesig tyRes pos lineStr
@@ -1257,6 +1278,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         )
 
     member x.FSharpSignatureData(p: TextDocumentPositionParams) =
+        Debug.print "[LSP call] FSharpSignatureData"
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {
                 let! res = commands.SignatureData tyRes pos lineStr
@@ -1274,6 +1296,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         )
 
     member __.FSharpLineLense(p) = async {
+        Debug.print "[LSP call] FSharpLineLense"
         let fn = p.Project.GetFilePath()
         if commands.FileStateWaiting then
             do! commands.FileStateSet.Publish |> Async.AwaitEvent
@@ -1291,6 +1314,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     member x.LineLensResolve(p) =
+        Debug.print "[LSP call] LineLensResolve"
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {
                 let! res = commands.SignatureData tyRes pos lineStr
@@ -1308,6 +1332,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         )
 
     member __.FSharpCompilerLocation(p) = async {
+        Debug.print "[LSP call] FSharpCompilerLocation"
         let res = commands.CompilerLocation ()
         let res =
             match res.[0] with
@@ -1322,6 +1347,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     member __.FSharpCompile(p) = async {
+        Debug.print "[LSP call] FSharpCompile"
         let fn = p.Project.GetFilePath()
         let! res = commands.Compile fn
         let res =
@@ -1337,6 +1363,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     member __.FSharpWorkspaceLoad(p) = async {
+        Debug.print "[LSP call] FSharpWorkspaceLoad"
         let fns = p.TextDocuments |> Array.map (fun fn -> fn.GetFilePath() ) |> Array.toList
         let! res = commands.WorkspaceLoad ignore fns config.DisableInMemoryProjectReferences
         let res =
@@ -1352,6 +1379,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     member __.FSharpWorkspacePeek(p: FsAutoComplete.HttpApiContract.WorkspacePeekRequest) = async {
+        Debug.print "[LSP call] FSharpWorkspacePeek"
         let! res = commands.WorkspacePeek p.Directory p.Deep (p.ExcludedDirs |> List.ofArray)
         let res =
             match res.[0] with
@@ -1368,6 +1396,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     member __.FSharpProject(p) = async {
+        Debug.print "[LSP call] FSharpProject"
         let fn = p.Project.GetFilePath()
         let! res = commands.Project fn false ignore
         let res =
@@ -1383,6 +1412,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     member __.FSharpFsdn(p: ProjectParms) = async {
+        Debug.print "[LSP call] FSharpFsdn"
         let! res = commands.Fsdn p.Project.Uri
         let res =
             match res.[0] with
@@ -1397,6 +1427,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     }
 
     member x.FSharpHelp(p: TextDocumentPositionParams) =
+        Debug.print "[LSP call] FSharpHelp"
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {
                 let! res = commands.Help tyRes pos lineStr
@@ -1414,6 +1445,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         )
 
     member x.FSharpDocumentation(p: TextDocumentPositionParams) =
+        Debug.print "[LSP call] FSharpDocumentation"
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {
                 let! res = commands.FormattedDocumentation tyRes pos lineStr
@@ -1432,6 +1464,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
 
 
     member x.FSharpDocumentationSymbol(p: FsAutoComplete.HttpApiContract.DocumentationForSymbolReuqest) =
+        Debug.print "[LSP call] FSharpDocumentationSymbol"
         match commands.LastCheckResult with
         | None -> AsyncLspResult.internalError "error"
         | Some tyRes ->

--- a/src/FsAutoComplete/FsAutoComplete.Stdio.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Stdio.fs
@@ -125,7 +125,7 @@ let start (commands: Commands) (args: Argu.ParseResults<Options.CLIArguments>) =
     let commandQueue = new BlockingCollection<Command>(10)
 
     args.TryGetResult(<@ Options.CLIArguments.HostPID @>)
-    |> Option.iter (Debug.zombieCheckWithHostPID (fun () -> commandQueue.Add(Command.Quit)))
+    |> Option.iter (ProcessWatcher.zombieCheckWithHostPID (fun () -> commandQueue.Add(Command.Quit)))
 
     try
         async {

--- a/src/FsAutoComplete/FsAutoComplete.Suave.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Suave.fs
@@ -233,9 +233,6 @@ let start (commands: Commands) (args: ParseResults<Options.CLIArguments>) =
                     commands.LoadAnalyzers data.FileName
                 with
                 | ex ->
-                    // printfn "EXCEPTION: %A" ex.Message
-                    // printfn "EXCEPTION: %A" ex.StackTrace
-                    // printfn "EXCEPTION: %A" ex.Source
                     reraise ()
                 )
             path "/quit" >=> handler (fun (_data: QuitRequest) ->

--- a/src/FsAutoComplete/FsAutoComplete.Suave.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Suave.fs
@@ -264,7 +264,7 @@ let start (commands: Commands) (args: ParseResults<Options.CLIArguments>) =
             Logging.Message.event Logging.LogLevel.Info (sprintf "git commit sha: %s" (commands.GetGitHash ()) ) |> ignore
             Logging.Message.event Logging.LogLevel.Info (sprintf "tracking host PID %i" pid)
         )
-        Debug.zombieCheckWithHostPID (fun () -> exit 0) pid
+        ProcessWatcher.zombieCheckWithHostPID (fun () -> exit 0) pid
     | None -> ()
 
     startWebServer serverConfig app

--- a/src/FsAutoComplete/FsAutoComplete.fsproj
+++ b/src/FsAutoComplete/FsAutoComplete.fsproj
@@ -13,7 +13,6 @@
     <Platform>x64</Platform>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Debug.fs" />
     <Compile Include="Options.fs" />
     <Compile Include="CommandInput.fs" />
     <Compile Include="CommandResponse.fs" />


### PR DESCRIPTION
This removes bunch of unnecessary `printfn` calls, moves `Debug` module to the Core project, and uses `Debug.print` to provide logging info when needed. 