### PR TITLE
Decompile nonexistent fsharp sources

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -67,8 +67,12 @@ type ParseAndCheckResults
       | FSharpFindDeclResult.DeclNotFound _ ->
         return ResultOrString.Error "Could not find declaration"
       | FSharpFindDeclResult.DeclFound range when range.FileName.EndsWith(Range.rangeStartup.FileName) -> return ResultOrString.Error "Could not find declaration"
-      | FSharpFindDeclResult.DeclFound range ->
+      | FSharpFindDeclResult.DeclFound range when System.IO.File.Exists range.FileName ->
+        Debug.print "Got a declresult of %A that supposedly exists" range
         return Ok (FindDeclarationResult.Range range)
+      | FSharpFindDeclResult.DeclFound rangeInNonexistentFile -> 
+        Debug.print "Got a declresult of %A that doesn't exist" rangeInNonexistentFile
+        return ResultOrString.Error (sprintf "Range for nonexistent file found: %s" rangeInNonexistentFile.FileName)
       | FSharpFindDeclResult.ExternalDecl (assembly, externalSym) ->
         match Decompiler.tryFindExternalDeclaration checkResults (assembly, externalSym) with
         | Ok extDec -> return ResultOrString.Ok (FindDeclarationResult.ExternalDeclaration extDec)

--- a/src/FsAutoComplete.Core/Debug.fs
+++ b/src/FsAutoComplete.Core/Debug.fs
@@ -5,7 +5,7 @@ namespace FsAutoComplete
 
 module Debug =
 
-  let mutable verbose = true
+  let mutable verbose = false
   let mutable categories : Set<string> option = None
 
   let mutable output = stderr

--- a/src/FsAutoComplete.Core/Debug.fs
+++ b/src/FsAutoComplete.Core/Debug.fs
@@ -5,7 +5,7 @@ namespace FsAutoComplete
 
 module Debug =
 
-  let mutable verbose = false
+  let mutable verbose = true
   let mutable categories : Set<string> option = None
 
   let mutable output = stderr

--- a/src/FsAutoComplete.Core/Decompiler.fs
+++ b/src/FsAutoComplete.Core/Decompiler.fs
@@ -149,7 +149,7 @@ let decompile (externalSym: ExternalSymbol) assemblyPath: Result<ExternalContent
         let typeDef =
             getDeclaringTypeName externalSym
             |> resolveType typeSystem
-
+            
         let symbol =
             match externalSym with
             | ExternalSymbol.Type _ -> Some (typeDef :> ISymbol)


### PR DESCRIPTION
(this bases off of the fsx preview fixes because current master barfs on fsx scripts).

This is a proof of concept fix for #485. That issue says that we get DeclFound for an external definition that doesn't exist locally. If we detect this case, then we _could_ do something like I've done here, to then do a symboluse call and extract out the assembly and an ExternalSymbol shim for the symbol in question.  I've implemented enough to mock out functions, so you can decompile `printfn` for example if you test this.

I'm not sure if we want to go down this path, rather than just fix it in FCS itself, but I haven't yet figured out how to do an FCS test.