### PR TITLE
Fix off by one on doc formatting

### DIFF
--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -969,7 +969,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                 let endLine = Array.length lines - 1
                 let endCharacter =
                     Array.tryLast lines
-                    |> Option.map (fun line -> if line.Length = 0 then 0 else line.Length - 1)
+                    |> Option.map (fun line -> line.Length)
                     |> Option.defaultValue 0
                 { Start = zero; End = { Line = endLine; Character = endCharacter } }
 

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -959,7 +959,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         return res
     }
 
-    override __.TextDocumentFormatting(p) = async {
+    override __.TextDocumentFormatting(p: DocumentFormattingParams) = async {
         let doc = p.TextDocument
         let fileName = doc.GetFilePath()
         match commands.TryGetFileCheckerOptionsWithLines fileName with

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Formatting/endCharacter.expected.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Formatting/endCharacter.expected.fsx
@@ -1,0 +1,3 @@
+module Input
+
+let modules = [ 109024; 137172; 80445; 80044 ]

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Formatting/endCharacter.input.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Formatting/endCharacter.input.fsx
@@ -1,0 +1,2 @@
+module Input
+    let modules = [109024;137172;80445;80044]


### PR DESCRIPTION
fixes https://github.com/ionide/ionide-vscode-fsharp/issues/1268 by fixing an off-by-one error we had.

Also introduces before/after tests to ensure the behavior is good/stable.