### PR TITLE
update version-finding algorithm to probe packs dir as well as runtime dir

### DIFF
--- a/src/ProjectSystem/Environment.fs
+++ b/src/ProjectSystem/Environment.fs
@@ -149,10 +149,10 @@ module Environment =
 
   /// because 3.x is the minimum SDK that we support for FSI, we want to float to the latest
   /// 3.x sdk that the user has installed, to prevent hard-coding.
-  let latest3xSdkVersion sdkRoot =
+  let latest3xSdkVersion dotnetRoot =
     let minSDKVersion = FSIRefs.NugetVersion(3,0,100,"")
     lazy (
-      match FSIRefs.sdkVersions sdkRoot with
+      match FSIRefs.sdkVersions dotnetRoot with
       | None -> None
       | Some sortedSdkVersions ->
         maxVersionWithThreshold minSDKVersion sortedSdkVersions
@@ -160,10 +160,10 @@ module Environment =
 
   /// because 3.x is the minimum runtime that we support for FSI, we want to float to the latest
   /// 3.x runtime that the user has installed, to prevent hard-coding.
-  let latest3xRuntimeVersion sdkRoot =
+  let latest3xRuntimeVersion dotnetRoot =
     let minRuntimeVersion = FSIRefs.NugetVersion(3,0,0,"")
     lazy (
-      match FSIRefs.runtimeVersions sdkRoot with
+      match FSIRefs.runtimeVersions dotnetRoot with
       | None -> None
       | Some sortedRuntimeVersions ->
         maxVersionWithThreshold minRuntimeVersion sortedRuntimeVersions


### PR DESCRIPTION
There are two phases to finding the complete set of .net core refs for typechecking:

* discovering SDK and runtime versions,
* using those versions to probe for dlls

The previous logic would check for _runtime_ versions only in the shared runtime implementation directory (`dotnet-root/shared/Microsoft.NETCore.App`), but then it would use that discovered runtime version when probing across the reference-assembly and implementation directories.  This would result in a mismatch when the reference-assembly directory existed, but the version found in the implementation directory had no match in the reference-assembly directory. As an example, think runtime version 3.1.1, which from a reference-assembly perspective is binary-compatible with the 3.1.0 reference assemblies.  

This situation happens when there's not an updated set of façades for the runtime when a new runtime version is shipped, which I would expect to be the case for patch versions like 3.1.1.