### PR TITLE
push changes to file system up to already-existing layer

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -16,56 +16,6 @@ type Version = int
 
 type FSharpCompilerServiceChecker(backgroundServiceEnabled) =
 
-  let fixedFileSystem =
-    let older = FSharp.Compiler.AbstractIL.Internal.Library.Shim.FileSystem
-    let fsLogger = LogProvider.getLoggerByName "FileSystem"
-    /// translation of the BCL's Windows logic for Path.IsPathRooted.
-    ///
-    /// either the first char is '/', or the first char is a drive identifier followed by ':'
-    let isWindowsStyleRootedPath (p: string) =
-        let isAlpha (c: char) =
-            (c >= 'A' && c <= 'Z')
-            || (c >= 'a' && c <= 'z')
-        (p.Length >= 1 && p.[0] = '/')
-        || (p.Length >= 2 && isAlpha p.[0] && p.[1] = ':')
-
-    /// translation of the BCL's Unix logic for Path.IsRooted.
-    ///
-    /// if the first character is '/' then the path is rooted
-    let isUnixStyleRootedPath (p: string) =
-        p.Length > 0 && p.[0] = '/'
-
-    { new IFileSystem with
-        member _.IsPathRootedShim (p: string) =
-          let r =
-            isWindowsStyleRootedPath p
-            || isUnixStyleRootedPath p
-          fsLogger.debug (Log.setMessage "Is {path} rooted? {result}" >> Log.addContext "path" p >> Log.addContext "result" r)
-          r
-
-        member _.GetFullPathShim (f: string) =
-          let expanded =
-            Path.FilePathToUri f
-            |> Path.FileUriToLocalPath
-          fsLogger.debug (Log.setMessage "{path} expanded to {expanded}" >> Log.addContext "path" f >> Log.addContext "expanded" expanded)
-          expanded
-
-        // delegate all others
-        member _.ReadAllBytesShim (f) = older.ReadAllBytesShim f
-        member _.FileStreamReadShim (f) = older.FileStreamReadShim f
-        member _.FileStreamCreateShim (f) = older.FileStreamCreateShim f
-        member _.FileStreamWriteExistingShim (f) = older.FileStreamWriteExistingShim f
-        member _.IsInvalidPathShim (f) = older.IsInvalidPathShim f
-        member _.GetTempPathShim () = older.GetTempPathShim()
-        member _.GetLastWriteTimeShim (f) = older.GetLastWriteTimeShim f
-        member _.SafeExists (f) = older.SafeExists f
-        member _.FileDelete (f) = older.FileDelete f
-        member _.AssemblyLoadFrom (f) = older.AssemblyLoadFrom f
-        member _.AssemblyLoad (f) = older.AssemblyLoad f
-        member _.IsStableFileHeuristic (f) = older.IsStableFileHeuristic f }
-
-  do FSharp.Compiler.AbstractIL.Internal.Library.Shim.FileSystem <- fixedFileSystem
-
   let checker =
     FSharpChecker.Create(
       projectCacheSize = 200,

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -2,6 +2,7 @@ namespace FsAutoComplete
 
 open FSharp.Compiler.AbstractIL.Internal.Library
 open System
+open FsAutoComplete.Logging
 
 type VolatileFile =
   { Touched: DateTime
@@ -11,44 +12,65 @@ type VolatileFile =
 open System.IO
 
 type FileSystem (actualFs: IFileSystem, tryFindFile: SourceFilePath -> VolatileFile option) =
-    let normalize = Utils.normalizePath
-    let getFile = normalize >> tryFindFile
-
     let getContent (filename: string) =
-        filename
-        |> getFile
-        |> Option.map (fun file ->
-             System.Text.Encoding.UTF8.GetBytes (String.Join ("\n", file.Lines)))
+         filename
+         |> tryFindFile
+         |> Option.map (fun file ->
+              System.Text.Encoding.UTF8.GetBytes (String.Join ("\n", file.Lines)))
+
+    let fsLogger = LogProvider.getLoggerByName "FileSystem"
+    /// translation of the BCL's Windows logic for Path.IsPathRooted.
+    ///
+    /// either the first char is '/', or the first char is a drive identifier followed by ':'
+    let isWindowsStyleRootedPath (p: string) =
+        let isAlpha (c: char) =
+            (c >= 'A' && c <= 'Z')
+            || (c >= 'a' && c <= 'z')
+        (p.Length >= 1 && p.[0] = '/')
+        || (p.Length >= 2 && isAlpha p.[0] && p.[1] = ':')
+
+    /// translation of the BCL's Unix logic for Path.IsRooted.
+    ///
+    /// if the first character is '/' then the path is rooted
+    let isUnixStyleRootedPath (p: string) =
+        p.Length > 0 && p.[0] = '/'
 
     interface IFileSystem with
-        member __.FileStreamReadShim fileName =
-            getContent fileName
-            |> Option.map (fun bytes -> new MemoryStream (bytes) :> Stream)
-            |> Option.defaultWith (fun _ -> actualFs.FileStreamReadShim fileName)
+        member _.IsPathRootedShim (p: string) =
+          let r =
+            isWindowsStyleRootedPath p
+            || isUnixStyleRootedPath p
+          fsLogger.debug (Log.setMessage "Is {path} rooted? {result}" >> Log.addContext "path" p >> Log.addContext "result" r)
+          r
 
-        member __.ReadAllBytesShim fileName =
-            getContent fileName
-            |> Option.defaultWith (fun _ -> actualFs.ReadAllBytesShim fileName)
+        member _.GetFullPathShim (f: string) =
+          let expanded =
+            Path.FilePathToUri f
+            |> Path.FileUriToLocalPath
+          fsLogger.debug (Log.setMessage "{path} expanded to {expanded}" >> Log.addContext "path" f >> Log.addContext "expanded" expanded)
+          expanded
 
-        member __.GetLastWriteTimeShim fileName =
-            getFile fileName
-            |> Option.map (fun x -> x.Touched)
-            |> Option.defaultWith (fun _ -> actualFs.GetLastWriteTimeShim fileName)
+              // delegate all others
+        member _.ReadAllBytesShim (f) =
+          getContent f
+          |> Option.defaultWith (fun _ -> actualFs.ReadAllBytesShim f)
 
-        member __.GetTempPathShim() = actualFs.GetTempPathShim()
-        member __.FileStreamCreateShim file = file |> normalize |> actualFs.FileStreamCreateShim
-        member __.FileStreamWriteExistingShim file = file |> normalize |> actualFs.FileStreamWriteExistingShim
-        member __.GetFullPathShim file = file |> normalize |> actualFs.GetFullPathShim
-        member __.IsInvalidPathShim file = file |> normalize |> actualFs.IsInvalidPathShim
-        member __.IsPathRootedShim file = file |> normalize |> actualFs.IsPathRootedShim
-        member __.SafeExists file = file |> normalize |> actualFs.SafeExists
-        member __.FileDelete file = file |> normalize |> actualFs.FileDelete
-        member __.AssemblyLoadFrom file = file |> normalize |> actualFs.AssemblyLoadFrom
-        member __.AssemblyLoad assemblyName = actualFs.AssemblyLoad assemblyName
-        member __.IsStableFileHeuristic fileName =
-            let directory = Path.GetDirectoryName(fileName)
-            directory.Contains("Reference Assemblies/") ||
-            directory.Contains("Reference Assemblies\\") ||
-            directory.Contains("packages/") ||
-            directory.Contains("packages\\") ||
-            directory.Contains("lib/mono/")
+        member _.FileStreamReadShim (f) =
+          getContent f
+          |> Option.map (fun bytes -> new MemoryStream(bytes) :> Stream)
+          |> Option.defaultWith (fun _ -> actualFs.FileStreamReadShim f)
+
+        member _.GetLastWriteTimeShim (f) =
+          tryFindFile f
+          |> Option.map (fun f -> f.Touched)
+          |> Option.defaultWith (fun _ -> actualFs.GetLastWriteTimeShim f)
+
+        member _.FileStreamCreateShim (f) = actualFs.FileStreamCreateShim f
+        member _.FileStreamWriteExistingShim (f) = actualFs.FileStreamWriteExistingShim f
+        member _.IsInvalidPathShim (f) = actualFs.IsInvalidPathShim f
+        member _.GetTempPathShim () = actualFs.GetTempPathShim()
+        member _.SafeExists (f) = actualFs.SafeExists f
+        member _.FileDelete (f) = actualFs.FileDelete f
+        member _.AssemblyLoadFrom (f) = actualFs.AssemblyLoadFrom f
+        member _.AssemblyLoad (f) = actualFs.AssemblyLoad f
+        member _.IsStableFileHeuristic (f) = actualFs.IsStableFileHeuristic f

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -64,6 +64,9 @@ let createServer () =
   let event = Event<string * obj> ()
   let client = FSharpLspClient (fun name o -> event.Trigger (name,o); AsyncLspResult.success () )
   let commands = Commands(FsAutoComplete.JsonSerializer.writeJson, false)
+  let originalFs = FSharp.Compiler.AbstractIL.Internal.Library.Shim.FileSystem
+  let fs = FsAutoComplete.FileSystem(originalFs, commands.Files.TryFind)
+  FSharp.Compiler.AbstractIL.Internal.Library.Shim.FileSystem <- fs
   let server = FsharpLspServer(commands, client)
   server, event
 


### PR DESCRIPTION
Because I can't read, I didn't see that we already had a FileSystem, and this layer was doing normalization that wasn't in line with the normalization used in the CompilerServiceInterface. I've pushed my changes up to the pre-existing implementation, and patched up the LSP tests to use that shared implementation as well.