### PR TITLE
Remove references to HTTP mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The `FsAutoComplete` project (`FSAC`) provides a backend service for rich editing or 'intellisense' features for editors.
 
-It can be hosted as command-line interface (`stdio` mode) or as http server (`http` mode), both using the same json protocol.
+It can be hosted as command-line interface (`stdio` mode) or using the Language Server Protocol (`lsp` mode).
 
 Currently it is used by:
 

--- a/src/FsAutoComplete/Options.fs
+++ b/src/FsAutoComplete/Options.fs
@@ -61,7 +61,6 @@ module Options =
       | [<CustomCommandLine("--wait-for-debugger")>] WaitForDebugger
       | [<EqualsAssignment; CustomCommandLine("--hostPID")>] HostPID of pid:int
       | Mode of TransportMode
-      | Port of tcp_port:int
       | [<CustomCommandLine("--background-service-enabled")>] BackgroundServiceEnabled
       with
           interface IArgParserTemplate with
@@ -75,7 +74,6 @@ module Options =
                   | Commands -> "list the commands that this program understands"
                   | WaitForDebugger _ -> "wait for a debugger to attach to the process"
                   | HostPID _ -> "the Host process ID."
-                  | Port _ -> "the listening port."
                   | Mode _ -> "the transport type."
                   | BackgroundServiceEnabled -> "enable background service"
 
@@ -101,8 +99,7 @@ module Options =
       | WaitForDebugger
       | BackgroundServiceEnabled
       | HostPID _
-      | Mode _
-      | Port _ ->
+      | Mode _ ->
           ()
 
     args.GetAllResults()


### PR DESCRIPTION
HTTP mode was removed in #409 

This PR removes references to HTTP mode in the readme. It also removes the unused `Port` command line argument.

It may also make sense to remove the reference to HTTP mode in the repo description.