### PR TITLE
Code folding provider via the structure service in FCS

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image:
-  - Previous Visual Studio 2019
+  - Visual Studio 2019
 
 build_script:
   - cmd: build.cmd All

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1122,26 +1122,17 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
     member x.GetChecker () = checker.GetFSharpChecker()
 
     member x.ScopesForFile (file: string) = async {
-        let rec blockForCheckResults file opts = async {
-            match checker.TryGetRecentCheckResultsForFile(file, opts) with
-            | None -> 
-                do! Async.Sleep 100
-                return! blockForCheckResults file opts
-            | Some tyRes -> 
-                return tyRes
-        }
         let file = Path.GetFullPath file
         match state.TryGetFileCheckerOptionsWithLines file with
         | Error s -> return Error s
-        | Ok (opts, source) -> 
-            do! Async.Sleep 5000
-            match checker.TryGetRecentCheckResultsForFile(file, opts) with
-            | None -> return Error "no checkresults :("
-            | Some tyRes -> 
-                match tyRes.GetAST with
-                | Some ast ->
-                    return Ok (Structure.getOutliningRanges source ast)
-                | None ->
-                    return Error (sprintf "No AST available for %s" file)
+        | Ok (opts, sourceLines) ->
+            let parseOpts = Utils.projectOptionsToParseOptions opts
+            let allSource = sourceLines |> String.concat "\n"
+            let! ast = checker.ParseFile(file, allSource, parseOpts)
+            match ast.ParseTree with
+            | None -> return Error (ast.Errors |> Array.map string |> String.concat "\n")
+            | Some ast' ->
+                let ranges = Structure.getOutliningRanges sourceLines ast'
+                return Ok ranges
     }
-        
+

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -107,7 +107,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     /// this lets commands like 'fold all comments' work sensibly.
     /// impl note: implemented as an exhaustive match here so that
     /// if new structure kinds appear we have to handle them.
-    let scopeToKind (scope: Structure.Scope): FoldingRangeKind option =
+    let scopeToKind (scope: Structure.Scope): string option =
         match scope with
         | Structure.Scope.Open -> Some FoldingRangeKind.Imports
         | Structure.Scope.Comment

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -103,17 +103,69 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         |> lspClient.TextDocumentPublishDiagnostics
         |> Async.Start
 
