### PR TITLE
implement a slew of code fixes

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -38,6 +38,7 @@ nuget Destructurama.FSharp 1.1.1-dev-00035 # prerelease is stable, just has diff
 nuget FSharp.UMX
 nuget FSharp.Formatting
 nuget Microsoft.Build.Utilities.Core 16.7
+nuget FsToolkit.ErrorHandling
 
 nuget Microsoft.SourceLink.GitHub copy_local:true
 nuget Microsoft.NETFramework.ReferenceAssemblies 1.0.0

--- a/paket.lock
+++ b/paket.lock
@@ -87,6 +87,8 @@ NUGET
       FSharp.Compiler.Service (>= 36.0.3)
     FSharp.UMX (1.0)
       FSharp.Core (>= 4.3.4)
+    FsToolkit.ErrorHandling (1.4.3)
+      FSharp.Core (>= 4.3.4)
     Humanizer.Core (2.8.26)
     ICSharpCode.Decompiler (6.2.1.6137)
       Humanizer.Core (>= 2.2)

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -75,6 +75,18 @@ module FCSPatches =
       | None ->
           None
 
+    member scope.TryRangeOfExprInYieldOrReturn pos =
+        match scope.ParseTree with
+        | Some parseTree ->
+            AstTraversal.Traverse(pos, parseTree, { new AstTraversal.AstVisitorBase<_>() with
+                member __.VisitExpr(_path, _, defaultTraverse, expr) =
+                    match expr with
+                    | SynExpr.YieldOrReturn(_, expr, range)
+                    | SynExpr.YieldOrReturnFrom(_, expr, range) when rangeContainsPos range pos ->
+                        Some expr.Range
+                    | _ -> defaultTraverse expr })
+        | None -> None
+
 type ParseAndCheckResults
     (
         parseResults: FSharpParseFileResults,

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -11,6 +11,7 @@ open ProjectSystem
 open FsAutoComplete.Logging
 open FsAutoComplete.Utils
 open FSharp.UMX
+open FSharp.Compiler.SyntaxTree
 
 [<RequireQualifiedAccess>]
 type FindDeclarationResult =
@@ -18,6 +19,35 @@ type FindDeclarationResult =
     | Range of FSharp.Compiler.Range.range
     /// The declaration refers to a file.
     | File of string
+
+/// TODO: remove this extension when we get https://github.com/dotnet/fsharp/pull/10480/files#diff-5d99a1a2e89452abe0d275ce060600f65c0c24d995703b5bc067106c38cb5e67R108 merged
+module FCSPatches =
+  type FSharpParseFileResults with
+    member scope.IsPositionContainedInACurriedParameter pos =
+      match scope.ParseTree with
+      | Some input ->
+          let result =
+              AstTraversal.Traverse(pos, input, { new AstTraversal.AstVisitorBase<_>() with
+                  member __.VisitExpr(_path, traverseSynExpr, defaultTraverse, expr) =
+                      defaultTraverse(expr)
+
+                  override __.VisitBinding (_, binding) =
+                      match binding with
+                      | SynBinding.Binding(_, _, _, _, _, _, valData, _, _, _, range, _) when rangeContainsPos range pos ->
+                          let info = valData.SynValInfo.CurriedArgInfos
+                          let mutable found = false
+                          for group in info do
+                              for arg in group do
+                                  match arg.Ident with
+                                  | Some ident when rangeContainsPos ident.idRange pos ->
+                                      found <- true
+                                  | _ -> ()
+                          if found then Some range else None
+                      | _ ->
+                          None
+              })
+          result.IsSome
+      | _ -> false
 
 type ParseAndCheckResults
     (

--- a/src/FsAutoComplete.Core/paket.references
+++ b/src/FsAutoComplete.Core/paket.references
@@ -14,6 +14,7 @@ System.Configuration.ConfigurationManager
 Fantomas
 Fantomas.Extras
 FSharp.UMX
+FsToolkit.ErrorHandling
 
 Microsoft.NETFramework.ReferenceAssemblies
 System.Reflection.Metadata

--- a/src/FsAutoComplete/CodeFixes.fs
+++ b/src/FsAutoComplete/CodeFixes.fs
@@ -1,0 +1,202 @@
+/// This module contains the logic for codefixes that FSAC surfaces, as well as conversion logic between
+/// compiler diagnostics and LSP diagnostics/code actions
+module FsAutoComplete.CodeFix
+
+open FsAutoComplete.LspHelpers
+open LanguageServerProtocol.Types
+
+module Types =
+  type IsEnabled = unit -> bool
+
+  type Fix =
+    { Edits: TextEdit []
+      File: TextDocumentIdentifier
+      Title: string
+      SourceDiagnostic: Diagnostic option }
+
+  type CodeFix = CodeActionParams -> Async<Fix list>
+
+  type CodeAction with
+
+    static member OfFix getFileVersion clientCapabilities (fix: Fix) =
+      let filePath = fix.File.GetFilePath()
+      let fileVersion = getFileVersion filePath
+
+      CodeAction.OfDiagnostic
+        fix.File
+        fileVersion
+        fix.Title
+        fix.SourceDiagnostic
+        fix.Edits
+        clientCapabilities
+
+    static member OfDiagnostic (fileUri) (fileVersion) title (diagnostic) (edits) clientCapabilities
+                               : CodeAction =
+
+      let edit =
+        { TextDocument =
+            { Uri = fileUri.Uri
+              Version = fileVersion }
+          Edits = edits }
+
+      let workspaceEdit =
+        WorkspaceEdit.Create([| edit |], clientCapabilities)
+
+      { CodeAction.Title = title
+        Kind = Some "quickfix"
+        Diagnostics = diagnostic |> Option.map Array.singleton
+        Edit = workspaceEdit
+        Command = None }
+
+open Types
+
+let ifEnabled enabled codeFix: CodeFix =
+  fun codeActionParams -> if enabled () then codeFix codeActionParams else async.Return []
+
+let ifDiagnosticByMessage enabled handler (checkMessage: string) =
+  ifEnabled
+    enabled
+    (fun codeActionParams ->
+      match codeActionParams.Context.Diagnostics
+            |> Array.tryFind (fun n -> n.Message.Contains checkMessage) with
+      | None -> async.Return []
+      | Some d -> handler d codeActionParams)
+
+let ifDiagnosticByType enabled handler (diagnosticType: string) =
+  ifEnabled
+    enabled
+    (fun codeActionParams ->
+      match codeActionParams.Context.Diagnostics
+            |> Seq.tryFind (fun n -> n.Source.Contains diagnosticType) with
+      | None -> async.Return []
+      | Some d -> handler d)
+
+module Fixes =
+  open FSharp.Compiler.SourceCodeServices
+
+  /// insert a line of text at a given line
+  let private insertLine line lineStr =
+    { Range =
+        { Start = { Line = line; Character = 0 }
+          End = { Line = line; Character = 0 } }
+      NewText = lineStr }
+
+
+  let private adjustInsertionPoint (lines: string []) (ctx: InsertContext) =
+    let l = ctx.Pos.Line
+
+    match ctx.ScopeKind with
+    | TopModule when l > 1 ->
+        let line = lines.[l - 2]
+
+        let isImplicitTopLevelModule =
+          not
+            (line.StartsWith "module"
+             && not (line.EndsWith "="))
+
+        if isImplicitTopLevelModule then 1 else l
+    | TopModule -> 1
+    | ScopeKind.Namespace when l > 1 ->
+        [ 0 .. l - 1 ]
+        |> List.mapi (fun i line -> i, lines.[line])
+        |> List.tryPick (fun (i, lineStr) -> if lineStr.StartsWith "namespace" then Some i else None)
+        |> function
+        // move to the next line below "namespace" and convert it to F# 1-based line number
+        | Some line -> line + 2
+        | None -> l
+    | ScopeKind.Namespace -> 1
+    | _ -> l
+
+  let unusedOpens enabled =
+    ifDiagnosticByMessage
+      enabled
+      (fun d codeActionParams ->
+        let range =
+          { Start =
+              { Line = d.Range.Start.Line - 1
+                Character = 1000 }
+            End =
+              { Line = d.Range.End.Line
+                Character = d.Range.End.Character } }
+
+        let fix =
+          { Edits = [| { Range = range; NewText = ""} |]
+            File = codeActionParams.TextDocument
+            Title = "Remove unused open"
+            SourceDiagnostic = Some d }
+
+        async.Return [ fix ])
+      "Unused open statement"
+
+
+  let resolveNamespace enabled getParseResultsForFile getNameSpaceSuggestions =
+    let qualifierFix file diagnostic qual =
+      { Edits = [| { Range = diagnostic.Range; NewText = qual } |]
+        File = file
+        Title = $"Use %s{qual}"
+        SourceDiagnostic = Some diagnostic }
+
+    let openFix fileLines file diagnostic (ns, name, ctx, multiple): Fix =
+      let insertPoint = adjustInsertionPoint lines ctx
+      let docLine = insertPoint - 1
+
+      let actualOpen =
+        if name.EndsWith word && name <> word then
+          let prefix =
+            name
+             .Substring(0, name.Length - word.Length)
+             .TrimEnd('.')
+
+          $"%s{ns}.%s{prefix}"
+        else
+          ns
+
+
+
+      let lineStr =
+        let whitespace = String.replicate ctx.Pos.Column " "
+        $"%s{whitespace}open %s{actualOpen}\n"
+
+      let edits =
+        [|  yield insertLine docLine lineStr
+            if lines.[docLine + 1].Trim() <> "" then yield insertLine (docLine + 1) ""
+            if (ctx.Pos.Column = 0 || ctx.ScopeKind = Namespace)
+              && docLine > 0
+              && not ((lines.[docLine - 1]).StartsWith "open")
+            then
+              yield insertLine (docLine - 1) "" |]
+
+      {
+        Edits = edits
+        File = file
+        SourceDiagnostic = Some diagnostic
+        Title = $"open %s{actualOpen}"
+      }
+
+    ifDiagnosticByMessage
+      enabled
+      (fun d codeActionParameter ->
+        async {
+          let pos = protocolPosToPos d.Range.Start
+          let filePath = codeActionParameter.TextDocument.GetFilePath()
+          match! getParseResultsForFile filePath pos with
+          | Ok (tyRes, line, lines) ->
+            match getNamespaceSuggestions tyRes pos line with
+            | CoreResponse.InfoRes msg
+            | CoreResponse.ErrorRes msg -> return []
+            | CoreResponse.Res (word, opens, qualifiers) ->
+                let quals =
+                  qualifiers
+                  |> List.map (fun (_, qual) -> qualifierFix codeActionParameter.TextDocument d qual)
+
+                let ops =
+                  opens
+                  |> List.map (openFix lines codeActionParameter.TextDocument)
+
+                return [ yield! ops; yield! quals ]
+
+            return res
+          | Error _ ->
+            return []
+        })
+      "is not defined"

--- a/src/FsAutoComplete/CodeFixes.fs
+++ b/src/FsAutoComplete/CodeFixes.fs
@@ -256,7 +256,6 @@ module Fixes =
 
           let filePath =
             codeActionParameter.TextDocument.GetFilePath()
-
           match! getParseResultsForFile filePath pos with
           | Ok (tyRes, line, lines) ->
               match! getNamespaceSuggestions tyRes pos line with
@@ -385,6 +384,7 @@ module Fixes =
             FSharp.Compiler.Range.mkPos (caseLine + 1) (col + 1) //Must points on first case in 1-based system
 
           let! (tyRes, line, lines) = getParseResultsForFile fileName pos
+
           match! generateCases tyRes pos lines line |> Async.map Ok with
           | CoreResponse.Res (insertString: string, insertPosition) ->
               let range =
@@ -452,6 +452,7 @@ module Fixes =
           protocolPosToPos codeActionParams.Range.Start
 
         let! (tyRes, line, lines) = getParseResultsForFile fileName pos
+
         match! genInterfaceStub tyRes pos lines line with
         | CoreResponse.Res (text, position) ->
             let replacements = getTextReplacements ()
@@ -489,6 +490,7 @@ module Fixes =
           protocolPosToPos codeActionParams.Range.Start
 
         let! (tyRes, line, lines) = getParseResultsForFile fileName pos
+
         match! genRecordStub tyRes pos lines line with
         | CoreResponse.Res (text, position) ->
             let replacements = getTextReplacements ()
@@ -694,3 +696,24 @@ module Fixes =
         }
         |> AsyncResult.foldResult id (fun _ -> []))
       (Set.ofList [ "27" ])
