### PR TITLE
Dotnet new integration

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -255,18 +255,14 @@ type Commands (serialize : Serializer, backgroundServiceEnabled) =
             return CoreResponse.Res results
         }
 
-    member x.DotnetNewList (filterstr) = async {
-            let results = DotnetNewTemplate.dotnetnewlist filterstr
+    member x.DotnetNewList () = async {
+            let results = DotnetNewTemplate.installedTemplates ()
             return CoreResponse.Res results
         }
 
-    member x.DotnetNewGetDetails (filterstr) = async {
-            let results = DotnetNewTemplate.dotnetnewgetDetails filterstr
-            return CoreResponse.Res results
-        }
 
-    member x.DotnetNewCreateCli (templateShortName : string) (parameterStr : (string * obj) list) = async {
-            let results = DotnetNewTemplate.dotnetnewCreateCli templateShortName parameterStr
+    member x.DotnetNewRun (templateShortName : string) (name: string option) (output: string option) (parameterStr : (string * obj) list) = async {
+            let results = DotnetNewTemplate.dotnetnewCreateCli templateShortName name output parameterStr
             return CoreResponse.Res results
         }
 

--- a/src/FsAutoComplete.Core/DotnetNewTemplate.fs
+++ b/src/FsAutoComplete.Core/DotnetNewTemplate.fs
@@ -137,7 +137,7 @@ module DotnetNewTemplate =
     | _ -> failwithf "Multiple templates found : \n%A" templates
 
   let dotnetnewCreateCli (templateShortName : string) (name: string option) (output: string option) (parameterList : (string * obj) list) =
-    let str = "new " + templateShortName + "-lang F#"
+    let str = "new " + templateShortName + " -lang F#"
     let str =
       match name with
       | None -> str

--- a/src/FsAutoComplete.Core/DotnetNewTemplate.fs
+++ b/src/FsAutoComplete.Core/DotnetNewTemplate.fs
@@ -66,7 +66,7 @@ module DotnetNewTemplate =
     readTemplates ()
     |> parseTemplateOutput
     |> Array.map (fun (name, shortName) ->
-      {Name = name; ShortName = shortName; Language = [TemplateLanguage.FSharp]; Tags = []}
+      {Name = name; ShortName = shortName; Language = []; Tags = []}
     )
     |> Array.toList
 

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -414,8 +414,7 @@ module CommandResponse =
     serialize { Kind = "fsdn"; Data = data }
 
   let dotnetnewlist (serialize : Serializer) (installedTemplate : DotnetNewTemplate.Template list) =
-    let data = { DotnetNewListResponse.Installed = installedTemplate }
-    serialize { Kind = "dotnetnewlist"; Data = data }
+    serialize { Kind = "dotnetnewlist"; Data = installedTemplate }
 
   let dotnetnewgetDetails (serialize : Serializer) (detailedTemplate : DotnetNewTemplate.DetailedTemplate) =
     let data = { DotnetNewGetDetailsResponse.Detailed = detailedTemplate }

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1794,7 +1794,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
 
     member __.FSharpDotnetNewList(p: DotnetNewListRequest) = async {
         Debug.print "[LSP call] FSharpDotnetNewList"
-        let! res = commands.DotnetNewList p.Query
+        let! res = commands.DotnetNewList ()
         let res =
             match res with
             | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
@@ -1806,15 +1806,15 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         return res
     }
 
-    member __.FSharpDotnetNewGetDetails(p: DotnetNewGetDetailsRequest) = async {
-        Debug.print "[LSP call] FSharpDotnetNewGetDetails"
-        let! res = commands.DotnetNewGetDetails p.Query
+    member __.FSharpDotnetNewRun(p: DotnetNewRunRequest) = async {
+        Debug.print "[LSP call] FSharpDotnetNewRun"
+        let! res = commands.DotnetNewRun p.Template p.Name p.Output []
         let res =
             match res with
             | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
                 LspResult.internalError msg
-            | CoreResponse.Res (funcs) ->
-                { Content = CommandResponse.dotnetnewgetDetails FsAutoComplete.JsonSerializer.writeJson funcs }
+            | CoreResponse.Res (_) ->
+                { Content = "" }
                 |> success
 
         return res
@@ -1947,7 +1947,7 @@ let startCore (commands: Commands) =
         |> Map.add "fsharp/project" (requestHandling (fun s p -> s.FSharpProject(p) ))
         |> Map.add "fsharp/fsdn" (requestHandling (fun s p -> s.FSharpFsdn(p) ))
         |> Map.add "fsharp/dotnetnewlist" (requestHandling (fun s p -> s.FSharpDotnetNewList(p) ))
-        |> Map.add "fsharp/dotnetnewgetDetails" (requestHandling (fun s p -> s.FSharpDotnetNewGetDetails(p) ))
+        |> Map.add "fsharp/dotnetnewrun" (requestHandling (fun s p -> s.FSharpDotnetNewRun(p) ))
         |> Map.add "fsharp/f1Help" (requestHandling (fun s p -> s.FSharpHelp(p) ))
         |> Map.add "fsharp/documentation" (requestHandling (fun s p -> s.FSharpDocumentation(p) ))
         |> Map.add "fsharp/documentationSymbol" (requestHandling (fun s p -> s.FSharpDocumentationSymbol(p) ))

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -511,7 +511,7 @@ type FsdnRequest = { Query: string }
 
 type DotnetNewListRequest = { Query: string }
 
-type DotnetNewGetDetailsRequest = { Query: string }
+type DotnetNewRunRequest = { Template: string; Output: string option; Name: string option }
 
 type FSharpConfigDto = {
     AutomaticWorkspaceInit: bool option

--- a/test/FsAutoComplete.Tests.Lsp/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Tests.fs
@@ -671,66 +671,6 @@ let uriTests =
     testList "fileName to uri tests" (samples |> List.map (fun (uriForm, filePath) -> convertRawPathToUri filePath uriForm))
  ]
 
-let dotnetnewTest =
-  let serverStart = lazy (
-    let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "Empty")
-    let (server, event) = serverInitialize path defaultConfigDto
-    waitForWorkspaceFinishedParsing event
-    server
-  )
-  let serverTest f () =
-    f serverStart.Value
-
-  testList "DotnetNew Tests" [
-      testCase "DotnetNewList on list" (serverTest (fun server ->
-        let p : DotnetNewListRequest = {
-            Query = "Console Application"
-        }
-
-        let sampleTemplate : DotnetNewTemplate.Template = { Name = "Console Application";
-                                               ShortName = "console";
-                                               Language = [ DotnetNewTemplate.TemplateLanguage.CSharp; DotnetNewTemplate.TemplateLanguage.FSharp; DotnetNewTemplate.TemplateLanguage.VB ];
-                                               Tags = ["Common"; "Console"] }
-
-        let res = server.FSharpDotnetNewList p |> Async.RunSynchronously
-        match res with
-        | Result.Error e -> failtestf "Request failed: %A" e
-        | Result.Ok n ->
-          Expect.stringContains n.Content "Console Application" (sprintf "the Console Application is a valid response, but was %A" n)
-          let r = JsonSerializer.readJson<CommandResponse.ResponseMsg<CommandResponse.DotnetNewListResponse>>(n.Content)
-          Expect.equal r.Kind "dotnetnewlist" (sprintf "dotnetnewlist response, but was %A, from json %A" r n)
-          Expect.equal r.Data.Installed.[0].Name sampleTemplate.Name (sprintf "the Console Application is a valid response, but was %A, from json %A" r n)
-          Expect.equal r.Data.Installed.[0].Language sampleTemplate.Language (sprintf "the Console Application is a valid response, but was %A, from json %A" r n)
-      ))
-
-      testCase "DotnetNewGetDetails on list" (serverTest (fun server ->
-        let p : DotnetNewGetDetailsRequest = {
-            Query = "Console Application"
-        }
-
-        let sampleTemplate : DotnetNewTemplate.DetailedTemplate = { TemplateName = "Console Application";
-                                                                    Author = "Microsoft";
-                                                                    TemplateDescription = "A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS";
-                                                                    Options =
-                                                                    [ { ParameterName = "--no-restore";
-                                                                        ShortName = "";
-                                                                        ParameterType = DotnetNewTemplate.TemplateParameterType.Bool;
-                                                                        ParameterDescription = "If specified, skips the automatic restore of the project on create.";
-                                                                        DefaultValue = "false / (*) true" }
-                                                                    ] }
-
-        let res = server.FSharpDotnetNewGetDetails p |> Async.RunSynchronously
-        match res with
-        | Result.Error e -> failtestf "Request failed: %A" e
-        | Result.Ok n ->
-          Expect.stringContains n.Content "Console Application" (sprintf "the Console Application is a valid response, but was %A" n)
-          let r = JsonSerializer.readJson<CommandResponse.ResponseMsg<CommandResponse.DotnetNewGetDetailsResponse>>(n.Content)
-          Expect.equal r.Kind "dotnetnewgetDetails" (sprintf "dotnetnewgetDetails response, but was %A, from json %A" r n)
-          Expect.equal r.Data.Detailed.TemplateName sampleTemplate.TemplateName (sprintf "the Console Application is a valid response, but was %A, from json %A" r n)
-          Expect.equal r.Data.Detailed.Options.[0].ParameterName sampleTemplate.Options.[0].ParameterName (sprintf "the Console Application is a valid response, but was %A, from json %A" r n)
-          Expect.equal r.Data.Detailed.Options.[0].ParameterType sampleTemplate.Options.[0].ParameterType (sprintf "the Console Application is a valid response, but was %A, from json %A" r n)
-      ))
-    ]
 
 let foldingTests =
   let serverStart = lazy (
@@ -1052,7 +992,6 @@ let tests =
     gotoTest
     fsdnTest
     uriTests
-    dotnetnewTest
     foldingTests
     linterTests
     // commented out because this will only work in a netcoreapp3.0 context, which CI doesn't have.


### PR DESCRIPTION
This PR finishes the `dotnet new` - FSAC integration. In the future, this code may be moved to the new version of Forge (based on LSP).

It adds two custom LSP handlers:
1. `fsharp/dotnetnewlist`  - returns a list of installed templates known to `dotnet` SDK
2. `fsharp/dotnetnewrun` - creates a project for given template, name, and output folder. 