### PR TITLE
add initial fake targets support to FSAC

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,24 +5,24 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core mode http (debug)",
+            "name": ".NET Core mode lsp (debug)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build_debug_netcore",
             "program": "${workspaceFolder}/src/FsAutoComplete/bin/Debug/netcoreapp2.1/fsautocomplete.dll",
-            "args": ["--mode", "http"],
+            "args": ["--mode", "lsp"],
             "cwd": "${workspaceFolder}",
             "console": "internalConsole",
             "stopAtEntry": false,
             "internalConsoleOptions": "openOnSessionStart"
         },
         {
-            "name": ".NET mode http (debug)",
+            "name": ".NET mode lsp (debug)",
             "type": "clr",
             "request": "launch",
             "preLaunchTask": "build_debug_net",
             "program": "${workspaceFolder}/src/FsAutoComplete/bin/Debug/net461/fsautocomplete.exe",
-            "args": ["--mode", "http"],
+            "args": ["--mode", "lsp"],
             "cwd": "${workspaceFolder}",
             "console": "internalConsole",
             "stopAtEntry": false,

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -54,7 +54,7 @@ type CoreResponse =
     | SymbolUseImplementationRange of ranges: SymbolCache.SymbolUseRange[]
     | RangesAtPositions of ranges: range list list
     | Fsdn of string list
-    | FakeTargets of result: FakeSupport.Target []
+    | FakeTargets of result: FakeSupport.GetTargetsResult
     | FakeRuntime of runtimePath: string
     
 [<RequireQualifiedAccess>]

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -35,7 +35,6 @@ type CoreResponse =
     | FindDeclaration of result: FindDeclarationResult
     | FindTypeDeclaration of range: range
     | Declarations of decls: (FSharpNavigationTopLevelDeclaration * string) []
-    | FakeTargets of result: FakeSupport.Target []
     | ToolTip of tip: FSharpToolTipText<string> * signature: string * footer: string * typeDoc: string option
     | FormattedDocumentation of tip: FSharpToolTipText<string> option * xmlSig: (string * string) option * signature: (string * (string [] * string [] * string [] * string [] * string [] * string [])) * footer: string * cn: string
     | FormattedDocumentationForSymbol of xmlSig: string * assembly: string * xmlDoc: string list * signature: (string * (string [] * string [] * string [] * string [] * string [] * string [])) * footer: string * cn: string
@@ -55,7 +54,9 @@ type CoreResponse =
     | SymbolUseImplementationRange of ranges: SymbolCache.SymbolUseRange[]
     | RangesAtPositions of ranges: range list list
     | Fsdn of string list
-
+    | FakeTargets of result: FakeSupport.Target []
+    | FakeRuntime of runtimePath: string
+    
 [<RequireQualifiedAccess>]
 type NotificationEvent =
     | ParseError of CoreResponse
@@ -470,12 +471,6 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
 
             let decls = decls |> Array.map (fun a -> a,file)
             return [CoreResponse.Declarations decls]
-    }
-
-    member x.FakeTargets file ctx = async {
-        let file = Path.GetFullPath file
-        let! targets = FakeSupport.getTargets file ctx
-        return [CoreResponse.FakeTargets targets]
     }
 
     member x.DeclarationsInProjects () = async {
@@ -1117,3 +1112,14 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
         async {
             return [ CoreResponse.InfoRes "quitting..." ]
         }
+
+    member x.FakeTargets file ctx = async {
+        let file = Path.GetFullPath file
+        let! targets = FakeSupport.getTargets file ctx
+        return [CoreResponse.FakeTargets targets]
+    }
+
+    member x.FakeRuntime () = async {
+        let! runtimePath = FakeSupport.getFakeRuntime ()
+        return [CoreResponse.FakeRuntime runtimePath]
+    }

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -35,6 +35,7 @@ type CoreResponse =
     | FindDeclaration of result: FindDeclarationResult
     | FindTypeDeclaration of range: range
     | Declarations of decls: (FSharpNavigationTopLevelDeclaration * string) []
+    | FakeTargets of result: FakeSupport.Target []
     | ToolTip of tip: FSharpToolTipText<string> * signature: string * footer: string * typeDoc: string option
     | FormattedDocumentation of tip: FSharpToolTipText<string> option * xmlSig: (string * string) option * signature: (string * (string [] * string [] * string [] * string [] * string [] * string [])) * footer: string * cn: string
     | FormattedDocumentationForSymbol of xmlSig: string * assembly: string * xmlDoc: string list * signature: (string * (string [] * string [] * string [] * string [] * string [] * string [])) * footer: string * cn: string
@@ -469,6 +470,12 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
 
             let decls = decls |> Array.map (fun a -> a,file)
             return [CoreResponse.Declarations decls]
+    }
+
+    member x.FakeTargets file ctx = async {
+        let file = Path.GetFullPath file
+        let! targets = FakeSupport.getTargets file ctx
+        return [CoreResponse.FakeTargets targets]
     }
 
     member x.DeclarationsInProjects () = async {

--- a/src/FsAutoComplete.Core/FakeSupport.fs
+++ b/src/FsAutoComplete.Core/FakeSupport.fs
@@ -169,14 +169,22 @@ module FakeSupport =
       let targets =
         lines
         |> Seq.filter (isNull >> not)
-        |> Seq.skip 1
-        |> Seq.map (fun line ->
-          let targetName = line.Trim()
-          { Name = targetName
-            HardDependencies = [| dep |]
-            SoftDependencies = [||]
-            Declaration = decl
-            Description = "To see a description, upgrade Fake.Core.Target to 5.15" })
+        |> Seq.choose (fun line ->
+          // heuristic
+          if line.StartsWith "   " then
+            let targetNameAndDesc = line.Substring(3)
+            // If people use ' - ' in their target name we are lost...
+            let splitIdx = targetNameAndDesc.IndexOf(" - ")
+            let targetName =
+              if splitIdx > 0 then targetNameAndDesc.Substring(0, splitIdx)
+              else targetNameAndDesc
+            { Name = targetName
+              HardDependencies = [| dep |]
+              SoftDependencies = [||]
+              Declaration = decl
+              Description = "To see a description, upgrade Fake.Core.Target to 5.15" }
+            |> Some
+          else None)
         |> Seq.toArray
       return targets
   }

