### PR TITLE
Fix uri localpath normalization on windows

### DIFF
--- a/src/FsAutoComplete.BackgroundServices/Program.fs
+++ b/src/FsAutoComplete.BackgroundServices/Program.fs
@@ -57,14 +57,19 @@ module Helpers =
             Tags = None
         }
 
+    /// Algorithm from https://stackoverflow.com/a/35734486/433393 for converting file paths to uris,
+    /// modified slightly to not rely on the System.Path members because they vary per-platform
     let filePathToUri (filePath: string): DocumentUri =
         let uri = StringBuilder(filePath.Length)
         for c in filePath do
             if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
-                c = '+' || c = '/' || c = ':' || c = '.' || c = '-' || c = '_' || c = '~' ||
+                c = '+' || c = '/' || c = '.' || c = '-' || c = '_' || c = '~' ||
                 c > '\xFF' then
                 uri.Append(c) |> ignore
-            else if c = Path.DirectorySeparatorChar || c = Path.AltDirectorySeparatorChar then
+            // handle windows path separator chars.
+            // we _would_ use Path.DirectorySeparator/AltDirectorySeparator, but those vary per-platform and we want this
+            // logic to work cross-platform (for tests)
+            else if c = '\\' then
                 uri.Append('/') |> ignore
             else
                 uri.Append('%') |> ignore

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1236,7 +1236,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             async {
                 let pos = FcsRange.mkPos (arg.Range.Start.Line + 1) (arg.Range.Start.Character + 2)
                 let data = arg.Data.Value.ToObject<string[]>()
-                let file = (Uri data.[0]).LocalPath
+                let file = fileUriToLocalPath data.[0]
                 Debug.print "[LSP] CodeLensResolve - Position request: %s at %A" file pos
                 return!
                     match commands.TryGetFileCheckerOptionsWithLinesAndLineStr(file, pos) with

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -94,14 +94,20 @@ module Conversions =
 
     /// a test that checks if the start of the line is a windows-style drive string, for example
     /// /d:, /c:, /z:, etc.
-    let private windowsStyleDriveLetterMatcher =
-        System.Text.RegularExpressions.Regex(@"^/[a-zA-Z]+\:")
+    let isWindowsStyleDriveLetterMatch (s: string) =
+        match s.[0..2].ToCharArray() with
+        | [| |]
+        | [| _ |]
+        | [| _; _ |] -> false
+        // 26 windows drive letters allowed, only
+        | [| '/'; c; ':' |] when Char.IsLetter c -> true
+        | _ -> false
 
     /// handles unifying the local-path logic for windows and non-windows paths,
     /// without doing a check based on what the current system's OS is.
     let fileUriToLocalPath (u: DocumentUri) =
         let initialLocalPath = Uri(u).LocalPath
-        if windowsStyleDriveLetterMatcher.IsMatch initialLocalPath
+        if isWindowsStyleDriveLetterMatch initialLocalPath
         then initialLocalPath.TrimStart('/')
         else initialLocalPath
 

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -92,14 +92,17 @@ module Conversions =
             }
         | FsAutoComplete.FindDeclarationResult.Range r -> fcsRangeToLspLocation r
 
+    let fileUriToLocalPath (u: DocumentUri) =
+        Uri(u).LocalPath
+
     type TextDocumentIdentifier with
-        member doc.GetFilePath() = Uri(doc.Uri).LocalPath
+        member doc.GetFilePath() = fileUriToLocalPath doc.Uri
 
     type VersionedTextDocumentIdentifier with
-        member doc.GetFilePath() = Uri(doc.Uri).LocalPath
+        member doc.GetFilePath() = fileUriToLocalPath doc.Uri
 
     type TextDocumentItem with
