### PR TITLE
Turn off `keepAssemblyContents` 🛰

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -446,7 +446,7 @@ type FSharpCompilerServiceChecker() =
     FSharpChecker.Create(
       projectCacheSize = 200,
       keepAllBackgroundResolutions = true,
-      keepAssemblyContents = true)
+      keepAssemblyContents = false)
 
   do checker.ImplicitlyStartBackgroundWork <- true
 


### PR DESCRIPTION
According to https://github.com/dotnet/fsharp/blob/4a695e798a05c8139c3cba89a7d971055bdd3160/src/fsharp/service/IncrementalBuild.fs#L1386 and discussion in Slack with @cartermp this option is considered harmful in context of editor tooling.

I've observed **40% drop** in memory usage while working on FSAC.sln