### PR TITLE
remove redundant text from lint warning and assign them a code

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -3,7 +3,6 @@ namespace FsAutoComplete
 open System
 open System.IO
 open FSharp.Compiler.SourceCodeServices
-open FSharpLint.Application
 open FsAutoComplete.UnionPatternMatchCaseGenerator
 open FsAutoComplete.RecordStubGenerator
 open FsAutoComplete.InterfaceStubGenerator
@@ -41,7 +40,7 @@ type CoreResponse =
     | FormattedDocumentationForSymbol of xmlSig: string * assembly: string * xmlDoc: string list * signature: (string * (string [] * string [] * string [] * string [] * string [] * string [])) * footer: string * cn: string
     | TypeSig of tip: FSharpToolTipText<string>
     | CompilerLocation of fcs: string option * fsi: string option * msbuild: string option
-    | Lint of file: string * warningsWithCodes: (string * string option * LintWarning.Warning) list
+    | Lint of file: string * warningsWithCodes: Lint.EnrichedLintWarning list
     | ResolveNamespaces of word: string * opens: (string * string * InsertContext * bool) list * qualifies: (string * string) list
     | UnionCase of text: string * position: pos
     | RecordStub of text: string * position: pos
@@ -237,33 +236,6 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
         let config = Dotnet.ProjInfo.Workspace.LoaderConfig.Default Environment.msbuildLocator
         let loader = Dotnet.ProjInfo.Workspace.Loader.Create(config)
         loader, checker.CreateFCSBinder(NETFrameworkInfoProvider.netFWInfo, loader)
-
-    let pageForLint (code: string) =
-        let codeNumber = code.Substring (2) |> int
-        match codeNumber with
-        | 1 | 2 | 3 -> Some "http://fsprojects.github.io/FSharpLint/TupleFormatting.html"
-        | 4 | 5 | 6 | 7 -> Some "http://fsprojects.github.io/FSharpLint/PatternMatchFormatting.html"
-        | 8 | 9 -> Some "http://fsprojects.github.io/FSharpLint/Spacing.html"
-        | 10 (* | 11 (not present?) *) | 12 -> Some "http://fsprojects.github.io/FSharpLint/Formatting.html"
-        | 13 | 14 | 15 -> Some "http://fsprojects.github.io/FSharpLint/Conventions.html"
-        | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 -> Some "http://fsprojects.github.io/FSharpLint/SourceLength.html"
-        | 34 | 35 -> Some "http://fsprojects.github.io/FSharpLint/FunctionReimplementation.html"
-        | 36 | 37 | 38 | 39 | 40 | 41 | 42 | 43 | 44 | 45 | 46 | 47 | 48 | 49 | 50 -> Some "http://fsprojects.github.io/FSharpLint/NameConventions.html"
-        | 51 | 52 | 53 | 54 -> Some "http://fsprojects.github.io/FSharpLint/NumberOfItems.html"
-        | 55 | 56 | 57 | 58 -> Some "http://fsprojects.github.io/FSharpLint/Binding.html"
-        | 60 | 61 | 62 | 63 | 64 -> Some "http://fsprojects.github.io/FSharpLint/Typography.html"
-        | _ -> None
-
-
-    /// lint warnings come to us with the lint identifier as part of the info message,
-    /// so we parse and split that out here for processing later.
-    /// In addition we add the url to the matching help page for fsharplint
-    let enrichLintWarning (w: LintWarning.Warning) =
-        match w.Info.IndexOf ":" with
-        | -1 -> "unknown", None, w
-        | n ->
-            let code = w.Info.[0..n-1]
-            code, pageForLint code, { w with Info = w.Info.Substring(n+1).Trim() }
 
     member __.Notify = notify.Publish
 
