### PR TITLE
add fsx files to normalizePath

### DIFF
--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -68,7 +68,7 @@ let isAScript (fileName: string) =
 
 
 let normalizePath (file : string) =
-  if file.EndsWith ".fs" || file.EndsWith ".fsi" then
+  if file.EndsWith ".fs" || file.EndsWith ".fsi" || file.EndsWith ".fsx" then
       let p = Path.GetFullPath file
       (p.Chars 0).ToString().ToLower() + p.Substring(1)
   else file


### PR DESCRIPTION
This fixes issue https://github.com/ionide/ionide-vscode-fsharp/issues/1396

All code actions don't work in fsx scripts, because the file version of the workspace edits is always `None`.

See this PR as a suggestion, because I obviously have no idea how the path handling should work in FSAC.  For example why does the `normalizePath` function handle fs und fsi files but not fsx files. I have no idea.