### PR TITLE
Responsiveness improvements

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -316,6 +316,7 @@ type Commands (serialize : Serializer) =
         let file = Path.GetFullPath file
         let stateVersion = state.TryGetFileVersion file
         let checkedVersion = state.TryGetLastCheckedVersion file
+        Debug.print "[Commands] TryGetLatestTypeCheckResultsForFile - %s; State - %A; Checked - %A" file stateVersion checkedVersion
         match stateVersion, checkedVersion with
         | Some sv, Some cv when cv < sv ->
             x.FileChecked

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -336,9 +336,6 @@ type Commands (serialize : Serializer) =
             |> async.Return
 
 
-    member x.CheckFileInProject(file, version,source,opts) =
-        let file = Path.GetFullPath file
-        checker.ParseAndCheckFileInProject'(file, version, source, opts)
 
     member x.TryGetFileCheckerOptionsWithLinesAndLineStr(file, pos) =
         let file = Path.GetFullPath file

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -19,7 +19,6 @@ type ParseAndCheckResults
     ) =
 
   member __.TryGetMethodOverrides (lines: LineStr[]) (pos: pos) = async {
-    let s = DateTime.Now
     // Find the starting point, ideally right after the first '('
     let lineCutoff = pos.Line - 6
     let commas, line, col =
@@ -55,7 +54,6 @@ type ParseAndCheckResults
     return Ok(meth, commas) }
 
   member __.TryFindDeclaration (pos: pos) (lineStr: LineStr) = async {
-    let s = DateTime.Now
     match Parsing.findLongIdents(pos.Column - 1, lineStr) with
     | None -> return ResultOrString.Error "Could not find ident at this location"
     | Some(col, identIsland) ->

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -429,8 +429,9 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                                         decls
                                         |> Array.mapi (fun id d ->
                                             let code =
-                                                if System.Text.RegularExpressions.Regex.IsMatch(d.Name, """^[a-zA-Z][a-zA-Z0-9']+$""") then d.Name else
-                                                PrettyNaming.QuoteIdentifierIfNeeded d.Name
+                                                if System.Text.RegularExpressions.Regex.IsMatch(d.Name, """^[a-zA-Z][a-zA-Z0-9']+$""") then d.Name
+                                                elif d.NamespaceToOpen.IsSome then d.Name
+                                                else PrettyNaming.QuoteIdentifierIfNeeded d.Name
                                             let label =
                                                 match d.NamespaceToOpen with
                                                 | Some no -> sprintf "%s (open %s)" d.Name no

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -373,6 +373,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
 
     override __.TextDocumentCompletion(p) = async {
         Debug.print "[LSP call] TextDocumentCompletion"
+        Debug.print "[LSP call] TextDocumentCompletion - context: %A" p.Context
         // Sublime-lsp doesn't like when we answer null so we answer an empty list instead
         let noCompletion = success (Some { IsIncomplete = true; Items = [||] })
         let doc = p.TextDocument
@@ -385,7 +386,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                 let line = p.Position.Line
                 let col = p.Position.Character
                 let lineStr = lines.[line]
-                let word = lineStr.Substring(0, col) //TODO
+                let word = lineStr.Substring(0, col)
                 let ok = line <= lines.Length && line >= 0 && col <= lineStr.Length + 1 && col >= 0
                 if not ok then
                     AsyncLspResult.internalError "not ok"
@@ -410,9 +411,9 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                             match p.Context with
                             | None -> commands.TryGetRecentTypeCheckResultsForFile(file, options) |> async.Return
                             | Some ctx ->
-                                if ctx.triggerKind = CompletionTriggerKind.Invoked || (ctx.triggerCharacter = Some ".") then
-                                    let f = String.concat "\n" lines
-                                    commands.CheckFileInProject(file, commands.LastVersionChecked + 1, f, options)
+                                //ctx.triggerKind = CompletionTriggerKind.Invoked ||
+                                if  (ctx.triggerCharacter = Some ".") then
+                                    commands.TryGetLatestTypeCheckResultsForFile(file, options)
                                 else
                                     commands.TryGetRecentTypeCheckResultsForFile(file, options) |> async.Return
 

--- a/src/FsAutoComplete/FsAutoComplete.Suave.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Suave.fs
@@ -165,9 +165,8 @@ let start (commands: Commands) (args: ParseResults<Options.CLIArguments>) =
                         let c = lineStr.[col - 2]
                         let! tyResOpt =
                             if c = '.' then
-                                let f = String.concat "\n" lines
                                 if commands.LastVersionChecked >= data.Version then
-                                    commands.CheckFileInProject(file, data.Version, f, options)
+                                    commands.TryGetRecentTypeCheckResultsForFile(file, options) |> async.Return
                                 else
                                     commands.FileChecked
                                     |> Event.filter (fun (_, name, version) -> name = file && version = data.Version)

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -116,7 +116,6 @@ let basicTests () =
       testList "Document Symbol Tests" [
         test "Document Symbol" {
           let p : DocumentSymbolParams = { TextDocument = { Uri = filePathToUri path}}
-          server.FileInit <- true
           let res = server.TextDocumentDocumentSymbol p |> Async.RunSynchronously
           match res with
           | Result.Error e -> failtest "Request failed"
@@ -227,7 +226,6 @@ let documentSymbolTest () =
     testList "Document Symbols Tests" [
       test "Get Document Symbols" {
         let p : DocumentSymbolParams = { TextDocument = { Uri = filePathToUri path}}
-        server.FileInit <- true
         let res = server.TextDocumentDocumentSymbol p |> Async.RunSynchronously
         match res with
         | Result.Error e -> failtest "Request failed"
@@ -252,7 +250,6 @@ let autocompleteTest () =
         let p : CompletionParams = { TextDocument = { Uri = filePathToUri path}
                                      Position = { Line = 8; Character = 2}
                                      Context = None }
-        server.FileInit <- true
         let res = server.TextDocumentCompletion p |> Async.RunSynchronously
         match res with
         | Result.Error e -> failtest "Request failed"
@@ -268,7 +265,6 @@ let autocompleteTest () =
         let p : CompletionParams = { TextDocument = { Uri = filePathToUri path}
                                      Position = { Line = 10; Character = 2}
                                      Context = None }
-        server.FileInit <- true
         let res = server.TextDocumentCompletion p |> Async.RunSynchronously
         match res with
         | Result.Error e -> failtest "Request failed"
@@ -284,7 +280,6 @@ let autocompleteTest () =
         let p : CompletionParams = { TextDocument = { Uri = filePathToUri path}
                                      Position = { Line = 12; Character = 7}
                                      Context = None }
-        server.FileInit <- true
         let res = server.TextDocumentCompletion p |> Async.RunSynchronously
         match res with
         | Result.Error e -> failtest "Request failed"
@@ -300,7 +295,6 @@ let autocompleteTest () =
         let p : CompletionParams = { TextDocument = { Uri = filePathToUri path}
                                      Position = { Line = 14; Character = 18}
                                      Context = None }
-        server.FileInit <- true
         let res = server.TextDocumentCompletion p |> Async.RunSynchronously
         match res with
         | Result.Error e -> failtest "Request failed"
@@ -332,7 +326,6 @@ let renameTest () =
         let p : RenameParams = { TextDocument = { Uri = filePathToUri path}
                                  Position = { Line = 7; Character = 12}
                                  NewName = "y" }
-        server.FileInit <- true
         let res = server.TextDocumentRename p |> Async.RunSynchronously
         match res with
         | Result.Error e -> failtest "Request failed"
@@ -351,7 +344,6 @@ let renameTest () =
         let p : RenameParams = { TextDocument = { Uri = filePathToUri pathTest}
                                  Position = { Line = 2; Character = 4}
                                  NewName = "y" }
-        server.FileInit <- true
         let res = server.TextDocumentRename p |> Async.RunSynchronously
         match res with
         | Result.Error e -> failtest "Request failed"


### PR DESCRIPTION
Fixes around:
1. Setting internal state correctly (it was broken in LSP version - mostly visible in the CodeLenses)
2. Waiting for the in-progress type-checking results. (in case of getting multiple requests at mostly the same time we make sure we don't queue additional typechecking and instead we await for the result of typechecking in progress)
3. Autocomplete performance fix (connected to 2. - we've run full typechecking on the file in some cases, instead of just waiting for the result or using recent result) [also fixed in HTTP version]

Together makes CodeLenses stable and Autocomplete pretty fast (GIF made on LSP version, with external autocomplete disabled):
![AutocompleteSpeed](https://user-images.githubusercontent.com/5427083/58516659-04b5f300-81a9-11e9-8a82-6f2a0f35dbdb.gif)