@@ -720,75 +692,32 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
     member x.Lint (file: SourceFilePath) =
         let file = Path.GetFullPath file
         async {
-            let res =
-                match state.TryGetFileCheckerOptionsWithSource file with
-                | Error s -> [CoreResponse.ErrorRes s]
-                | Ok (options, source) ->
-                    let tyResOpt = checker.TryGetRecentCheckResultsForFile(file, options)
+            match state.TryGetFileCheckerOptionsWithSource file with
+            | Error s -> return [CoreResponse.ErrorRes s]
+            | Ok (options, source) ->
+                let tyResOpt = checker.TryGetRecentCheckResultsForFile(file, options)
 
-                    match tyResOpt with
-                    | None -> [ CoreResponse.InfoRes "Cached typecheck results not yet available"]
-                    | Some tyRes ->
-                        match tyRes.GetAST with
-                        | None -> [ CoreResponse.InfoRes "Something went wrong during parsing"]
-                        | Some tree ->
-                            try
-                                let loadXmlConfig projectFilePath =
-                                    match FSharpLint.Application.XmlConfiguration.tryLoadConfigurationForProject projectFilePath with
-                                    | None -> Result.Ok None
-                                    | Some xmlConfig ->
-                                        { ConfigurationManager.Configuration.conventions = xmlConfig |> FSharpLint.Application.XmlConfiguration.convertConventions
-                                          ConfigurationManager.Configuration.formatting = xmlConfig |> FSharpLint.Application.XmlConfiguration.convertFormatting
-                                          ConfigurationManager.Configuration.hints = xmlConfig |> FSharpLint.Application.XmlConfiguration.convertHints
-                                          ConfigurationManager.Configuration.ignoreFiles = xmlConfig |> FSharpLint.Application.XmlConfiguration.convertIgnoreFiles
-                                          ConfigurationManager.Configuration.typography = xmlConfig |> FSharpLint.Application.XmlConfiguration.convertTypography }
-                                        |> Some
-                                        |> Result.Ok
-                                let loadJsonConfig projectFilePath =
-                                    match FSharpLint.Application.ConfigurationManagement.loadConfigurationForProject projectFilePath with
-                                    | ConfigurationManagement.ConfigurationResult.Success config ->
-                                        Result.Ok config
-                                    | ConfigurationManagement.ConfigurationResult.Failure errors ->
-                                        Result.Error errors
-                                let fsharpLintConfig =
-                                    // first we check if exists xml config (backward compatibility)
-                                    // after that if exists json config
-                                    match loadXmlConfig file with
-                                    | Result.Ok (Some config) ->
-                                        Result.Ok config
-                                    | Result.Ok None
-                                    | Result.Error _ ->
-                                        //TODO log xml config error
-                                        match loadJsonConfig file with
-                                        | Result.Ok config ->
-                                            Result.Ok config
-                                        | Result.Error e ->
-                                            Result.Error e
+                match tyResOpt with
+                | None -> return [CoreResponse.InfoRes "Cached typecheck results not yet available"]
+                | Some tyRes ->
+                    match tyRes.GetAST with
+                    | None -> return [CoreResponse.InfoRes "Something went wrong during parsing"]
+                    | Some tree ->
+                        try
+                            let fsharpLintConfig = Lint.tryLoadConfiguration file
+                            let opts =
+                                match fsharpLintConfig with
+                                | Ok config -> Some config
+                                | Error _ -> None
 
-                                let opts =
-                                    match fsharpLintConfig with
-                                    | Result.Ok config -> Some config
-                                    | Result.Error _ -> None
-
-                                let res =
-                                    Lint.lintParsedSource
-                                        { Lint.OptionalLintParameters.Default with Configuration = opts}
-                                        { Ast = tree
-                                          Source = source
-                                          TypeCheckResults = Some tyRes.GetCheckResults }
-                                let res' =
-                                    match res with
-                                    | LintResult.Failure _ -> [ CoreResponse.InfoRes "Something went wrong, linter failed"]
-                                    | LintResult.Success warnings ->
-                                        let splitWarnings = warnings |> List.map enrichLintWarning
-                                        let res = CoreResponse.Lint (file, splitWarnings)
-                                        notify.Trigger (NotificationEvent.Lint res)
-                                        [ res ]
-
-                                res'
-                            with _ex ->
-                                [ CoreResponse.InfoRes "Something went wrong during linter"]
-            return res
+                            match Lint.lintWithConfiguration opts tree source tyRes.GetCheckResults with
+                            | Error e -> return [CoreResponse.InfoRes e]
+                            | Ok enrichedWarnings ->
+                                let res = CoreResponse.Lint (file, enrichedWarnings)
+                                notify.Trigger (NotificationEvent.Lint res)
+                                return [res]
+                        with _ex ->
+                            return [CoreResponse.InfoRes "Something went wrong during linter"]
         } |> x.AsCancellable file
 
     member x.GetNamespaceSuggestions (tyRes : ParseAndCheckResults) (pos: pos) (line: LineStr) =

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -263,7 +263,7 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
         | -1 -> "unknown", None, w
         | n ->
             let code = w.Info.[0..n-1]
