### PR TITLE
Update FSharpLint rule url

### DIFF
--- a/src/FsAutoComplete.Core/Lint.fs
+++ b/src/FsAutoComplete.Core/Lint.fs
@@ -12,7 +12,7 @@ type EnrichedLintWarning =
       Code: string }
 
 let pageForLint (identifier: string) =
-  sprintf "http://fsprojects.github.io/FSharpLint/rules/%s.html" identifier
+  sprintf "http://fsprojects.github.io/FSharpLint/how-tos/rules/%s.html" identifier
 
 /// In addition we add the url to the matching help page for fsharplint
 let enrichLintWarning (w: Suggestion.LintWarning): EnrichedLintWarning =


### PR DESCRIPTION
The FSharpLint rule URLs have changed slightly, so updating the `pageForLint` function with the correct URL. We may expose this URL automatically as part of the `LintWarning` type in the future, so the correct URL is included in the warning.