-    let toFoldingRange (item: Structure.ScopeRange): FoldingRange option = 
-        match item.Collapse with
-        | Structure.Collapse.Same -> None
-        | Structure.Collapse.Below -> 
-            // map the collapserange to the foldingRange
-            let lsp = fcsRangeToLsp item.CollapseRange
-            Some { StartCharacter = Some lsp.Start.Character
-                   StartLine = lsp.Start.Line
-                   EndCharacter = Some lsp.End.Character
-                   EndLine = lsp.End.Line
-                   Kind = None }
+    /// convert structure scopes to known kinds of folding range.
+    /// this lets commands like 'fold all comments' work sensibly.
+    /// impl note: implemented as an exhaustive match here so that
+    /// if new structure kinds appear we have to handle them.
+    let scopeToKind (scope: Structure.Scope): FoldingRangeKind option =
+        match scope with
+        | Structure.Scope.Open -> Some FoldingRangeKind.Imports
+        | Structure.Scope.Comment
+        | Structure.Scope.XmlDocComment -> Some FoldingRangeKind.Comment
+        | Structure.Scope.Namespace
+        | Structure.Scope.Module
+        | Structure.Scope.Type
+        | Structure.Scope.Member
+        | Structure.Scope.LetOrUse
+        | Structure.Scope.Val
+        | Structure.Scope.CompExpr
+        | Structure.Scope.IfThenElse
+        | Structure.Scope.ThenInIfThenElse
+        | Structure.Scope.ElseInIfThenElse
+        | Structure.Scope.TryWith
+        | Structure.Scope.TryInTryWith
+        | Structure.Scope.WithInTryWith
+        | Structure.Scope.TryFinally
+        | Structure.Scope.TryInTryFinally
+        | Structure.Scope.FinallyInTryFinally
+        | Structure.Scope.ArrayOrList
+        | Structure.Scope.ObjExpr
+        | Structure.Scope.For
+        | Structure.Scope.While
+        | Structure.Scope.Match
+        | Structure.Scope.MatchBang
+        | Structure.Scope.MatchLambda
+        | Structure.Scope.MatchClause
+        | Structure.Scope.Lambda
+        | Structure.Scope.CompExprInternal
+        | Structure.Scope.Quote
+        | Structure.Scope.Record
+        | Structure.Scope.SpecialFunc
+        | Structure.Scope.Do
+        | Structure.Scope.New
+        | Structure.Scope.Attribute
+        | Structure.Scope.Interface
+        | Structure.Scope.HashDirective
+        | Structure.Scope.LetOrUseBang
+        | Structure.Scope.TypeExtension
+        | Structure.Scope.YieldOrReturn
+        | Structure.Scope.YieldOrReturnBang
+        | Structure.Scope.Tuple
+        | Structure.Scope.UnionCase
+        | Structure.Scope.EnumCase
+        | Structure.Scope.RecordField
+        | Structure.Scope.RecordDefn
+        | Structure.Scope.UnionDefn -> None
+
+    let toFoldingRange (item: Structure.ScopeRange): FoldingRange option =
+        let kind = scopeToKind item.Scope
+        // map the collapserange to the foldingRange
+        let lsp = fcsRangeToLsp item.CollapseRange
+        Some { StartCharacter   = Some lsp.Start.Character
+               StartLine        = lsp.Start.Line
+               EndCharacter     = Some lsp.End.Character
+               EndLine          = lsp.End.Line
+               Kind             = kind }
 
     do
         commands.Notify.Subscribe(fun n ->
@@ -1452,10 +1504,10 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         Debug.print "[LSP call] TextDocument/FoldingRange"
         let file = rangeP.TextDocument.GetFilePath()
         match! commands.ScopesForFile file with
-        | Ok scopes -> 
+        | Ok scopes ->
             let ranges = scopes |> Seq.choose toFoldingRange |> List.ofSeq
             return LspResult.success (Some ranges)
-        | Result.Error error -> 
+        | Result.Error error ->
             return LspResult.internalError error
     }
 

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -157,15 +157,15 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         | Structure.Scope.RecordDefn
         | Structure.Scope.UnionDefn -> None
 
-    let toFoldingRange (item: Structure.ScopeRange): FoldingRange option =
+    let toFoldingRange (item: Structure.ScopeRange): FoldingRange =
         let kind = scopeToKind item.Scope
         // map the collapserange to the foldingRange
         let lsp = fcsRangeToLsp item.CollapseRange
-        Some { StartCharacter   = Some lsp.Start.Character
-               StartLine        = lsp.Start.Line
-               EndCharacter     = Some lsp.End.Character
-               EndLine          = lsp.End.Line
-               Kind             = kind }
+        { StartCharacter   = Some lsp.Start.Character
+          StartLine        = lsp.Start.Line
+          EndCharacter     = Some lsp.End.Character
+          EndLine          = lsp.End.Line
+          Kind             = kind }
 
     do
         commands.Notify.Subscribe(fun n ->
@@ -1505,7 +1505,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         let file = rangeP.TextDocument.GetFilePath()
         match! commands.ScopesForFile file with
         | Ok scopes ->
-            let ranges = scopes |> Seq.choose toFoldingRange |> List.ofSeq
+            let ranges = scopes |> Seq.map toFoldingRange |> Set.ofSeq |> List.ofSeq
             return LspResult.success (Some ranges)
         | Result.Error error ->
             return LspResult.internalError error

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -368,6 +368,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                                      Change = Some TextDocumentSyncKind.Full
                                      Save = Some { IncludeText = Some true }
                                  }
+                        FoldingRangeProvider = Some true
                     }
             }
             |> success
@@ -1434,6 +1435,9 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         Debug.print "[LSP call] WorkspaceDidChangeConfiguration:\n %A" c
         return ()
     }
