### PR TITLE
implement codefix for C# lambda => F# lambda

### DIFF
--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -20,9 +20,15 @@ type FindDeclarationResult =
     /// The declaration refers to a file.
     | File of string
 
+
 /// TODO: remove this extension when we get https://github.com/dotnet/fsharp/pull/10480/files#diff-5d99a1a2e89452abe0d275ce060600f65c0c24d995703b5bc067106c38cb5e67R108 merged
 module FCSPatches =
+  let (|Ident|_|) ofName =
+    function | SynExpr.Ident ident when ident.idText = ofName -> Some ()
+             | _ -> None
+
   type FSharpParseFileResults with
+
     member scope.IsPositionContainedInACurriedParameter pos =
       match scope.ParseTree with
       | Some input ->
@@ -48,6 +54,20 @@ module FCSPatches =
               })
           result.IsSome
       | _ -> false
+
+    member scope.TryRangeOfParenEnclosingOpEqualsGreaterUsage opGreaterEqualPos =
+      match scope.ParseTree with
+      | None -> None
+      | Some input ->
+        let visitor = {
+          new AstTraversal.AstVisitorBase<_>() with
+            member _.VisitExpr(_, _, defaultTraverse, expr) =
+              match expr with
+              | SynExpr.Paren(SynExpr.App(ExprAtomicFlag.NonAtomic, false, SynExpr.App(ExprAtomicFlag.NonAtomic, true, Ident "op_EqualsGreater", actualParamListExpr, _), actualLambdaBodyExpr, _), _, _, fullParenRange) ->
+                Some (fullParenRange, actualParamListExpr.Range, actualLambdaBodyExpr.Range)
+              | _ -> defaultTraverse expr
+          }
+        AstTraversal.Traverse(opGreaterEqualPos, input, visitor)
 
     member scope.TryRangeOfRefCellDereferenceContainingPos expressionPos =
       match scope.ParseTree with

--- a/src/FsAutoComplete.Core/UntypedAstUtils.fs
+++ b/src/FsAutoComplete.Core/UntypedAstUtils.fs
@@ -1483,6 +1483,11 @@ let getModuleOrNamespacePath (pos: pos) (ast: ParsedInput) =
     |> Seq.map (fun ident -> ident.idText)
     |> String.concat "."
 
+let getIdentUsagesByName ast name =
+  let idents = getLongIdents (Some ast)
+  idents
+  |> Seq.choose (fun (KeyValue(pos, ident)) -> if ident = name then Some pos else None)
+  |> List.ofSeq
 
 module HashDirectiveInfo =
     open System.IO

--- a/src/FsAutoComplete/CodeFixes.fs
+++ b/src/FsAutoComplete/CodeFixes.fs
@@ -840,7 +840,7 @@ module Fixes =
                  |> List.map (fun (fullParenRange, lambdaArgRange, lambdaBodyRange) ->
                     let argExprText = getText lines (fcsRangeToLsp lambdaArgRange)
                     let bodyExprText = getText lines (fcsRangeToLsp lambdaBodyRange)
-                    let replacementText = $"(fun {argExprText} -> {bodyExprText})"
+                    let replacementText = $"fun {argExprText} -> {bodyExprText}"
                     let replacementRange = fcsRangeToLsp fullParenRange
 
                     { Title = "Replace C#-style lambda with F# lambda"

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -478,6 +478,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             Fixes.comparisonToMutableAssignment tryGetParseResultsForFile
             Fixes.partialOrInvalidRecordExpressionToAnonymousRecord tryGetParseResultsForFile
             Fixes.removeUnnecessaryReturnOrYield tryGetParseResultsForFile
+            Fixes.rewriteCSharpLambdaToFSharpLambda tryGetParseResultsForFile
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -469,7 +469,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
               (Fixes.generateRecordStub getFileLines tryGetParseResultsForFile commands.GetRecordStub getRecordStubReplacements)
             Fixes.addMissingEqualsToTypeDefinition getFileLines
             Fixes.changeNegationToSubtraction getFileLines
-            Fixes.doubleEqualsToSingleEquality
+            Fixes.doubleEqualsToSingleEquality getFileLines
             Fixes.addMissingColonToFieldDefinition
             Fixes.parenthesizeExpression getFileLines
             Fixes.refCellDerefToNot tryGetParseResultsForFile


### PR DESCRIPTION
![lambda](https://user-images.githubusercontent.com/573979/100160701-b2c15c80-2e75-11eb-8379-2ebfef17daee.gif)


when passing a C# lambda (wrapped in parens), the compiler sees it as (roughly):

```
SynExpr.Paren(
  SynExpr.App(
    SynExpr.App (
      Ident "op_EqualsGreater",
      <expr for lambda args>
    ),
    <expr for lambda body>
)
```

so we can extract that pattern out and rewrite it.


This handles the following cases:

* `someFunc (thing => otherthing)`
* `let thing = args => body`

