### PR TITLE
[WIP] Add project options caching for script file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build_lsp_tests",
-            "program": "${workspaceFolder}/test/FsAutoComplete.Tests.Lsp/bin/Debug/netcoreapp2.1/FsAutoComplete.Tests.Lsp.dll",
+            "program": "${workspaceFolder}/test/FsAutoComplete.Tests.Lsp/bin/Debug/netcoreapp3.1/FsAutoComplete.Tests.Lsp.dll",
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
             "stopAtEntry": false,

--- a/src/FsAutoComplete.Core/State.fs
+++ b/src/FsAutoComplete.Core/State.fs
@@ -15,6 +15,7 @@ type State =
     Files : ConcurrentDictionary<SourceFilePath, VolatileFile>
     LastCheckedVersion: ConcurrentDictionary<SourceFilePath, int>
     ProjectController: ProjectController
+    ScriptProjectOptions: ConcurrentDictionary<SourceFilePath, int * FSharpProjectOptions>
 
     HelpText : ConcurrentDictionary<DeclName, FSharpToolTipText>
     Declarations: ConcurrentDictionary<DeclName, FSharpDeclarationListItem * pos * SourceFilePath>
@@ -32,6 +33,7 @@ type State =
     { Files = ConcurrentDictionary()
       LastCheckedVersion = ConcurrentDictionary()
       ProjectController = ProjectController(checker)
+      ScriptProjectOptions = ConcurrentDictionary()
       HelpText = ConcurrentDictionary()
       Declarations = ConcurrentDictionary()
       CurrentAST = None
@@ -157,3 +159,14 @@ type State =
                pos.Column <= lines.[pos.Line - 1].Length + 1 && pos.Column >= 1
       if not ok then ResultOrString.Error "Position is out of range"
       else Ok (opts, lines, lines.[pos.Line - 1])
+
+  member this.TryGetScriptProjectOptions (file, referencesVersion) = 
+    this.ScriptProjectOptions.TryFind file
+    |> Option.filter (fun (v,_) -> v = referencesVersion)
+    |> Option.map snd
+
+  member this.UpdateScriptProjectOptions (file, referencesVersion, projectOptions) =
+    this.ScriptProjectOptions.[file] <- (referencesVersion, projectOptions)
+
+  member this.PurgeScriptProjectOptions() =
+    this.ScriptProjectOptions.Clear()

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -75,6 +75,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         commands.SetDotnetSDKRoot config.DotNetRoot
         commands.SetFSIAdditionalArguments [| yield! config.FSICompilerToolLocations |> Array.map toCompilerToolArgument; yield! config.FSIExtraParameters |]
         commands.SetLinterConfigRelativePath config.LinterConfig
+        commands.PurgeScriptProjectOptions()
 #if ANALYZER_SUPPORT
         match config.AnalyzersPath with
         | [||] ->
@@ -1939,6 +1940,8 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
 
       return res
     }
+
+    member __.ScriptFileProjectOptions = commands.ScriptFileProjectOptions
 
 let startCore (commands: Commands) =
     use input = Console.OpenStandardInput()

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/ScriptProjectOptsCache/script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/ScriptProjectOptsCache/script.fsx
@@ -1,0 +1,5 @@
+#r "nuget: Newtonsoft.Json"
+open Newtonsoft.Json
+
+let x = [1..10]
+let z = JsonConvert.SerializeObject x


### PR DESCRIPTION
Hi

Inspired by the Stream on Twitch and your branch *projectOptionsForScript* I thought maybe I can help you to resolve #593.

All tests pass and the project options of the script files are cached.

However, I had a hard time to understand the existing caching strategy. So i didn't really know what I can reuse and what has to be implemented from scratch.

I'd appreciate your feedback.

Thanks
Philipp