--- a/src/FsAutoComplete.Core/FakeSupport.fs
+++ b/src/FsAutoComplete.Core/FakeSupport.fs
@@ -169,11 +169,6 @@ module FakeSupport =
     let resultsFile = Path.GetTempFileName()
     try
       let workingDir = Path.GetDirectoryName file
-      // delete .dll and .pdb file in order to have proper fsiargs.      
-      let fnNoExt = Path.GetFileNameWithoutExtension file
-      let fakeDir = Path.Combine(workingDir, ".fake", fileName)
-      Directory.EnumerateFiles (fakeDir, fnNoExt + "*")
-          |> Seq.iter File.Delete
       let fakeArgs = sprintf "-s run --fsiargs \"--debug:portable --optimize-\" \"%s\" -- --write-info \"%s\"" fileName resultsFile
       let args = sprintf "\"%s\" %s" rt fakeArgs
       let exitCode, _ = Utils.runProcess (lines.Add) workingDir ctx.DotNetRuntime args

--- a/src/FsAutoComplete.Core/FakeSupport.fs
+++ b/src/FsAutoComplete.Core/FakeSupport.fs
@@ -195,7 +195,9 @@ module FakeSupport =
     let resultsFile = Path.GetTempFileName()
     try
       let workingDir = Path.GetDirectoryName file
-      let fakeArgs = sprintf "-s run --fsiargs \"--debug:portable --optimize-\" \"%s\" -- --write-info \"%s\"" fileName resultsFile
+      // the nocache option is needed because if a script only changes whitespace,
+      // FAKE is clever enough to not recompile
+      let fakeArgs = sprintf "-s run --nocache --fsiargs \"--debug:portable --optimize-\" \"%s\" -- --write-info \"%s\"" fileName resultsFile
       let args = sprintf "\"%s\" %s" rt fakeArgs
       let exitCode, _ = Utils.runProcess (lines.Add) workingDir ctx.DotNetRuntime args
       if exitCode <> 0 then

--- a/src/FsAutoComplete.Core/FakeSupport.fs
+++ b/src/FsAutoComplete.Core/FakeSupport.fs
@@ -2,8 +2,76 @@ namespace FsAutoComplete
 
 open Fake.Runtime
 open Fake.Runtime.Trace
