### PR TITLE
Fix diagnostics reporting 

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -137,7 +137,7 @@ type Commands (serialize : Serializer) =
             with
             | _ -> ()
         }
-        |> if notifyErrorsInBackground then Async.Start else ignore
+        |> Async.Start
 
         async {
             try

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -971,7 +971,6 @@ type Commands (serialize : Serializer) =
 
     member x.GetSimplifiedNames file =
         let file = Path.GetFullPath file
-
         async {
             match state.TryGetFileCheckerOptionsWithLines file with
             | Error s ->  return [CoreResponse.ErrorRes s]

--- a/src/FsAutoComplete.Core/SimplifyNameAnalyzer.fs
+++ b/src/FsAutoComplete.Core/SimplifyNameAnalyzer.fs
@@ -4,6 +4,7 @@ namespace FsAutoComplete
 open FsAutoComplete
 
 module SimplifyNameDiagnosticAnalyzer =
+    open FSharp.Compiler
     open FSharp.Compiler.SourceCodeServices
     open FSharp.Compiler.Range
 
@@ -18,15 +19,14 @@ module SimplifyNameDiagnosticAnalyzer =
                 |> Array.Parallel.map (fun symbolUse ->
                     let lineStr = source.[symbolUse.RangeAlternate.StartLine - 1].ToString()
                     // for `System.DateTime.Now` it returns ([|"System"; "DateTime"|], "Now")
-                    let plid, name = Parsing.findLongIdentsAndResidue (symbolUse.RangeAlternate.EndColumn - 1, lineStr)
+                    let partialName = QuickParse.GetPartialLongNameEx(lineStr, symbolUse.RangeAlternate.EndColumn - 1)
                     // `symbolUse.RangeAlternate.Start` does not point to the start of plid, it points to start of `name`,
                     // so we have to calculate plid's start ourselves.
-                    let plidStartCol = symbolUse.RangeAlternate.EndColumn - name.Length - (getPlidLength plid)
-                    symbolUse, plid, plidStartCol, name)
+                    let plidStartCol = symbolUse.RangeAlternate.EndColumn - partialName.PartialIdent.Length - (getPlidLength partialName.QualifyingIdents)
+                    symbolUse, partialName.QualifyingIdents, plidStartCol, partialName.PartialIdent)
                 |> Array.filter (fun (_, plid, _, name) -> name <> "" && not (List.isEmpty plid))
                 |> Array.groupBy (fun (symbolUse, _, plidStartCol, _) -> symbolUse.RangeAlternate.StartLine, plidStartCol)
                 |> Array.map (fun (_, xs) -> xs |> Array.maxBy (fun (symbolUse, _, _, _) -> symbolUse.RangeAlternate.EndColumn))
-
             for symbolUse, plid, plidStartCol, name in symbolUses do
                 if not symbolUse.IsFromDefinition then
                     let posAtStartOfName =

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -97,7 +97,6 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                 n.Range.Start.Line
             )
             |> Seq.toArray
-        Debug.print "[LSP] Send Diag - %A" diags
         {Uri = uri; Diagnostics = diags}
         |> lspClient.TextDocumentPublishDiagnostics
         |> Async.Start

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -97,6 +97,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                 n.Range.Start.Line
             )
             |> Seq.toArray
+        Debug.print "[LSP] Send Diag - %A" diags
         {Uri = uri; Diagnostics = diags}
         |> lspClient.TextDocumentPublishDiagnostics
         |> Async.Start
@@ -104,6 +105,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     do
         commands.Notify.Subscribe(fun n ->
             try
+                Debug.print "[LSP] Notify - %A" n
                 match n with
                 | NotificationEvent.Workspace ws ->
                     let ws = CommandResponse.serialize JsonSerializer.writeJson ws

--- a/src/FsAutoComplete/FsAutoComplete.Stdio.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Stdio.fs
@@ -19,9 +19,7 @@ let main (commands: Commands) (commandQueue: BlockingCollection<Command>) =
 
             let msgText =
                 match msg with
-                | NotificationEvent.ParseError x -> Some x
                 | NotificationEvent.Workspace x -> Some x
-                | NotificationEvent.AnalyzerMessage x -> Some x
                 | _ -> None
 
             msgText |> Option.iter Console.WriteLine


### PR DESCRIPTION
1. Fixes error reporting for LSP version (`MinimizeBacgroundParsing` was disabling too much - it was not a problem in HTTP version due to the fact it used errors directly returned from the function calls, not based on triggered events)
2. Fixes the Simplify Name Analyzer
