### PR TITLE
Add Go To Type Defintion for external types

### DIFF
--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -911,7 +911,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                     | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
                         LspResult.internalError msg
                     | CoreResponse.Res r ->
-                        fcsRangeToLspLocation r
+                        findDeclToLspLocation r
                         |> GotoResult.Single
                         |> Some
                         |> success

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/External.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/External.fs
@@ -13,3 +13,13 @@ let myButton props children = button props children
 let myConcat listA listB = List.concat [listA; listB]
 
 let myStringConcat (separator: string) (strings: string []) = System.String.Join(separator, strings)
+
+let myList = System.Collections.Generic.List<string>()
+
+let o v = Some v
+
+
+type B() =
+    member val Value = Some "" with get,set
+let b = B()
+b.Value |> ignore


### PR DESCRIPTION
Go to type definition currently only works for types with available source files. This adds support for external sources (sourcelink and decompilation -- same as Go To Definition).
Additional this adds go to type definition for constructors, properties and union cases.



There's one issue with external types:
It doesn't work for some built-in types like `string` or `int` when using .net core (like `TargetFramework` = `netcoreapp3.0` or `net5`). It detects `string` in `netstandard.dll` -- which is a meta dll and doesn't directly contain `string`:
```fsharp
let value: string = ""
//    ^
//    cursor
```

> Error while decompiling symbol 'ExternalSymbol.Type "System.String"' in file 'C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\3.0.0\ref\netcoreapp3.0\netstandard.dll': Decompiling types that are not part of the main module is not supported.

It does work with .Net (like `TargetFramerwork` = `net4.8`) or using `String` instead of `string`.
Go To Definition gets the correct assembly directly from the [F# compiler](https://github.com/fsharp/FsAutoComplete/blob/30703eb76114e1e54ddf71f7c163ca8308cbe7c2/src/FsAutoComplete.Core/ParseAndCheckResults.fs#L105), but that can't be used for Go to type def. And I couldn't find any other suitable method.
Somebody any ideas?

Otherwise I don't think that isn't a huge issue: As far as I can tell that's only happening for the basic types (like `int`, `float`, or `string`).  
Currently the above error message + stacktrace is passed to the client (like ionide) -- which looks quite threatening. If there's no easy fix, it might be wise to handle these cases separately and return a simpler message. But for now it's still returning the full error.