+open System
+open System.IO
+open System.IO.Compression
+open System.Net
+open FSharpLint.Rules.Helper.SourceLength
 
 module FakeSupport =
+  let private downloadUri = Uri "https://github.com/fsharp/FAKE/releases/latest/download/fake-dotnetcore-portable.zip"
+
+  let downloadAndExtract (uri:Uri) directory = async {
+    use client = new WebClient()
+    client.Headers.Add("user-agent", "Ionide")
+    let tempFile = Path.GetTempFileName()
+    try
+      do! client.DownloadFileTaskAsync(uri, tempFile) |> Async.AwaitTask
+      ZipFile.ExtractToDirectory(tempFile, directory)
+    finally
+      try
+        File.Delete tempFile
+      with e -> ()
+  }
+
+  let private downloadAndGetFakeDll uri directory = async {
+    let fakeDll = Path.Combine(directory, "fake.dll")
+    if File.Exists fakeDll then
+      return fakeDll
+    else    
+      do! downloadAndExtract uri directory
+      return fakeDll
+  }
+
+  let mutable fakeDll = None
+  let locker = obj()
+  let getFakeRuntimeAsTask(runtimeDir:string) =
+    match fakeDll with
+    | None ->
+      lock locker (fun _ ->
+        match fakeDll with
+        | None ->
+          if not (Directory.Exists runtimeDir) then
+            Directory.CreateDirectory runtimeDir |> ignore
+          let t = downloadAndGetFakeDll downloadUri runtimeDir |> Async.StartAsTask
+          fakeDll <- Some t
+          t
+        | Some s -> s
+      )
+    | Some s -> s
+  let getFakeRuntime (runtimeDir) = getFakeRuntimeAsTask runtimeDir |> Async.AwaitTask  
+
+  type Declaration =
+      { File : string
+        Line : int
+        Column : int }
+
+  type FakeContext =
+      { DotNetRuntime : string
+        PortableFakeRuntime : string }
+
+  /// a target dependency, either a hard or a soft dependency.
+  type Dependency =
+      { Name : string
+        Declaration : Declaration }
+  /// a FAKE target, its description and its relations to other targets (dependencies), including the declaration lines of the target and the dependencies.           
+  type Target =
+      { Name : string
+        HardDependencies : Dependency []
+        SoftDependencies : Dependency []
+        Declaration : Declaration
+        Description : string }
+
   type DebugTraceListener() =
     interface ITraceListener with
       /// Writes the given message to the Console.
@@ -45,3 +113,87 @@ module FakeSupport =
     
     "--simpleresolution" :: "--targetprofile:netstandard" :: "--nowin32manifest" :: args
     |> List.toArray