+
+  /// a codefix that changes equality checking to mutalbe assignment when the compiler thinks it's relevant
+  let comparisonToMutableAssignment (getFileLines: string -> Result<string [], string>): CodeFix =
+    ifDiagnosticByCode
+      (fun diagnostic codeActionParams ->
+        match getFileLines (codeActionParams.TextDocument.GetFilePath()) with
+        | Ok lines ->
+            // try to find the '=' at from the start of the range
+            match walkForwardUntilCondition lines diagnostic.Range.Start (fun c -> c = '=') with
+            | Some equalsPos ->
+                async.Return [ { File = codeActionParams.TextDocument
+                                 Title = "Use mutable assignment instead of equality"
+                                 SourceDiagnostic = Some diagnostic
+                                 Edits =
+                                   [| { Range =
+                                          { Start = equalsPos
+                                            End = (inc lines equalsPos) }
+                                        NewText = "<-" } |] } ]
+            | None -> async.Return []
+        | Error _ -> async.Return [])
+      (Set.ofList [ "20" ])

--- a/src/FsAutoComplete/CodeFixes.fs
+++ b/src/FsAutoComplete/CodeFixes.fs
@@ -554,3 +554,17 @@ module Fixes =
     }
     |> AsyncResult.foldResult id  (fun _ -> [])
     ) (Set.ofList ["3"])