-        member doc.GetFilePath() = Uri(doc.Uri).LocalPath
+        member doc.GetFilePath() = fileUriToLocalPath doc.Uri
 
     type ITextDocumentPositionParams with
         member p.GetFilePath() = p.TextDocument.GetFilePath()

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -561,8 +561,8 @@ let fsdnTest =
 
 let uriTests =
   let verifyUri (given: string) (expectedLocal: string) = test (sprintf "roundtrip '%s' -> '%s'" given expectedLocal) {
-    let givenU = Uri given
-    Expect.equal givenU.LocalPath expectedLocal (sprintf "LocalPath of '%s' should be '%s'" given expectedLocal)
+    let actual = LspHelpers.Conversions.fileUriToLocalPath given
+    Expect.equal actual expectedLocal (sprintf "LocalPath of '%s' should be '%s'" given expectedLocal)
   }
 
   let convertRawPathToUri (rawPath: string) (expectedPath: string) = test (sprintf "convert '%s' -> '%s'" rawPath expectedPath) {
@@ -581,9 +581,10 @@ let uriTests =
       "file:///Users/carlyrae/oss/f%23test", "/Users/carlyrae/oss/f#test" // escaped chars, unix-style
       "file:///C:/carly rae/oss/f%23test", "C:\\carly rae\\oss\\f#test" // spaces and escaped chars, windows-style
       "file:///Users/carly rae/oss/f%23test", "/Users/carly rae/oss/f#test" // spaces and escaped chars, unix-style
+      "file:///d%3A/code/Saturn/src/Saturn/Utils.fs", "d:/code/Saturn/src/Saturn/Utils.fs"
     ]
 
-  testList "Uri tests"[
+  ftestList "Uri tests"[
     testList "roundtrip tests" (samples |> List.map (fun (uriForm, filePath) -> verifyUri uriForm filePath))
     testList "fileName to uri tests" (samples |> List.map (fun (uriForm, filePath) -> convertRawPathToUri filePath uriForm))
  ]

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -584,7 +584,7 @@ let uriTests =
       "file:///d%3A/code/Saturn/src/Saturn/Utils.fs", "d:/code/Saturn/src/Saturn/Utils.fs"
     ]
 
-  ftestList "Uri tests"[
+  testList "Uri tests"[
     testList "roundtrip tests" (samples |> List.map (fun (uriForm, filePath) -> verifyUri uriForm filePath))
     testList "fileName to uri tests" (samples |> List.map (fun (uriForm, filePath) -> convertRawPathToUri filePath uriForm))
  ]

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -573,14 +573,14 @@ let uriTests =
   }
 
   let samples =
-    [ "file:///C:/foo/bar/baz", "C:\\foo\\bar\\baz"
-      "file:///C:/foo/bar bar/baz", "C:\\foo\\bar bar\\baz" // spaces, windows-style
-      "file:///Users/bob jones/foo/bar", "/Users/bob jones/foo/bar" // spaces, unix-style
+    [ "file:///C%3A/foo/bar/baz", "C:/foo/bar/baz"
+      "file:///C%3A/foo/bar bar/baz", "C:/foo/bar bar/baz" // spaces, windows-root
+      "file:///Users/bob jones/foo/bar", "/Users/bob jones/foo/bar" // spaces, unix-root
       "file:///Users/bobjones/foo/bar", "/Users/bobjones/foo/bar"
-      "file:///C:/f%23/bar/baz", "C:\\f#\\bar\\baz" // escaped chars, windows style
-      "file:///Users/carlyrae/oss/f%23test", "/Users/carlyrae/oss/f#test" // escaped chars, unix-style
-      "file:///C:/carly rae/oss/f%23test", "C:\\carly rae\\oss\\f#test" // spaces and escaped chars, windows-style
-      "file:///Users/carly rae/oss/f%23test", "/Users/carly rae/oss/f#test" // spaces and escaped chars, unix-style
+      "file:///C%3A/f%23/bar/baz", "C:/f#/bar/baz" // escaped chars, windows-root
+      "file:///Users/carlyrae/oss/f%23test", "/Users/carlyrae/oss/f#test" // escaped chars, unix-root
+      "file:///C%3A/carly rae/oss/f%23test", "C:/carly rae/oss/f#test" // spaces and escaped chars, windows-root
+      "file:///Users/carly rae/oss/f%23test", "/Users/carly rae/oss/f#test" // spaces and escaped chars, unix-root
       "file:///d%3A/code/Saturn/src/Saturn/Utils.fs", "d:/code/Saturn/src/Saturn/Utils.fs"
     ]
 


### PR DESCRIPTION
Fixes #440 by tweaking the uri localpath sanitation logic as described in that issue, as well as making a slight modification to the `filePathToUri` method to ensure we stay in sync with vscode-encodings.