### PR TITLE
Endpoint for retrieving parsetree/ast formatted in different ways

### DIFF
--- a/src/FsAutoComplete.Core/AstFormat.fs
+++ b/src/FsAutoComplete.Core/AstFormat.fs
@@ -1,0 +1,13 @@
+
+[<RequireQualifiedAccess>]
+module FsAutoComplete.AstFormat
+
+module ParseTree =
+    open FSharp.Compiler.SyntaxTree
+
+    let printfFormat (tree: ParsedInput) = sprintf "%A" tree
+
+module TypedTree =
+    open FSharp.Compiler.SourceCodeServices
+
+    let printfFormat (tast: FSharpImplementationFileContents) = sprintf "%A" tast.Declarations

--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Debug.fs" />
+    <Compile Include="AstFormat.fs" />
     <Compile Include="Utils.fs" />
     <Compile Include="DotnetNewTemplate.fs" />
     <Compile Include="ProcessWatcher.fs" />

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -511,4 +511,4 @@ type ParseAndCheckResults
   member __.GetAST = parseResults.ParseTree
   member __.GetCheckResults = checkResults
   member __.GetParseResults = parseResults
-  member __.FileName = parseResults.FileName
+  member __.FileName: string = parseResults.FileName

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -340,7 +340,7 @@ type WorkspaceLoadParms = {
 }
 
 type WorkspacePeekRequest = {Directory : string; Deep: int; ExcludedDirs: string array}
-type DocumentationForSymbolReuqest = {XmlSig: string; Assembly: string}
+type DocumentationForSymbolRequest = {XmlSig: string; Assembly: string}
 
 type FakeTargetsRequest = {FileName : string; FakeContext : FakeSupport.FakeContext; }
 
@@ -356,6 +356,14 @@ type FsdnRequest = { Query: string }
 type DotnetNewListRequest = { Query: string }
 
 type DotnetNewRunRequest = { Template: string; Output: string option; Name: string option }
+
+type AstOutputFormat =
+| Printf
+
+type AstRepresentationRequest =
+    { file: TextDocumentIdentifier
+      astKind: AstKind
+      format: AstOutputFormat }
 
 type FSharpConfigDto = {
     AutomaticWorkspaceInit: bool option

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -31,6 +31,7 @@ let tests =
     //dependencyManagerTests //Requires .Net 5 preview
     scriptGotoTests
     interactiveDirectivesUnitTests
+    astTests
 
     fsdnTest
     uriTests

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/AST/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/AST/Script.fsx
@@ -1,0 +1,6 @@
+let i = 1
+
+let f x = x ** x
+
+let a b = sprintf "%A" b
+


### PR DESCRIPTION
A stab at #525 for whole files.  This works as it stands for parse trees and TAST representations, though the only supported format is `printf`-equivalents.  This is enough for what @theangrybyrd is starting with AST fragments, and makes it easier to open a sample file in a repo somewhere to see that the structures are for real code.  

This needs to be plumbed through on a right-click action on files in ionide itself to close the loop, though.

A next phase (perhaps for a json representation that ionide could feed into a D3 view or something) would be accomplished by adding new DU cases to the output 
 format DU.