-            code, pageForLint code, { w with Info = w.Info.Substring(n+1) }
+            code, pageForLint code, { w with Info = w.Info.Substring(n+1).Trim() }
 
     member __.Notify = notify.Publish
 

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -41,7 +41,7 @@ type CoreResponse =
     | FormattedDocumentationForSymbol of xmlSig: string * assembly: string * xmlDoc: string list * signature: (string * (string [] * string [] * string [] * string [] * string [] * string [])) * footer: string * cn: string
     | TypeSig of tip: FSharpToolTipText<string>
     | CompilerLocation of fcs: string option * fsi: string option * msbuild: string option
-    | Lint of file: string * warnings: LintWarning.Warning list
+    | Lint of file: string * warningsWithCodes: (string * string option * LintWarning.Warning) list
     | ResolveNamespaces of word: string * opens: (string * string * InsertContext * bool) list * qualifies: (string * string) list
     | UnionCase of text: string * position: pos
     | RecordStub of text: string * position: pos
@@ -237,6 +237,33 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
         let config = Dotnet.ProjInfo.Workspace.LoaderConfig.Default Environment.msbuildLocator
         let loader = Dotnet.ProjInfo.Workspace.Loader.Create(config)
         loader, checker.CreateFCSBinder(NETFrameworkInfoProvider.netFWInfo, loader)
+
+    let pageForLint (code: string) =
+        let codeNumber = code.Substring (2) |> int
+        match codeNumber with
+        | 1 | 2 | 3 -> Some "http://fsprojects.github.io/FSharpLint/TupleFormatting.html"
+        | 4 | 5 | 6 | 7 -> Some "http://fsprojects.github.io/FSharpLint/PatternMatchFormatting.html"
+        | 8 | 9 -> Some "http://fsprojects.github.io/FSharpLint/Spacing.html"
+        | 10 (* | 11 (not present?) *) | 12 -> Some "http://fsprojects.github.io/FSharpLint/Formatting.html"
+        | 13 | 14 | 15 -> Some "http://fsprojects.github.io/FSharpLint/Conventions.html"
+        | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 -> Some "http://fsprojects.github.io/FSharpLint/SourceLength.html"
+        | 34 | 35 -> Some "http://fsprojects.github.io/FSharpLint/FunctionReimplementation.html"
+        | 36 | 37 | 38 | 39 | 40 | 41 | 42 | 43 | 44 | 45 | 46 | 47 | 48 | 49 | 50 -> Some "http://fsprojects.github.io/FSharpLint/NameConventions.html"
+        | 51 | 52 | 53 | 54 -> Some "http://fsprojects.github.io/FSharpLint/NumberOfItems.html"
+        | 55 | 56 | 57 | 58 -> Some "http://fsprojects.github.io/FSharpLint/Binding.html"
+        | 60 | 61 | 62 | 63 | 64 -> Some "http://fsprojects.github.io/FSharpLint/Typography.html"
+        | _ -> None
+
+
+    /// lint warnings come to us with the lint identifier as part of the info message,
+    /// so we parse and split that out here for processing later.
+    /// In addition we add the url to the matching help page for fsharplint
+    let enrichLintWarning (w: LintWarning.Warning) =
+        match w.Info.IndexOf ":" with
+        | -1 -> "unknown", None, w
+        | n ->
+            let code = w.Info.[0..n-1]
+            code, pageForLint code, { w with Info = w.Info.Substring(n+1) }
 
     member __.Notify = notify.Publish
 
@@ -753,7 +780,8 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
                                     match res with
                                     | LintResult.Failure _ -> [ CoreResponse.InfoRes "Something went wrong, linter failed"]
                                     | LintResult.Success warnings ->
-                                        let res = CoreResponse.Lint (file,warnings)
+                                        let splitWarnings = warnings |> List.map enrichLintWarning
+                                        let res = CoreResponse.Lint (file, splitWarnings)
                                         notify.Trigger (NotificationEvent.Lint res)
                                         [ res ]
 