+
+  /// a codefix that corrects == equality to = equality
+  let doubleEqualsToSingleEquality: CodeFix =
+    ifDiagnosticByCode (fun diagnostic codeActionParams ->
+      async.Return [{
+        Title = "Use '=' for equality check"
+        File = codeActionParams.TextDocument
+        SourceDiagnostic = Some diagnostic
+        Edits = [|{
+          Range = diagnostic.Range
+          NewText = "="
+        }|]
+      }]
+    ) (Set.ofList ["43"])

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -427,6 +427,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         }
 
         let getFileLines = commands.TryGetFileCheckerOptionsWithLines >> Result.map snd
+        let tryGetProjectOptions = commands.TryGetFileCheckerOptionsWithLines >> Result.map fst
 
         let interfaceStubReplacements =
           Map.ofList [
@@ -473,6 +474,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             Fixes.parenthesizeExpression getFileLines
             Fixes.refCellDerefToNot getFileLines
             Fixes.upcastUsage getFileLines
+            Fixes.makeDeclarationMutable tryGetParseResultsForFile tryGetProjectOptions
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -468,6 +468,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
               (Fixes.generateRecordStub getFileLines tryGetParseResultsForFile commands.GetRecordStub getRecordStubReplacements)
             Fixes.addMissingEquals getFileLines
             Fixes.changeNegationToSubtraction getFileLines
+            Fixes.doubleEqualsToSingleEquality
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -466,9 +466,10 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
               (Fixes.generateInterfaceStub getFileLines tryGetParseResultsForFile commands.GetInterfaceStub getInterfaceStubReplacements)
             ifEnabled (fun _ -> config.RecordStubGeneration)
               (Fixes.generateRecordStub getFileLines tryGetParseResultsForFile commands.GetRecordStub getRecordStubReplacements)
-            Fixes.addMissingEquals getFileLines
+            Fixes.addMissingEqualsToTypeDefintion getFileLines
             Fixes.changeNegationToSubtraction getFileLines
             Fixes.doubleEqualsToSingleEquality
+            Fixes.addMissingColonToFieldDefinition
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -467,6 +467,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             ifEnabled (fun _ -> config.RecordStubGeneration)
               (Fixes.generateRecordStub getFileLines tryGetParseResultsForFile commands.GetRecordStub getRecordStubReplacements)
             Fixes.addMissingEquals getFileLines
+            Fixes.changeNegationToSubtraction getFileLines
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -466,10 +466,11 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
               (Fixes.generateInterfaceStub getFileLines tryGetParseResultsForFile commands.GetInterfaceStub getInterfaceStubReplacements)
             ifEnabled (fun _ -> config.RecordStubGeneration)
               (Fixes.generateRecordStub getFileLines tryGetParseResultsForFile commands.GetRecordStub getRecordStubReplacements)
-            Fixes.addMissingEqualsToTypeDefintion getFileLines
+            Fixes.addMissingEqualsToTypeDefinition getFileLines
             Fixes.changeNegationToSubtraction getFileLines
             Fixes.doubleEqualsToSingleEquality
             Fixes.addMissingColonToFieldDefinition
+            Fixes.parenthesizeExpression getFileLines
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -472,6 +472,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             Fixes.addMissingColonToFieldDefinition
             Fixes.parenthesizeExpression getFileLines
             Fixes.refCellDerefToNot getFileLines
+            Fixes.upcastUsage getFileLines
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -475,7 +475,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             Fixes.refCellDerefToNot getFileLines
             Fixes.upcastUsage getFileLines
             Fixes.makeDeclarationMutable tryGetParseResultsForFile tryGetProjectOptions
-            Fixes.comparisonToMutableAssignment getFileLines
+            Fixes.comparisonToMutableAssignment tryGetParseResultsForFile
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -491,10 +491,11 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         }
         codeFixes <- fun p ->
           [|
-            Fixes.unusedOpens (fun _ -> config.UnusedOpensAnalyzer)
-            Fixes.resolveNamespace (fun _ -> config.ResolveNamespaces) tryGetParseResultsForFile commands.GetNamespaceSuggestions
+            ifEnabled (fun _ -> config.UnusedOpensAnalyzer) Fixes.unusedOpens
+            ifEnabled (fun _ -> config.ResolveNamespaces) (Fixes.resolveNamespace tryGetParseResultsForFile commands.GetNamespaceSuggestions)
             Fixes.errorSuggestion
             Fixes.redundantQualifier
+            Fixes.unusedValue (commands.TryGetFileCheckerOptionsWithLines >> Result.map snd)
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -475,6 +475,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             Fixes.refCellDerefToNot getFileLines
             Fixes.upcastUsage getFileLines
             Fixes.makeDeclarationMutable tryGetParseResultsForFile tryGetProjectOptions
+            Fixes.comparisonToMutableAssignment getFileLines
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -153,70 +153,6 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         |> lspClient.TextDocumentPublishDiagnostics
         |> Async.Start
 
-    /// convert structure scopes to known kinds of folding range.
-    /// this lets commands like 'fold all comments' work sensibly.
-    /// impl note: implemented as an exhaustive match here so that
-    /// if new structure kinds appear we have to handle them.
-    let scopeToKind (scope: Structure.Scope): string option =
-        match scope with
-        | Structure.Scope.Open -> Some FoldingRangeKind.Imports
-        | Structure.Scope.Comment
-        | Structure.Scope.XmlDocComment -> Some FoldingRangeKind.Comment
-        | Structure.Scope.Namespace
-        | Structure.Scope.Module
-        | Structure.Scope.Type
-        | Structure.Scope.Member
-        | Structure.Scope.LetOrUse
-        | Structure.Scope.Val
-        | Structure.Scope.CompExpr
-        | Structure.Scope.IfThenElse
-        | Structure.Scope.ThenInIfThenElse
-        | Structure.Scope.ElseInIfThenElse
-        | Structure.Scope.TryWith
-        | Structure.Scope.TryInTryWith
-        | Structure.Scope.WithInTryWith
-        | Structure.Scope.TryFinally
-        | Structure.Scope.TryInTryFinally
-        | Structure.Scope.FinallyInTryFinally
-        | Structure.Scope.ArrayOrList
-        | Structure.Scope.ObjExpr
-        | Structure.Scope.For
-        | Structure.Scope.While
-        | Structure.Scope.Match
-        | Structure.Scope.MatchBang
-        | Structure.Scope.MatchLambda
-        | Structure.Scope.MatchClause
-        | Structure.Scope.Lambda
-        | Structure.Scope.CompExprInternal
-        | Structure.Scope.Quote
-        | Structure.Scope.Record
-        | Structure.Scope.SpecialFunc
-        | Structure.Scope.Do
-        | Structure.Scope.New
-        | Structure.Scope.Attribute
-        | Structure.Scope.Interface
-        | Structure.Scope.HashDirective
-        | Structure.Scope.LetOrUseBang
-        | Structure.Scope.TypeExtension
-        | Structure.Scope.YieldOrReturn
-        | Structure.Scope.YieldOrReturnBang
-        | Structure.Scope.Tuple
-        | Structure.Scope.UnionCase
-        | Structure.Scope.EnumCase
-        | Structure.Scope.RecordField
-        | Structure.Scope.RecordDefn
-        | Structure.Scope.UnionDefn -> None
-
-    let toFoldingRange (item: Structure.ScopeRange): FoldingRange =
-        let kind = scopeToKind item.Scope
-        // map the collapserange to the foldingRange
-        let lsp = fcsRangeToLsp item.CollapseRange
-        { StartCharacter   = Some lsp.Start.Character
-          StartLine        = lsp.Start.Line
-          EndCharacter     = Some lsp.End.Character
-          EndLine          = lsp.End.Line
-          Kind             = kind }
-
     do
         commands.Notify.Subscribe(fun n ->
             try
@@ -1500,7 +1436,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         let file = rangeP.TextDocument.GetFilePath()
         match! commands.ScopesForFile file with
         | Ok scopes ->
-            let ranges = scopes |> Seq.map toFoldingRange |> Set.ofSeq |> List.ofSeq
+            let ranges = scopes |> Seq.map Structure.toFoldingRange |> Set.ofSeq |> List.ofSeq
             return LspResult.success (Some ranges)
         | Result.Error error ->
             return LspResult.internalError error

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -472,10 +472,11 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             Fixes.doubleEqualsToSingleEquality
             Fixes.addMissingColonToFieldDefinition
             Fixes.parenthesizeExpression getFileLines
-            Fixes.refCellDerefToNot getFileLines
+            Fixes.refCellDerefToNot tryGetParseResultsForFile
             Fixes.upcastUsage getFileLines
             Fixes.makeDeclarationMutable tryGetParseResultsForFile tryGetProjectOptions
             Fixes.comparisonToMutableAssignment tryGetParseResultsForFile
+            Fixes.partialOrInvalidRecordExpressionToAnonymousRecord tryGetParseResultsForFile
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -471,6 +471,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             Fixes.doubleEqualsToSingleEquality
             Fixes.addMissingColonToFieldDefinition
             Fixes.parenthesizeExpression getFileLines
+            Fixes.refCellDerefToNot getFileLines
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -477,6 +477,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             Fixes.makeDeclarationMutable tryGetParseResultsForFile tryGetProjectOptions
             Fixes.comparisonToMutableAssignment tryGetParseResultsForFile
             Fixes.partialOrInvalidRecordExpressionToAnonymousRecord tryGetParseResultsForFile
+            Fixes.removeUnnecessaryReturnOrYield tryGetParseResultsForFile
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/src/FsAutoComplete/FsAutoComplete.fsproj
+++ b/src/FsAutoComplete/FsAutoComplete.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="CommandResponse.fs" />
     <Compile Include="JsonSerializer.fs" />
     <Compile Include="LspHelpers.fs" />
+    <Compile Include="CodeFixes.fs" />
     <Compile Include="FsAutoComplete.Lsp.fs" />
     <Compile Include="Program.fs" />
     <None Include="FsAutoComplete.fsproj.paket.references" />

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -18,7 +18,7 @@ module Conversions =
 
     /// convert an LSP position to a compiler position
     let protocolPosToPos (pos: Lsp.Position): FcsRange.pos =
-        FcsRange.mkPos (pos.Line + 1) (pos.Character)
+        FcsRange.mkPos (pos.Line + 1) (pos.Character + 1)
 
     /// convert a compiler position to an LSP position
     let fcsPosToLsp (pos: FcsRange.pos): Lsp.Position =

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -325,7 +325,70 @@ module SigantureData =
 
         if String.IsNullOrEmpty args then typ else args + " -> " + formatType typ
 
+module Structure =
+      /// convert structure scopes to known kinds of folding range.
+    /// this lets commands like 'fold all comments' work sensibly.
+    /// impl note: implemented as an exhaustive match here so that
+    /// if new structure kinds appear we have to handle them.
+    let scopeToKind (scope: Structure.Scope): string option =
+        match scope with
+        | Structure.Scope.Open -> Some FoldingRangeKind.Imports
+        | Structure.Scope.Comment
+        | Structure.Scope.XmlDocComment -> Some FoldingRangeKind.Comment
+        | Structure.Scope.Namespace
+        | Structure.Scope.Module
+        | Structure.Scope.Type
+        | Structure.Scope.Member
+        | Structure.Scope.LetOrUse
+        | Structure.Scope.Val
+        | Structure.Scope.CompExpr
+        | Structure.Scope.IfThenElse
+        | Structure.Scope.ThenInIfThenElse
+        | Structure.Scope.ElseInIfThenElse
+        | Structure.Scope.TryWith
+        | Structure.Scope.TryInTryWith
+        | Structure.Scope.WithInTryWith
+        | Structure.Scope.TryFinally
+        | Structure.Scope.TryInTryFinally
+        | Structure.Scope.FinallyInTryFinally
+        | Structure.Scope.ArrayOrList
+        | Structure.Scope.ObjExpr
+        | Structure.Scope.For
+        | Structure.Scope.While
+        | Structure.Scope.Match
+        | Structure.Scope.MatchBang
+        | Structure.Scope.MatchLambda
+        | Structure.Scope.MatchClause
+        | Structure.Scope.Lambda
+        | Structure.Scope.CompExprInternal
+        | Structure.Scope.Quote
+        | Structure.Scope.Record
+        | Structure.Scope.SpecialFunc
+        | Structure.Scope.Do
+        | Structure.Scope.New
+        | Structure.Scope.Attribute
+        | Structure.Scope.Interface
+        | Structure.Scope.HashDirective
+        | Structure.Scope.LetOrUseBang
+        | Structure.Scope.TypeExtension
+        | Structure.Scope.YieldOrReturn
+        | Structure.Scope.YieldOrReturnBang
+        | Structure.Scope.Tuple
+        | Structure.Scope.UnionCase
+        | Structure.Scope.EnumCase
+        | Structure.Scope.RecordField
+        | Structure.Scope.RecordDefn
+        | Structure.Scope.UnionDefn -> None
 
+    let toFoldingRange (item: Structure.ScopeRange): FoldingRange =
+        let kind = scopeToKind item.Scope
+        // map the collapserange to the foldingRange
+        let lsp = fcsRangeToLsp item.CollapseRange
+        { StartCharacter   = Some lsp.Start.Character
+          StartLine        = lsp.Start.Line
+          EndCharacter     = Some lsp.End.Character
+          EndLine          = lsp.End.Line
+          Kind             = kind }
 
 type PlainNotification= { Content: string }
 

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -34,6 +34,14 @@ module Conversions =
     let protocolRangeToRange fn (range: Lsp.Range): FcsRange.range =
         FcsRange.mkRange fn (protocolPosToPos range.Start) (protocolPosToPos range.End)
 
+    /// convert an FCS position to a single-character range in LSP
+    let fcsPosToProtocolRange (pos: FcsRange.pos): Lsp.Range =
+      {
+        Start = fcsPosToLsp pos
+        End = fcsPosToLsp pos
+      }
+
+
     let symbolUseRangeToLsp (range: SymbolCache.SymbolUseRange): Lsp.Range =
         {
             Start = { Line = range.StartLine - 1; Character = range.StartColumn - 1 }

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -16,15 +16,15 @@ module FcsRange = FSharp.Compiler.Range
 module Conversions =
     module Lsp = LanguageServerProtocol.Types
 
+    /// convert an LSP position to a compiler position
     let protocolPosToPos (pos: Lsp.Position): FcsRange.pos =
-        FcsRange.mkPos (pos.Line + 1) (pos.Character + 1)
+        FcsRange.mkPos (pos.Line + 1) (pos.Character)
 
-    let posToProtocolPos (pos: FcsRange.pos): Lsp.Position =
-        { Line = pos.Line - 1; Character = pos.Column - 1 }
-
+    /// convert a compiler position to an LSP position
     let fcsPosToLsp (pos: FcsRange.pos): Lsp.Position =
         { Line = pos.Line - 1; Character = pos.Column }
 
+    /// convert a compiler range to an LSP range
     let fcsRangeToLsp(range: FcsRange.range): Lsp.Range =
         {
             Start = fcsPosToLsp range.Start

--- a/src/FsAutoComplete/paket.references
+++ b/src/FsAutoComplete/paket.references
@@ -15,7 +15,7 @@ ICSharpCode.Decompiler
 Fantomas
 FSharp.Analyzers.SDK
 FSharp.DependencyManager.Nuget
-
+FsToolkit.ErrorHandling
 Serilog
 Serilog.Sinks.File
 Serilog.Sinks.Console


### PR DESCRIPTION
Refactored the way code fixes hook into the LSP server, and implemented the following new codefixes:

* [x] add missing '=' for type definitions
* [x] convert unary negation to subtraction
* [x] convert == equality to = when the type supports it
* [x] change '=' to ':' in record field type declarations
* [x] parenthesize expression that requires it (e.g. passing a member method call to a function: `printfn "%d" System.Random().Next(5)`)
* [x] change ! for ref cell dereference to `not` function
* [x] change unsafe casts to upcast/downcast when known to be safe
* [x] convert binding to mutable when mutable assignment is used on it 
* [x] convert equality to mutable assignment when using equality on a mutable binding
* [x] convert unknown/invalid record expression to anonymous record
* [x] remove the 'return'/'yield' (and bang-variants) from expressions that don't use need them (eg `let foo x = return x + 1`)