### PR TITLE
custom dotnet root via environment variable/explicit user setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Custom endpoints are using (for messages body) `PlainNotification` type and stri
 
 * `--background-service-enabled` - passing this flag enables background service feature, increasing FSAC responsiveness by moving some of the operations (especially background type checking) to other process. It results in increased memory usage. Used by default in Ionide.
 * `--verbose` - passing this flag enables additional logging being printed out in `stderr`
+* `DOTNET_ROOT` - setting this environment variable will set the dotnet SDK root, which is used when finding references for FSX scripts.
 
 #### Initialization options:
 
@@ -148,6 +149,7 @@ Options that should be send as `initializationOptions` as part of `initialize` r
 * `FSharp.SimplifyNameAnalyzer` - enables simplify name analyzer and remove redundant qualifier quick fix, recommended default value: `false`
 * `FSharp.ResolveNamespaces` - enables resolve namespace quick fix (add `open` if symbol is from not yet opened module/namespace), recommended default value: `true`
 * `FSharp.EnableReferenceCodeLens` - enables reference count code lenses, recommended default value: `true` if `--background-service-enabled` is used by default, `false` otherwise
+* `FSharp.dotNetRoot` - sets the root path for finding dotnet SDK references. Primarily used for FSX Scripts. Default value: operating-system dependent. On windows, `C:\Program Files\dotnet`; on Unix, `/usr/local/share/dotnet`
 
 ### Old stdio protocol
 

--- a/src/FsAutoComplete.BackgroundServices/Program.fs
+++ b/src/FsAutoComplete.BackgroundServices/Program.fs
@@ -105,9 +105,14 @@ type BackgroundServiceServer(state: State, client: FsacClient) =
     inherit LspServer()
 
     let checker = FSharpChecker.Create(projectCacheSize = 1, keepAllBackgroundResolutions = false, suggestNamesForErrors = true)
-    let fsxBinder = Dotnet.ProjInfo.Workspace.FCS.FsxBinder(NETFrameworkInfoProvider.netFWInfo, checker)
 
     do checker.ImplicitlyStartBackgroundWork <- false
+
+    //TODO: does the backgroundservice ever get config updates?
+    let sdkRoot = Environment.dotnetSDKRoot.Value
+    let latestSdkVersion = Environment.latest3xSdkVersion sdkRoot
+    let latestRuntimeVersion = Environment.latest3xSdkVersion sdkRoot
+
 
     let getFilesFromOpts (opts: FSharpProjectOptions) =
         if Array.isEmpty opts.SourceFiles then
@@ -119,7 +124,7 @@ type BackgroundServiceServer(state: State, client: FsacClient) =
         let replaceRefs (projOptions: FSharpProjectOptions) =
             let okOtherOpts = projOptions.OtherOptions |> Array.filter (fun r -> not <| r.StartsWith("-r"))
             let assemblyPaths =
-              match Environment.latest3xSdkVersion.Value, Environment.latest3xRuntimeVersion.Value with
+              match latestSdkVersion.Value, latestRuntimeVersion.Value with
               | None, _
               | _, None ->
                 []

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -39,7 +39,7 @@ type CoreResponse =
     | FormattedDocumentation of tip: FSharpToolTipText<string> option * xmlSig: (string * string) option * signature: (string * (string [] * string [] * string [] * string [] * string [] * string [])) * footer: string * cn: string
     | FormattedDocumentationForSymbol of xmlSig: string * assembly: string * xmlDoc: string list * signature: (string * (string [] * string [] * string [] * string [] * string [] * string [])) * footer: string * cn: string
     | TypeSig of tip: FSharpToolTipText<string>
-    | CompilerLocation of fcs: string option * fsi: string option * msbuild: string option
+    | CompilerLocation of fcs: string option * fsi: string option * msbuild: string option * sdkRoot: string option
     | Lint of file: string * warningsWithCodes: Lint.EnrichedLintWarning list
     | ResolveNamespaces of word: string * opens: (string * string * InsertContext * bool) list * qualifies: (string * string) list
     | UnionCase of text: string * position: pos
@@ -558,7 +558,7 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
 
 
 
