### PR TITLE
Fix fsx preview langversion parsing and SDK detection

### DIFF
--- a/src/FsAutoComplete.BackgroundServices/Program.fs
+++ b/src/FsAutoComplete.BackgroundServices/Program.fs
@@ -111,7 +111,7 @@ type BackgroundServiceServer(state: State, client: FsacClient) =
     //TODO: does the backgroundservice ever get config updates?
     let sdkRoot = Environment.dotnetSDKRoot.Value
     let latestSdkVersion = Environment.latest3xSdkVersion sdkRoot
-    let latestRuntimeVersion = Environment.latest3xSdkVersion sdkRoot
+    let latestRuntimeVersion = Environment.latest3xRuntimeVersion sdkRoot
 
 
     let getFilesFromOpts (opts: FSharpProjectOptions) =

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -604,6 +604,6 @@ type FSharpCompilerServiceChecker(backgroundServiceEnabled) =
   member __.SetDotnetRoot(path) =
     sdkRoot <- Some path
     sdkVersion <- Environment.latest3xSdkVersion path
-    runtimeVersion <- Environment.latest3xSdkVersion path
+    runtimeVersion <- Environment.latest3xRuntimeVersion path
 
   member __.GetDotnetRoot () = sdkRoot

--- a/src/FsAutoComplete.Core/Environment.fs
+++ b/src/FsAutoComplete.Core/Environment.fs
@@ -96,12 +96,11 @@ module Environment =
       defaultArg fromEnv FSIRefs.defaultDotNetSDKRoot
     )
 
-  let private maxVersionWithThreshold minVersion versions =
+  let private maxVersionWithThreshold (minVersion: FSIRefs.NugetVersion) (versions: FSIRefs.NugetVersion []) =
     versions
-    |> List.filter (fun v -> v >= minVersion)
-    // can't use `List.max` here because it throws, and there's no `List.tryMax`
-    |> List.sortDescending
-    |> List.tryHead
+    |> Array.filter (fun v -> FSIRefs.compareNugetVersion v minVersion >= 0) // get all versions that compare as greater than the minVersion
+    |> Array.sortWith FSIRefs.compareNugetVersion
+    |> Array.tryLast
 
   /// because 3.x is the minimum SDK that we support for FSI, we want to float to the latest
   /// 3.x sdk that the user has installed, to prevent hard-coding.

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/PreviewScriptFeatures/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/PreviewScriptFeatures/Script.fsx
@@ -1,0 +1,15 @@
+(*
+ This file demonstrates the use of F# 4.7 preview language features, 
+ which must be opted-in to.  Parsing/typechecking will fail if preview
+ feature are not enabled.
+*)
+
+open System
+
+let add x y = 
+    if x < 0 then raise (ArgumentOutOfRangeException(nameof(x)))
+    x + y
+
+open System.Math
+
+let minimal = Min(1.0, 2.0)

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -352,10 +352,7 @@ let logDotnetRestore section line =
     logger.debug (eventX "[{section}] dotnet restore: {line}" >> setField "section" section >> setField "line" line)
 
 let getDiagnosticsEvents =
-  Event.filter (fun (typ, _o) ->
-    printfn "event of type %s" typ
-    typ = "textDocument/publishDiagnostics"
-  )
+  Event.filter (fun (typ, _o) -> typ = "textDocument/publishDiagnostics")
   >> Event.map (fun (_typ, o) -> unbox<LanguageServerProtocol.Types.PublishDiagnosticsParams> o)
 
 let matchFiles (files: string Set) =
@@ -774,7 +771,6 @@ let scriptPreviewTests =
       do server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath } |> Async.RunSynchronously
       match waitForParseResultsForFile scriptPath events with
       | Ok () ->
