### PR TITLE
pick a .net core TFM for scripts based on teh latest runtime we detect

### DIFF
--- a/src/FsAutoComplete.BackgroundServices/Program.fs
+++ b/src/FsAutoComplete.BackgroundServices/Program.fs
@@ -129,7 +129,7 @@ type BackgroundServiceServer(state: State, client: FsacClient) =
               | _, None ->
                 []
               | Some sdkVersion, Some runtimeVersion ->
-                FSIRefs.netCoreRefs Environment.dotnetSDKRoot.Value (string sdkVersion) (string runtimeVersion) Environment.fsiTFMMoniker true
+                FSIRefs.netCoreRefs Environment.dotnetSDKRoot.Value (string sdkVersion) (string runtimeVersion) (FSIRefs.tfmForRuntime sdkVersion) true
             let refs = assemblyPaths |> List.map (fun r -> "-r:" + r)
             let finalOpts = Array.append okOtherOpts (Array.ofList refs)
             { projOptions with OtherOptions = finalOpts }

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -480,15 +480,6 @@ type FSharpCompilerServiceChecker(backgroundServiceEnabled) =
 
   let mutable disableInMemoryProjectReferences = false
 
-  let tfmForRuntime =
-    let netcore3 = FSIRefs.NugetVersion(3, 0, 100, "")
-    let netcore31 = FSIRefs.NugetVersion(3, 1, 100, "")
-    fun (sdkVersion: FSIRefs.NugetVersion) ->
-      match FSIRefs.compareNugetVersion sdkVersion netcore3 with
-      | 1 | 0 when FSIRefs.compareNugetVersion sdkVersion netcore31 = -1 -> "netcoreapp3.0"
-      | 1 | 0 -> "netcoreapp3.1"
-      | _ -> "netcoreapp2.2"
-
   /// evaluates the set of assemblies found given the current sdkRoot/sdkVersion/runtimeVersion
   let computeAssemblyMap () =
     match sdkRoot, sdkVersion.Value, runtimeVersion.Value with
@@ -505,8 +496,8 @@ type FSharpCompilerServiceChecker(backgroundServiceEnabled) =
       Debug.print "Couldn't find latest 3.x runtime version inside root %s" root
       Map.empty
     | Some dotnetSdkRoot, Some sdkVersion, Some runtimeVersion ->
-      let refs = FSIRefs.netCoreRefs dotnetSdkRoot (string sdkVersion) (string runtimeVersion) (tfmForRuntime sdkVersion) true
-      Debug.print "found refs for SDK %O/Runtime %O/TFM %s:\n%A" sdkVersion runtimeVersion (tfmForRuntime sdkVersion) refs
+      let refs = FSIRefs.netCoreRefs dotnetSdkRoot (string sdkVersion) (string runtimeVersion) (FSIRefs.tfmForRuntime sdkVersion) true
+      Debug.print "found refs for SDK %O/Runtime %O/TFM %s:\n%A" sdkVersion runtimeVersion (FSIRefs.tfmForRuntime sdkVersion) refs
       refs
       |> List.map (fun path -> Path.GetFileNameWithoutExtension path, path)
       |> Map.ofList

--- a/src/FsAutoComplete.Core/Environment.fs
+++ b/src/FsAutoComplete.Core/Environment.fs
@@ -125,7 +125,3 @@ module Environment =
         Debug.print "Runtime versions: %A" sortedRuntimeVersions
         maxVersionWithThreshold minRuntimeVersion sortedRuntimeVersions
     )
-
-  /// When resolving fsi references for .net core, this is the TFM that we use.
-  /// Will need to be bumped as fsi advances in TFMs.
-  let fsiTFMMoniker = "netcoreapp3.0"

--- a/src/FsAutoComplete.Core/FSIRefs.fs
+++ b/src/FsAutoComplete.Core/FSIRefs.fs
@@ -124,3 +124,12 @@ let netCoreRefs dotnetRoot sdkVersion runtimeVersion tfm useFsiAuxLib =
   [ yield! findRuntimeRefs (appPackDir dotnetRoot runtimeVersion tfm) (runtimeDir dotnetRoot runtimeVersion)
     yield! compilerAndInteractiveRefs (compilerDir dotnetRoot sdkVersion) useFsiAuxLib ]
 
+/// picks a TFM for F# scripts based on the provided SDK version.
+let tfmForRuntime =
+  let netcore3 = NugetVersion(3, 0, 100, "")
+  let netcore31 = NugetVersion(3, 1, 100, "")
+  fun (sdkVersion: NugetVersion) ->
+    match compareNugetVersion sdkVersion netcore3 with
+    | 1 | 0 when compareNugetVersion sdkVersion netcore31 = -1 -> "netcoreapp3.0"
+    | 1 | 0 -> "netcoreapp3.1"
+    | _ -> "netcoreapp2.2"


### PR DESCRIPTION
with .net core 3.1 out, our sdk/runtime floating was finding 3.1 as the sdk/runtime version, but it was looking for `netcoreapp3.0` in those folders. it never found them, so we were defaulting to the actual runtime dlls instead of the ref dlls.

I added a helper function to pivot the TFM we use based on the nuget version range the user ends up on.

I also added a filtering for a few known-bad 2.x dlls that were coming from the logic in FCS because we run FSAC in .netcoreapp2.1.