--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -49,6 +49,7 @@
     <Compile Include="SymbolCache.fs" />
     <Compile Include="BackgroundServices.fs" />
     <Compile Include="Fsdn.fs" />
+    <Compile Include="Lint.fs" />
     <Compile Include="Commands.fs" />
   </ItemGroup>
 

--- a/src/FsAutoComplete.Core/Lint.fs
+++ b/src/FsAutoComplete.Core/Lint.fs
@@ -1,0 +1,86 @@
+module FsAutoComplete.Lint
+
+open FSharpLint.Application
+open FSharpLint.Application.ConfigurationManagement
+open FSharpLint.Application.ConfigurationManager
+
+type EnrichedLintWarning = 
+    { Warning: LintWarning.Warning 
+      HelpUrl: string option
+      Code: int option }
+
+let private loadXmlConfig projectFilePath =
+    match XmlConfiguration.tryLoadConfigurationForProject projectFilePath with
+    | None -> Ok None
+    | Some xmlConfig ->
+        { conventions = xmlConfig |> XmlConfiguration.convertConventions
+          formatting = xmlConfig |> XmlConfiguration.convertFormatting
+          hints = xmlConfig |> XmlConfiguration.convertHints
+          ignoreFiles = xmlConfig |> XmlConfiguration.convertIgnoreFiles
+          typography = xmlConfig |> XmlConfiguration.convertTypography }
+        |> Some
+        |> Ok
+    
+let private loadJsonConfig projectFilePath =
+    match loadConfigurationForProject projectFilePath with
+    | ConfigurationResult.Success config ->
+        Ok config
+    | ConfigurationResult.Failure errors ->
+        Error errors
+
+let pageForLint (code: int) =
+    let codeNumber = code |> int
+    match codeNumber with
+    | 1 | 2 | 3 -> Some "http://fsprojects.github.io/FSharpLint/TupleFormatting.html"
+    | 4 | 5 | 6 | 7 -> Some "http://fsprojects.github.io/FSharpLint/PatternMatchFormatting.html"
+    | 8 | 9 -> Some "http://fsprojects.github.io/FSharpLint/Spacing.html"
+    | 10 (* | 11 (not present?) *) | 12 -> Some "http://fsprojects.github.io/FSharpLint/Formatting.html"
+    | 13 | 14 | 15 -> Some "http://fsprojects.github.io/FSharpLint/Conventions.html"
+    | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 -> Some "http://fsprojects.github.io/FSharpLint/SourceLength.html"
+    | 34 | 35 -> Some "http://fsprojects.github.io/FSharpLint/FunctionReimplementation.html"
+    | 36 | 37 | 38 | 39 | 40 | 41 | 42 | 43 | 44 | 45 | 46 | 47 | 48 | 49 | 50 -> Some "http://fsprojects.github.io/FSharpLint/NameConventions.html"
+    | 51 | 52 | 53 | 54 -> Some "http://fsprojects.github.io/FSharpLint/NumberOfItems.html"
+    | 55 | 56 | 57 | 58 -> Some "http://fsprojects.github.io/FSharpLint/Binding.html"
+    | 60 | 61 | 62 | 63 | 64 -> Some "http://fsprojects.github.io/FSharpLint/Typography.html"
+    | _ -> None
+
+/// lint warnings come to us with the lint identifier as part of the info message,
+/// so we parse and split that out here for processing later.
+/// In addition we add the url to the matching help page for fsharplint
+let enrichLintWarning (w: LintWarning.Warning): EnrichedLintWarning =
+    match String.splitAtChar ':' w.Info with
+    | String.SplitResult.NoMatch -> 
+        { Code = None; HelpUrl = None; Warning = w }
+    | String.SplitResult.Split(left, right) -> 
+        let tleft, tright = left.Trim(), right.Trim()
+        let code = tleft.Substring(2) |> int
+        let message = tright
+        let warning' = { w with Info = message }
+        { Code = Some code; HelpUrl = pageForLint code; Warning = warning' }
+    
+/// Attempts to load the F#Lint configuration from the closest available settings file to the given project file.
+/// We attempt the old xml config style first, then the newer json format.
+let tryLoadConfiguration (projectFilePath: string) = 
+    // first we check if exists xml config (backward compatibility)
+    // after that if exists json config
+    match loadXmlConfig projectFilePath with
+    | Ok (Some config) ->
+        Ok config
+    | Ok None
+    | Error _ ->
+        //TODO log xml config error
+        loadJsonConfig projectFilePath
+
+let lintWithConfiguration (lintConfig: Configuration option) ast sourceCode typeCheckResults = 
+    let res =
+        Lint.lintParsedSource
+            { Lint.OptionalLintParameters.Default with Configuration = lintConfig }
+            { Ast = ast
+              Source = sourceCode
+              TypeCheckResults = Some typeCheckResults }
+
+    match res with
+    | LintResult.Failure f -> Error (sprintf "Something went wrong, linter failed: %s" f.Description)
+    | LintResult.Success warnings ->
+        let splitWarnings = warnings |> List.map enrichLintWarning
+        Ok splitWarnings

--- a/src/FsAutoComplete.Core/Lint.fs
+++ b/src/FsAutoComplete.Core/Lint.fs
@@ -42,6 +42,7 @@ let pageForLint (code: int) =
     | 51 | 52 | 53 | 54 -> Some "http://fsprojects.github.io/FSharpLint/NumberOfItems.html"
     | 55 | 56 | 57 | 58 -> Some "http://fsprojects.github.io/FSharpLint/Binding.html"
     | 60 | 61 | 62 | 63 | 64 -> Some "http://fsprojects.github.io/FSharpLint/Typography.html"
+    | 65 -> Some "http://fsprojects.github.io/FSharpLint/Hints.html"
     | _ -> None
 
 /// lint warnings come to us with the lint identifier as part of the info message,

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -493,6 +493,15 @@ module String =
                 yield String.Empty
         |]
 
