### PR TITLE
Goto load

### DIFF
--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -28,6 +28,7 @@
     <Compile Include="Decompiler.fs" />
     <Compile Include="Sourcelink.fs" />
     <Compile Include="FakeSupport.fs" />
+    <Compile Include="InteractiveDirectives.fs" />
     <Compile Include="ParseAndCheckResults.fs" />
     <Compile Include="CompilerServiceInterface.fs" />
     <Compile Include="State.fs" />

--- a/src/FsAutoComplete.Core/InteractiveDirectives.fs
+++ b/src/FsAutoComplete.Core/InteractiveDirectives.fs
@@ -1,0 +1,114 @@
+module FsAutoComplete.InteractiveDirectives
+
+open System
+open System.Text.RegularExpressions
+
+/// Remove escaping from standard (non verbatim & non triple quotes) string
+let private unescapeStandardString (s: string) =
+  let mutable result = ""
+  let mutable escaped = false
+  let mutable unicodeHeaderChar = '?'
+  let mutable remainingUnicodeChars = 0
+  let mutable currentUnicodeChars = ""
+
+  for i in [ 0 .. s.Length - 1 ] do
+    let c = s.[i]
+    if remainingUnicodeChars > 0 then
+      if (c >= 'A' && c <= 'Z')
+         || (c >= 'a' && c <= 'z')
+         || (c >= '0' && c <= '9') then
+        currentUnicodeChars <- currentUnicodeChars + string (c)
+        remainingUnicodeChars <- remainingUnicodeChars - 1
+
+        if remainingUnicodeChars = 0 then
+          result <-
+            result
+            + string (char (Convert.ToUInt32(currentUnicodeChars, 16)))
+      else
+        // Invalid unicode sequence, bail out
+        result <-
+          result
+          + "\\"
+          + string (unicodeHeaderChar)
+          + currentUnicodeChars
+          + string (c)
+        remainingUnicodeChars <- 0
+    else if escaped then
+      escaped <- false
+      match c with
+      | 'b' -> result <- result + "\b"
+      | 'n' -> result <- result + "\n"
+      | 'r' -> result <- result + "\r"
+      | 't' -> result <- result + "\t"
+      | '\\' -> result <- result + "\\"
+      | '"' -> result <- result + "\""
+      | ''' -> result <- result + "'"
+      | 'u' ->
+          unicodeHeaderChar <- 'u'
+          currentUnicodeChars <- ""
+          remainingUnicodeChars <- 4
+      | 'U' ->
+          unicodeHeaderChar <- 'U'
+          currentUnicodeChars <- ""
+          remainingUnicodeChars <- 8
+      | _ -> result <- result + "\\" + string (c)
+    else if c = '\\' then
+      escaped <- true
+    else
+      result <- result + string (c)
+
+  if remainingUnicodeChars > 0 then
+    result <-
+      result
+      + "\\"
+      + string (unicodeHeaderChar)
+      + currentUnicodeChars
+  else if escaped then
+    result <- result + "\\"
+
+  result
+
+
+let private loadRegex = Regex(@"#load\s+")
+let private standardStringRegex = Regex(@"^""(((\\"")|[^""])*)""")
+let private verbatimStringRegex = Regex(@"^@""((""""|[^""])*)""")
+let private tripleStringRegex = Regex(@"^""""""(.*?)""""""")
+
+// The following function can be probably moved to general Utils, as it's general purpose.
+// Or is there already such function?
+
+/// Get the string starting at index in any of the string forms (standard, verbatim or triple quotes)
+let private tryParseStringFromStart (s: string) (index: int) =
+  let s = s.Substring(index)
+  let verbatim = verbatimStringRegex.Match(s)
+  if verbatim.Success then
+    let s = verbatim.Groups.[1].Value
+    Some(s.Replace("\"\"", "\""))
+  else
+    let triple = tripleStringRegex.Match(s)
+    if triple.Success then
+      let s = triple.Groups.[1].Value
+      Some s
+    else
+      let standard = standardStringRegex.Match(s)
+      if standard.Success then
+        let s = standard.Groups.[1].Value
+        Some(unescapeStandardString s)
+      else
+        None
+
+/// Parse the content of a "#load" instruction at the given line. Returns the script file name on success.
+let tryParseLoad (line: string) (column: int) =
+  let potential =
+    seq {
+      let matches = loadRegex.Matches(line)
+      for i in [ 0 .. matches.Count - 1 ] do
+        let m = matches.[i]
+        if m.Index <= column then yield m
+    }
+
+  match potential |> Seq.tryLast with
+  | Some m ->
+      let stringIndex = m.Index + m.Length
+      tryParseStringFromStart line stringIndex
+  | None -> None

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -879,7 +879,6 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         logger.info (Log.setMessage "TextDocumentDefinition Request: {parms}" >> Log.addContextDestructured "parms" p )
         p |> x.positionHandler (fun p pos tyRes lineStr lines ->
             async {
-                //TODO: Add #load reference
                 let! res = commands.FindDeclaration tyRes pos lineStr
                 let res =
                     match res with

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -68,6 +68,15 @@ module Conversions =
                 }
             }
         | FsAutoComplete.FindDeclarationResult.Range r -> fcsRangeToLspLocation r
+        | FsAutoComplete.FindDeclarationResult.File file ->
+            let fileUri = Path.FilePathToUri file
+            {
+                Uri = fileUri
+                Range = {
+                    Start = { Line = 0; Character = 0 }
+                    End = { Line = 0; Character = 0 }
+                }
+            }
 
     type TextDocumentIdentifier with
         member doc.GetFilePath() = Path.FileUriToLocalPath doc.Uri

--- a/test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="CoreTests.fs" />
     <Compile Include="ScriptTests.fs" />
     <Compile Include="ExtensionsTests.fs" />
+    <Compile Include="InteractiveDirectivesTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/test/FsAutoComplete.Tests.Lsp/InteractiveDirectivesTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InteractiveDirectivesTests.fs
@@ -1,0 +1,38 @@
+module FsAutoComplete.Tests.InteractiveDirectivesTests
+
+open Expecto
+open FsAutoComplete.InteractiveDirectives
+
+let interactiveDirectivesUnitTests = testList "interactive directives unit tests" [
+
+  testList "tryParseLoad" [
+    testCase "happy cases" <| fun () ->
+      let cases = [
+        "#load \"script\"", 0, "script"
+        "#load \"script\"", 2, "script"
+        "#load  \"script\" ", 0, "script"
+        "#load @\"script\"", 0, "script"
+        "#load @\"path/to\\script\"", 0, "path/to\\script"
+        "#load \"\"\"script\"\"\"", 0, "script"
+        "#load \"script.fsx\"", 0, "script.fsx"
+      ]
+      Expect.all cases (fun (line, index, expected) ->
+        let actual = tryParseLoad line index
+        actual = Some expected
+      ) "all are valid cases"
+
+    testCase "invalid directives" <| fun () ->
+      let cases = [
+        "load \"script\"", 0
+        "##load \"script\"", 0
+        "#loda \"script\"", 0
+        "#LOAD \"script\"", 0
+        "  #load \"script\"", 1
+        "#load \"script", 0
+      ]
+      Expect.all cases (fun (line, index) ->
+        let actual = tryParseLoad line index
+        actual = None
+      ) "all are invalid cases"
+  ]
+]

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -8,6 +8,7 @@ open Serilog.Events
 open FsAutoComplete.Tests.CoreTest
 open FsAutoComplete.Tests.ScriptTest
 open FsAutoComplete.Tests.ExtensionsTests
+open FsAutoComplete.Tests.InteractiveDirectivesTests
 
 ///Global list of tests
 let tests =
@@ -28,6 +29,8 @@ let tests =
     scriptEvictionTests
     scriptProjectOptionsCacheTests
     //dependencyManagerTests //Requires .Net 5 preview
+    scriptGotoTests
+    interactiveDirectivesUnitTests
 
     fsdnTest
     uriTests

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/Script.fsx
@@ -1,0 +1,1 @@
+#load "simple.fsx"


### PR DESCRIPTION
This PR brings go-to-definition for `#load` directives to FSAC. The feature was originally implemented in ionide/ionide-vscode-fsharp#517, but later removed during a refactoring. This PR supersedes PR #368 and resolves #210.

The `TextDocumentDefinition` command implementation was modified, so that it checks first for a possible identifier, and then for a load directive. I've added an integration test for single use case, and also some unit tests to cover other cases.
