### PR TITLE
Disable range formatting

### DIFF
--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -349,7 +349,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                         DocumentSymbolProvider = Some true
                         WorkspaceSymbolProvider = Some true
                         DocumentFormattingProvider = Some true
-                        DocumentRangeFormattingProvider = Some true
+                        DocumentRangeFormattingProvider = Some false
                         SignatureHelpProvider = Some {
                             SignatureHelpOptions.TriggerCharacters = Some [| "("; ","|]
                         }

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -36,7 +36,7 @@ let initTests =
       Expect.equal res.Capabilities.DocumentHighlightProvider (Some true) "Document Highligthing Provider"
       Expect.equal res.Capabilities.DocumentLinkProvider None "Document Link Provider"
       Expect.equal res.Capabilities.DocumentOnTypeFormattingProvider None "Document OnType Formatting Provider"
-      Expect.equal res.Capabilities.DocumentRangeFormattingProvider (Some true) "Document Range Formatting Provider"
+      Expect.equal res.Capabilities.DocumentRangeFormattingProvider None "Document Range Formatting Provider"
       Expect.equal res.Capabilities.DocumentSymbolProvider (Some true) "Document Symbol Provider"
       Expect.equal res.Capabilities.ExecuteCommandProvider None "Execute Command Provider"
       Expect.equal res.Capabilities.Experimental None "Experimental"


### PR DESCRIPTION
We're still keeping full document formatting enabled, I've found it behave OK in most of the cases. 
For range formatting I've experienced way to many problems where Fantomas just removed some code - it's probably issue with handling ranges correctly. 

FYI, @nojaf 