### PR TITLE
handle null initializationOptions

### DIFF
--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -279,6 +279,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
 
         let c =
             p.InitializationOptions
+            |> Option.bind (fun options -> if options.HasValues then Some options else None)
             |> Option.map Server.deserialize<FSharpConfigDto>
             |> Option.map FSharpConfig.FromDto
             |> Option.getOrElse FSharpConfig.Default


### PR DESCRIPTION
Fixes null ref exception when LSP client invokes "initialize" with `{initializationOptions: null}`

I'm using Emacs LSP Client  [eglot](https://github.com/joaotavora/eglot).
Calling (`JSON` in Emacs Lisp notation):
```
(:jsonrpc "2.0" :id 1 :method "initialize" :params
	  (:processId 6225 :rootPath "/home/juergen/fsharp/HelloFsharp/" :rootUri "file:///home/juergen/fsharp/HelloFsharp/"
 :initializationOptions nil :capabilities
		      (:workspace
...
```
results in:

```
(:jsonrpc "2.0" :id 1 :error
	  (:code -32603 :message "System.NullReferenceException: Object reference not set to an instance of an object.\n   at FsAutoComplete.LspHelpers.FSharpConfig.FromDto(FSharpConfigDto dto) in C:\\projects\\fsautocomplete\\src\\FsAutoComplete\\LspHelpers.fs:line 585\n   at FsAutoComplete.Lsp.Initialize@274.Invoke(Unit unitVar) in C:\\projects\\fsautocomplete\\src\\FsAutoComplete\\FsAutoComplete.Lsp.fs:line 274\n   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke[T,TResult](AsyncActivation`1 ctxt, TResult result1, FSharpFunc`2 part2)\n   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction)"))
```