### PR TITLE
Try improve project loading to use internal DPI cache

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -836,8 +836,10 @@ type Commands<'analyzer> (serialize : Serializer, backgroundServiceEnabled) =
     }
 
     member x.WorkspaceLoad onChange (files: string list) (disableInMemoryProjectReferences: bool) tfmForScripts = async {
+        commandsLogger.info (Log.setMessage "Workspace loading started '{files}'" >> Log.addContextDestructured "files" files)
         checker.DisableInMemoryProjectReferences <- disableInMemoryProjectReferences
         let! res = state.ProjectController.LoadWorkspace onChange files tfmForScripts onProjectLoaded
+        commandsLogger.info (Log.setMessage "Workspace loading finished ")
         return CoreResponse.Res res
     }
 

--- a/src/ProjectSystem/ProjectCrackerTypes.fs
+++ b/src/ProjectSystem/ProjectCrackerTypes.fs
@@ -4,13 +4,6 @@ open System
 open System.IO
 
 type GetProjectOptionsErrors = Dotnet.ProjInfo.Workspace.GetProjectOptionsErrors
-    //| ProjectNotRestored of projFile:string
-    //| LanguageNotSupported of projFile:string
-    //| ProjectNotLoaded of projFile:string
-    //| MissingExtraProjectInfos of projFile:string
-    //| InvalidExtraProjectInfos of projFile:string * error:string
-    //| ReferencesNotLoaded of projFile:string * referenceErrors:seq<string*GetProjectOptionsErrors>
-    //| GenericError of projFile:string * string
 
 type [<RequireQualifiedAccess>] WorkspaceProjectState =
     | Loading of string
@@ -48,3 +41,10 @@ module internal ProjectRecognizer =
             |> Seq.truncate 3
             |> List.ofSeq
             |> getProjectType
+
+    ///We only support Old Verbose projects and modern SDK projects. We don't support .Net Core preview `project.json` nor .Net Core 1.X `FSharp.NET.Sdk`
+    let isSupported (file: string) =
+      match file with
+      | Net45
+      | NetCoreSdk -> true
+      | _ -> false