+    type SplitResult =
+    | NoMatch
+    | Split of left: string * right: string
+
+    let splitAtChar (splitter: char) (s: string) =
+        match s.IndexOf splitter with
+        | -1 -> NoMatch
+        | n -> Split(s.[0..n-1], s.Substring(n+1))
+
 type ConcurrentDictionary<'key, 'value> with
     member x.TryFind key =
         match x.TryGetValue key with

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -704,21 +704,9 @@ module CommandResponse =
   let message (serialize : Serializer) (kind: string, data: 'a) =
     serialize { Kind = kind; Data = data }
 
-  let lint (serialize : Serializer) (warnings : LintWarning.Warning list) =
+  let lint (serialize : Serializer) (warnings : (string * string option * LintWarning.Warning) list) =
 
-    /// strip the fsharp lint warning code, in the format `FS01234: info"`
-    let removeLinterCode (s: string) =
-      let index = s.IndexOf(":")
-      if index > 0 && (index + 2) < s.Length then
-        s.Substring(index + 2)
-      else
-        s
-
-    let data =
-      warnings
-      |> List.map (fun w -> { w with Info = removeLinterCode w.Info })
-      |> List.toArray
-
+    let data = warnings |> List.map (fun (_,_,w) -> w) |> List.toArray
     serialize { Kind = "lint"; Data = data }
 
 

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -4,7 +4,6 @@ open System
 
 open FSharp.Compiler
 open FSharp.Compiler.SourceCodeServices
-open FSharpLint.Application
 open System.Text.RegularExpressions
 open FSharp.Analyzers
 open FsAutoComplete.WorkspacePeek
@@ -704,9 +703,9 @@ module CommandResponse =
   let message (serialize : Serializer) (kind: string, data: 'a) =
     serialize { Kind = kind; Data = data }
 
-  let lint (serialize : Serializer) (warnings : (string * string option * LintWarning.Warning) list) =
+  let lint (serialize : Serializer) (warnings : Lint.EnrichedLintWarning list) =
 
-    let data = warnings |> List.map (fun (_,_,w) -> w) |> List.toArray
+    let data = warnings |> List.map (fun w -> w.Warning) |> List.toArray
     serialize { Kind = "lint"; Data = data }
 
 


### PR DESCRIPTION
here we parse out the code from the fsharplint warning information (since it's always formatted a certain way) and do three interesting things with it:

1. match it to a documentation url,
2. remove it from the info structure so that it's no longer redundant, and
3. set the code in the LSP diagnostic so that it's viewable to the user.

Turns out we were already doing (2) in another location, so this actually unified/simplified some code.