### PR TITLE
Use System.Uri for the DocumentUri type in LSP

### DIFF
--- a/src/FsAutoComplete.BackgroundServices/Program.fs
+++ b/src/FsAutoComplete.BackgroundServices/Program.fs
@@ -71,9 +71,9 @@ module Helpers =
                 uri.Append((int c).ToString("X2")) |> ignore
 
         if uri.Length >= 2 && uri.[0] = '/' && uri.[1] = '/' then // UNC path
-            "file:" + uri.ToString()
+            Uri ("file:" + uri.ToString())
         else
-            "file:///" + (uri.ToString()).TrimStart('/')
+            Uri ("file:///" + (uri.ToString()).TrimStart('/'))
 
 
 

--- a/src/FsAutoComplete.Core/WorkspacePeek.fs
+++ b/src/FsAutoComplete.Core/WorkspacePeek.fs
@@ -60,7 +60,7 @@ let tryParseSln (slnFilePath: string) =
                         item.FolderFiles
                         |> Seq.map makeAbsoluteFromSlnDir
                         |> List.ofSeq
-                    item.ProjectName, SolutionItemKind.Folder (children, files)
+                    item.ProjectName |> makeAbsoluteFromSlnDir, SolutionItemKind.Folder (children, files)
                 | Microsoft.Build.Construction.SolutionProjectType.EtpSubProject
                 | Microsoft.Build.Construction.SolutionProjectType.WebDeploymentProject
                 | Microsoft.Build.Construction.SolutionProjectType.WebProject ->

--- a/src/FsAutoComplete.Core/WorkspacePeek.fs
+++ b/src/FsAutoComplete.Core/WorkspacePeek.fs
@@ -20,7 +20,7 @@ and SolutionItem = {
     }
 and SolutionItemKind =
     | MsbuildFormat of SolutionItemMsbuildConfiguration list
-    | Folder of (SolutionItem list) * (string list)
+    | Folder of childProjects: SolutionItem list * looseFiles: string list
     | Unsupported
     | Unknown
 and SolutionItemMsbuildConfiguration = {
@@ -31,10 +31,10 @@ and SolutionItemMsbuildConfiguration = {
 
 [<RequireQualifiedAccess>]
 type Interesting =
-| Solution of string * SolutionData
-| Directory of string * string list
+| Solution of solutionFilePath: string * data: SolutionData
+| Directory of directoryPath: string * projectFiles: string list
 
-let tryParseSln (slnFilePath: string) = 
+let tryParseSln (slnFilePath: string) =
     let parseSln (sln: Microsoft.Build.Construction.SolutionFile) =
         let slnDir = Path.GetDirectoryName slnFilePath
         let makeAbsoluteFromSlnDir =

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -87,22 +87,14 @@ module Conversions =
             }
         | FsAutoComplete.FindDeclarationResult.Range r -> fcsRangeToLspLocation r
 
-    /// Sometimes the DocumentUris that are given are escaped and so Windows-specific LocalPath resolution fails.
-    /// To fix this, we normalize the uris by unescaping them.
-    let inline normalizeDocumentUri (docUri: Uri) =
-        docUri.AbsoluteUri // the absoluteUri is the raw value
-        |> System.Net.WebUtility.UrlDecode
-        |> Uri
-
-
     type TextDocumentIdentifier with
-        member doc.GetFilePath() = (normalizeDocumentUri doc.Uri).LocalPath
+        member doc.GetFilePath() = doc.Uri.LocalPath
 
     type VersionedTextDocumentIdentifier with
-        member doc.GetFilePath() = (normalizeDocumentUri doc.Uri).LocalPath
+        member doc.GetFilePath() = doc.Uri.LocalPath
 
     type TextDocumentItem with
-        member doc.GetFilePath() = (normalizeDocumentUri doc.Uri).LocalPath
+        member doc.GetFilePath() = doc.Uri.LocalPath
 
     type ITextDocumentPositionParams with
         member p.GetFilePath() = p.TextDocument.GetFilePath()

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -54,9 +54,9 @@ module Conversions =
                 uri.Append((int c).ToString("X2")) |> ignore
 
         if uri.Length >= 2 && uri.[0] = '/' && uri.[1] = '/' then // UNC path
-            "file:" + uri.ToString()
+            Uri("file:" + uri.ToString())
         else
-            "file:///" + (uri.ToString()).TrimStart('/')
+            Uri("file:///" + (uri.ToString()).TrimStart('/'))
 
     let fcsRangeToLspLocation(range: FSharp.Compiler.Range.range): Lsp.Location =
         let fileUri = filePathToUri range.FileName
@@ -89,8 +89,8 @@ module Conversions =
 
     /// Sometimes the DocumentUris that are given are escaped and so Windows-specific LocalPath resolution fails.
     /// To fix this, we normalize the uris by unescaping them.
-    let inline normalizeDocumentUri (docUri: string) =
-        docUri
+    let inline normalizeDocumentUri (docUri: Uri) =
+        docUri.AbsoluteUri // the absoluteUri is the raw value
         |> System.Net.WebUtility.UrlDecode
         |> Uri
 
@@ -148,7 +148,7 @@ module Conversions =
         let map (decl: FSharpNavigationDeclarationItem): CodeLens =
             {
                 Command = None
-                Data = Some (Newtonsoft.Json.Linq.JToken.FromObject [|uri; typ |] )
+                Data = Some (Newtonsoft.Json.Linq.JToken.FromObject [|string uri; typ |] )
                 Range = fcsRangeToLsp decl.Range
             }
         topLevel.Nested

--- a/src/LanguageServerProtocol/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol/LanguageServerProtocol.fs
@@ -126,7 +126,7 @@ module Types =
         End: Position
     }
 