-    member x.CompilerLocation () = [CoreResponse.CompilerLocation (Environment.fsc, Environment.fsi, Environment.msbuild)]
+    member x.CompilerLocation () = [CoreResponse.CompilerLocation (Environment.fsc, Environment.fsi, Environment.msbuild, checker.GetDotnetRoot())]
     member x.Colorization enabled = state.ColorizationOutput <- enabled
     member x.Error msg = [CoreResponse.ErrorRes msg]
 

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -75,7 +75,6 @@ type NotificationEvent =
     | FileParsed of string
 
 type Commands (serialize : Serializer, backgroundServiceEnabled) =
-
     let checker = FSharpCompilerServiceChecker(backgroundServiceEnabled)
     let state = State.Initial
     let fileParsed = Event<FSharpParseFileResults>()
@@ -1136,3 +1135,4 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
                 return Ok ranges
     }
 
+    member __.SetDotnetSDKRoot(path) = checker.SetDotnetRoot(path)

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -430,6 +430,10 @@ type FSharpCompilerServiceChecker(backgroundServiceEnabled) =
 
   let entityCache = EntityCache()
 
+  let mutable sdkRoot = None
+  let mutable sdkVersion = lazy(None)
+  let mutable runtimeVersion = lazy(None)
+
   let mutable disableInMemoryProjectReferences = false
 
   let clearProjectReferecnes (opts: FSharpProjectOptions) =
@@ -442,15 +446,21 @@ type FSharpCompilerServiceChecker(backgroundServiceEnabled) =
   let replaceRefs (projOptions: FSharpProjectOptions) =
     let okOtherOpts = projOptions.OtherOptions |> Array.filter (fun r -> not <| r.StartsWith("-r"))
     let assemblyPaths =
-      match Environment.latest3xSdkVersion.Value, Environment.latest3xRuntimeVersion.Value with
-      | None, _ ->
-        Debug.print "Couldn't find latest 3.x sdk version"
+      match sdkRoot, sdkVersion.Value, runtimeVersion.Value with
+      | None, _, _ ->
+        Debug.print "No dotnet SDK root path found"
         []
-      | _, None ->
-        Debug.print "Couldn't find latest 3.x runtime version"
+      | Some root, None, None ->
+        Debug.print "Couldn't find latest 3.x sdk and runtime versions inside root %s" root
         []
-      | Some sdkVersion, Some runtimeVersion ->
-        let refs = FSIRefs.netCoreRefs Environment.dotnetSDKRoot.Value (string sdkVersion) (string runtimeVersion) Environment.fsiTFMMoniker true
+      | Some root, None, _ ->
+        Debug.print "Couldn't find latest 3.x sdk version inside root %s" root
+        []
+      | Some root, _, None ->
+        Debug.print "Couldn't find latest 3.x runtime version inside root %s" root
+        []
+      | Some dotnetSdkRoot, Some sdkVersion, Some runtimeVersion ->
+        let refs = FSIRefs.netCoreRefs dotnetSdkRoot (string sdkVersion) (string runtimeVersion) Environment.fsiTFMMoniker true
         Debug.print "found refs for SDK %O/Runtime %O/TFM %s:\n%A" sdkVersion runtimeVersion Environment.fsiTFMMoniker refs
         refs
     let refs = assemblyPaths |> List.map (fun r -> "-r:" + r)
@@ -590,3 +600,8 @@ type FSharpCompilerServiceChecker(backgroundServiceEnabled) =
   member __.Compile = checker.Compile
 
   member internal x.GetFSharpChecker() = checker
+
+  member __.SetDotnetRoot(path) =
+    sdkRoot <- Some path
+    sdkVersion <- Environment.latest3xSdkVersion path
+    runtimeVersion <- Environment.latest3xSdkVersion path

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -605,3 +605,5 @@ type FSharpCompilerServiceChecker(backgroundServiceEnabled) =
     sdkRoot <- Some path
     sdkVersion <- Environment.latest3xSdkVersion path
     runtimeVersion <- Environment.latest3xSdkVersion path
+
+  member __.GetDotnetRoot () = sdkRoot

--- a/src/FsAutoComplete.Core/Environment.fs
+++ b/src/FsAutoComplete.Core/Environment.fs
@@ -88,7 +88,13 @@ module Environment =
 
   /// The sdk root that we assume for FSI-ref-location purposes.
   /// TODO: make this settable via ENV variable or explicit LSP config
