### PR TITLE
only set the dotnetRoot value if it is in fact a directory that exists

### DIFF
--- a/src/FsAutoComplete.BackgroundServices/Program.fs
+++ b/src/FsAutoComplete.BackgroundServices/Program.fs
@@ -108,11 +108,15 @@ type BackgroundServiceServer(state: State, client: FsacClient) =
     let checker = FSharpChecker.Create(projectCacheSize = 1, keepAllBackgroundResolutions = false, suggestNamesForErrors = true)
 
     do checker.ImplicitlyStartBackgroundWork <- false
-
+    let mutable latestSdkVersion = lazy None
+    let mutable latestRuntimeVersion = lazy None
     //TODO: does the backgroundservice ever get config updates?
-    let sdkRoot = Environment.dotnetSDKRoot.Value
-    let latestSdkVersion = Environment.latest3xSdkVersion sdkRoot
-    let latestRuntimeVersion = Environment.latest3xRuntimeVersion sdkRoot
+    do
+      let sdkRoot = Environment.dotnetSDKRoot.Value
+      if sdkRoot.Exists
+      then
+        latestSdkVersion <- Environment.latest3xSdkVersion sdkRoot
+        latestRuntimeVersion <- Environment.latest3xRuntimeVersion sdkRoot
 
 
     let getFilesFromOpts (opts: FSharpProjectOptions) =

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -973,7 +973,7 @@ type Commands<'analyzer> (serialize : Serializer, backgroundServiceEnabled) =
                 return Ok ranges
     }
 
-    member __.SetDotnetSDKRoot(path) = checker.SetDotnetRoot(path)
+    member __.SetDotnetSDKRoot(directory: System.IO.DirectoryInfo) = checker.SetDotnetRoot(directory)
     member __.SetFSIAdditionalArguments args = checker.SetFSIAdditionalArguments args
 
     member x.FormatDocument (file: SourceFilePath) = async {

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -303,13 +303,13 @@ type FSharpCompilerServiceChecker(backgroundServiceEnabled) =
 
   member internal __.GetFSharpChecker() = checker
 
-  member __.SetDotnetRoot(path) =
-    if sdkRoot = Some path
+  member __.SetDotnetRoot(directory: DirectoryInfo) =
+    if sdkRoot = Some directory
     then ()
     else
-      sdkRoot <- Some path
-      sdkVersion <- Environment.latest3xSdkVersion path
-      runtimeVersion <- Environment.latest3xRuntimeVersion path
+      sdkRoot <- Some directory
+      sdkVersion <- Environment.latest3xSdkVersion directory
+      runtimeVersion <- Environment.latest3xRuntimeVersion directory
       discoveredAssembliesByName <- lazy(computeAssemblyMap ())
       scriptTypecheckRequirementsChanged.Trigger ()
 

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -75,6 +75,14 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         if di.Exists
         then
           commands.SetDotnetSDKRoot di
+        else
+          // if we were mistakenly given the path to a dotnet binary
+          // then use the parent directory as the dotnet root instead
+          let fi = FileInfo (di.FullName)
+          if fi.Exists &&
+            ( fi.Name = "dotnet" || fi.Name = "dotnet.exe")
+          then
+            commands.SetDotnetSDKRoot (fi.Directory)
 
         commands.SetFSIAdditionalArguments [| yield! config.FSICompilerToolLocations |> Array.map toCompilerToolArgument; yield! config.FSIExtraParameters |]
         commands.SetLinterConfigRelativePath config.LinterConfig

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -458,7 +458,7 @@ with
                 Prefix =""
             }
             UseSdkScripts = false
-            DotNetRoot = Environment.dotnetSDKRoot.Value
+            DotNetRoot = Environment.dotnetSDKRoot.Value.FullName
             FSIExtraParameters = [||]
             FSICompilerToolLocations = [||]
             TooltipMode = "full"
@@ -497,7 +497,7 @@ with
             DotNetRoot =
                 dto.DotNetRoot
                 |> Option.bind (fun s -> if String.IsNullOrEmpty s then None else Some s)
-                |> Option.defaultValue Environment.dotnetSDKRoot.Value
+                |> Option.defaultValue Environment.dotnetSDKRoot.Value.FullName
             FSIExtraParameters = defaultArg dto.FSIExtraParameters FSharpConfig.Default.FSIExtraParameters
             FSICompilerToolLocations = defaultArg dto.FSICompilerToolLocations FSharpConfig.Default.FSICompilerToolLocations
             TooltipMode = defaultArg dto.TooltipMode "full"

--- a/src/ProjectSystem/Environment.fs
+++ b/src/ProjectSystem/Environment.fs
@@ -138,6 +138,11 @@ module Environment =
       let fromEnv =
         Environment.GetEnvironmentVariable "DOTNET_ROOT"
         |> Option.ofObj
