### PR TITLE
fix path issue in windows

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -248,6 +248,7 @@ type Commands<'analyzer> (serialize : Serializer, backgroundServiceEnabled) =
         with get() = lastCheckResult
 
     member __.SetFileContent(file: SourceFilePath, lines: LineStr[], version, tfmIfScript) =
+        let file = Path.GetFullPath file
         state.AddFileText(file, lines, version)
         let payload =
             if Utils.isAScript file


### PR DESCRIPTION
This PR fixes [Ionide Issue 1289](https://github.com/ionide/ionide-vscode-fsharp/issues/1289).

In windows there was a problem with forward and backward slashes in path.
`Commands.SetFileContent` die not call `System.IO.Path.GetFullPath` and the `State.Files` was setting the content to the key with forward slashes and all queries used backslashes.

After `TextDocumentDidChange` was called it save the new version of .fsx lines with forward slashes but the `TextDocumentCompletion` queried with backslashes and got the old version of the '.fsx' lines and completion did not work.

This was only a problem for fsx files because `Utils.normalizePath` calls GetFullPath only for '.fs' and '.fsi' files.

We (@pihai and me) extended the logging to see the `State.Files` changes. Here are the logs where the issue can be seen.

```
[10:17:37.637 INF] [LSP] TextDocumentDidChange Request: c:/Users/leko.tomas/private-source/FsAutoCompleteTest/test.fsx
[10:17:37.637 INF] [LSP] TextDocumentDidChange Content: ["System.IO.Path."], DocVersion: 29
[10:17:37.637 INF] [State] State.AddFileText: c:/Users/leko.tomas/private-source/FsAutoCompleteTest/test.fsx, Some(29), ["System.IO.Path."]
[10:17:37.637 INF] [LSP] TextDocumentDidChange Saved content: ["System.IO.Path."], DocVersion: 29
[10:17:37.639 INF] [LSP] TextDocumentCompletion Request: {"TextDocument": {"Uri": "file:///c%3A/Users/leko.tomas/private-source/FsAutoCompleteTest/test.fsx", "$type": "TextDocumentIdentifier"}, "Position": {"Line": 0, "Character": 15, "$type": "Position"}, "Context": {"Value": {"triggerKind": "TriggerCharacter", "triggerCharacter": {"Value": ".", "$type": "Some"}, "$type": "CompletionContext"}, "$type": "Some"}, "$type": "CompletionParams"}
[10:17:37.639 INF] [State] State.TryGetFileCheckerOptionsWithLines.TryFind c:\Users\leko.tomas\private-source\FsAutoCompleteTest\test.fsx
[10:17:37.639 INF] [State] State.TryGetFileCheckerOptionsWithLines.VolFile Some(28), ["System.IO.Path"]
```