### PR TITLE
fix <Note> display by un-mangling declaration names

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -541,6 +541,7 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
         | Some s ->
             CoreResponse.Res (HelpText.Simple (sym, s))
         | None ->
+        let sym = if sym.StartsWith "``" && sym.EndsWith "``" then sym.TrimStart([|'`'|]).TrimEnd([|'`'|]) else sym
         match state.Declarations.TryFind sym with
         | None -> //Isn't in sync filled cache, we don't have result
             CoreResponse.ErrorRes (sprintf "No help text available for symbol '%s'" sym)

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -509,7 +509,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             ()
     }
 
-    override __.TextDocumentCompletion(p) = async {
+    override __.TextDocumentCompletion(p: CompletionParams) = async {
         Debug.print "[LSP call] TextDocumentCompletion"
         Debug.print "[LSP call] TextDocumentCompletion - context: %A" p.Context
         // Sublime-lsp doesn't like when we answer null so we answer an empty list instead


### PR DESCRIPTION
When we look for 'resolves' for completion items we need to check the declaration map based on the un-prettyQuoted declaration name.  This means that `<Note>` works again!