### PR TITLE
fix struct tuple rendering

### DIFF
--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -33,9 +33,13 @@ module SignatureFormatter =
     let rec formatFSharpType (context: FSharpDisplayContext) (typ: FSharpType) : string =
         try
             if typ.IsTupleType || typ.IsStructTupleType then
-                typ.GenericArguments
-                |> Seq.map (formatFSharpType context)
-                |> String.concat " * "
+                let refTupleStr =
+                    typ.GenericArguments
+                    |> Seq.map (formatFSharpType context)
+                    |> String.concat " * "
+                if typ.IsStructTupleType
+                then sprintf "struct(%s)" refTupleStr
+                else refTupleStr
             elif typ.IsGenericParameter then
                 (if typ.GenericParameter.IsSolveAtCompileTime then "^" else "'") + typ.GenericParameter.Name
             elif typ.HasTypeDefinition && typ.GenericArguments.Count > 0 then

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -1,2 +1,3 @@
 let arrayOfTuples = [| 1, 2 |]
 let listOfTuples = [ 1, 2 ]
+let listOfStructTuples = [ struct(1, 2) ]

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -995,6 +995,7 @@ let tooltipTests =
   testList "tooltip evaluation" [
     verifyTooltip 0 4 "val arrayOfTuples : (int * int) array"
     verifyTooltip 1 4 "val listOfTuples : list<int * int>"
+    verifyTooltip 2 4 "val listOfStructTuples : list<struct(int * int)>"
   ]
 
 ///Global list of tests


### PR DESCRIPTION
Fix #500 by making struct tuples in generic parameters add the `struct(<blah>)` construct.