-        printfn "wut"
         () // all good, no parsing/checking errors
       | Core.Result.Error errors ->
         failwithf "Errors while parsing script %s: %A" scriptPath errors

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -358,7 +358,7 @@ let getDiagnosticsEvents =
 /// note that the files here are intended to be the filename only., not the full URI.
 let matchFiles (files: string Set) =
   Event.choose (fun (p: LanguageServerProtocol.Types.PublishDiagnosticsParams) ->
-    let filename = p.Uri.Split([|'/'|], StringSplitOptions.RemoveEmptyEntries) |> Array.last
+    let filename = p.Uri.Split([| '/'; '\\' |], StringSplitOptions.RemoveEmptyEntries) |> Array.last
     if Set.contains filename files
     then Some (filename, p)
     else None

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -355,9 +355,10 @@ let getDiagnosticsEvents =
   Event.filter (fun (typ, _o) -> typ = "textDocument/publishDiagnostics")
   >> Event.map (fun (_typ, o) -> unbox<LanguageServerProtocol.Types.PublishDiagnosticsParams> o)
 
+/// note that the files here are intended to be the filename only., not the full URI.
 let matchFiles (files: string Set) =
   Event.choose (fun (p: LanguageServerProtocol.Types.PublishDiagnosticsParams) ->
-    let filename = p.Uri.Replace('\\', '/').Substring("file://".Length)
+    let filename = p.Uri.Split([|'/'|], StringSplitOptions.RemoveEmptyEntries) |> Array.last
     if Set.contains filename files
     then Some (filename, p)
     else None
@@ -385,19 +386,22 @@ let waitForParsed (m: System.Threading.ManualResetEvent) files (event: Event<str
     d
 
   let fileNames = files |> Set.ofList
-
+  logger.debug (eventX "waiting for {files} to be parsed" >> setField "files" fileNames)
   event.Publish
   |> getDiagnosticsEvents
   |> matchFiles fileNames
   |> Event.add (fun (filename, n) ->
       if Array.isEmpty n.Diagnostics then // no errors
         found.AddOrUpdate(filename, true, (fun x y -> true)) |> ignore
+        logger.debug (eventX "{file} was parsed successfully" >> setField "file" filename)
 
-      let fileUnderWatchStatus = found.ToArray() |> Array.map (fun kv -> kv.Value)
-
-      if (not (fileUnderWatchStatus |> Seq.contains false)) then
+      match found |> Seq.filter (fun (KeyValue(name, found)) -> not found) with
+      | s when Seq.isEmpty s ->
         logger.debug (eventX "all parsed without error, signaling...")
         m.Set() |> ignore
+      | s ->
+        logger.debug (eventX "still waiting for {files}" >> setField "files" (s |> Seq.map (fun (KeyValue(name, _)) -> name)))
+        ()
       )
 
 ///Rename tests
@@ -759,17 +763,17 @@ let foldingTests =
 let scriptPreviewTests =
   let serverStart = lazy (
     let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "PreviewScriptFeatures")
-    let libraryPath = Path.Combine(path, "Script.fsx")
+    let scriptPath = Path.Combine(path, "Script.fsx")
     let (server, events) = serverInitialize path defaultConfigDto
     do waitForWorkspaceFinishedParsing events
-    server, events, libraryPath
+    server, events, scriptPath
   )
   let serverTest f () = f serverStart.Value
 
   testList "script preview language features" [
     testCase "can typecheck scripts when preview features are used" (serverTest (fun (server, events, scriptPath) ->
       do server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath } |> Async.RunSynchronously
-      match waitForParseResultsForFile scriptPath events with
+      match waitForParseResultsForFile "Script.fsx" events with
       | Ok () ->
         () // all good, no parsing/checking errors
       | Core.Result.Error errors ->

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -766,7 +766,7 @@ let scriptPreviewTests =
   )
   let serverTest f () = f serverStart.Value
 
-  ftestList "script preview language features" [
+  testList "script preview language features" [
     testCase "can typecheck scripts when preview features are used" (serverTest (fun (server, events, scriptPath) ->
       do server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath } |> Async.RunSynchronously
       match waitForParseResultsForFile scriptPath events with

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -795,5 +795,7 @@ let tests =
     uriTests
     dotnetnewTest
     foldingTests
+#if false // commented out because this will only work in a netcoreapp3.0 context, which CI doesn't have.
     scriptPreviewTests
+#endif
   ]


### PR DESCRIPTION
Found two issues with our support:

1. we didn't add `--langversion:preview` to the default set of options so if someone was using preview features we'd never typecheck the same way as they were executing, and
2. somehow the comparison logic for the nuget versions got borked, and the SDK versions were being used for the runtime versions.

I've fixed both of these by:
* hardcoding `--langversion:preview` in the FSI options for the netcore branch of project options discovery
* tagging the NugetVersion type with `NoComparison` and implementing property comparison by a function, which is then used in a few places.

I ran into 1) while talking with @PaulDorehill on Slack, and 2 while attempting to fix 1 on my machine (a 3.0.100 preview SDK was being selected over the 3.0.100 stable, which was a big clue).

Unrelated to either of these: we currently don't have a good answer for anyone working with 3.1 previews (3.1.1xx versions) about how to pin SDK versions (aside from global.json maybe?).