### PR TITLE
Add generics info to SignatureData

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -28,7 +28,7 @@ type CoreResponse =
     | Completion of decls: FSharpDeclarationListItem[] * includeKeywords: bool
     | SymbolUse of symbol: FSharpSymbolUse * uses: FSharpSymbolUse[]
     | SymbolUseImplementation of symbol: FSharpSymbolUse * uses: FSharpSymbolUse[]
-    | SignatureData of typ: string * parms: (string * string) list list
+    | SignatureData of typ: string * parms: (string * string) list list * generics : string list
     | Help of data: string
     | Methods of meth: FSharpMethodGroup * commas: int
     | Errors of errors: FSharpErrorInfo[] * file: string
@@ -58,7 +58,7 @@ type CoreResponse =
     | FakeTargets of result: FakeSupport.GetTargetsResult
     | FakeRuntime of runtimePath: string
     | DotnetNewList of Template list
-    | DotnetNewGetDetails of DetailedTemplate 
+    | DotnetNewGetDetails of DetailedTemplate
 
 [<RequireQualifiedAccess>]
 type NotificationEvent =
@@ -283,7 +283,7 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
             let results = DotnetNewTemplate.dotnetnewgetDetails filterstr
             return [ CoreResponse.DotnetNewGetDetails results ]
         }
-    
+
     member private x.AsCancellable (filename : SourceFilePath) (action : Async<CoreResponse list>) =
         let cts = new CancellationTokenSource()
         state.AddCancellationToken(filename, cts)

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -324,6 +324,7 @@ module CommandResponse =
   type SignatureData = {
     OutputType : string
     Parameters : Parameter list list
+    Generics : string list
   }
 
   type UnusedDeclaration = {
@@ -417,7 +418,7 @@ module CommandResponse =
   }
 
   type DotnetNewGetDetailsResponse = {
-    Detailed : DotnetNewTemplate.DetailedTemplate 
+    Detailed : DotnetNewTemplate.DetailedTemplate
   }
 
   let info (serialize : Serializer) (s: string) = serialize { Kind = "info"; Data = s }
@@ -592,11 +593,11 @@ module CommandResponse =
       }
     serialize { Kind = "symbolimplementation"; Data = su }
 
-  let signatureData (serialize : Serializer) ((typ, parms) : string * ((string * string) list list) ) =
+  let signatureData (serialize : Serializer) ((typ, parms, generics) : string * ((string * string) list list) * string list) =
     let pms =
       parms
       |> List.map (List.map (fun (n, t) -> { Name= n; Type = t }))
-    serialize { Kind = "signatureData"; Data = { Parameters = pms; OutputType = typ } }
+    serialize { Kind = "signatureData"; Data = { Parameters = pms; OutputType = typ; Generics = generics } }
 
   let help (serialize : Serializer) (data : string) =
     serialize { Kind = "help"; Data = data }
@@ -820,7 +821,7 @@ module CommandResponse =
 
   let fakeTargets (serialize : Serializer) (targets : FakeSupport.GetTargetsResult) =
      serialize targets
-  
+
   let fakeRuntime (serialize : Serializer) (runtimePath : string) =
      serialize { Kind = "fakeRuntime"; Data = runtimePath }
 
@@ -849,8 +850,8 @@ module CommandResponse =
       symbolUse s (symbol, uses)
     | CoreResponse.SymbolUseImplementation(symbol, uses) ->
       symbolImplementation s (symbol, uses)
-    | CoreResponse.SignatureData(typ, parms) ->
-      signatureData s (typ, parms)
+    | CoreResponse.SignatureData(typ, parms, generics) ->
+      signatureData s (typ, parms, generics)
     | CoreResponse.Help(data) ->
       help s data
     | CoreResponse.Methods(meth, commas) ->
@@ -906,5 +907,5 @@ module CommandResponse =
     | CoreResponse.FakeRuntime(runtimePath) ->
       fakeRuntime s runtimePath
     | CoreResponse.DotnetNewList (installedTemplate) -> dotnetnewlist s installedTemplate
-    | CoreResponse.DotnetNewGetDetails (detailedTemplate) -> 
+    | CoreResponse.DotnetNewGetDetails (detailedTemplate) ->
       dotnetnewgetDetails s detailedTemplate

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1282,7 +1282,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                             Debug.print "[LSP] CodeLensResolve - error: %s" msg
                             let cmd = {Title = ""; Command = None; Arguments = None}
                             {p with Command = Some cmd} |> success
-                        | CoreResponse.SignatureData (typ, parms) ->
+                        | CoreResponse.SignatureData (typ, parms, _) ->
                             let formatted = SigantureData.formatSignature typ parms
                             let cmd = {Title = formatted; Command = None; Arguments = None}
                             {p with Command = Some cmd} |> success
@@ -1422,8 +1422,8 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                     match res.[0] with
                     | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
                         LspResult.internalError msg
-                    | CoreResponse.SignatureData (typ, parms) ->
-                        { Content =  CommandResponse.signatureData FsAutoComplete.JsonSerializer.writeJson (typ, parms) }
+                    | CoreResponse.SignatureData (typ, parms, generics) ->
+                        { Content =  CommandResponse.signatureData FsAutoComplete.JsonSerializer.writeJson (typ, parms, generics) }
                         |> success
                     | _ -> LspResult.notImplemented
 
@@ -1440,8 +1440,8 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                     match res.[0] with
                     | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
                         LspResult.internalError msg
-                    | CoreResponse.SignatureData (typ, parms) ->
-                        { Content =  CommandResponse.signatureData FsAutoComplete.JsonSerializer.writeJson (typ, parms) }
+                    | CoreResponse.SignatureData (typ, parms, generics) ->
+                        { Content =  CommandResponse.signatureData FsAutoComplete.JsonSerializer.writeJson (typ, parms, generics) }
                         |> success
                     | _ -> LspResult.notImplemented
 
@@ -1473,8 +1473,8 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                     match res.[0] with
                     | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
                         LspResult.internalError msg
-                    | CoreResponse.SignatureData(typ, parms) ->
-                        { Content =  CommandResponse.signatureData FsAutoComplete.JsonSerializer.writeJson (typ, parms) }
+                    | CoreResponse.SignatureData(typ, parms, generics) ->
+                        { Content =  CommandResponse.signatureData FsAutoComplete.JsonSerializer.writeJson (typ, parms, generics) }
                         |> success
                     | _ -> LspResult.notImplemented
 


### PR DESCRIPTION
I am working on https://github.com/ionide/ionide-vscode-fsharp/issues/1012

I discovered that [`<typeparam>`](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/typeparam) exist in order to documents the generics. So I am trying to add it to the doc comment generation.

The doc comment generation of Ionide is using `SignatureData` infos. Is it ok if I add a new `Generics : string list` property or should I create a separate `Command` ?

Example:

```fs
/// <summary>
/// 
/// </summary>
/// <param name="url"></param>
/// <param name="data"></param>
/// <param name="responseResolver"></param>
/// <param name="dataResolver"></param>
/// <typeparam name="Data"></typeparam>
/// <typeparam name="Response"></typeparam>
/// <returns></returns>
static member tryDelete<'Data, 'Response>(url : string,
                                          data : 'Data,
                                          [<Inject>] ?responseResolver: ITypeResolver<'Response>,
                                          [<Inject>] ?dataResolver: ITypeResolver<'Data>) =
```