### PR TITLE
as tool package fsautocomplete, invoke as `dotnet fsautocomplete`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Title>FsAutoComplete</Title>
     <Product>FsAutoComplete</Product>
     <Description>A command line tool for interfacing with FSharp.Compiler.Service over a pipe.</Description>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageLicenseExpression Condition=" '$(PackAsTool)' != 'true' ">Apache-2.0</PackageLicenseExpression>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,5 +7,5 @@ build_script:
 test: off
 
 artifacts:
-  - path: bin\pkgs\*.zip
+  - path: bin\pkgs\*
     name: pkgs

--- a/build.fsx
+++ b/build.fsx
@@ -194,6 +194,9 @@ Target "ReleaseArchive" (fun _ ->
 
     !! "bin/release_netcore/**/*"
     |> Zip "bin/release_netcore" releaseArchiveNetCore
+
+    !! (sprintf "bin/release_as_tool/fsautocomplete.%s.nupkg" release.AssemblyVersion)
+    |> Copy "bin/pkgs"
 )
 
 Target "LocalRelease" (fun _ ->
@@ -216,6 +219,14 @@ Target "LocalRelease" (fun _ ->
            Project = "src/FsAutoComplete"
            Configuration = configuration
            AdditionalArgs = [ "/p:SourceLinkCreate=true"; sprintf "/p:Version=%s" release.AssemblyVersion ]  })
+
+    CleanDirs [ "bin/release_as_tool" ]
+    DotNetCli.Pack (fun p ->
+       { p with
+           OutputPath = __SOURCE_DIRECTORY__ </> "bin/release_as_tool"
+           Project = "src/FsAutoComplete"
+           Configuration = configuration
+           AdditionalArgs = [ "/p:SourceLinkCreate=true"; sprintf "/p:Version=%s" release.AssemblyVersion; "/p:PackAsTool=true" ]  })
 )
 
 Target "Clean" (fun _ ->

--- a/src/FsAutoComplete/FsAutoComplete.fsproj
+++ b/src/FsAutoComplete/FsAutoComplete.fsproj
@@ -35,19 +35,20 @@
     <ProjectReference Include="..\LanguageServerProtocol\LanguageServerProtocol.fsproj" />
   </ItemGroup>
 
-  <!-- bundle the net461 exe inside the .net core tool package -->
+  <!-- do not bundle the net461 exe inside the .net core tool package -->
   <PropertyGroup Condition=" '$(PackAsTool)' == 'true' ">
     <TargetFrameworks></TargetFrameworks>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <AssemblyName>dotnet-fsautocomplete</AssemblyName>
+    <PackageId>fsautocomplete</PackageId>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(PackAsTool)' == 'true' ">
-    <Content Include="$(RepoDir)/bin/release/*">
-      <Pack>true</Pack>
-      <PackagePath>tools\net461\any\%(Filename)%(Extension)</PackagePath>
-      <Visible>true</Visible>
-    </Content>
-  </ItemGroup>
+  <!-- workaround for not being able to make Backend and Domain as inlined in a complete way https://github.com/nuget/home/issues/3891#issuecomment-377319939 -->
+  <!-- <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths -> WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+    </ItemGroup>
+  </Target> -->
 
   <Target Name="CopyBackgroundServiceJsonToOutputDir"
           AfterTargets="ComputeFilesToPublish"

--- a/src/FsAutoComplete/FsAutoComplete.fsproj
+++ b/src/FsAutoComplete/FsAutoComplete.fsproj
@@ -41,14 +41,17 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>dotnet-fsautocomplete</AssemblyName>
     <PackageId>fsautocomplete</PackageId>
+
+    <!-- workaround for not being able to have p2p dependencies in tool output dir https://github.com/nuget/home/issues/3891#issuecomment-377319939 -->
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 
-  <!-- workaround for not being able to make Backend and Domain as inlined in a complete way https://github.com/nuget/home/issues/3891#issuecomment-377319939 -->
-  <!-- <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
+  <!-- workaround for not being able to have p2p dependencies in tool output dir https://github.com/nuget/home/issues/3891#issuecomment-377319939 -->
+  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
     <ItemGroup>
       <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths -> WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
     </ItemGroup>
-  </Target> -->
+  </Target>
 
   <Target Name="CopyBackgroundServiceJsonToOutputDir"
           AfterTargets="ComputeFilesToPublish"

--- a/src/FsAutoComplete/paket.references
+++ b/src/FsAutoComplete/paket.references
@@ -9,3 +9,9 @@ FSharpLint.Core
 Dotnet.ProjInfo
 Dotnet.ProjInfo.Workspace.FCS
 FSharp.Analyzers.SDK
+Fake.Runtime
+Dapper
+FSharp.Data
+Microsoft.Data.Sqlite
+OptimizedPriorityQueue
+ICSharpCode.Decompiler

--- a/src/FsAutoComplete/paket.references
+++ b/src/FsAutoComplete/paket.references
@@ -5,3 +5,7 @@ Newtonsoft.Json
 FSharp.Core
 Microsoft.SourceLink.GitHub
 System.Configuration.ConfigurationManager
+FSharpLint.Core
+Dotnet.ProjInfo
+Dotnet.ProjInfo.Workspace.FCS
+FSharp.Analyzers.SDK


### PR DESCRIPTION
as tool package fsautocomplete, invoke as `dotnet fsautocomplete`

Workaround for .net tool
- add transitive p2p deps to fsautocomplete console proj because workaround doesnt work with paket
- nuget error out as licenseid and licenseurl both set

fix https://github.com/fsharp/FsAutoComplete/issues/36