### PR TITLE
fix invalid handling of --embed and other arguments

### DIFF
--- a/src/ProjectSystem/FscArguments.fs
+++ b/src/ProjectSystem/FscArguments.fs
@@ -7,8 +7,9 @@ open System.IO
 
 module FscArguments =
 
-  let isCompileFile (s:string) =
-      s.EndsWith(".fs") || s.EndsWith (".fsi")
+  let isCompileFile (s: string) =
+      let isArg = s.StartsWith("-") && s.Contains(":")
+      (not isArg) && (s.EndsWith(".fs") || s.EndsWith (".fsi") || s.EndsWith (".fsx"))
 
   let references =
       //TODO valid also --reference:


### PR DESCRIPTION
There is an argument for embeding files in the .pdb files and there are some project files which get AssemblyInfo files wrapped in this argument like this `--embed:obj\...AssemblyInfo.fs`. 
The AssemblyInfo file is once more listed as a normal source file arg.

The function isCompileFile checked only the extension at the end and assigned this arg to source files. Later the file is converted tu full path and access to it throws exception.

There was also a TODO comment with excatly this statement so I removed it after fixing this.