+ 
+  let private errorTarget file msg desc =
+      let decl = 
+          { File = file
+            Line = 0
+            Column = 0 }
+      let target =
+          { Name = msg
+            HardDependencies = [||]
+            SoftDependencies = [||]
+            Declaration = decl
+            Description = desc }
+      target
+
+  let private getTargetsLegacy (file:string) (ctx:FakeContext) : Async<Target []> = async {
+    // pre Fake.Core.Targets upgrade
+    let decl = 
+        { File = file
+          Line = 0
+          Column = 0 }
+    let dep =
+        { Name = "To see dependencies, upgrade Fake.Core.Target to 5.15"
+          Declaration = decl }
+    let! rt = getFakeRuntime ctx.PortableFakeRuntime
+    let lines = ResizeArray<_>()
+    let fileName = Path.GetFileName file
+    let workingDir = Path.GetDirectoryName file
+    let fakeArgs = sprintf "-s run \"%s\" -- --list" fileName
+    let args = sprintf "\"%s\" %s" rt fakeArgs
+    let exitCode, _ = Utils.runProcess (lines.Add) workingDir ctx.DotNetRuntime args
+    if exitCode <> 0 then
+      return [| errorTarget file (sprintf "Running Script 'fake %s' failed (%d)" fakeArgs exitCode) "We tried to list the targets but your script failed" |]
+    else
+      let targets =
+        lines
+        |> Seq.filter (fun l -> l <> null)
+        |> Seq.skip 1
+        |> Seq.map (fun line ->
+          let targetName = line.Trim()
+          { Name = targetName
+            HardDependencies = [| dep |]
+            SoftDependencies = [||]
+            Declaration = decl
+            Description = "To see a description, upgrade Fake.Core.Target to 5.15" })
+        |> Seq.toArray
+      return targets
+  }      
+
+  let private getTargetsVersion (context:Runners.FakeContext) : Version option =
+
+    // soon there will be public apis and getProp can be removed...
+    let getProp (n:string) (t:obj) : 't =
+      let bf = System.Reflection.BindingFlags.Instance ||| System.Reflection.BindingFlags.NonPublic
+      t.GetType().GetProperty(n, bf).GetMethod.Invoke(t, [||]) :?> 't
+    let runtimeDeps : Runners.AssemblyInfo list = getProp "RuntimeDependencies" context.Config.RuntimeOptions
+    let targetVersion =
+      runtimeDeps
+      |> Seq.map (fun r -> System.Reflection.AssemblyName(r.FullName))
+      |> Seq.tryFind (fun a -> a.Name = "Fake.Core.Target")
+      |> Option.map (fun a -> a.Version)
+    targetVersion
+
+  let getTargets (file:string) (ctx:FakeContext) : Async<Target []> = async {
+    setupLogging()
+    match detectFakeScript file with
+    | None ->
+      return [| errorTarget file "not a FAKE 5 script" "This file is not a valid FAKE 5 script" |]
+
+    | Some (config, prepared) ->
+      let! rt = getFakeRuntime ctx.PortableFakeRuntime
+      let prov = FakeRuntime.restoreAndCreateCachingProvider prepared
+      let context, cache = CoreCache.prepareContext config prov
+      match getTargetsVersion context with
+      | None ->
+        return [| errorTarget file "No Fake.Core.Target dependency" "This file a valid FAKE 5 script, but doesn't use Fake.Core.Target" |]
+      | Some v when v <= Version(5, 15, 0, 0) ->
+        let! targets = getTargetsLegacy file ctx
+        return targets
+      | Some v ->
+        // Use newer logic
+        let! targets = getTargetsLegacy file ctx
+        return targets
+  }
+    

--- a/src/FsAutoComplete.Core/FakeSupport.fs
+++ b/src/FsAutoComplete.Core/FakeSupport.fs
@@ -169,7 +169,12 @@ module FakeSupport =
     let resultsFile = Path.GetTempFileName()
     try
       let workingDir = Path.GetDirectoryName file
-      let fakeArgs = sprintf "-s run \"%s\" -- --write-info \"%s\"" fileName resultsFile
+      // delete .dll and .pdb file in order to have proper fsiargs.      
+      let fnNoExt = Path.GetFileNameWithoutExtension file
+      let fakeDir = Path.Combine(workingDir, ".fake", fileName)
+      Directory.EnumerateFiles (fakeDir, fnNoExt + "*")
+          |> Seq.iter File.Delete
+      let fakeArgs = sprintf "-s run --fsiargs \"--debug:portable --optimize-\" \"%s\" -- --write-info \"%s\"" fileName resultsFile
       let args = sprintf "\"%s\" %s" rt fakeArgs
       let exitCode, _ = Utils.runProcess (lines.Add) workingDir ctx.DotNetRuntime args
       if exitCode <> 0 then

--- a/src/FsAutoComplete.Core/FakeSupport.fs
+++ b/src/FsAutoComplete.Core/FakeSupport.fs
@@ -8,6 +8,7 @@ open System.IO.Compression
 open System.Threading.Tasks
 open System.Net
 open Newtonsoft.Json.Linq
+open Newtonsoft.Json.Linq
 
 module FakeSupport =
   let private compatibleFakeVersion = "5.15.0"
@@ -202,9 +203,11 @@ module FakeSupport =
       else
         let jsonStr = File.ReadAllText resultsFile
         let jobj = JObject.Parse jsonStr
-
+        let parseStringWithNull (t:JToken) =
+            if isNull t || t.Type = JTokenType.Null then null
+            else string t 
         let parseDecl (t:JToken) =