-    type DocumentUri = string
+    type DocumentUri = Uri
 
     /// Represents a location inside a resource, such as a line inside a text file.
     type Location = {
@@ -134,17 +134,11 @@ module Types =
         Range: Range
     }
 
-    type ITextDocumentIdentifier =
-        /// Warning: normalize this member by UrlDecoding it before use
-        abstract member Uri : DocumentUri with get
-
     type TextDocumentIdentifier =
         {
             /// The text document's URI.
             Uri: DocumentUri
         }
-        interface ITextDocumentIdentifier with
-            member this.Uri with get() = this.Uri
 
     type VersionedTextDocumentIdentifier =
         {
@@ -158,8 +152,6 @@ module Types =
             /// truth (as speced with document content ownership)
             Version: int option
         }
-        interface ITextDocumentIdentifier with
-            member this.Uri with get() = this.Uri
 
     type SymbolKind =
     | File = 1

--- a/test/FsAutoComplete.IntegrationTests/MultiProj/workspacepeek.json
+++ b/test/FsAutoComplete.IntegrationTests/MultiProj/workspacepeek.json
@@ -9,7 +9,7 @@
           "Items": [
             {
               "Guid": "b9fef411-5f4d-4021-9a20-fb6597faa915",
-              "Name": "docs",
+              "Name": "<absolute path removed>/FsAutoComplete.IntegrationTests/MultiProj/Sample/docs",
               "Kind": {
                 "Kind": "folder",
                 "Data": {
@@ -33,7 +33,7 @@
             },
             {
               "Guid": "7fe228f9-217e-41a8-924d-f9dfedfdd2b4",
-              "Name": "Tests",
+              "Name": "<absolute path removed>/FsAutoComplete.IntegrationTests/MultiProj/Sample/Tests",
               "Kind": {
                 "Kind": "folder",
                 "Data": {

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -335,8 +335,8 @@ let renameTest () =
           | None -> failtest "No changes"
           | Some result ->
             Expect.equal result.Length 2 "Rename has all changes"
-            Expect.exists result (fun n -> n.TextDocument.Uri.Contains "Program.fs" && n.Edits |> Seq.exists (fun r -> r.Range = { Start = {Line = 7; Character = 12 }; End = {Line = 7; Character = 13 } }) ) "Rename contains changes in Program.fs"
-            Expect.exists result (fun n -> n.TextDocument.Uri.Contains "Test.fs" && n.Edits |> Seq.exists (fun r -> r.Range = { Start = {Line = 2; Character = 4 }; End = {Line = 2; Character = 5 } }) ) "Rename contains changes in Test.fs"
+            Expect.exists result (fun n -> (string n.TextDocument.Uri).Contains "Program.fs" && n.Edits |> Seq.exists (fun r -> r.Range = { Start = {Line = 7; Character = 12 }; End = {Line = 7; Character = 13 } }) ) "Rename contains changes in Program.fs"
+            Expect.exists result (fun n -> (string n.TextDocument.Uri).Contains "Test.fs" && n.Edits |> Seq.exists (fun r -> r.Range = { Start = {Line = 2; Character = 4 }; End = {Line = 2; Character = 5 } }) ) "Rename contains changes in Test.fs"
             ()
       }
 
@@ -388,7 +388,7 @@ let gotoTest () =
           match res with
           | GotoResult.Multiple _ -> failtest "Should be single GotoResult"
           | GotoResult.Single res ->
-            Expect.stringContains res.Uri "Definition.fs" "Result should be in Definition.fs"
+            Expect.stringContains (string res.Uri) "Definition.fs" "Result should be in Definition.fs"
             Expect.equal res.Range { Start = {Line = 2; Character = 4 }; End = {Line = 2; Character = 16 }} "Result should have correct range"
       }
 
@@ -404,7 +404,7 @@ let gotoTest () =
           match res with
           | GotoResult.Multiple _ -> failtest "Should be single GotoResult"
           | GotoResult.Single res ->
-            Expect.stringContains res.Uri "Definition.fs" "Result should be in Definition.fs"
+            Expect.stringContains (string res.Uri) "Definition.fs" "Result should be in Definition.fs"
             Expect.equal res.Range { Start = {Line = 6; Character = 4 }; End = {Line = 6; Character = 19 }} "Result should have correct range"
       }
 
@@ -420,7 +420,7 @@ let gotoTest () =
           match res with
           | GotoResult.Multiple _ -> failtest "Should be single GotoResult"
           | GotoResult.Single res ->
-            Expect.stringContains res.Uri "Definition.fs" "Result should be in Definition.fs"
+            Expect.stringContains (string res.Uri) "Definition.fs" "Result should be in Definition.fs"
             Expect.equal res.Range { Start = {Line = 4; Character = 5 }; End = {Line = 4; Character = 6 }} "Result should have correct range"
       }
 


### PR DESCRIPTION
(All of this is only changes for the LSP mode)

This changes the serialization of the `DocumentUri` type to be a `System.Uri` by way of a custom `JsonConverter` that handles url-decoding the value when it comes to us.  This is required if we want easier handling of `DocumentUri`s (ie not having to remember to always call `normalizeUri`). 

The intent here would be that the output of the workspacepeek command would be proper file URIs for all files returned as part of the `Interesting` type, so that Ionide can pass them around as opaque strings and they will be handled correctly.

I think if this change is merged Ionide would need to update a bit of handling around solution folders to translate from a file-uri for the folder (`file:///users/chethusk/oss/fsautocomplete/src`) to the folder name (`src`) for display purposes.

The most contentious part of this I'd expect would be the `Name` property of the Folder SolutionItemKind case.  I went with `DocumentUri` here because we craft absolute file paths in the workspacepeek implementation for every case here _except_ folders, where we do relatives. I figured it was easier to unify the representation in terms of file URIs and do the name-munging on the consumer side, because at least then we have the invariant that every file returned from LSP is an absolute, valid file.