### PR TITLE
if a range is from the 'startup' sentinel range, do not treat that as a success

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -66,6 +66,7 @@ type ParseAndCheckResults
       match declarations with
       | FSharpFindDeclResult.DeclNotFound _ ->
         return ResultOrString.Error "Could not find declaration"
+      | FSharpFindDeclResult.DeclFound range when range.FileName.EndsWith(Range.rangeStartup.FileName) -> return ResultOrString.Error "Could not find declaration"
       | FSharpFindDeclResult.DeclFound range ->
         return Ok (FindDeclarationResult.Range range)
       | FSharpFindDeclResult.ExternalDecl (assembly, externalSym) ->

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/External.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/External.fs
@@ -1,0 +1,5 @@
+module External
+
+open System.Net
+
+let getHttpMethod (r: HttpWebRequest) = r.Method

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/GoToTests.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/GoToTests.fsproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="Definition.fs" />
     <Compile Include="Library.fs" />
+    <Compile Include="External.fs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This fixes the current behavior where you can gotodeclaration (CMD+click on a namespace like `open System.Net`) and get a bright red error notification about navigating to a file called 'startup' for your trouble.

This 'startup' range seems to be a sentinel value in FCS that leaks through in the case when you ask for the declaration location of a namespace.  A proper fix would be to make changes in FCS so that some appropriate response was returned for namespaces instead of this sentinel.

I also re-enabled a few tests, which seem to be working great on my machine, as well as adding tests specifically around this behavior (goto existing external decl type, and not going to namespaces).