--- a/src/ProjectSystem/Workspace.fs
+++ b/src/ProjectSystem/Workspace.fs
@@ -55,7 +55,7 @@ let private getProjectOptions (loader: Dotnet.ProjInfo.Workspace.Loader) (fcsBin
       let error = GenericError(e, sprintf "File '%s' does not exist" e)
       onLoaded (ProjectSystem.WorkspaceProjectState.Failed (e, error))
 
-    let supproted, notSupported = existing |> List.partition (isSupported)
+    let supported, notSupported = existing |> List.partition (isSupported)
     for e in notSupported do
       let error = GenericError(e, (sprintf "Project file '%s' not supported" e))
       onLoaded (ProjectSystem.WorkspaceProjectState.Failed (e, error))

--- a/src/ProjectSystem/Workspace.fs
+++ b/src/ProjectSystem/Workspace.fs
@@ -71,7 +71,7 @@ let private getProjectOptions (loader: Dotnet.ProjInfo.Workspace.Loader) (fcsBin
       )
 
     use notif = loader.Notifications.Subscribe handler
-    loader.LoadProjects supproted
+    loader.LoadProjects supported
 
 let internal loadInBackground onLoaded (loader, fcsBinder) (projects: Project list) = async {
     let (resProjects, otherProjects) =

--- a/src/ProjectSystem/Workspace.fs
+++ b/src/ProjectSystem/Workspace.fs
@@ -20,7 +20,77 @@ let extractOptionsDPW (opts: FSharp.Compiler.SourceCodeServices.FSharpProjectOpt
         | x ->
             Error (GenericError(opts.ProjectFileName, (sprintf "expected ExtraProjectInfo after project parsing, was %A" x)))
 
-let private getProjectOptions (loader: Dotnet.ProjInfo.Workspace.Loader, fcsBinder: Dotnet.ProjInfo.Workspace.FCS.FCSBinder) (projectFileName: string) =
+let private bindResults fn res =
+  res
+  |> Result.bind (fun po ->
+    extractOptionsDPW po
+    |> Result.bind (fun optsDPW ->
+        let logMap = [ fn, "" ] |> Map.ofList
+        let projViewer = Dotnet.ProjInfo.Workspace.ProjectViewer ()
+        let view = projViewer.Render optsDPW
+        let items =
+            if obj.ReferenceEquals(view.Items, null) then [] else view.Items
+        Result.Ok (po, optsDPW, items, logMap)))
+
+let private loaderNotificationHandler (fcsBinder: Dotnet.ProjInfo.Workspace.FCS.FCSBinder) ((loader, state): Loader * WorkspaceProjectState) =
+  match state with
+  | WorkspaceProjectState.Loading(_,_) -> None //we just ignore loading notifications in this case
+  | WorkspaceProjectState.Loaded(po, _) ->
+    let projectFileName = po.ProjectFileName
+    let x =
+      fcsBinder.GetProjectOptions projectFileName
+      |> bindResults projectFileName
+
+    Some x
+  | WorkspaceProjectState.Failed(projectFileName, _) ->
+    let x =
+      fcsBinder.GetProjectOptions projectFileName
+      |> bindResults projectFileName
+
+    Some x
+
+let private getProjectOptions (loader: Dotnet.ProjInfo.Workspace.Loader) (fcsBinder: Dotnet.ProjInfo.Workspace.FCS.FCSBinder) (onLoaded: ProjectSystem.WorkspaceProjectState -> unit) (projectFileNames: string list) =
+    let existing, notExisting = projectFileNames |> List.partition (File.Exists)
+    for e in notExisting do
+      let error = GenericError(e, sprintf "File '%s' does not exist" e)
+      onLoaded (ProjectSystem.WorkspaceProjectState.Failed (e, error))
+
+    let supproted, notSupported = existing |> List.partition (isSupported)
+    for e in notSupported do
+      let error = GenericError(e, (sprintf "Project file '%s' not supported" e))
+      onLoaded (ProjectSystem.WorkspaceProjectState.Failed (e, error))
+
+    let handler res =
+      loaderNotificationHandler fcsBinder res
+      |> Option.iter (fun n ->
+          match n with
+          | Ok (opts, optsDPW, projViewerItems, logMap) ->
+              onLoaded (ProjectSystem.WorkspaceProjectState.Loaded (opts, optsDPW.ExtraProjectInfo, projViewerItems, logMap))
+          | Error error ->
+              onLoaded (ProjectSystem.WorkspaceProjectState.Failed (error.ProjFile, error))
+      )
+
+    use notif = loader.Notifications.Subscribe handler
+    loader.LoadProjects supproted
+
+let internal loadInBackground onLoaded (loader, fcsBinder) (projects: Project list) = async {
+    let (resProjects, otherProjects) =
+      projects |> List.partition (fun n -> n.Response.IsSome)
+
+    for project in resProjects do
+      match project.Response with
+      | Some res ->
+          onLoaded (ProjectSystem.WorkspaceProjectState.Loaded (res.Options, res.ExtraInfo, res.Items, res.Log))
+      | None ->
+        () //Shouldn't happen
+
+    otherProjects
+    |> List.map (fun n -> n.FileName)
+    |> getProjectOptions loader fcsBinder onLoaded
+  }
+
+
+let private getProjectOptionsSingle (loader: Dotnet.ProjInfo.Workspace.Loader, fcsBinder: Dotnet.ProjInfo.Workspace.FCS.FCSBinder) (projectFileName: string) =
     if not (File.Exists projectFileName) then
         Error (GenericError(projectFileName, sprintf "File '%s' does not exist" projectFileName))
     else
@@ -46,27 +116,7 @@ let private getProjectOptions (loader: Dotnet.ProjInfo.Workspace.Loader, fcsBind
         | Unsupported ->
             Error (GenericError(projectFileName, (sprintf "Project file '%s' not supported" projectFileName)))
 
-let private parseProject' (loader, fcsBinder) projectFileName =
-    projectFileName
-    |> getProjectOptions (loader, fcsBinder)
 
 let internal parseProject (loader, fcsBinder) projectFileName =
     projectFileName
-    |> parseProject' (loader, fcsBinder)
-
-let internal loadInBackground onLoaded (loader, fcsBinder) (projects: Project list) = async {
-
-    for project in projects do
-        match project.Response with
-        | Some res ->
-            onLoaded (ProjectSystem.WorkspaceProjectState.Loaded (res.Options, res.ExtraInfo, res.Items, res.Log))
-        | None ->
-            project.FileName
-            |> parseProject' (loader, fcsBinder)
-            |> function
-               | Ok (opts, optsDPW, projViewerItems, logMap) ->
-                   onLoaded (ProjectSystem.WorkspaceProjectState.Loaded (opts, optsDPW.ExtraProjectInfo, projViewerItems, logMap))
-               | Error error ->
-                   onLoaded (ProjectSystem.WorkspaceProjectState.Failed (project.FileName, error))
-
-    }
+    |> getProjectOptionsSingle (loader, fcsBinder)


### PR DESCRIPTION
This is an attempt to call DPI's `LoadProjects` function with all projects that need to be loaded instead of running it separately for each project. Thanks to this change, theoretically, this project loading should use internal DPI cache (https://github.com/ionide/dotnet-proj-info/blob/master/src/Dotnet.ProjInfo.Workspace/Library.fs#L76) which should improve performance for projects with lot of p2p references. 