+        |> Option.bind (fun d ->
+          let di = DirectoryInfo d
+          if di.Exists then Some di
+          else None
+        )
       defaultArg fromEnv FSIRefs.defaultDotNetSDKRoot
     )
 
@@ -149,7 +154,7 @@ module Environment =
 
   /// because 3.x is the minimum SDK that we support for FSI, we want to float to the latest
   /// 3.x sdk that the user has installed, to prevent hard-coding.
-  let latest3xSdkVersion dotnetRoot =
+  let latest3xSdkVersion (dotnetRoot: DirectoryInfo) =
     let minSDKVersion = FSIRefs.NugetVersion(3,0,100,"")
     lazy (
       match FSIRefs.sdkVersions dotnetRoot with
@@ -160,7 +165,7 @@ module Environment =
 
   /// because 3.x is the minimum runtime that we support for FSI, we want to float to the latest
   /// 3.x runtime that the user has installed, to prevent hard-coding.
-  let latest3xRuntimeVersion dotnetRoot =
+  let latest3xRuntimeVersion (dotnetRoot: DirectoryInfo) =
     let minRuntimeVersion = FSIRefs.NugetVersion(3,0,0,"")
     lazy (
       match FSIRefs.runtimeVersions dotnetRoot with

--- a/src/ProjectSystem/FSIRefs.fs
+++ b/src/ProjectSystem/FSIRefs.fs
@@ -9,11 +9,13 @@ open System.IO
 open System.Runtime.InteropServices
 
 let defaultDotNetSDKRoot =
-  if RuntimeInformation.IsOSPlatform OSPlatform.OSX
-  then "/usr/local/share/dotnet"
-  else if RuntimeInformation.IsOSPlatform OSPlatform.Linux
-  then "/usr/share/dotnet"
-  else @"C:\Program Files\dotnet"
+  let path =
+    if RuntimeInformation.IsOSPlatform OSPlatform.OSX
+    then "/usr/local/share/dotnet"
+    else if RuntimeInformation.IsOSPlatform OSPlatform.Linux
+    then "/usr/share/dotnet"
+    else @"C:\Program Files\dotnet"
+  DirectoryInfo path
 
 type TFM =
 | NetFx
@@ -63,83 +65,84 @@ let deconstructVersion (version: string): NugetVersion =
   else
       NugetVersion(Int32.Parse(elements.[0]), Int32.Parse(elements.[1]), Int32.Parse(elements.[2]), suffix)
 
-let versionDirectoriesIn (baseDir: string) =
-  baseDir
-  |> Directory.EnumerateDirectories
+let versionDirectoriesIn (baseDir: DirectoryInfo) =
+  baseDir.EnumerateDirectories()
   |> Array.ofSeq // have to convert to array to get a sortWith that takes our custom comparison function
-  |> Array.map (Path.GetFileName >> deconstructVersion)
+  |> Array.map (fun dir -> deconstructVersion dir.Name)
   |> Array.sortWith compareNugetVersion
 
 /// path to the directory where .Net SDK versions are stored
-let sdkDir dotnetRoot = Path.Combine (dotnetRoot, "sdk")
+let sdkDir (dotnetRoot: DirectoryInfo) = Path.Combine (dotnetRoot.FullName, "sdk") |> DirectoryInfo
 
 /// returns a sorted list of the SDK versions available at the given dotnet root
 let sdkVersions dotnetRoot =
   let sdkDir = sdkDir dotnetRoot
-  if Directory.Exists sdkDir
+  if sdkDir.Exists
   then Some (versionDirectoriesIn sdkDir)
   else None
 
 /// path to the .netcoreapp reference assembly storage location
-let netcoreAppPacksDir dotnetRoot = Path.Combine(dotnetRoot, "packs/Microsoft.NETCore.App.Ref")
+let netcoreAppPacksDir (dotnetRoot: DirectoryInfo) = Path.Combine(dotnetRoot.FullName, "packs/Microsoft.NETCore.App.Ref") |> DirectoryInfo
 /// path to the .netcoreapp implementation assembly storage location
-let netcoreAppDir dotnetRoot = Path.Combine(dotnetRoot, "shared/Microsoft.NETCore.App")
+let netcoreAppDir (dotnetRoot: DirectoryInfo) = Path.Combine(dotnetRoot.FullName, "shared/Microsoft.NETCore.App") |> DirectoryInfo
 
 /// Returns a sorted list of the .Net Core runtime versions available at the given dotnet root.
 ///
-/// If the reference-dll packs directory (`<dotnet root>/packs/Microsoft.NETCore.App.Ref`) is present that is used, otherwise
-/// defaults to the actual runtime implementation dlls (`<dotnet root>/shared/Microsoft.NETCore.app`).
-let runtimeVersions dotnetRoot =
+/// If the reference-dll packs directory ('dotnet root'/packs/Microsoft.NETCore.App.Ref) is present that is used, otherwise
+/// defaults to the actual runtime implementation dlls ('dotnet root'/shared/Microsoft.NETCore.app).
+let runtimeVersions (dotnetRoot: DirectoryInfo) =
   let runtimesDir = netcoreAppDir dotnetRoot
   let packsDir = netcoreAppPacksDir dotnetRoot
-  if Directory.Exists packsDir
+  if packsDir.Exists
   then
     Some (versionDirectoriesIn packsDir)
     else
-      if Directory.Exists runtimesDir
+      if runtimesDir.Exists
       then Some (versionDirectoriesIn runtimesDir)
       else None
 
 let appPackDir dotnetRoot runtimeVersion tfm =
-  let packDir = Path.Combine(netcoreAppPacksDir dotnetRoot, runtimeVersion, "ref", tfm)
-  if Directory.Exists packDir then Some packDir else None
+  let packDir = Path.Combine((netcoreAppPacksDir dotnetRoot).FullName, runtimeVersion, "ref", tfm)
+  if Directory.Exists packDir then Some (DirectoryInfo packDir) else None
 
 let compilerDir dotnetRoot sdkVersion =
-  let compilerDir = Path.Combine(sdkDir dotnetRoot, sdkVersion, "FSharp")
-  if Directory.Exists compilerDir then Some compilerDir else None
+  let compilerDir = Path.Combine((sdkDir dotnetRoot).FullName, sdkVersion, "FSharp")
+  if Directory.Exists compilerDir then Some (DirectoryInfo compilerDir) else None
 
 let runtimeDir dotnetRoot runtimeVersion =
-  let runtimeDir = Path.Combine(netcoreAppDir dotnetRoot, runtimeVersion)
-  if Directory.Exists runtimeDir then Some runtimeDir else None
+  let runtimeDir = Path.Combine((netcoreAppDir dotnetRoot).FullName, runtimeVersion)
+  if Directory.Exists runtimeDir then Some (DirectoryInfo runtimeDir) else None
 
 /// given the pack directory and the runtime directory, we prefer the pack directory (because these are ref dlls)
 /// but will accept the runtime dir if no pack exists.
 let findRuntimeRefs packDir runtimeDir =
   match packDir, runtimeDir with
-  | Some refDir, _
-  | _, Some refDir ->
-    Directory.EnumerateFiles(refDir, "*.dll")
+  | Some (refDir: DirectoryInfo), _
+  | _, Some (refDir: DirectoryInfo) ->
+    refDir.EnumerateFiles()
     // SUPER IMPORTANT: netstandard/netcore assembly resolution _must not_ contain mscorlib or else
     // its presence triggers old netfx fallbacks, which end up bringing assemblies that aren't part
     // of netcore.
-    |> Seq.filter (fun r -> not (Path.GetFileNameWithoutExtension(r) = "mscorlib"))
+    |> Seq.choose (fun r ->
+      if r.Extension.EndsWith "dll" && not (Path.GetFileNameWithoutExtension(r.Name) = "mscorlib")
+      then Some r.FullName
+      else None
+    )
     |> Seq.toArray
   | None, None -> [||]
 
 /// given the compiler root dir and if to include FSI refs, returns the set of compiler assemblies to references if that dir exists.
 let compilerAndInteractiveRefs compilerDir useFsiAuxLib =
   match compilerDir with
-  | Some dir ->
-    [ yield Path.Combine(dir, "FSharp.Core.dll")
-      if useFsiAuxLib then yield Path.Combine(dir, "FSharp.Compiler.Interactive.Settings.dll") ]
+  | Some (dir: DirectoryInfo) ->
+    [ yield Path.Combine(dir.FullName, "FSharp.Core.dll")
+      if useFsiAuxLib then yield Path.Combine(dir.FullName, "FSharp.Compiler.Interactive.Settings.dll") ]
   | None -> []
 
 /// refs for .net core include:
 /// * runtime-required refs (either ref façades if available or full assemblies if no ref façades are present), and
 /// * compiler/fsi-required refs
-
 let netCoreRefs dotnetRoot sdkVersion runtimeVersion tfm useFsiAuxLib =
-
   [ yield! findRuntimeRefs (appPackDir dotnetRoot runtimeVersion tfm) (runtimeDir dotnetRoot runtimeVersion)
     yield! compilerAndInteractiveRefs (compilerDir dotnetRoot sdkVersion) useFsiAuxLib ]
 


### PR DESCRIPTION
This fixes an issue that I saw when testing on windows:

* We init without a dotnetRoot
* LSP/Ionide then calls the configChanged endpoint with a new config that has a full path to a `dotnet.exe` as the `dotnetRoot`
* FSAC gladly uses this non-directory value as the `dotnetRoot`, which causes issues when probing for references.

Now we do one of three things:
* if passed a root that is a directory, accept it
* if passed a full path to a dotnet binary, use the parent directory
* else do nothing