### PR TITLE
Update comment to use ' instead of `

### DIFF
--- a/src/LanguageServerProtocol/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol/LanguageServerProtocol.fs
@@ -1688,7 +1688,7 @@ module Types =
         /// The zero-based character offset before the folded range ends. If not defined, defaults to the length of the end line.
         EndCharacter: int option
 
-        /// Describes the kind of the folding range such as `comment' or 'region'. The kind
+        /// Describes the kind of the folding range such as 'comment' or 'region'. The kind
         /// is used to categorize folding ranges and used by commands like 'Fold all comments'. See
         /// [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
         Kind: string option


### PR DESCRIPTION
This should fix how the full file renders on github