### PR TITLE
Fix array tuple representation

### DIFF
--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -45,7 +45,11 @@ module SignatureFormatter =
                     |> Seq.map (formatFSharpType context)
                     |> String.concat ","
                 if entityIsArray typeDef then
-                    sprintf "%s array" genericArgs
+                    if typ.GenericArguments.Count = 1 && typ.GenericArguments.[0].IsTupleType
+                    then
+                        sprintf "(%s) array" genericArgs
+                    else
+                        sprintf "%s array" genericArgs
                 else sprintf "%s<%s>" (PrettyNaming.QuoteIdentifierIfNeeded typeDef.DisplayName) genericArgs
             else
                 if typ.HasTypeDefinition then

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -659,7 +659,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             }
         )
 
-    override x.TextDocumentHover(p) =
+    override x.TextDocumentHover(p: TextDocumentPositionParams) =
         Debug.print "[LSP call] TextDocumentHover"
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -1,0 +1,1 @@
+let arrayOfTuples = [| 1, 2 |]

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -1,1 +1,2 @@
 let arrayOfTuples = [| 1, 2 |]
+let listOfTuples = [ 1, 2 ]

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -976,10 +976,9 @@ let tooltipTests =
     server, scriptPath
   )
 
-  let server, scriptPath = serverStart.Value
-
   let verifyTooltip line character expectedTooltip =
     ftestCase (sprintf "tooltip for line %d character %d should be '%s" line character expectedTooltip) (fun _ ->
+      let server, scriptPath = serverStart.Value
       let pos: TextDocumentPositionParams = {
         TextDocument =  { Uri = sprintf "file://%s" scriptPath }
         Position = { Line = line; Character = character }
@@ -995,6 +994,7 @@ let tooltipTests =
 
   testList "tooltip evaluation" [
     verifyTooltip 0 4 "val arrayOfTuples : (int * int) array"
+    verifyTooltip 1 4 "val listOfTuples : list<int * int>"
   ]
 
 ///Global list of tests

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -955,6 +955,48 @@ let scriptEvictionTests =
     ))
   ]
 
+let tooltipTests =
+  let (|Tooltip|_|) (hover: Hover) =
+    match hover with
+    | { Contents = MarkedStrings [| MarkedString.WithLanguage { Language = "fsharp"; Value = tooltip }; MarkedString.String newline; MarkedString.String fullname; MarkedString.String assembly |] } -> Some tooltip
+    | _ -> None
+
+  let serverStart = lazy (
+    let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "Tooltips")
+    let scriptPath = Path.Combine(path, "Script.fsx")
+    let (server, events) = serverInitialize path defaultConfigDto
+    do waitForWorkspaceFinishedParsing events
+    do server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath } |> Async.RunSynchronously
+    match waitForParseResultsForFile "Script.fsx" events with
+    | Ok () ->
+      () // all good, no parsing/checking errors
+    | Core.Result.Error errors ->
+      failwithf "Errors while parsing script %s: %A" scriptPath errors
+
+    server, scriptPath
+  )
+
+  let server, scriptPath = serverStart.Value
+
+  let verifyTooltip line character expectedTooltip =
+    ftestCase (sprintf "tooltip for line %d character %d should be '%s" line character expectedTooltip) (fun _ ->
+      let pos: TextDocumentPositionParams = {
+        TextDocument =  { Uri = sprintf "file://%s" scriptPath }
+        Position = { Line = line; Character = character }
+      }
+      match server.TextDocumentHover pos |> Async.RunSynchronously with
+      | Ok (Some (Tooltip tooltip)) ->
+        Expect.equal tooltip expectedTooltip (sprintf "Should have a tooltip of '%s'" expectedTooltip)
+      | Ok _ ->
+        failwithf "Should have gotten hover text"
+      | Result.Error errors ->
+        failwithf "Error while getting hover text: %A" errors
+    )
+
+  testList "tooltip evaluation" [
+    verifyTooltip 0 4 "val arrayOfTuples : (int * int) array"
+  ]
+
 ///Global list of tests
 let tests =
    testSequenced <| testList "lsp" [
@@ -973,4 +1015,5 @@ let tests =
     // commented out because this will only work in a netcoreapp3.0 context, which CI doesn't have.
     //scriptPreviewTests
     //scriptEvictionTests
+    //tooltipTests
   ]


### PR DESCRIPTION
Fixes #498 by checking if the type being represented is an array of tuples, wrapping the tuple in parens. I know that @MangelMaxime is working on a more unified fix overall, but this seems like a minimal fix to sidestep confusion, and it also brings tooltips under LSP test a bit.