### PR TITLE
preserve order of params, exceptions und type args in tool tips

### DIFF
--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -609,7 +609,7 @@ let tooltipTests =
         failwithf "Error while getting hover text: %A" errors
     )
 
-  let verifyDesscription line character expectedTooltip =
+  let verifyDescription line character expectedTooltip =
     testCase (sprintf "tooltip for line %d character %d should be '%s" line character expectedTooltip) (fun _ ->
       let server, scriptPath = serverStart.Value
       let pos: TextDocumentPositionParams = {
@@ -624,13 +624,16 @@ let tooltipTests =
       | Result.Error errors ->
         failwithf "Error while getting hover text: %A" errors
     )
+    
+  let concatLines = String.concat Environment.NewLine
 
   testList "tooltip evaluation" [
     verifyTooltip 0 4 "val arrayOfTuples : (int * int) array"
     verifyTooltip 1 4 "val listOfTuples : list<int * int>"
     verifyTooltip 2 4 "val listOfStructTuples : list<struct(int * int)>"
     verifyTooltip 3 4 "val floatThatShouldHaveGenericReportedInTooltip : float" //<MeasureOne>
-    //verifyDesscription 4 4 """**Description**\n\nPrint to a string using the given format.\n\n**Parameters**\n\n* `format`: The formatter.\n\n**Returns**\n\nThe formatted result.\n\n**Generic parameters**\n\n* `'T` is `string`"""
+    //verifyDescription 4 4 """**Description**\n\nPrint to a string using the given format.\n\n**Parameters**\n\n* `format`: The formatter.\n\n**Returns**\n\nThe formatted result.\n\n**Generic parameters**\n\n* `'T` is `string`"""
+    verifyDescription 13 10 (concatLines ["**Description**"; ""; "\nMy super summary\n "; ""; "**Parameters**"; ""; "* `c`: foo"; "* `b`: bar"; "* `a`: baz"; ""; "**Returns**"; ""; ""])
   ]
 
 

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -3,3 +3,12 @@ let listOfTuples = [ 1, 2 ]
 let listOfStructTuples = [ struct(1, 2) ]
 let floatThatShouldHaveGenericReportedInTooltip = 1.
 sprintf "asd"
+
+/// <summary>
+/// My super summary
+/// </summary>
+/// <param name="c">foo</param>
+/// <param name="b">bar</param>
+/// <param name="a">baz</param>
+/// <returns></returns>
+let someFunction () = ()


### PR DESCRIPTION
This PR fixes #612 by using key value pair lists instead of maps. I did the same for exceptions and type parameters, because I think it makes sense there too.

The unit test currently works on windows. I hope that it works on all platforms even with different line breaks.