-            { File = string t.["file"]; Line = int t.["line"]; Column = int t.["column"] }
+            { File = parseStringWithNull t.["file"]; Line = int t.["line"]; Column = int t.["column"] }
         let parseDep (t:JToken) =
             { Name = string t.["name"]; Declaration = parseDecl t.["declaration"] }
         let parseArray parseItem (a:JToken) =

--- a/src/FsAutoComplete.Core/FakeSupport.fs
+++ b/src/FsAutoComplete.Core/FakeSupport.fs
@@ -250,7 +250,7 @@ module FakeSupport =
       match getTargetsVersion context with
       | None ->
         return [| errorTarget file "No Fake.Core.Target dependency" "This file a valid FAKE 5 script, but doesn't use Fake.Core.Target" |]
-      | Some v when v <= Version(5, 15, 0, 0) ->
+      | Some v when v < Version(5, 15) ->
         let! targets = getTargetsLegacy file ctx
         return targets
       | Some v ->

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -803,8 +803,8 @@ module CommandResponse =
       |> Seq.toList
     serialize { Kind = "analyzer"; Data = { File = file; Messages = r}}
 
-  let fakeTargets (serialize : Serializer) (targets : (FakeSupport.Target) []) =
-     serialize { Kind = "fakeTargets"; Data = targets }
+  let fakeTargets (serialize : Serializer) (targets : FakeSupport.GetTargetsResult) =
+     serialize targets
   
   let fakeRuntime (serialize : Serializer) (runtimePath : string) =
      serialize { Kind = "fakeRuntime"; Data = runtimePath }

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -657,6 +657,14 @@ module CommandResponse =
         })
      serialize { Kind = "declarations"; Data = decls' }
 
+  let fakeTargets (serialize : Serializer) (targets : (FakeSupport.Target) []) =
+     //let decls' =
+     // targets |> Array.map (fun (d, fn) ->
+     //   { Declaration = Declaration.OfDeclarationItem (d.Declaration, fn);
+     //     Nested = d.Nested |> Array.map ( fun a -> Declaration.OfDeclarationItem(a,fn))
+     //   })
+     serialize { Kind = "fakeTargets"; Data = targets }
+   
   let toolTip (serialize : Serializer) (tip, signature, footer, typeDoc) =
     let data = TipFormatter.formatTipEnhanced tip signature footer typeDoc |> List.map(List.map(fun (n,m,f) -> {Footer =f; Signature = n; Comment = m} ))
     serialize { Kind = "tooltip"; Data = data }
@@ -844,6 +852,8 @@ module CommandResponse =
       findTypeDeclaration s range
     | CoreResponse.Declarations(decls) ->
       declarations s decls
+    | CoreResponse.FakeTargets(targets) ->
+      fakeTargets s targets
     | CoreResponse.ToolTip(tip, signature, footer, typeDoc) ->
       toolTip s (tip, signature, footer, typeDoc)
     | CoreResponse.FormattedDocumentation(tip, xmlSig, signature, footer, cn) ->

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -657,14 +657,6 @@ module CommandResponse =
         })
      serialize { Kind = "declarations"; Data = decls' }
 
-  let fakeTargets (serialize : Serializer) (targets : (FakeSupport.Target) []) =
-     //let decls' =
-     // targets |> Array.map (fun (d, fn) ->
-     //   { Declaration = Declaration.OfDeclarationItem (d.Declaration, fn);
-     //     Nested = d.Nested |> Array.map ( fun a -> Declaration.OfDeclarationItem(a,fn))
-     //   })
-     serialize { Kind = "fakeTargets"; Data = targets }
-   
   let toolTip (serialize : Serializer) (tip, signature, footer, typeDoc) =
     let data = TipFormatter.formatTipEnhanced tip signature footer typeDoc |> List.map(List.map(fun (n,m,f) -> {Footer =f; Signature = n; Comment = m} ))
     serialize { Kind = "tooltip"; Data = data }
@@ -811,6 +803,12 @@ module CommandResponse =
       |> Seq.toList
     serialize { Kind = "analyzer"; Data = { File = file; Messages = r}}
 
+  let fakeTargets (serialize : Serializer) (targets : (FakeSupport.Target) []) =
+     serialize { Kind = "fakeTargets"; Data = targets }
+  
+  let fakeRuntime (serialize : Serializer) (runtimePath : string) =
+     serialize { Kind = "fakeRuntime"; Data = runtimePath }
+
   let serialize (s: Serializer) = function
     | CoreResponse.InfoRes(text) ->
       info s text
@@ -852,8 +850,6 @@ module CommandResponse =
       findTypeDeclaration s range
     | CoreResponse.Declarations(decls) ->
       declarations s decls
-    | CoreResponse.FakeTargets(targets) ->
-      fakeTargets s targets
     | CoreResponse.ToolTip(tip, signature, footer, typeDoc) ->
       toolTip s (tip, signature, footer, typeDoc)
     | CoreResponse.FormattedDocumentation(tip, xmlSig, signature, footer, cn) ->
@@ -890,3 +886,7 @@ module CommandResponse =
       interfaceStub s generatedCode insertPosition
     | CoreResponse.RangesAtPositions(ranges) -> rangesAtPosition s ranges
     | CoreResponse.Fsdn(functions) -> fsdn s functions
+    | CoreResponse.FakeTargets(targets) ->
+      fakeTargets s targets
+    | CoreResponse.FakeRuntime(runtimePath) ->
+      fakeRuntime s runtimePath

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1589,6 +1589,20 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         return res
     }
 