-  let dotnetSDKRoot = lazy (FsAutoComplete.FSIRefs.defaultDotNetSDKRoot)
+  let dotnetSDKRoot =
+    lazy (
+      let fromEnv =
+        Environment.GetEnvironmentVariable "DOTNET_ROOT"
+        |> Option.ofObj
+      defaultArg fromEnv FSIRefs.defaultDotNetSDKRoot
+    )
 
   let private maxVersionWithThreshold minVersion versions =
     versions
@@ -99,10 +105,10 @@ module Environment =
 
   /// because 3.x is the minimum SDK that we support for FSI, we want to float to the latest
   /// 3.x sdk that the user has installed, to prevent hard-coding.
-  let latest3xSdkVersion =
+  let latest3xSdkVersion sdkRoot =
     let minSDKVersion = FSIRefs.NugetVersion(3,0,100,"")
     lazy (
-      match FsAutoComplete.FSIRefs.sdkVersions dotnetSDKRoot.Value with
+      match FSIRefs.sdkVersions sdkRoot with
       | None -> None
       | Some sortedSdkVersions ->
         Debug.print "SDK versions: %A" sortedSdkVersions
@@ -111,10 +117,10 @@ module Environment =
 
   /// because 3.x is the minimum runtime that we support for FSI, we want to float to the latest
   /// 3.x runtime that the user has installed, to prevent hard-coding.
-  let latest3xRuntimeVersion =
+  let latest3xRuntimeVersion sdkRoot =
     let minRuntimeVersion = FSIRefs.NugetVersion(3,0,0,"")
     lazy (
-      match FsAutoComplete.FSIRefs.runtimeVersions dotnetSDKRoot.Value with
+      match FSIRefs.runtimeVersions sdkRoot with
       | None -> None
       | Some sortedRuntimeVersions ->
         Debug.print "Runtime versions: %A" sortedRuntimeVersions

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -218,6 +218,7 @@ module CommandResponse =
       Fsc: string option
       Fsi: string option
       MSBuild: string option
+      SdkRoot: string option
     }
 
   type FSharpErrorInfo =
@@ -749,8 +750,8 @@ module CommandResponse =
     let data = TipFormatter.extractSignature tip
     serialize { Kind = "typesig"; Data = data }
 
-  let compilerLocation (serialize : Serializer) fsc fsi msbuild =
-    let data = { Fsi = fsi; Fsc = fsc; MSBuild = msbuild }
+  let compilerLocation (serialize : Serializer) fsc fsi msbuild sdkRoot =
+    let data = { Fsi = fsi; Fsc = fsc; MSBuild = msbuild; SdkRoot = sdkRoot }
     serialize { Kind = "compilerlocation"; Data = data }
 
   let message (serialize : Serializer) (kind: string, data: 'a) =
@@ -914,8 +915,8 @@ module CommandResponse =
       formattedDocumentationForSymbol s xml assembly xmlDoc (signature, footer, cn)
     | CoreResponse.TypeSig(tip) ->
       typeSig s tip
-    | CoreResponse.CompilerLocation(fcs, fsi, msbuild) ->
-      compilerLocation s fcs fsi msbuild
+    | CoreResponse.CompilerLocation(fcs, fsi, msbuild, sdk) ->
+      compilerLocation s fcs fsi msbuild sdk
     | CoreResponse.Lint(_,warnings) ->
       lint s warnings
     | CoreResponse.ResolveNamespaces(word, opens, qualifies) ->

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1640,8 +1640,8 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             match res.[0] with
             | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
                 LspResult.internalError msg
-            | CoreResponse.CompilerLocation(fsc, fsi, msbuld) ->
-                { Content =  CommandResponse.compilerLocation FsAutoComplete.JsonSerializer.writeJson fsc fsi msbuld }
+            | CoreResponse.CompilerLocation(fsc, fsi, msbuild, sdk) ->
+                { Content =  CommandResponse.compilerLocation FsAutoComplete.JsonSerializer.writeJson fsc fsi msbuild sdk}
                 |> success
             | _ -> LspResult.notImplemented
 

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -53,6 +53,10 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
 
     let mutable config = FSharpConfig.Default
 
+    /// centralize any state changes when the config is updated here
+    let updateConfig (newConfig: FSharpConfig) =
+        config <- newConfig
+        commands.SetDotnetSDKRoot config.DotNetRoot
 
     //TODO: Thread safe version
     let fixes = System.Collections.Generic.Dictionary<DocumentUri, (LanguageServerProtocol.Types.Range * TextEdit) list>()
@@ -349,7 +353,8 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             |> Option.map FSharpConfig.FromDto
             |> Option.getOrElse FSharpConfig.Default
 
-        config <- c
+        updateConfig c
+
         // Debug.print "Config: %A" c
 
         match p.RootPath, c.AutomaticWorkspaceInit with
@@ -1495,7 +1500,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             p.Settings
             |> Server.deserialize<FSharpConfigRequest>
         let c = config.AddDto dto.FSharp
-        config <- c
+        updateConfig c
         Debug.print "[LSP call] WorkspaceDidChangeConfiguration:\n %A" c
         return ()
     }

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -522,6 +522,7 @@ type FSharpConfigDto = {
     DisableInMemoryProjectReferences: bool option
     LineLens: LineLensConfig option
     UseSdkScripts: bool option
+    DotNetRoot: string option
 }
 
 type FSharpConfigRequest = {
@@ -552,6 +553,7 @@ type FSharpConfig = {
     DisableInMemoryProjectReferences: bool
     LineLens: LineLensConfig
     UseSdkScripts: bool
+    DotNetRoot: string
 }
 with
     static member Default =
@@ -582,6 +584,7 @@ with
                 Prefix =""
             }
             UseSdkScripts = false
+            DotNetRoot = Environment.dotnetSDKRoot.Value
         }
 
     static member FromDto(dto: FSharpConfigDto) =
