### PR TITLE
Set fsi additional args and expire script typechecking when options change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-[![Build Status](https://dev.azure.com/fsautocomplete/fsautocomplete/_apis/build/status/fsharp.FsAutoComplete?branchName=master)](https://dev.azure.com/fsautocomplete/fsautocomplete/_build/latest?definitionId=1&branchName=master)
 
 # FsAutoComplete
 
-The `FsAutoComplete` project (`FSAC`) provides a backend service for rich editing or 'intellisense' features for editors.
+[![Build Status](https://dev.azure.com/fsautocomplete/fsautocomplete/_apis/build/status/fsharp.FsAutoComplete?branchName=master)](https://dev.azure.com/fsautocomplete/fsautocomplete/_build/latest?definitionId=1&branchName=master)
+
+The `FsAutoComplete` project (`FSAC`) provides a backend service for rich editing or intellisense features for editors.
 
 It can be hosted using the Language Server Protocol.
 
@@ -14,9 +15,9 @@ Currently it is used by:
 
 It's based on:
 
-- [FSharp.Compiler.Service](https://github.com/fsharp/FSharp.Compiler.Service/) for F# language info.
-- [Dotnet.ProjInfo](https://github.com/enricosada/dotnet-proj-info/) for project/sln management.
-- [FSharpLint](https://github.com/fsprojects/FSharpLint/) for the linter feature.
+* [FSharp.Compiler.Service](https://github.com/fsharp/FSharp.Compiler.Service/) for F# language info.
+* [Dotnet.ProjInfo](https://github.com/enricosada/dotnet-proj-info/) for project/solution management.
+* [FSharpLint](https://github.com/fsprojects/FSharpLint/) for the linter feature.
 
 ## Required software
 
@@ -36,21 +37,20 @@ FsAutoComplete can run on .NET/mono or .NET Core.
 
 Requirements:
 
-- .NET Core Sdk, see [global.json](global.json) for the exact version.
-- Mono 5.18 on unix/osx
-- Microsoft Build Tools 2013
+* .NET Core Sdk, see [global.json](global.json) for the exact version.
+* Mono 5.18 on unix/osx
+* Microsoft Build Tools 2013
 
 There is a [FAKE script](build.fsx) who can be invoked with `build.cmd`/`build.sh`.
 
-- To build fsautocomplete binaries in `~/bin` directory, do run `build LocalRelease`
-- To build, run all tests and create packages, do run `build All`
-
+* To build fsautocomplete binaries in `~/bin` directory, do run `build LocalRelease`
+* To build, run all tests and create packages, do run `build All`
 
 ## Communication protocol
 
-FsAutoComplete supports [LSP](https://microsoft.github.io/language-server-protocol/) as a communication protocol. 
+FsAutoComplete supports [LSP](https://microsoft.github.io/language-server-protocol/) as a communication protocol.
 
-#### Supported LSP endpoints
+### Supported LSP endpoints
 
 * `initialize`
 * `textDocument/didOpen`
@@ -63,18 +63,18 @@ FsAutoComplete supports [LSP](https://microsoft.github.io/language-server-protoc
 * `textDocument/typeDefinition`
 * `textDocument/implementation`
 * `textDocument/codeAction`:
-  - Remove unused `open`
-  - Resolve namespace/module
-  - Replace unused symbol with `_`
-  - Fix typo based on error message
-  - Remove redundant qualifier
-  - Add missing `new` keyword for `IDisposable`
-  - Generate cases for all DU case in pattern matching
-  - Generate empty interface implementation
-  - Fixes suggested by [FSharpLint](https://github.com/fsprojects/FSharpLint)
+  * Remove unused `open`
+  * Resolve namespace/module
+  * Replace unused symbol with `_`
+  * Fix typo based on error message
+  * Remove redundant qualifier
+  * Add missing `new` keyword for `IDisposable`
+  * Generate cases for all DU case in pattern matching
+  * Generate empty interface implementation
+  * Fixes suggested by [FSharpLint](https://github.com/fsprojects/FSharpLint)
 * `textDocument/codeLens` & `codeLens/resolve`:
-  - signature Code Lenses
-  - reference number Code Lenses
+  * signature Code Lenses
+  * reference number Code Lenses
 * `textDocument/formatting` - powered by [fantomas](https://github.com/fsprojects/fantomas)
 * `textDocument/references`
 * `textDocument/documentHighlight`
@@ -84,11 +84,11 @@ FsAutoComplete supports [LSP](https://microsoft.github.io/language-server-protoc
 * `workspace/didChangeConfiguration`
 * `workspace/symbol`
 
-**Custom endpoints:**
+### Custom endpoints
 
 Custom endpoints are using (for messages body) `PlainNotification` type and string format serialized with exactly same serialization format as old JSON protocol
 
-* `fsharp/signature` - accepts `TextDocumentPositionParams`, returns signature of symbol at given position as formated string
+* `fsharp/signature` - accepts `TextDocumentPositionParams`, returns signature of symbol at given position as a formatted string
 * `fsharp/signatureData` - accepts `TextDocumentPositionParams`, returns signature of symbol at given position as DTO
 * `fsharp/lineLens` - accepts `ProjectParms` (`Project` filed contain F# file path), returns locations where LineLenses should be displayed
 * `fsharp/compilerLocation` - no input, returns paths to FCS, FSI and MsBuild
@@ -101,30 +101,30 @@ Custom endpoints are using (for messages body) `PlainNotification` type and stri
 * `fsharp/documentation` - accepts `TextDocumentPositionParams`, returns documentation data about symbol at given position, used for InfoPanel
 * `fsharp/documentationSymbol` - accepts `DocumentationForSymbolReuqest`, returns documentation data about given symbol from given assembly, used for InfoPanel
 
-#### Supported LSP notifications
+### Supported LSP notifications
 
 * `window/showMessage`
 * `window/logMessage`
 * `textDocument/publishDiagnostics`
 
-**Custom notifications:**
+### Custom notifications
 
 * `fsharp/notifyWorkspace` - notification for workspace/solution/project loading events
 * `fsharp/notifyWorkspacePeek` - notification for initial workspace peek
 
-#### Additional startup options:
+### Additional startup options
 
 * `--background-service-enabled` - passing this flag enables background service feature, increasing FSAC responsiveness by moving some of the operations (especially background type checking) to other process. It results in increased memory usage. Used by default in Ionide.
 * `--verbose` - passing this flag enables additional logging being printed out in `stderr`
 * `DOTNET_ROOT` - setting this environment variable will set the dotnet SDK root, which is used when finding references for FSX scripts.
 
-#### Initialization options:
+### Initialization options
 
 Options that should be send as `initializationOptions` as part of `initialize` request.
 
 * `AutomaticWorkspaceInit` - setting it to `true` will start Workspace Loading without need to run `fsharp/workspacePeek` and `fsharp/workspaceLoad` commands. It will always choose top workspace from the found list - all projects in workspace if 0 `.sln` files are found, `.sln` file if 1 `.sln` file was found, `.sln` file with most projects if multiple `.sln` files were found. It's designed to be used in clients that doesn't allow to create custom UI for selecting workspaces.
 
-#### Settings:
+### Settings
 
 * `FSharp.keywordsAutocomplete` - provides keywords in autocomplete list, recommended default value: `true`
 * `FSharp.ExternalAutocomplete` - provides autocomplete for symbols from not opened namespaces/modules, insert `open` on accept, recommended default value: `false`
@@ -148,20 +148,20 @@ Options that should be send as `initializationOptions` as part of `initialize` r
 
 ### FileWatcher exceptions
 
-You may see a stack trace finishing with `System.IO.IOException: kqueue() error at init, error code = ’0’`. This is due to a limitation in the number of filehandles that the Mono file watchers can keep open. Restarting FsAutoComplete or the hosting editor should help. If not, try setting `export MONO_MANAGED_WATCHER=disabled` in your `~/.bash_profile`. Note that on OSX, this setting will only take effect if you launch emacs from the terminal.
-
+You may see a stack trace finishing with `System.IO.IOException: kqueue() error at init, error code = ’0’`. This is due to a limitation in the number of file handles that the Mono file watchers can keep open. Restarting FsAutoComplete or the hosting editor should help. If not, try setting `export MONO_MANAGED_WATCHER=disabled` in your `~/.bash_profile`. Note that on OSX, this setting will only take effect if you launch emacs from the terminal.
 
 ## Maintainers
 
 The maintainers of this repository are:
 
-- [Steffen Forkmann](http://github.com/forki)
-- [Karl Nilsson](http://github.com/kjnilsson)
-- [Enrico Sada](http://github.com/enricosada)
-- [Krzysztof Cieślak](http://github.com/Krzysztof-Cieslak)
+* [Steffen Forkmann](http://github.com/forki)
+* [Karl Nilsson](http://github.com/kjnilsson)
+* [Enrico Sada](http://github.com/enricosada)
+* [Krzysztof Cieślak](http://github.com/Krzysztof-Cieslak)
+* [Chester Husk](http://github.com/baronfel)
 
 The primary maintainer for this repository is [Enrico Sada](http://github.com/enricosada)
 
 Previous maintainers:
 
-- [Robin Neatherway](https://github.com/rneatherway)
+* [Robin Neatherway](https://github.com/rneatherway)

--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ Options that should be send as `initializationOptions` as part of `initialize` r
 * `FSharp.ResolveNamespaces` - enables resolve namespace quick fix (add `open` if symbol is from not yet opened module/namespace), recommended default value: `true`
 * `FSharp.EnableReferenceCodeLens` - enables reference count code lenses, recommended default value: `true` if `--background-service-enabled` is used by default, `false` otherwise
 * `FSharp.dotNetRoot` - sets the root path for finding dotnet SDK references. Primarily used for FSX Scripts. Default value: operating-system dependent. On windows, `C:\Program Files\dotnet`; on Unix, `/usr/local/share/dotnet`
+* `FSharp.fsiExtraParameters` - an array of additional runtime arguments that are passed to FSI. These are used when typechecking scripts to ensure that typechecking has the same context as your FSI instances.  An example would be to set the following parameters to enable Preview features (like opening static classes) for typechecking.
+
+    ```json
+        "FSharp.fsiExtraParameters": ["--langversion:preview"]
+    ```
+
 
 ## Troubleshooting
 

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1134,3 +1134,4 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
     }
 
     member __.SetDotnetSDKRoot(path) = checker.SetDotnetRoot(path)
+    member __.SetFSIAdditionalArguments args = checker.SetFSIAdditionalArguments args

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -649,13 +649,19 @@ type FSharpCompilerServiceChecker(backgroundServiceEnabled) =
   member internal __.GetFSharpChecker() = checker
 
   member __.SetDotnetRoot(path) =
-    sdkRoot <- Some path
-    sdkVersion <- Environment.latest3xSdkVersion path
-    runtimeVersion <- Environment.latest3xRuntimeVersion path
-    scriptTypecheckRequirementsChanged.Trigger ()
+    if sdkRoot = Some path
+    then ()
+    else
+      sdkRoot <- Some path
+      sdkVersion <- Environment.latest3xSdkVersion path
+      runtimeVersion <- Environment.latest3xRuntimeVersion path
+      scriptTypecheckRequirementsChanged.Trigger ()
 
   member __.GetDotnetRoot () = sdkRoot
 
   member __.SetFSIAdditionalArguments args =
-    fsiAdditionalArguments <- args
-    scriptTypecheckRequirementsChanged.Trigger ()
+    if fsiAdditionalArguments = args
+    then ()
+    else
+      fsiAdditionalArguments <- args
+      scriptTypecheckRequirementsChanged.Trigger ()

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -1,6 +1,31 @@
 [<AutoOpen>]
 module FsAutoComplete.Utils
 
+module Map =
+    /// Combine two maps of identical types by starting with the first map and overlaying the second one.
+    /// Because map updates shadow, any keys in the second map will have priority.
+    let merge (first: Map<'a, 'b>) (second: Map<'a, 'b>) =
+        let mutable result = first
+        for (KeyValue(key, value)) in second do
+            result <- Map.add key value result
+        result
+
+    /// Combine two maps by taking the first value of each key found.
+    let combineTakeFirst (first: Map<_,_>) (second: Map<_,_>) =
+        let mutable result = first
+        for (KeyValue(key, value)) in second do
+            if result.ContainsKey key
+            then ()
+            else result <- Map.add key value result
+        result
+
+    let values (m: Map<_, _>) =
+        seq {
+            for (KeyValue(_,value)) in m do
+                yield value
+        }
+
+
 open System.IO
 open System.Collections.Concurrent
 open System.Diagnostics

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -57,6 +57,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     let updateConfig (newConfig: FSharpConfig) =
         config <- newConfig
         commands.SetDotnetSDKRoot config.DotNetRoot
+        commands.SetFSIAdditionalArguments config.FSIExtraParameters
 
     //TODO: Thread safe version
     let fixes = System.Collections.Generic.Dictionary<DocumentUri, (LanguageServerProtocol.Types.Range * TextEdit) list>()

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -523,6 +523,7 @@ type FSharpConfigDto = {
     LineLens: LineLensConfig option
     UseSdkScripts: bool option
     DotNetRoot: string option
+    FSIExtraParameters: string [] option
 }
 
 type FSharpConfigRequest = {
@@ -554,6 +555,7 @@ type FSharpConfig = {
     LineLens: LineLensConfig
     UseSdkScripts: bool
     DotNetRoot: string
+    FSIExtraParameters: string []
 }
 with
     static member Default =
@@ -585,6 +587,7 @@ with
             }
             UseSdkScripts = false
             DotNetRoot = Environment.dotnetSDKRoot.Value
+            FSIExtraParameters = [||]
         }
 
     static member FromDto(dto: FSharpConfigDto) =
@@ -616,6 +619,7 @@ with
             }
             UseSdkScripts = defaultArg dto.UseSdkScripts false
             DotNetRoot = defaultArg dto.DotNetRoot Environment.dotnetSDKRoot.Value
+            FSIExtraParameters = defaultArg dto.FSIExtraParameters FSharpConfig.Default.FSIExtraParameters
         }
 
     /// called when a configuration change takes effect, so empty members here should revert options
@@ -649,6 +653,7 @@ with
             }
             UseSdkScripts = defaultArg dto.UseSdkScripts x.UseSdkScripts
             DotNetRoot = defaultArg dto.DotNetRoot FSharpConfig.Default.DotNetRoot
+            FSIExtraParameters = defaultArg dto.FSIExtraParameters FSharpConfig.Default.FSIExtraParameters
         }
 
     member x.ScriptTFM =

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -43,7 +43,8 @@ let defaultConfigDto : FSharpConfigDto =
     InterfaceStubGenerationMethodBody = None
     LineLens = None
     UseSdkScripts = Some true
-    DotNetRoot = None }
+    DotNetRoot = None
+    FSIExtraParameters = None }
 
 let clientCaps : ClientCapabilities =
   let dynCaps : DynamicCapabilities = { DynamicRegistration = Some true}

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -902,7 +902,7 @@ let scriptPreviewTests =
   let serverStart = lazy (
     let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "PreviewScriptFeatures")
     let scriptPath = Path.Combine(path, "Script.fsx")
-    let (server, events) = serverInitialize path defaultConfigDto
+    let (server, events) = serverInitialize path { defaultConfigDto with FSIExtraParameters = Some [| "--langversion:preview" |] }
     do waitForWorkspaceFinishedParsing events
     server, events, scriptPath
   )


### PR DESCRIPTION
Fixes #496 and a little extra.

This hooks up the pre-existing `fsiExtraParameters` setting that's in Ionide into the FSX typechecking loop.

In addition, this introduces a solution to stale script typechecking brought on by the checker cache not being invalidated when script-typechecking-relevant data is changed. Now we have an event that is triggered when updates occur, and the commands state can be invalidated as appropriate.  I added a test to show this live-update capability.

The only outstanding question I have is: how doe FSX script relate to the background processor? Will similar invalidation need to be done there?