### PR TITLE
 Wait for type check if project is not parsed

### DIFF
--- a/src/FsAutoComplete.Core/State.fs
+++ b/src/FsAutoComplete.Core/State.fs
@@ -135,6 +135,12 @@ type State =
     | ResultOrString.Error x -> ResultOrString.Error x
     | Ok (opts, lines) -> Ok (opts, String.concat "\n" lines)
 
+  member x.TryGetFileSource(file: SourceFilePath) : ResultOrString<string[]> =
+    let file = Utils.normalizePath file
+    match x.Files.TryFind(file) with
+    | None -> ResultOrString.Error (sprintf "File '%s' not parsed" file)
+    | Some f -> Ok (f.Lines)
+
   member x.TryGetFileCheckerOptionsWithLinesAndLineStr(file: SourceFilePath, pos : pos) : ResultOrString<FSharpProjectOptions * LineStr[] * LineStr> =
     let file = Utils.normalizePath file
     match x.TryGetFileCheckerOptionsWithLines(file) with

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1227,7 +1227,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                                 JToken.FromObject locs
                             |]
 
-                            let cmd = {Title = formatted; Command = Some "editor.action.showReferences"; Arguments = Some args}
+                            let cmd = {Title = formatted; Command = Some "fsharp.showReferences"; Arguments = Some args}
                             {p with Command = Some cmd} |> success
                         | CoreResponse.SymbolUseRange (uses) ->
                             let formatted =


### PR DESCRIPTION
This solves problem with Code Lenses not showing on the editor startup in LSP version - if the `FSharpProjectOptions` are not available we wait for first `FileChecked` event.  