+
+    override __.TextDocumentFoldingRange(rangeP: FoldingRangeParams) =
+        AsyncLspResult.success (Some [||])
 
     member x.FSharpSignature(p: TextDocumentPositionParams) =
         Debug.print "[LSP call] FSharpSignature"

--- a/src/LanguageServerProtocol/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol/LanguageServerProtocol.fs
@@ -1659,11 +1659,10 @@ module Types =
         TextDocument: TextDocumentIdentifier
     }
 
-    type FoldingRangeKind =
-    | Comment
-    | Imports
-    | Region
-    | Custom of kind: string
+    module FoldingRangeKind =
+        let Comment = "comment"
+        let Imports = "imports"
+        let Region = "region"
 
     type FoldingRange = {
         /// The zero-based line number from where the folded range starts.
@@ -1681,7 +1680,7 @@ module Types =
         /// Describes the kind of the folding range such as `comment' or 'region'. The kind
         /// is used to categorize folding ranges and used by commands like 'Fold all comments'. See
         /// [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
-        Kind: FoldingRangeKind option
+        Kind: string option
     }
 
 module LowLevel =

--- a/src/LanguageServerProtocol/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol/LanguageServerProtocol.fs
@@ -2146,7 +2146,7 @@ type LspServer() =
     default __.TextDocumentDidClose(_) = ignoreNotification
 
     /// The folding range request is sent from the client to the server to return all folding ranges found in a given text document.
-    abstract member TextDocumentFoldingRange: FoldingRangeParams -> AsyncLspResult<FoldingRange [] option>
+    abstract member TextDocumentFoldingRange: FoldingRangeParams -> AsyncLspResult<FoldingRange list option>
     default __.TextDocumentFoldingRange(_) = notImplemented
 
 module Server =

--- a/src/LanguageServerProtocol/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol/LanguageServerProtocol.fs
@@ -477,6 +477,19 @@ module Types =
         TagSupport: bool option
     }
 
+    type FoldingRangeCapabilities =  {
+        /// Whether implementation supports dynamic registration for folding range providers. If this is set to `true`
+        /// the client supports the new `(FoldingRangeProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+        /// return value for the corresponding server capability as well.
+        DynamicRegistration: bool option
+        /// The maximum number of folding ranges that the client prefers to receive per document. The value serves as a
+        /// hint, servers are free to follow the limit.
+        RangeLimit: int option
+        /// If set, the client signals that it only supports folding complete lines. If set, client will
+        /// ignore specified `startCharacter` and `endCharacter` properties in a FoldingRange.
+        LineFoldingOnly: bool option
+    }
+
     /// Text document specific client capabilities.
     type TextDocumentClientCapabilities = {
         Synchronization: SynchronizationCapabilities option
@@ -525,6 +538,9 @@ module Types =
 
         /// Capabilities specific to the `textDocument/rename`
         Rename: DynamicCapabilities option
+
+        /// capabilities for the `textDocument/foldingRange`
+        FoldingRange: FoldingRangeCapabilities option
     }
 
     type ClientCapabilities = {
@@ -686,6 +702,10 @@ module Types =
 
         /// Experimental server capabilities.
         Experimental: JToken option
+
+        ///
+        FoldingRangeProvider: bool option
+
     }
     with
         static member Default =
@@ -710,6 +730,7 @@ module Types =
                 DocumentLinkProvider = None
                 ExecuteCommandProvider = None
                 Experimental = None
+                FoldingRangeProvider = None
             }
 
     type InitializeResult = {
@@ -1633,6 +1654,36 @@ module Types =
         ActiveParameter: int option
     }
 
+    type FoldingRangeParams = {
+        /// the document to generate ranges for
+        TextDocument: TextDocumentIdentifier
+    }
+
+    type FoldingRangeKind =
+    | Comment
+    | Imports
+    | Region
+    | Custom of kind: string
+
+    type FoldingRange = {
+        /// The zero-based line number from where the folded range starts.
+        StartLine: int
+
+        /// The zero-based character offset from where the folded range starts. If not defined, defaults to the length of the start line.
+        StartCharacter: int option
+
+        /// The zero-based line number where the folded range ends.
+        EndLine: int
+
+        /// The zero-based character offset before the folded range ends. If not defined, defaults to the length of the end line.
+        EndCharacter: int option
+
+        /// Describes the kind of the folding range such as `comment' or 'region'. The kind
+        /// is used to categorize folding ranges and used by commands like 'Fold all comments'. See
+        /// [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
+        Kind: FoldingRangeKind option
+    }
+
 module LowLevel =
     open System
     open System.IO
