### PR TITLE
Add change tracking for projects

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -838,17 +838,17 @@ type Commands<'analyzer> (serialize : Serializer, backgroundServiceEnabled) =
         return CoreResponse.Res d
     }
 
-    member x.WorkspaceLoad onChange (files: string list) (disableInMemoryProjectReferences: bool) tfmForScripts (generateBinlog: bool) = async {
+    member x.WorkspaceLoad (files: string list) (disableInMemoryProjectReferences: bool) tfmForScripts (generateBinlog: bool) = async {
         commandsLogger.info (Log.setMessage "Workspace loading started '{files}'" >> Log.addContextDestructured "files" files)
         checker.DisableInMemoryProjectReferences <- disableInMemoryProjectReferences
-        let! res = state.ProjectController.LoadWorkspace onChange files tfmForScripts onProjectLoaded generateBinlog
+        let! res = state.ProjectController.LoadWorkspace files tfmForScripts onProjectLoaded generateBinlog
         commandsLogger.info (Log.setMessage "Workspace loading finished ")
         return CoreResponse.Res res
     }
 
-    member x.Project onChange projectFileName tfmForScripts (generateBinlog: bool)  = async {
+    member x.Project projectFileName tfmForScripts (generateBinlog: bool)  = async {
         commandsLogger.info (Log.setMessage "Project loading '{file}'" >> Log.addContextDestructured "file" projectFileName)
-        let! res = state.ProjectController.LoadProject onChange projectFileName tfmForScripts onProjectLoaded generateBinlog
+        let! res = state.ProjectController.LoadProject projectFileName tfmForScripts onProjectLoaded generateBinlog
         return CoreResponse.Res res
     }
 

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -532,7 +532,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                     match peeks with
                     | [] -> ()
                     | [CommandResponse.WorkspacePeekFound.Directory projs] ->
-                        commands.WorkspaceLoad ignore projs.Fsprojs false config.ScriptTFM config.GenerateBinlog
+                        commands.WorkspaceLoad projs.Fsprojs false config.ScriptTFM config.GenerateBinlog
                         |> Async.Ignore
                         |> Async.Start
                     | CommandResponse.WorkspacePeekFound.Solution sln::_ ->
@@ -540,7 +540,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                             sln.Items
                             |> List.collect Workspace.foldFsproj
                             |> List.map fst
-                        commands.WorkspaceLoad ignore projs false config.ScriptTFM config.GenerateBinlog
+                        commands.WorkspaceLoad projs false config.ScriptTFM config.GenerateBinlog
                         |> Async.Ignore
                         |> Async.Start
                     | _ ->
@@ -1805,7 +1805,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         logger.info (Log.setMessage "FSharpWorkspaceLoad Request: {parms}" >> Log.addContextDestructured "parms" p )
 
         let fns = p.TextDocuments |> Array.map (fun fn -> fn.GetFilePath() ) |> Array.toList
-        let! res = commands.WorkspaceLoad ignore fns config.DisableInMemoryProjectReferences config.ScriptTFM config.GenerateBinlog
+        let! res = commands.WorkspaceLoad fns config.DisableInMemoryProjectReferences config.ScriptTFM config.GenerateBinlog
         let res =
             match res with
             | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
@@ -1836,7 +1836,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         logger.info (Log.setMessage "FSharpProject Request: {parms}" >> Log.addContextDestructured "parms" p )
 
         let fn = p.Project.GetFilePath()
-        let! res = commands.Project ignore fn config.ScriptTFM config.GenerateBinlog
+        let! res = commands.Project fn config.ScriptTFM config.GenerateBinlog
         let res =
             match res with
             | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->


### PR DESCRIPTION
This adds proper change tracking for `fsproj` files and `asset` files. Up to this point, we were depending on Ionide to track those changes and set `load` request when necessary, which was problematic for different LSP clients.

There are additional two things that we probably should move to FSAC that are currently done on Ionide side, but I'll move them in separate PRs:
* watch for changes in `sln` file
* run `dotnet restore` if project loading returns NotResotred status.