@@ -612,8 +615,11 @@ with
                 Prefix = defaultArg (dto.LineLens |> Option.map (fun n -> n.Prefix)) ""
             }
             UseSdkScripts = defaultArg dto.UseSdkScripts false
+            DotNetRoot = defaultArg dto.DotNetRoot Environment.dotnetSDKRoot.Value
         }
 
+    /// called when a configuration change takes effect, so empty members here should revert options
+    /// back to their defaults
     member x.AddDto(dto: FSharpConfigDto) =
         {
             AutomaticWorkspaceInit = defaultArg dto.AutomaticWorkspaceInit x.AutomaticWorkspaceInit
@@ -642,6 +648,7 @@ with
                 Prefix = defaultArg (dto.LineLens |> Option.map (fun n -> n.Prefix)) x.LineLens.Prefix
             }
             UseSdkScripts = defaultArg dto.UseSdkScripts x.UseSdkScripts
+            DotNetRoot = defaultArg dto.DotNetRoot FSharpConfig.Default.DotNetRoot
         }
 
     member x.ScriptTFM =

--- a/src/FsAutoComplete/Program.fs
+++ b/src/FsAutoComplete/Program.fs
@@ -36,7 +36,6 @@ let entry args =
       let backgroundServiceEnabled =
         results.Contains <@ Options.CLIArguments.BackgroundServiceEnabled @>
 
-
       let commands = Commands(writeJson, backgroundServiceEnabled)
       let originalFs = AbstractIL.Internal.Library.Shim.FileSystem
       let fs = FileSystem(originalFs, commands.Files.TryFind)

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -42,7 +42,8 @@ let defaultConfigDto : FSharpConfigDto =
     InterfaceStubGenerationObjectIdentifier = None
     InterfaceStubGenerationMethodBody = None
     LineLens = None
-    UseSdkScripts = Some true }
+    UseSdkScripts = Some true
+    DotNetRoot = None }
 
 let clientCaps : ClientCapabilities =
   let dynCaps : DynamicCapabilities = { DynamicRegistration = Some true}


### PR DESCRIPTION
Fixes #475 by supporting both explicit configuration settings from a LSP client (via the existing configuration mechanism) or via environment variable (DOTNET_ROOT) when the FSAC server is started.

The order of preference is:
* user setting
* environment variable
* hardcoded defaults