@@ -2094,6 +2145,10 @@ type LspServer() =
     abstract member TextDocumentDidClose: DidCloseTextDocumentParams -> Async<unit>
     default __.TextDocumentDidClose(_) = ignoreNotification
 
+    /// The folding range request is sent from the client to the server to return all folding ranges found in a given text document.
+    abstract member TextDocumentFoldingRange: FoldingRangeParams -> AsyncLspResult<FoldingRange [] option>
+    default __.TextDocumentFoldingRange(_) = notImplemented
+
 module Server =
     open System
     open System.IO
@@ -2198,6 +2253,7 @@ module Server =
             "textDocument/didSave", requestHandling (fun s p -> s.TextDocumentDidSave(p) |> notificationSuccess)
             "textDocument/didClose", requestHandling (fun s p -> s.TextDocumentDidClose(p) |> notificationSuccess)
             "textDocument/documentSymbol", requestHandling (fun s p -> s.TextDocumentDocumentSymbol(p))
+            "textDocument/foldingRange", requestHandling (fun s p -> s.TextDocumentFoldingRange(p))
             "workspace/didChangeWatchedFiles", requestHandling (fun s p -> s.WorkspaceDidChangeWatchedFiles(p) |> notificationSuccess)
             "workspace/didChangeWorkspaceFolders", requestHandling (fun s p -> s.WorkspaceDidChangeWorkspaceFolders (p) |> notificationSuccess)
             "workspace/didChangeConfiguration", requestHandling (fun s p -> s.WorkspaceDidChangeConfiguration (p) |> notificationSuccess)

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -95,6 +95,11 @@ let clientCaps : ClientCapabilities =
       { DynamicRegistration = Some true
         SymbolKind = Some skCaps}
 
+    let foldingRangeCaps: FoldingRangeCapabilities =
+      { DynamicRegistration = Some true
+        LineFoldingOnly = Some true
+        RangeLimit = Some 100 }
+
     { Synchronization = Some syncCaps
       PublishDiagnostics = diagCaps
       Completion = Some compCaps
@@ -110,7 +115,8 @@ let clientCaps : ClientCapabilities =
       CodeAction = Some dynCaps
       CodeLens = Some dynCaps
       DocumentLink = Some dynCaps
-      Rename = Some dynCaps}
+      Rename = Some dynCaps
+      FoldingRange = Some foldingRangeCaps }
 
 
   { Workspace = Some workspaceCaps
@@ -151,7 +157,7 @@ let loadDocument path : TextDocumentItem =
     Text = File.ReadAllText path  }
 
 let parseProject projectFilePath (server: FsharpLspServer) = async {
-  let projectParams: ProjectParms = 
+  let projectParams: ProjectParms =
     { Project = { Uri = filePathToUri projectFilePath } }
   // first restore the project
   let psi = System.Diagnostics.ProcessStartInfo()

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/FoldingTests/FoldingTests.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/FoldingTests/FoldingTests.fsproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+  </ItemGroup>
+
+</Project>

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/FoldingTests/Library.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/FoldingTests/Library.fs
@@ -1,0 +1,7 @@
+namespace FoldingTests
+
+/// some comments
+/// multiline, of course
+module Say =
+    let hello name =
+        printfn "Hello %s" name


### PR DESCRIPTION
Implements #478 using the structure service in FCS.  

We categorize scopes into a few different groups based on what the current LSP API supports, so user commands like 'fold all comments' work.

~This seems to work ok in my quick hack so far.  I'd like to be able to add a few more smarts on top of this to identify contiguous ranges of open statement and mark those as 'imports'.~

~Right now we also don't collapse any 'inline' ranges, though I suppose we could easily enough....~ we do this now.