+    member __.FakeRuntimePath(p) = async {
+        Debug.print "[LSP call] FakeRuntime"
+        let! res = commands.FakeRuntime ()
+        let res =
+            match res.[0] with
+            | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
+                LspResult.internalError msg
+            | CoreResponse.FakeRuntime (runtimePath) ->
+                { Content = CommandResponse.fakeRuntime FsAutoComplete.JsonSerializer.writeJson runtimePath }
+                |> success
+            | _ -> LspResult.notImplemented
+        return res
+    }
+
 let startCore (commands: Commands) =
     use input = Console.OpenStandardInput()
     use output = Console.OpenStandardOutput()
@@ -1607,7 +1621,8 @@ let startCore (commands: Commands) =
         |> Map.add "fsharp/f1Help" (requestHandling (fun s p -> s.FSharpHelp(p) ))
         |> Map.add "fsharp/documentation" (requestHandling (fun s p -> s.FSharpDocumentation(p) ))
         |> Map.add "fsharp/documentationSymbol" (requestHandling (fun s p -> s.FSharpDocumentationSymbol(p) ))
-        |> Map.add "fsharp/fakeTargets" (requestHandling (fun s p -> s.FakeTargets(p) ))
+        |> Map.add "fake/listTargets" (requestHandling (fun s p -> s.FakeTargets(p) ))
+        |> Map.add "fake/runtimePath" (requestHandling (fun s p -> s.FakeRuntimePath(p) ))
 
 
 

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1607,7 +1607,7 @@ let startCore (commands: Commands) =
         |> Map.add "fsharp/f1Help" (requestHandling (fun s p -> s.FSharpHelp(p) ))
         |> Map.add "fsharp/documentation" (requestHandling (fun s p -> s.FSharpDocumentation(p) ))
         |> Map.add "fsharp/documentationSymbol" (requestHandling (fun s p -> s.FSharpDocumentationSymbol(p) ))
-        |> Map.add "fake/targets" (requestHandling (fun s p -> s.FakeTargets(p) ))
+        |> Map.add "fsharp/fakeTargets" (requestHandling (fun s p -> s.FakeTargets(p) ))
 
 
 

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -470,6 +470,8 @@ type WorkspaceLoadParms = {
 type WorkspacePeekRequest = {Directory : string; Deep: int; ExcludedDirs: string array}
 type DocumentationForSymbolReuqest = {XmlSig: string; Assembly: string}
 
+type FakeTargetsRequest = {FileName : string; FakeContext : FakeSupport.FakeContext; }
+
 type FSharpConfigDto = {
     AutomaticWorkspaceInit: bool option
     WorkspaceModePeekDeepLevel: int option


### PR DESCRIPTION
Replaces https://github.com/fsharp/FsAutoComplete/pull/414

TODO:
- [x] Limited Support `Fake.Core.Target < 5.15`. The following will not work:
      - will only show the list of targets in outline
      - navigating to targets will not work
      - Target dependencies are missing
      - Target description is missing
- [x] Improved support for `Fake.Core.Target >= 5.15`
- [x] add support for debugging and running buttons (ie add `fake/downloadRuntime` action)