### PR TITLE
Add abstract class generation for cases where members are missing

### DIFF
--- a/src/FsAutoComplete.Core/AbstractClassStubGenerator.fs
+++ b/src/FsAutoComplete.Core/AbstractClassStubGenerator.fs
@@ -1,0 +1,194 @@
+module FsAutoComplete.AbstractClassStubGenerator
+
+open System
+open FsAutoComplete.CodeGenerationUtils
+open FSharp.Compiler.Range
+open FSharp.Compiler.SyntaxTree
+open FSharp.Compiler.SourceCodeServices
+
+type AbstractClassData =
+  | ObjExpr of baseTy: SynType * bindings: SynBinding list * overallRange: range
+  | ExplicitImpl of baseTy: SynType * members: SynMemberDefn list * safeInsertPosition: pos
+  member x.AbstractTypeIdentRange =
+    match x with
+    | ObjExpr (baseTy, _, _)
+    | ExplicitImpl (baseTy, _, _) -> baseTy.Range
+  member x.TypeParameters =
+    match x with
+    | ObjExpr(t, _, _)
+    | ExplicitImpl(t, _, _) -> expandTypeParameters t
+
+let private walkTypeDefn (SynTypeDefn.TypeDefn(info, repr, members, range)) =
+  let inheritMember = members |> List.tryPick (function SynMemberDefn.ImplicitInherit(inheritType, inheritArgs, alias, range) -> Some (inheritType) | _ -> None)
+  let otherMembers =
+    members |> List.filter (
+      // filter out implicit/explicit constructors and inherit statements, as all members _must_ come after these
+      function | SynMemberDefn.ImplicitCtor _
+               | SynMemberDefn.ImplicitInherit _ -> false
+               | SynMemberDefn.Member (SynBinding.Binding(valData = SynValData(Some({ MemberKind = MemberKind.Constructor } ), _, _)) ,  _) -> false
+               | _ -> true)
+  match inheritMember with
+  | Some inheritMember ->
+    let safeInsertPosition =
+      match otherMembers with
+      | [] -> mkPos (inheritMember.Range.End.Line + 1) (inheritMember.Range.Start.Column + 2)
+      | x :: _ -> mkPos (x.Range.End.Line - 1) (x.Range.Start.Column + 2)
+
+    Some(AbstractClassData.ExplicitImpl(inheritMember, otherMembers, safeInsertPosition))
+  | _ -> None
+
+/// find the declaration of the abstract class being filled in at the given position
+let private tryFindAbstractClassExprInParsedInput (pos: pos) (parsedInput: ParsedInput) : AbstractClassData option =
+  AstTraversal.Traverse(pos, parsedInput,
+    { new AstTraversal.AstVisitorBase<_>() with
+        member _.VisitExpr (path, traverseExpr, defaultTraverse, expr) =
+          match expr with
+          | SynExpr.ObjExpr (baseTy, constructorArgs, bindings, extraImpls, newExprRange, range) ->
+            Some (AbstractClassData.ObjExpr(baseTy, bindings, range))
+          | _ -> defaultTraverse expr
+        override _.VisitModuleDecl (defaultTraverse, decl) =
+          match decl with
+          | SynModuleDecl.Types(types, m) ->
+            List.tryPick walkTypeDefn types
+          | _ -> defaultTraverse decl
+      })
+
+let tryFindAbstractClassExprInBufferAtPos (codeGenService: CodeGenerationService) (pos: pos) (document : Document) =
+    asyncMaybe {
+        let! parseResults = codeGenService.ParseFileInProject(document.FullName)
+        return!
+            parseResults.ParseTree
+            |> Option.bind (tryFindAbstractClassExprInParsedInput pos)
+    }
+
+let rec private isAbstractClass (e: FSharpEntity) =
+  e.IsClass || (e.IsFSharpAbbreviation && isAbstractClass e.AbbreviatedType.TypeDefinition)
+
+let getAbstractClassIdentifier (abstractClassData: AbstractClassData) tokens =
+  let newKeywordIndex =
+    match abstractClassData with
+    | AbstractClassData.ObjExpr _ ->
+        tokens
+        // Find the `new` keyword
+        |> List.findIndex (fun token ->
+            token.CharClass = FSharpTokenCharKind.Keyword
+                && token.TokenName = "NEW"
+        )
+    | _ -> failwith "don't call me with this bro"
+
+  findLastIdentifier tokens.[newKeywordIndex + 2..] tokens.[newKeywordIndex + 2]
+
+let getMemberNameAndRanges (abstractClassData) =
+  match abstractClassData with
+  | AbstractClassData.ExplicitImpl(ty, members, _) ->
+    members
+    |> Seq.choose (function (SynMemberDefn.Member(binding, _)) -> Some binding | _ -> None)
+    |> Seq.choose (|MemberNameAndRange|_|)
+    |> Seq.toList
+  | AbstractClassData.ObjExpr (_, bindings, _) -> List.choose (|MemberNameAndRange|_|) bindings
+
+
+/// Try to find the start column, so we know what the base indentation should be
+let inferStartColumn  (codeGenServer : CodeGenerationService) (pos : pos) (doc : Document) (lines: LineStr[]) (lineStr : string) (abstractClassData : AbstractClassData) (indentSize : int) =
+    match getMemberNameAndRanges abstractClassData with
+    | (_, range) :: _ ->
+        getLineIdent lines.[range.StartLine-1]
+    | [] ->
+        match abstractClassData with
+        | AbstractClassData.ExplicitImpl _ ->
+            // 'interface ISomething with' is often in a new line, we use the indentation of that line
+            getLineIdent lineStr + indentSize
+        | AbstractClassData.ObjExpr (_, _, newExprRange) ->
+            match codeGenServer.TokenizeLine(doc.FullName, pos.Line) with
+            | Some tokens ->
+                tokens
+                |> List.tryPick (fun (t: FSharpTokenInfo) ->
+                        if t.CharClass = FSharpTokenCharKind.Keyword && t.TokenName = "NEW" then
+                            // We round to nearest so the generated code will align on the indentation guides
+                            findGreaterMultiple (t.LeftColumn + indentSize) indentSize
+                            |> Some
+                        else None)
+                // There is no reference point, we indent the content at the start column of the interface
+                |> Option.defaultValue newExprRange.StartColumn
+            | None -> newExprRange.StartColumn
+
+let writeAbstractClassStub (codeGenServer : CodeGenerationService) (checkResultForFile: ParseAndCheckResults) (doc : Document) (lines: LineStr[]) (lineStr : string) (abstractClassData : AbstractClassData) = async {
+  let pos = mkPos abstractClassData.AbstractTypeIdentRange.Start.Line (abstractClassData.AbstractTypeIdentRange.Start.Column + 1)
+  let! result = asyncMaybe {
+        let! _symbol, symbolUse = codeGenServer.GetSymbolAndUseAtPositionOfKind(doc.FullName, pos, SymbolKind.Ident)
+        let! thing = async {
+            match! symbolUse with
+            | None -> return None
+            | Some symbolUse ->
+              match symbolUse.Symbol with
+              | :? FSharpEntity as entity when isAbstractClass entity ->
+                      match! checkResultForFile.GetCheckResults.GetDisplayContextForPos(pos) with
+                      | Some displayContext ->
+                        return Some (displayContext, entity)
+                      | None -> return None
+              | _ -> return None
+        }
+        return thing
+    }
+
+  match result with
+  | Some (displayContext, entity) ->
+      let getMemberByLocation (name, range: range) =
+          asyncMaybe {
+              let pos = Pos.fromZ (range.StartLine - 1) (range.StartColumn + 1)
+              return! checkResultForFile.GetCheckResults.GetSymbolUseAtLocation (pos.Line, pos.Column, lineStr, [])
+          }
+
+      let insertInfo =
+          match codeGenServer.TokenizeLine(doc.FullName, pos.Line) with
+          | Some tokens ->
+            match abstractClassData with
+            | AbstractClassData.ObjExpr _ -> findLastPositionOfWithKeyword tokens entity pos (getAbstractClassIdentifier abstractClassData)
+            | AbstractClassData.ExplicitImpl (_, _, safeInsertPosition) -> Some (false, safeInsertPosition)
+          | None -> None
+
+      let desiredMemberNamesWithRanges = getMemberNameAndRanges abstractClassData
+
+      let! implementedSignatures =
+          getImplementedMemberSignatures getMemberByLocation displayContext desiredMemberNamesWithRanges
+
+      let generatedString =
+          let formattedString =
+              formatMembersAt
+                  (inferStartColumn codeGenServer pos doc lines lineStr abstractClassData 4) // 4 here correspond to the indent size
+                  4 // Should we make it a setting from the IDE ?
+                  abstractClassData.TypeParameters
+                  "$objectIdent"
+                  "$methodBody"
+                  displayContext
+                  implementedSignatures
+                  entity
+                  getAbstractNonVirtualMembers
+                  true // Always generate the verbose version of the code
+
+          // If we are in a object expression, we remove the last new line, so the `}` stay on the same line
+          match abstractClassData with
+          | AbstractClassData.ExplicitImpl _ ->
+              formattedString
+          | AbstractClassData.ObjExpr _ ->
+              formattedString.TrimEnd('\n')
+
+      // If generatedString is empty it means nothing is missing to the abstract class
+      // So we return None, in order to not show a "Falsy Hint"
+      if System.String.IsNullOrEmpty generatedString then
+          return None
+      else
+          match insertInfo with
+          | Some (shouldAppendWith, insertPosition) ->
+              if shouldAppendWith then
+                  return Some (insertPosition, " with" + generatedString)
+              else
+                  return Some (insertPosition, generatedString)
+          | None ->
+              // Unable to find an optimal insert position so return the position under the cursor
+              // By doing that we allow the user to copy/paste the code if the insertion break the code
+              // If we return None, then user would not benefit from interface stub generation at all
+              return Some (pos, generatedString)
+  | None ->
+      return None
+}

--- a/src/FsAutoComplete.Core/AbstractClassStubGenerator.fs
+++ b/src/FsAutoComplete.Core/AbstractClassStubGenerator.fs
@@ -5,9 +5,6 @@ open FsAutoComplete.CodeGenerationUtils
 open FSharp.Compiler.Range
 open FSharp.Compiler.SyntaxTree
 open FSharp.Compiler.SourceCodeServices
-open FsAutoComplete.Logging
-
-let logger = LogProvider.getLoggerByName "AbstractClassStub"
 
 type AbstractClassData =
   | ObjExpr of baseTy: SynType * bindings: SynBinding list * overallRange: range
@@ -123,7 +120,6 @@ let inferStartColumn  (codeGenServer : CodeGenerationService) (pos : pos) (doc :
 let writeAbstractClassStub (codeGenServer : CodeGenerationService) (checkResultForFile: ParseAndCheckResults) (doc : Document) (lines: LineStr[]) (lineStr : string) (abstractClassData : AbstractClassData) (implementedRange: range) =
   asyncMaybe {
     let pos = mkPos abstractClassData.AbstractTypeIdentRange.Start.Line (abstractClassData.AbstractTypeIdentRange.Start.Column + 1)
-    logger.info (Log.setMessage "Looking for interface implementation at {pos}" >> Log.addContextDestructured "pos" pos)
     let! (_lexerSym, usages) = codeGenServer.GetSymbolAndUseAtPositionOfKind(doc.FullName, pos, SymbolKind.Ident)
     let! usage = usages
     let! (displayContext, entity) =

--- a/src/FsAutoComplete.Core/CodeGeneration.fs
+++ b/src/FsAutoComplete.Core/CodeGeneration.fs
@@ -59,10 +59,8 @@ type CodeGenerationService(checker : FSharpCompilerServiceChecker, state : State
             with
             | _ -> None
 
-[<AutoOpen>]
-module internal CodeGenerationUtils =
+module CodeGenerationUtils =
     open FSharp.Compiler.SourceCodeServices.PrettyNaming
-
 
     type ColumnIndentedTextWriter() =
         let stringWriter = new StringWriter()
@@ -107,6 +105,11 @@ module internal CodeGenerationUtils =
 
     let hasAttribute<'T> (attrs: seq<FSharpAttribute>) =
         attrs |> Seq.exists (fun a -> a.AttributeType.CompiledName = typeof<'T>.Name)
+
+    let rec internal getNonAbbreviatedType (typ: FSharpType) =
+      if typ.HasTypeDefinition && typ.TypeDefinition.IsFSharpAbbreviation then
+          getNonAbbreviatedType typ.AbbreviatedType
+      else typ
 
     let tryFindTokenLPosInRange (codeGenService: CodeGenerationService) (range: range) (document: Document) (predicate: FSharpTokenInfo -> bool) =
         // Normalize range
@@ -154,7 +157,45 @@ module internal CodeGenerationUtils =
 
     let keywordSet = set KeywordNames
 
-    /// Rename a given argument if the identifier has been used
+    let getTypeParameterName (typar: FSharpGenericParameter) =
+      (if typar.IsSolveAtCompileTime then "^" else "'") + typar.Name
+
+    [<NoComparison>]
+    type Context =
+        {
+            Writer: ColumnIndentedTextWriter
+            /// Map generic types to specific instances for specialized interface implementation
+            TypeInstantations: Map<string, string>
+            /// Data for interface instantiation
+            ArgInstantiations: (FSharpGenericParameter * FSharpType) seq
+            /// Indentation inside method bodies
+            Indentation: int
+            /// Object identifier of the interface e.g. 'x', 'this', '__', etc.
+            ObjectIdent: string
+            /// A list of lines represents skeleton of each member
+            MethodBody: string []
+            /// Context in order to display types in the short form
+            DisplayContext: FSharpDisplayContext
+        }
+
+    // Adapt from MetadataFormat module in FSharp.Formatting
+
+    let (|AllAndLast|_|) (xs: 'T list) =
+        match xs with
+        | [] ->
+            None
+        | _ ->
+            let revd = List.rev xs
+            Some (List.rev revd.Tail, revd.Head)
+
+    let bracket (str: string) =
+        if str.Contains(" ") then "(" + str + ")" else str
+
+    let formatType ctx (typ: FSharpType) =
+        let genericDefinition = typ.Instantiate(Seq.toList ctx.ArgInstantiations).Format(ctx.DisplayContext)
+        (genericDefinition, ctx.TypeInstantations)
+        ||> Map.fold (fun s k v -> s.Replace(k, v))
+
     let normalizeArgName (namesWithIndices: NamesWithIndices) nm =
         match nm with
         | "()" -> nm, namesWithIndices
@@ -181,3 +222,586 @@ module internal CodeGenerationUtils =
 
             let nm = if Set.contains nm keywordSet then sprintf "``%s``" nm else nm
             nm, namesWithIndices
+
+    // Format each argument, including its name and type
+    let formatArgUsage ctx hasTypeAnnotation (namesWithIndices: Map<string, Set<int>>) (arg: FSharpParameter) =
+        let nm =
+            match arg.Name with
+            | None ->
+                if arg.Type.HasTypeDefinition && arg.Type.TypeDefinition.XmlDocSig = "T:Microsoft.FSharp.Core.unit" then "()"
+                else sprintf "arg%d" (namesWithIndices |> Map.toSeq |> Seq.map snd |> Seq.sumBy Set.count |> max 1)
+            | Some x -> x
+
+        let nm, namesWithIndices = normalizeArgName namesWithIndices nm
+
+        // Detect an optional argument
+        let isOptionalArg = hasAttribute<OptionalArgumentAttribute> arg.Attributes
+        let argName = if isOptionalArg then "?" + nm else nm
+        (if hasTypeAnnotation && argName <> "()" then
+            argName + ": " + formatType ctx arg.Type
+        else argName),
+        namesWithIndices
+
+    let formatArgsUsage ctx hasTypeAnnotation (v: FSharpMemberOrFunctionOrValue) args =
+        let isItemIndexer = (v.IsInstanceMember && v.DisplayName = "Item")
+        let unit, argSep, tupSep = "()", " ", ", "
+        let args, namesWithIndices =
+            args
+            |> List.fold (fun (argsSoFar: string list list, namesWithIndices) args ->
+                let argsSoFar', namesWithIndices =
+                    args
+                    |> List.fold (fun (acc: string list, allNames) arg ->
+                        let name, allNames = formatArgUsage ctx hasTypeAnnotation allNames arg
+                        name :: acc, allNames) ([], namesWithIndices)
+                List.rev argsSoFar' :: argsSoFar, namesWithIndices)
+                ([], Map.ofList [ ctx.ObjectIdent, Set.empty ])
+        args
+        |> List.rev
+        |> List.map (function
+            | [] -> unit
+            | [arg] when arg = unit -> unit
+            | [arg] when not v.IsMember || isItemIndexer -> arg
+            | args when isItemIndexer -> String.concat tupSep args
+            | args -> bracket (String.concat tupSep args))
+        |> String.concat argSep
+        , namesWithIndices
+
+    [<RequireQualifiedAccess; NoComparison>]
+    type MemberInfo =
+        | PropertyGetSet of FSharpMemberOrFunctionOrValue * FSharpMemberOrFunctionOrValue
+        | Member of FSharpMemberOrFunctionOrValue
+
+    let getArgTypes (ctx: Context) (v: FSharpMemberOrFunctionOrValue) =
+        let argInfos = v.CurriedParameterGroups |> Seq.map Seq.toList |> Seq.toList
+
+        let retType = v.ReturnParameter.Type
+
+        let argInfos, retType =
+            match argInfos, v.IsPropertyGetterMethod, v.IsPropertySetterMethod with
+            | [ AllAndLast(args, last) ], _, true -> [ args ], Some last.Type
+            | [[]], true, _ -> [], Some retType
+            | _, _, _ -> argInfos, Some retType
+
+        let retType =
+            match retType with
+            | Some typ ->
+                let coreType = formatType ctx typ
+                if v.IsEvent then
+                    let isEventHandler =
+                        typ.BaseType
+                        |> Option.bind (fun t ->
+                            if t.HasTypeDefinition then
+                                t.TypeDefinition.TryGetFullName()
+                             else None)
+                        |> Option.exists ((=) "System.MulticastDelegate")
+                    if isEventHandler then sprintf "IEvent<%s, _>" coreType else coreType
+                else coreType
+            | None ->
+                "unit"
+
+        argInfos, retType
+
+    /// Convert a getter/setter to its canonical form
+    let normalizePropertyName (v: FSharpMemberOrFunctionOrValue) =
+        let displayName = v.DisplayName
+        if (v.IsPropertyGetterMethod && displayName.StartsWith("get_")) ||
+            (v.IsPropertySetterMethod && displayName.StartsWith("set_")) then
+            displayName.[4..]
+        else displayName
+
+    let isEventMember (m: FSharpMemberOrFunctionOrValue) =
+        m.IsEvent || hasAttribute<CLIEventAttribute> m.Attributes
+
+        /// Rename a given argument if the identifier has been used
+
+
+    let formatMember (ctx: Context) m verboseMode =
+        let getParamArgs (argInfos: FSharpParameter list list) (ctx: Context) (v: FSharpMemberOrFunctionOrValue) =
+            let args, namesWithIndices =
+                match argInfos with
+                | [[x]] when v.IsPropertyGetterMethod && x.Name.IsNone
+                                && x.Type.TypeDefinition.XmlDocSig = "T:Microsoft.FSharp.Core.unit" ->
+                    "", Map.ofList [ctx.ObjectIdent, Set.empty]
+                | _  -> formatArgsUsage ctx verboseMode v argInfos
+
+            if String.IsNullOrWhiteSpace(args) then ""
+            elif args.StartsWith("(") then args
+            elif v.CurriedParameterGroups.Count > 1 && (not verboseMode) then " " + args
+            else sprintf "(%s)" args
+            , namesWithIndices
+
+        let preprocess (ctx: Context) (v: FSharpMemberOrFunctionOrValue) =
+            let buildUsage argInfos =
+                let parArgs, _ = getParamArgs argInfos ctx v
+                match v.IsMember, v.IsInstanceMember, v.LogicalName, v.DisplayName with
+                // Constructors
+                | _, _, ".ctor", _ -> "new" + parArgs
+                // Properties (skipping arguments)
+                | _, true, _, name when v.IsPropertyGetterMethod || v.IsPropertySetterMethod ->
+                    if name.StartsWith("get_") || name.StartsWith("set_") then name.[4..] else name
+                // Ordinary instance members
+                | _, true, _, name -> name + parArgs
+                // Ordinary functions or values
+                | false, _, _, name when
+                    not (hasAttribute<RequireQualifiedAccessAttribute> v.ApparentEnclosingEntity.Attributes) ->
+                    name + " " + parArgs
+                // Ordinary static members or things (?) that require fully qualified access
+                | _, _, _, name -> name + parArgs
+
+            let modifiers =
+                [ if v.InlineAnnotation = FSharpInlineAnnotation.AlwaysInline then yield "inline"
+                  if v.Accessibility.IsInternal then yield "internal" ]
+
+            let argInfos, retType = getArgTypes ctx v
+            let usage = buildUsage argInfos
+            usage, modifiers, argInfos, retType
+
+        // A couple of helper methods for emitting close declarations of members and stub method bodies.
+        let closeDeclaration (returnType:string) (writer:ColumnIndentedTextWriter) =
+            if verboseMode then writer.Write(": {0}", returnType)
+            writer.Write(" = ", returnType)
+            if verboseMode then writer.WriteLine("")
+        let writeImplementation (ctx:Context) (writer:ColumnIndentedTextWriter) =
+            match verboseMode, ctx.MethodBody with
+            | false, [| singleLine |] -> writer.WriteLine(singleLine)
+            | _, lines ->
+                writer.Indent ctx.Indentation
+                for line in lines do
+                    writer.WriteLine(line)
+                writer.Unindent ctx.Indentation
+
+        match m with
+        | MemberInfo.PropertyGetSet(getter, setter) ->
+            let (usage, modifiers, getterArgInfos, retType) = preprocess ctx getter
+            let closeDeclaration = closeDeclaration retType
+            let writeImplementation = writeImplementation ctx
+            let (_, _, setterArgInfos, _) = preprocess ctx setter
+            let writer = ctx.Writer
+            writer.Write("member ")
+            for modifier in modifiers do
+                writer.Write("{0} ", modifier)
+            writer.Write("{0}.", ctx.ObjectIdent)
+
+            // Try to print getters and setters on the same identifier
+            writer.WriteLine(usage)
+            writer.Indent ctx.Indentation
+            match getParamArgs getterArgInfos ctx getter with
+            | "", _ | "()", _ -> writer.Write("with get ()")
+            | args, _ -> writer.Write("with get {0}", args)
+            writer |> closeDeclaration
+            writer |> writeImplementation
+            match getParamArgs setterArgInfos ctx setter with
+            | "", _ | "()", _ ->
+                if verboseMode then writer.WriteLine("and set (v: {0}): unit = ", retType)
+                else writer.Write("and set v = ")
+            | args, namesWithIndices ->
+                let valueArgName, _ = normalizeArgName namesWithIndices "v"
+                if verboseMode then writer.WriteLine("and set {0} ({1}: {2}): unit = ", args, valueArgName, retType)
+                else writer.Write("and set {0} {1} = ", args, valueArgName)
+            writer |> writeImplementation
+            writer.Unindent ctx.Indentation
+
+        | MemberInfo.Member v ->
+            let (usage, modifiers, argInfos, retType) = preprocess ctx v
+            let closeDeclaration = closeDeclaration retType
+            let writeImplementation = writeImplementation ctx
+            let writer = ctx.Writer
+            if isEventMember v then
+                writer.WriteLine("[<CLIEvent>]")
+            writer.Write("member ")
+            for modifier in modifiers do
+                writer.Write("{0} ", modifier)
+            writer.Write("{0}.", ctx.ObjectIdent)
+
+            if v.IsEvent then
+                writer.Write(usage)
+                writer |> closeDeclaration
+                writer |> writeImplementation
+            elif v.IsPropertySetterMethod then
+                writer.WriteLine(usage)
+                writer.Indent ctx.Indentation
+                match getParamArgs argInfos ctx v with
+                | "", _ | "()", _ ->
+                    writer.WriteLine("with set (v: {0}): unit = ", retType)
+                | args, namesWithIndices ->
+                    let valueArgName, _ = normalizeArgName namesWithIndices "v"
+                    writer.Write("with set {0} ({1}", args, valueArgName)
+                    if verboseMode then writer.Write(": {0}): unit", retType)
+                    else writer.Write(")")
+                    writer.Write(" = ")
+                    if verboseMode then writer.WriteLine("")
+
+                writer |> writeImplementation
+                writer.Unindent ctx.Indentation
+            elif v.IsPropertyGetterMethod then
+                writer.Write(usage)
+                match getParamArgs argInfos ctx v with
+                | "", _ | "()", _ ->
+                    // Use the short-hand notation for getters without arguments
+                    writer |> closeDeclaration
+                    writer |> writeImplementation
+                | args, _ ->
+                    writer.WriteLine("")
+                    writer.Indent ctx.Indentation
+                    writer.Write("with get {0}", args)
+                    writer |> closeDeclaration
+                    writer |> writeImplementation
+                    writer.Unindent ctx.Indentation
+            else
+                writer.Write(usage)
+                writer |> closeDeclaration
+                writer |> writeImplementation
+
+    // Sometimes interface members are stored in the form of `IInterface<'T> -> ...`,
+    // so we need to get the 2nd generic argument
+    let (|MemberFunctionType|_|) (typ: FSharpType) =
+        if typ.IsFunctionType && typ.GenericArguments.Count = 2 then
+            Some typ.GenericArguments.[1]
+        else None
+
+    let (|TypeOfMember|_|) (m: FSharpMemberOrFunctionOrValue) =
+        match m.FullTypeSafe with
+        | Some (MemberFunctionType typ) when m.IsProperty
+                                            && m.DeclaringEntity.IsSome
+                                            && m.DeclaringEntity.Value.IsFSharp ->
+            Some typ
+        | Some typ -> Some typ
+        | None -> None
+
+    let (|EventFunctionType|_|) (typ: FSharpType) =
+        match typ with
+        | MemberFunctionType typ ->
+            if typ.IsFunctionType && typ.GenericArguments.Count = 2 then
+                let retType = typ.GenericArguments.[0]
+                let argType = typ.GenericArguments.[1]
+                if argType.GenericArguments.Count = 2 then
+                    Some (argType.GenericArguments.[0], retType)
+                else None
+            else None
+        | _ ->
+            None
+
+    let removeWhitespace (str: string) =
+        str.Replace(" ", "")
+
+    /// Filter out duplicated interfaces in inheritance chain
+    let rec internal getInterfaces (e: FSharpEntity) =
+        seq { for iface in e.AllInterfaces ->
+                let typ = getNonAbbreviatedType iface
+                // Argument should be kept lazy so that it is only evaluated when instantiating a new type
+                typ.TypeDefinition, Seq.zip typ.TypeDefinition.GenericParameters typ.GenericArguments
+        }
+        |> Seq.distinct
+
+    /// Get members in the decreasing order of inheritance chain
+    let getInterfaceMembers (e: FSharpEntity) =
+        seq {
+            for (iface, instantiations) in getInterfaces e do
+                yield! iface.TryGetMembersFunctionsAndValues
+                       |> Seq.choose (fun m ->
+                           // Use this hack when FCS doesn't return enough information on .NET properties and events
+                           if m.IsProperty || m.IsEventAddMethod || m.IsEventRemoveMethod then
+                               None
+                           else Some (m, instantiations))
+         }
+
+    let getAbstractNonVirtualMembers (e: FSharpEntity) =
+      seq {
+         let typeDef, genericParams =
+          let typ = getNonAbbreviatedType e.AbbreviatedType
+          typ.TypeDefinition, Seq.zip typ.TypeDefinition.GenericParameters typ.GenericArguments
+         yield!
+          e.MembersFunctionsAndValues
+          |> Seq.choose (fun m ->
+              if m.IsDispatchSlot then Some(m, genericParams)
+              else None
+          )
+      }
+
+    /// Check whether an interface is empty
+    let hasNoInterfaceMember e =
+        getInterfaceMembers e |> Seq.isEmpty
+
+    let (|LongIdentPattern|_|) = function
+        | SynPat.LongIdent(LongIdentWithDots(xs, _), _, _, _, _, _) ->
+    //            let (name, range) = xs |> List.map (fun x -> x.idText, x.idRange) |> List.last
+            let last = List.last xs
+            Some(last.idText, last.idRange)
+        | _ ->
+            None
+
+    // Get name and associated range of a member
+    // On merged properties (consisting both getters and setters), they have the same range values,
+    // so we use 'get_' and 'set_' prefix to ensure corresponding symbols are retrieved correctly.
+    let (|MemberNameAndRange|_|) = function
+        | Binding(_access, _bindingKind, _isInline, _isMutable, _attrs, _xmldoc, SynValData(Some mf, _, _), LongIdentPattern(name, range),
+                    _retTy, _expr, _bindingRange, _seqPoint) when mf.MemberKind = MemberKind.PropertyGet ->
+            if name.StartsWith("get_") then Some(name, range) else Some("get_" + name, range)
+        | Binding(_access, _bindingKind, _isInline, _isMutable, _attrs, _xmldoc, SynValData(Some mf, _, _), LongIdentPattern(name, range),
+                    _retTy, _expr, _bindingRange, _seqPoint) when mf.MemberKind = MemberKind.PropertySet ->
+            if name.StartsWith("set_") then Some(name, range) else Some("set_" + name, range)
+        | Binding(_access, _bindingKind, _isInline, _isMutable, _attrs, _xmldoc, _valData, LongIdentPattern(name, range),
+                    _retTy, _expr, _bindingRange, _seqPoint) ->
+            Some(name, range)
+        | _ ->
+            None
+
+    let normalizeEventName (m: FSharpMemberOrFunctionOrValue) =
+        let name = m.DisplayName
+        if name.StartsWith("add_") then name.[4..]
+        elif name.StartsWith("remove_")  then name.[7..]
+        else name
+
+    /// Ideally this info should be returned in error symbols from FCS.
+    /// Because it isn't, we implement a crude way of getting member signatures:
+    ///  (1) Crack ASTs to get member names and their associated ranges
+    ///  (2) Check symbols of those members based on ranges
+    ///  (3) If any symbol found, capture its member signature
+    let getImplementedMemberSignatures (getMemberByLocation: string * range -> Async<FSharpSymbolUse option>) displayContext memberNamesAndRanges =
+        let formatMemberSignature (symbolUse: FSharpSymbolUse) =
+            match symbolUse.Symbol with
+            | :? FSharpMemberOrFunctionOrValue as m ->
+                match m.FullTypeSafe with
+                | Some _ when isEventMember m ->
+                    // Events don't have overloads so we use only display names for comparison
+                    let signature = normalizeEventName m
+                    Some [signature]
+                | Some typ ->
+                    let signature = removeWhitespace (sprintf "%s:%s" m.DisplayName (typ.Format(displayContext)))
+                    Some [signature]
+                | None ->
+                    None
+            | _ ->
+                fail "Should only accept symbol uses of members."
+                None
+        async {
+            let! symbolUses =
+                memberNamesAndRanges
+                |> List.toArray
+                |> Async.Array.map getMemberByLocation
+            return symbolUses |> Array.choose (Option.bind formatMemberSignature >> Option.map String.Concat)
+                              |> Set.ofArray
+        }
+
+    /// Check whether an entity is an interface or type abbreviation of an interface
+    let rec isInterface (e: FSharpEntity) =
+        e.IsInterface || (e.IsFSharpAbbreviation && isInterface e.AbbreviatedType.TypeDefinition)
+
+    let findLastGreaterOperator (tokens : FSharpTokenInfo list) =
+      tokens
+      |> List.findBack(fun token ->
+          token.CharClass = FSharpTokenCharKind.Operator
+              && token.TokenName = "GREATER"
+      )
+
+    /// Return the greater multiple of `powerNumber` which is smaller than `value`
+    /// Ex: roundToNearest 14 4 -> 12
+    let findGreaterMultiple (value : int) (powerNumber : int) =
+        let mutable res = powerNumber
+        while res + powerNumber < value do
+            res <- res + powerNumber
+        res
+
+    let findLastPositionOfWithKeyword (tokens: FSharpTokenInfo list) (entity: FSharpEntity) (pos: pos) (entityAdvancer) =
+      let endPosOfWidth =
+          tokens
+          |> List.tryPick (fun (t: FSharpTokenInfo) ->
+                  if t.CharClass = FSharpTokenCharKind.Keyword && t.LeftColumn >= pos.Column && t.TokenName = "WITH" then
+                      Some (Pos.fromZ (pos.Line - 1) (t.RightColumn + 1))
+                  else None)
+
+      match endPosOfWidth with
+      // If we found the position of `with` keyword, return it as it will serve as a reference position for insertion
+      | Some pos -> Some (false, pos)
+      // `with` not found, so we need to find the end position of the interface identifer
+      | None ->
+          let position =
+              if entity.GenericParameters.Count = 0 then
+                  let token = entityAdvancer tokens
+                  Pos.fromZ (pos.Line - 1) (token.RightColumn + 1)
+              // Otherwise, returns the position after the last greater angle (>)
+              else
+                  let token = findLastGreaterOperator tokens
+                  Pos.fromZ (pos.Line - 1) (token.RightColumn + 1)
+
+          Some (true, position)
+
+    let rec findLastIdentifier (tokens : FSharpTokenInfo list) (lastValidToken : FSharpTokenInfo) =
+        match tokens with
+        // This rule try to move on step in the namespace declaration
+        // System.Collections.ICollection
+        //          ^
+        // { new System.Collections.ICollection }
+        //                 ^
+        | _::potentialDot::validIdentifier::tail
+            when potentialDot.CharClass = FSharpTokenCharKind.Delimiter
+                    && potentialDot.TokenName = "DOT"
+                    && validIdentifier.CharClass = FSharpTokenCharKind.Identifier
+                    && validIdentifier.TokenName = "IDENT" ->
+            findLastIdentifier tail validIdentifier
+        // This rule match when we are at the end of the namespace and there is some tokens left in the pile
+        // { new System.Collections.ICollection }
+        //                              ^
+        | potentialDot::validIdentifier::_
+            when potentialDot.CharClass = FSharpTokenCharKind.Delimiter
+                    && potentialDot.TokenName = "DOT"
+                    && validIdentifier.CharClass = FSharpTokenCharKind.Identifier
+                    && validIdentifier.TokenName = "IDENT" ->
+            validIdentifier
+        // This rule match when we are at the end of the namespace and there is no more tokens
+        // interface System.Collections.ICollection
+        //                              ^
+        | potentialDot::validIdentifier::[]
+            when potentialDot.CharClass = FSharpTokenCharKind.Delimiter
+                    && potentialDot.TokenName = "DOT"
+                    && validIdentifier.CharClass = FSharpTokenCharKind.Identifier
+                    && validIdentifier.TokenName = "IDENT" ->
+            validIdentifier
+        // If no special rule found, return the last valid token found
+        | _ -> lastValidToken
+
+    /// The code below is responsible for handling the code generation and determining the insert position
+    let getLineIdent (lineStr: string) =
+      lineStr.Length - lineStr.TrimStart(' ').Length
+
+    let formatMembersAt startColumn indentation (typeInstances: string []) objectIdent
+        (methodBody: string) (displayContext: FSharpDisplayContext) excludedMemberSignatures
+        (e: FSharpEntity)
+        (getMembersToImplement: FSharpEntity -> seq<FSharpMemberOrFunctionOrValue * seq<FSharpGenericParameter * FSharpType>>) verboseMode =
+      let lines = String.getLines methodBody
+      use writer = new ColumnIndentedTextWriter()
+      let typeParams = Seq.map getTypeParameterName e.GenericParameters
+      let instantiations =
+          let insts =
+              Seq.zip typeParams typeInstances
+              // Filter out useless instances (when it is replaced by the same name or by wildcard)
+              |> Seq.filter(fun (t1, t2) -> t1 <> t2 && t2 <> "_")
+              |> Map.ofSeq
+          // A simple hack to handle instantiation of type alias
+          if e.IsFSharpAbbreviation then
+              let typ = getNonAbbreviatedType e.AbbreviatedType
+              (typ.TypeDefinition.GenericParameters |> Seq.map getTypeParameterName,
+                  typ.GenericArguments |> Seq.map (fun typ -> typ.Format(displayContext)))
+              ||> Seq.zip
+              |> Seq.fold (fun acc (x, y) -> Map.add x y acc) insts
+          else insts
+      let ctx = { Writer = writer; TypeInstantations = instantiations; ArgInstantiations = Seq.empty;
+                  Indentation = indentation; ObjectIdent = objectIdent; MethodBody = lines; DisplayContext = displayContext }
+      let missingMembers =
+          getMembersToImplement e
+          |> Seq.groupBy (fun (m, insts) ->
+              match m with
+              | _ when isEventMember m  ->
+                  Some (normalizeEventName m)
+              | TypeOfMember typ ->
+                  let signature = removeWhitespace (sprintf "%s:%s" m.DisplayName (formatType { ctx with ArgInstantiations = insts } typ))
+                  Some signature
+              | _ ->
+                  debug "FullType throws exceptions due to bugs in FCS."
+                  None)
+          |> Seq.collect (fun (signature, members) ->
+              match signature with
+              | None ->
+                  members
+              | Some signature when not (Set.contains signature excludedMemberSignatures) ->
+                  // Return the first member from a group of members for a particular signature
+                  Seq.truncate 1 members
+              | _ -> Seq.empty)
+
+      // All members have already been implemented
+      if Seq.isEmpty missingMembers then
+          String.Empty
+      else
+          writer.Indent startColumn
+          writer.WriteLine("")
+          let duplicatedMembers =
+              missingMembers
+              |> Seq.countBy(fun (m, insts) -> m.DisplayName, insts |> Seq.length)
+              |> Seq.filter (snd >> (<) 1)
+              |> Seq.map (fst >> fst)
+              |> Set.ofSeq
+
+          let getReturnType v = snd (getArgTypes ctx v)
+          let rec formatMembers (members : (FSharpMemberOrFunctionOrValue * _) list) =
+              match members with
+              // Since there is no unified source of information for properties,
+              // we try to merge getters and setters when they seem to match.
+              // Assume that getter and setter come right after each other.
+              // They belong to the same property if names and return types are the same
+              | (getter as first, insts) :: (setter, _) :: otherMembers
+              | (setter as first, _) :: (getter, insts) :: otherMembers when
+                  getter.IsPropertyGetterMethod && setter.IsPropertySetterMethod &&
+                  normalizePropertyName getter = normalizePropertyName setter &&
+                  getReturnType getter = getReturnType setter ->
+                  let useVerboseMode = verboseMode || duplicatedMembers.Contains first.DisplayName
+                  formatMember { ctx with ArgInstantiations = insts } (MemberInfo.PropertyGetSet(getter, setter)) useVerboseMode
+                  formatMembers otherMembers
+              | (m, insts) :: otherMembers ->
+                  let useVerboseMode = verboseMode || duplicatedMembers.Contains m.DisplayName
+                  formatMember { ctx with ArgInstantiations = insts } (MemberInfo.Member m) useVerboseMode
+                  formatMembers otherMembers
+              | [] -> ()
+
+          missingMembers
+          |> Seq.sortBy (fun (m, _) ->
+              // Sort by normalized name and return type so that getters and setters of the same properties
+              // are guaranteed to be neighboring.
+              normalizePropertyName m, getReturnType m)
+          |> Seq.toList
+          |> formatMembers
+          writer.Dump()
+
+    let rec (|RationalConst|) = function
+        | SynRationalConst.Integer i ->
+            string i
+        | SynRationalConst.Rational(numerator, denominator, _) ->
+            sprintf "(%i/%i)" numerator denominator
+        | SynRationalConst.Negate (RationalConst s) ->
+            sprintf "- %s" s
+
+    let rec (|TypeIdent|_|) = function
+        | SynType.Var(SynTypar.Typar(s, req , _), _) ->
+            match req with
+            | NoStaticReq ->
+                Some ("'" + s.idText)
+            | HeadTypeStaticReq ->
+                Some ("^" + s.idText)
+        | SynType.LongIdent(LongIdentWithDots(xs, _)) ->
+            xs |> Seq.map (fun x -> x.idText) |> String.concat "." |> Some
+        | SynType.App(t, _, ts, _, _, isPostfix, _) ->
+            match t, ts with
+            | TypeIdent typeName, [] -> Some typeName
+            | TypeIdent typeName, [TypeIdent typeArg] ->
+                if isPostfix then
+                    Some (sprintf "%s %s" typeArg typeName)
+                else
+                    Some (sprintf "%s<%s>" typeName typeArg)
+            | TypeIdent typeName, _ ->
+                let typeArgs = ts |> Seq.choose (|TypeIdent|_|) |> String.concat ", "
+                if isPostfix then
+                    Some (sprintf "(%s) %s" typeArgs typeName)
+                else
+                    Some(sprintf "%s<%s>" typeName typeArgs)
+            | _ ->
+                debug "Unsupported case with %A and %A" t ts
+                None
+        | SynType.Anon _ ->
+            Some "_"
+        | SynType.Tuple(_, ts, _) ->
+            Some (ts |> Seq.choose (snd >> (|TypeIdent|_|)) |> String.concat " * ")
+        | SynType.Array(dimension, TypeIdent typeName, _) ->
+            Some (sprintf "%s [%s]" typeName (new String(',', dimension-1)))
+        | SynType.MeasurePower(TypeIdent typeName, RationalConst power, _) ->
+            Some (sprintf "%s^%s" typeName power)
+        | SynType.MeasureDivide(TypeIdent numerator, TypeIdent denominator, _) ->
+            Some (sprintf "%s/%s" numerator denominator)
+        | _ ->
+            None
+
+    let expandTypeParameters (typ: SynType) =
+      match typ with
+      | SynType.App(_, _, ts, _, _, _, _)
+      | SynType.LongIdentApp(_, _, _, ts, _, _, _) ->
+          ts |> Seq.choose (|TypeIdent|_|) |> Seq.toArray
+      | _ ->
+          [||]

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -250,7 +250,7 @@ type Commands<'analyzer> (serialize : Serializer, backgroundServiceEnabled) =
 
         if not isFromCache then
           response.Items
-          |> List.choose (function Dotnet.ProjInfo.Workspace.ProjectViewerItem.Compile(p, _) -> if p.Contains "--embed:" then None else Some p)
+          |> List.choose (function Dotnet.ProjInfo.Workspace.ProjectViewerItem.Compile(p, _) -> Some p)
           |> parseFilesInTheBackground tfmForScripts
           |> Async.Start
         else

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -910,7 +910,6 @@ type Commands<'analyzer> (serialize : Serializer, backgroundServiceEnabled) =
             | None -> return CoreResponse.InfoRes "Interface at position not found"
             | Some interfaceData ->
                 let! stubInfo = handleImplementInterface codeGenServer tyRes pos doc lines lineStr interfaceData
-
                 match stubInfo with
                 | Some (insertPosition, generatedCode) ->
                     return CoreResponse.Res (generatedCode, insertPosition)
@@ -926,23 +925,11 @@ type Commands<'analyzer> (serialize : Serializer, backgroundServiceEnabled) =
             match res with
             | None -> return CoreResponse.InfoRes "Abstract class at position not found"
             | Some abstractClass ->
-                commandsLogger.info (
-                  Log.setMessage "Found abstract class at pos {pos}"
-                  >> Log.addContextDestructured "pos" objExprRange.Start
-                )
                 let! stubInfo = AbstractClassStubGenerator.writeAbstractClassStub codeGenServer tyRes doc lines lineStr abstractClass objExprRange
                 match stubInfo with
                 | Some (insertPosition, generatedCode) ->
-                    commandsLogger.info (
-                      Log.setMessage "Abstract class generated code is at pos {pos}\n{code}"
-                      >> Log.addContextDestructured "pos" insertPosition
-                      >> Log.addContextDestructured "code" generatedCode
-                    )
                     return CoreResponse.Res (generatedCode, insertPosition)
                 | None ->
-                  commandsLogger.info (
-                    Log.setMessage "No abstract class members generated"
-                    )
                   return CoreResponse.InfoRes "Abstract class at position not found"
         }
         |> x.AsCancellable (Path.GetFullPath tyRes.FileName)

--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -36,6 +36,7 @@
     <Compile Include="UnionPatternMatchCaseGenerator.fs" />
     <Compile Include="RecordStubGenerator.fs" />
     <Compile Include="InterfaceStubGenerator.fs" />
+    <Compile Include="AbstractClassStubGenerator.fs" />
     <Compile Include="SymbolCache.fs" />
     <Compile Include="BackgroundServices.fs" />
     <Compile Include="Fsdn.fs" />

--- a/src/FsAutoComplete.Core/InterfaceStubGenerator.fs
+++ b/src/FsAutoComplete.Core/InterfaceStubGenerator.fs
@@ -7,6 +7,7 @@ open FsAutoComplete.UntypedAstUtils
 open FSharp.Compiler.SyntaxTree
 open FSharp.Compiler.Range
 open FSharp.Compiler.SourceCodeServices
+open FsAutoComplete.CodeGenerationUtils
 
 /// Capture information about an interface in ASTs
 [<RequireQualifiedAccess; NoEquality; NoComparison>]
@@ -22,410 +23,7 @@ type InterfaceData =
     member x.TypeParameters =
         match x with
         | InterfaceData.Interface(typ, _)
-        | InterfaceData.ObjExpr(typ, _) ->
-            let rec (|RationalConst|) = function
-                | SynRationalConst.Integer i ->
-                    string i
-                | SynRationalConst.Rational(numerator, denominator, _) ->
-                    sprintf "(%i/%i)" numerator denominator
-                | SynRationalConst.Negate (RationalConst s) ->
-                    sprintf "- %s" s
-
-            let rec (|TypeIdent|_|) = function
-                | SynType.Var(SynTypar.Typar(s, req , _), _) ->
-                    match req with
-                    | NoStaticReq ->
-                        Some ("'" + s.idText)
-                    | HeadTypeStaticReq ->
-                        Some ("^" + s.idText)
-                | SynType.LongIdent(LongIdentWithDots(xs, _)) ->
-                    xs |> Seq.map (fun x -> x.idText) |> String.concat "." |> Some
-                | SynType.App(t, _, ts, _, _, isPostfix, _) ->
-                    match t, ts with
-                    | TypeIdent typeName, [] -> Some typeName
-                    | TypeIdent typeName, [TypeIdent typeArg] ->
-                        if isPostfix then
-                            Some (sprintf "%s %s" typeArg typeName)
-                        else
-                            Some (sprintf "%s<%s>" typeName typeArg)
-                    | TypeIdent typeName, _ ->
-                        let typeArgs = ts |> Seq.choose (|TypeIdent|_|) |> String.concat ", "
-                        if isPostfix then
-                            Some (sprintf "(%s) %s" typeArgs typeName)
-                        else
-                            Some(sprintf "%s<%s>" typeName typeArgs)
-                    | _ ->
-                        debug "Unsupported case with %A and %A" t ts
-                        None
-                | SynType.Anon _ ->
-                    Some "_"
-                | SynType.Tuple(_, ts, _) ->
-                    Some (ts |> Seq.choose (snd >> (|TypeIdent|_|)) |> String.concat " * ")
-                | SynType.Array(dimension, TypeIdent typeName, _) ->
-                    Some (sprintf "%s [%s]" typeName (new String(',', dimension-1)))
-                | SynType.MeasurePower(TypeIdent typeName, RationalConst power, _) ->
-                    Some (sprintf "%s^%s" typeName power)
-                | SynType.MeasureDivide(TypeIdent numerator, TypeIdent denominator, _) ->
-                    Some (sprintf "%s/%s" numerator denominator)
-                | _ ->
-                    None
-            match typ with
-            | SynType.App(_, _, ts, _, _, _, _)
-            | SynType.LongIdentApp(_, _, _, ts, _, _, _) ->
-                ts |> Seq.choose (|TypeIdent|_|) |> Seq.toArray
-            | _ ->
-                [||]
-
-[<NoComparison>]
-type internal Context =
-    {
-        Writer: ColumnIndentedTextWriter
-        /// Map generic types to specific instances for specialized interface implementation
-        TypeInstantations: Map<string, string>
-        /// Data for interface instantiation
-        ArgInstantiations: (FSharpGenericParameter * FSharpType) seq
-        /// Indentation inside method bodies
-        Indentation: int
-        /// Object identifier of the interface e.g. 'x', 'this', '__', etc.
-        ObjectIdent: string
-        /// A list of lines represents skeleton of each member
-        MethodBody: string []
-        /// Context in order to display types in the short form
-        DisplayContext: FSharpDisplayContext
-    }
-
-// Adapt from MetadataFormat module in FSharp.Formatting
-
-let internal (|AllAndLast|_|) (xs: 'T list) =
-    match xs with
-    | [] ->
-        None
-    | _ ->
-        let revd = List.rev xs
-        Some (List.rev revd.Tail, revd.Head)
-
-let internal getTypeParameterName (typar: FSharpGenericParameter) =
-    (if typar.IsSolveAtCompileTime then "^" else "'") + typar.Name
-
-let internal bracket (str: string) =
-    if str.Contains(" ") then "(" + str + ")" else str
-
-let internal formatType ctx (typ: FSharpType) =
-    let genericDefinition = typ.Instantiate(Seq.toList ctx.ArgInstantiations).Format(ctx.DisplayContext)
-    (genericDefinition, ctx.TypeInstantations)
-    ||> Map.fold (fun s k v -> s.Replace(k, v))
-
-// Format each argument, including its name and type
-let internal formatArgUsage ctx hasTypeAnnotation (namesWithIndices: Map<string, Set<int>>) (arg: FSharpParameter) =
-    let nm =
-        match arg.Name with
-        | None ->
-            if arg.Type.HasTypeDefinition && arg.Type.TypeDefinition.XmlDocSig = "T:Microsoft.FSharp.Core.unit" then "()"
-            else sprintf "arg%d" (namesWithIndices |> Map.toSeq |> Seq.map snd |> Seq.sumBy Set.count |> max 1)
-        | Some x -> x
-
-    let nm, namesWithIndices = normalizeArgName namesWithIndices nm
-
-    // Detect an optional argument
-    let isOptionalArg = hasAttribute<OptionalArgumentAttribute> arg.Attributes
-    let argName = if isOptionalArg then "?" + nm else nm
-    (if hasTypeAnnotation && argName <> "()" then
-        argName + ": " + formatType ctx arg.Type
-    else argName),
-    namesWithIndices
-
-let internal formatArgsUsage ctx hasTypeAnnotation (v: FSharpMemberOrFunctionOrValue) args =
-    let isItemIndexer = (v.IsInstanceMember && v.DisplayName = "Item")
-    let unit, argSep, tupSep = "()", " ", ", "
-    let args, namesWithIndices =
-        args
-        |> List.fold (fun (argsSoFar: string list list, namesWithIndices) args ->
-            let argsSoFar', namesWithIndices =
-                args
-                |> List.fold (fun (acc: string list, allNames) arg ->
-                    let name, allNames = formatArgUsage ctx hasTypeAnnotation allNames arg
-                    name :: acc, allNames) ([], namesWithIndices)
-            List.rev argsSoFar' :: argsSoFar, namesWithIndices)
-            ([], Map.ofList [ ctx.ObjectIdent, Set.empty ])
-    args
-    |> List.rev
-    |> List.map (function
-        | [] -> unit
-        | [arg] when arg = unit -> unit
-        | [arg] when not v.IsMember || isItemIndexer -> arg
-        | args when isItemIndexer -> String.concat tupSep args
-        | args -> bracket (String.concat tupSep args))
-    |> String.concat argSep
-    , namesWithIndices
-
-[<RequireQualifiedAccess; NoComparison>]
-type internal MemberInfo =
-    | PropertyGetSet of FSharpMemberOrFunctionOrValue * FSharpMemberOrFunctionOrValue
-    | Member of FSharpMemberOrFunctionOrValue
-
-let internal getArgTypes (ctx: Context) (v: FSharpMemberOrFunctionOrValue) =
-    let argInfos = v.CurriedParameterGroups |> Seq.map Seq.toList |> Seq.toList
-
-    let retType = v.ReturnParameter.Type
-
-    let argInfos, retType =
-        match argInfos, v.IsPropertyGetterMethod, v.IsPropertySetterMethod with
-        | [ AllAndLast(args, last) ], _, true -> [ args ], Some last.Type
-        | [[]], true, _ -> [], Some retType
-        | _, _, _ -> argInfos, Some retType
-
-    let retType =
-        match retType with
-        | Some typ ->
-            let coreType = formatType ctx typ
-            if v.IsEvent then
-                let isEventHandler =
-                    typ.BaseType
-                    |> Option.bind (fun t ->
-                        if t.HasTypeDefinition then
-                            t.TypeDefinition.TryGetFullName()
-                         else None)
-                    |> Option.exists ((=) "System.MulticastDelegate")
-                if isEventHandler then sprintf "IEvent<%s, _>" coreType else coreType
-            else coreType
-        | None ->
-            "unit"
-
-    argInfos, retType
-
-/// Convert a getter/setter to its canonical form
-let internal normalizePropertyName (v: FSharpMemberOrFunctionOrValue) =
-    let displayName = v.DisplayName
-    if (v.IsPropertyGetterMethod && displayName.StartsWith("get_")) ||
-        (v.IsPropertySetterMethod && displayName.StartsWith("set_")) then
-        displayName.[4..]
-    else displayName
-
-let internal isEventMember (m: FSharpMemberOrFunctionOrValue) =
-    m.IsEvent || hasAttribute<CLIEventAttribute> m.Attributes
-
-let internal formatMember (ctx: Context) m verboseMode =
-    let getParamArgs (argInfos: FSharpParameter list list) (ctx: Context) (v: FSharpMemberOrFunctionOrValue) =
-        let args, namesWithIndices =
-            match argInfos with
-            | [[x]] when v.IsPropertyGetterMethod && x.Name.IsNone
-                            && x.Type.TypeDefinition.XmlDocSig = "T:Microsoft.FSharp.Core.unit" ->
-                "", Map.ofList [ctx.ObjectIdent, Set.empty]
-            | _  -> formatArgsUsage ctx verboseMode v argInfos
-
-        if String.IsNullOrWhiteSpace(args) then ""
-        elif args.StartsWith("(") then args
-        elif v.CurriedParameterGroups.Count > 1 && (not verboseMode) then " " + args
-        else sprintf "(%s)" args
-        , namesWithIndices
-
-    let preprocess (ctx: Context) (v: FSharpMemberOrFunctionOrValue) =
-        let buildUsage argInfos =
-            let parArgs, _ = getParamArgs argInfos ctx v
-            match v.IsMember, v.IsInstanceMember, v.LogicalName, v.DisplayName with
-            // Constructors
-            | _, _, ".ctor", _ -> "new" + parArgs
-            // Properties (skipping arguments)
-            | _, true, _, name when v.IsPropertyGetterMethod || v.IsPropertySetterMethod ->
-                if name.StartsWith("get_") || name.StartsWith("set_") then name.[4..] else name
-            // Ordinary instance members
-            | _, true, _, name -> name + parArgs
-            // Ordinary functions or values
-            | false, _, _, name when
-                not (hasAttribute<RequireQualifiedAccessAttribute> v.ApparentEnclosingEntity.Attributes) ->
-                name + " " + parArgs
-            // Ordinary static members or things (?) that require fully qualified access
-            | _, _, _, name -> name + parArgs
-
-        let modifiers =
-            [ if v.InlineAnnotation = FSharpInlineAnnotation.AlwaysInline then yield "inline"
-              if v.Accessibility.IsInternal then yield "internal" ]
-
-        let argInfos, retType = getArgTypes ctx v
-        let usage = buildUsage argInfos
-        usage, modifiers, argInfos, retType
-
-    // A couple of helper methods for emitting close declarations of members and stub method bodies.
-    let closeDeclaration (returnType:string) (writer:ColumnIndentedTextWriter) =
-        if verboseMode then writer.Write(": {0}", returnType)
-        writer.Write(" = ", returnType)
-        if verboseMode then writer.WriteLine("")
-    let writeImplementation (ctx:Context) (writer:ColumnIndentedTextWriter) =
-        match verboseMode, ctx.MethodBody with
-        | false, [| singleLine |] -> writer.WriteLine(singleLine)
-        | _, lines ->
-            writer.Indent ctx.Indentation
-            for line in lines do
-                writer.WriteLine(line)
-            writer.Unindent ctx.Indentation
-
-    match m with
-    | MemberInfo.PropertyGetSet(getter, setter) ->
-        let (usage, modifiers, getterArgInfos, retType) = preprocess ctx getter
-        let closeDeclaration = closeDeclaration retType
-        let writeImplementation = writeImplementation ctx
-        let (_, _, setterArgInfos, _) = preprocess ctx setter
-        let writer = ctx.Writer
-        writer.Write("member ")
-        for modifier in modifiers do
-            writer.Write("{0} ", modifier)
-        writer.Write("{0}.", ctx.ObjectIdent)
-
-        // Try to print getters and setters on the same identifier
-        writer.WriteLine(usage)
-        writer.Indent ctx.Indentation
-        match getParamArgs getterArgInfos ctx getter with
-        | "", _ | "()", _ -> writer.Write("with get ()")
-        | args, _ -> writer.Write("with get {0}", args)
-        writer |> closeDeclaration
-        writer |> writeImplementation
-        match getParamArgs setterArgInfos ctx setter with
-        | "", _ | "()", _ ->
-            if verboseMode then writer.WriteLine("and set (v: {0}): unit = ", retType)
-            else writer.Write("and set v = ")
-        | args, namesWithIndices ->
-            let valueArgName, _ = normalizeArgName namesWithIndices "v"
-            if verboseMode then writer.WriteLine("and set {0} ({1}: {2}): unit = ", args, valueArgName, retType)
-            else writer.Write("and set {0} {1} = ", args, valueArgName)
-        writer |> writeImplementation
-        writer.Unindent ctx.Indentation
-
-    | MemberInfo.Member v ->
-        let (usage, modifiers, argInfos, retType) = preprocess ctx v
-        let closeDeclaration = closeDeclaration retType
-        let writeImplementation = writeImplementation ctx
-        let writer = ctx.Writer
-        if isEventMember v then
-            writer.WriteLine("[<CLIEvent>]")
-        writer.Write("member ")
-        for modifier in modifiers do
-            writer.Write("{0} ", modifier)
-        writer.Write("{0}.", ctx.ObjectIdent)
-
-        if v.IsEvent then
-            writer.Write(usage)
-            writer |> closeDeclaration
-            writer |> writeImplementation
-        elif v.IsPropertySetterMethod then
-            writer.WriteLine(usage)
-            writer.Indent ctx.Indentation
-            match getParamArgs argInfos ctx v with
-            | "", _ | "()", _ ->
-                writer.WriteLine("with set (v: {0}): unit = ", retType)
-            | args, namesWithIndices ->
-                let valueArgName, _ = normalizeArgName namesWithIndices "v"
-                writer.Write("with set {0} ({1}", args, valueArgName)
-                if verboseMode then writer.Write(": {0}): unit", retType)
-                else writer.Write(")")
-                writer.Write(" = ")
-                if verboseMode then writer.WriteLine("")
-
-            writer |> writeImplementation
-            writer.Unindent ctx.Indentation
-        elif v.IsPropertyGetterMethod then
-            writer.Write(usage)
-            match getParamArgs argInfos ctx v with
-            | "", _ | "()", _ ->
-                // Use the short-hand notation for getters without arguments
-                writer |> closeDeclaration
-                writer |> writeImplementation
-            | args, _ ->
-                writer.WriteLine("")
-                writer.Indent ctx.Indentation
-                writer.Write("with get {0}", args)
-                writer |> closeDeclaration
-                writer |> writeImplementation
-                writer.Unindent ctx.Indentation
-        else
-            writer.Write(usage)
-            writer |> closeDeclaration
-            writer |> writeImplementation
-
-let rec internal getNonAbbreviatedType (typ: FSharpType) =
-    if typ.HasTypeDefinition && typ.TypeDefinition.IsFSharpAbbreviation then
-        getNonAbbreviatedType typ.AbbreviatedType
-    else typ
-
-// Sometimes interface members are stored in the form of `IInterface<'T> -> ...`,
-// so we need to get the 2nd generic argument
-let internal (|MemberFunctionType|_|) (typ: FSharpType) =
-    if typ.IsFunctionType && typ.GenericArguments.Count = 2 then
-        Some typ.GenericArguments.[1]
-    else None
-
-let internal (|TypeOfMember|_|) (m: FSharpMemberOrFunctionOrValue) =
-    match m.FullTypeSafe with
-    | Some (MemberFunctionType typ) when m.IsProperty
-                                        && m.DeclaringEntity.IsSome
-                                        && m.DeclaringEntity.Value.IsFSharp ->
-        Some typ
-    | Some typ -> Some typ
-    | None -> None
-
-let internal (|EventFunctionType|_|) (typ: FSharpType) =
-    match typ with
-    | MemberFunctionType typ ->
-        if typ.IsFunctionType && typ.GenericArguments.Count = 2 then
-            let retType = typ.GenericArguments.[0]
-            let argType = typ.GenericArguments.[1]
-            if argType.GenericArguments.Count = 2 then
-                Some (argType.GenericArguments.[0], retType)
-            else None
-        else None
-    | _ ->
-        None
-
-let internal removeWhitespace (str: string) =
-    str.Replace(" ", "")
-
-/// Filter out duplicated interfaces in inheritance chain
-let rec internal getInterfaces (e: FSharpEntity) =
-    seq { for iface in e.AllInterfaces ->
-            let typ = getNonAbbreviatedType iface
-            // Argument should be kept lazy so that it is only evaluated when instantiating a new type
-            typ.TypeDefinition, Seq.zip typ.TypeDefinition.GenericParameters typ.GenericArguments
-    }
-    |> Seq.distinct
-
-/// Get members in the decreasing order of inheritance chain
-let getInterfaceMembers (e: FSharpEntity) =
-    seq {
-        for (iface, instantiations) in getInterfaces e do
-            yield! iface.TryGetMembersFunctionsAndValues
-                   |> Seq.choose (fun m ->
-                       // Use this hack when FCS doesn't return enough information on .NET properties and events
-                       if m.IsProperty || m.IsEventAddMethod || m.IsEventRemoveMethod then
-                           None
-                       else Some (m, instantiations))
-     }
-
-/// Check whether an interface is empty
-let hasNoInterfaceMember e =
-    getInterfaceMembers e |> Seq.isEmpty
-
-let internal (|LongIdentPattern|_|) = function
-    | SynPat.LongIdent(LongIdentWithDots(xs, _), _, _, _, _, _) ->
-//            let (name, range) = xs |> List.map (fun x -> x.idText, x.idRange) |> List.last
-        let last = List.last xs
-        Some(last.idText, last.idRange)
-    | _ ->
-        None
-
-// Get name and associated range of a member
-// On merged properties (consisting both getters and setters), they have the same range values,
-// so we use 'get_' and 'set_' prefix to ensure corresponding symbols are retrieved correctly.
-let internal (|MemberNameAndRange|_|) = function
-    | Binding(_access, _bindingKind, _isInline, _isMutable, _attrs, _xmldoc, SynValData(Some mf, _, _), LongIdentPattern(name, range),
-                _retTy, _expr, _bindingRange, _seqPoint) when mf.MemberKind = MemberKind.PropertyGet ->
-        if name.StartsWith("get_") then Some(name, range) else Some("get_" + name, range)
-    | Binding(_access, _bindingKind, _isInline, _isMutable, _attrs, _xmldoc, SynValData(Some mf, _, _), LongIdentPattern(name, range),
-                _retTy, _expr, _bindingRange, _seqPoint) when mf.MemberKind = MemberKind.PropertySet ->
-        if name.StartsWith("set_") then Some(name, range) else Some("set_" + name, range)
-    | Binding(_access, _bindingKind, _isInline, _isMutable, _attrs, _xmldoc, _valData, LongIdentPattern(name, range),
-                _retTy, _expr, _bindingRange, _seqPoint) ->
-        Some(name, range)
-    | _ ->
-        None
+        | InterfaceData.ObjExpr(typ, _) -> expandTypeParameters typ
 
 /// Get associated member names and ranges
 /// In case of properties, intrinsic ranges might not be correct for the purpose of getting
@@ -441,391 +39,44 @@ let getMemberNameAndRanges = function
     | InterfaceData.ObjExpr(_, bindings) ->
         List.choose (|MemberNameAndRange|_|) bindings
 
-let internal normalizeEventName (m: FSharpMemberOrFunctionOrValue) =
-    let name = m.DisplayName
-    if name.StartsWith("add_") then name.[4..]
-    elif name.StartsWith("remove_")  then name.[7..]
-    else name
-
-/// Ideally this info should be returned in error symbols from FCS.
-/// Because it isn't, we implement a crude way of getting member signatures:
-///  (1) Crack ASTs to get member names and their associated ranges
-///  (2) Check symbols of those members based on ranges
-///  (3) If any symbol found, capture its member signature
-let getImplementedMemberSignatures (getMemberByLocation: string * range -> Async<FSharpSymbolUse option>) displayContext interfaceData =
-    let formatMemberSignature (symbolUse: FSharpSymbolUse) =
-        match symbolUse.Symbol with
-        | :? FSharpMemberOrFunctionOrValue as m ->
-            match m.FullTypeSafe with
-            | Some _ when isEventMember m ->
-                // Events don't have overloads so we use only display names for comparison
-                let signature = normalizeEventName m
-                Some [signature]
-            | Some typ ->
-                let signature = removeWhitespace (sprintf "%s:%s" m.DisplayName (typ.Format(displayContext)))
-                Some [signature]
-            | None ->
-                None
-        | _ ->
-            fail "Should only accept symbol uses of members."
-            None
-    async {
-        let! symbolUses =
-            getMemberNameAndRanges interfaceData
-            |> List.toArray
-            |> Async.Array.map getMemberByLocation
-        return symbolUses |> Array.choose (Option.bind formatMemberSignature >> Option.map String.Concat)
-                         // |> Array.concat
-                          |> Set.ofArray
-    }
-
-/// Check whether an entity is an interface or type abbreviation of an interface
-let rec isInterface (e: FSharpEntity) =
-    e.IsInterface || (e.IsFSharpAbbreviation && isInterface e.AbbreviatedType.TypeDefinition)
-
-/// Generate stub implementation of an interface at a start column
-let formatInterface startColumn indentation (typeInstances: string []) objectIdent
-        (methodBody: string) (displayContext: FSharpDisplayContext) excludedMemberSignatures
-        (e: FSharpEntity) verboseMode =
-    Debug.Assert(isInterface e, "The entity should be an interface.")
-    let lines = String.getLines methodBody
-    use writer = new ColumnIndentedTextWriter()
-    let typeParams = Seq.map getTypeParameterName e.GenericParameters
-    let instantiations =
-        let insts =
-            Seq.zip typeParams typeInstances
-            // Filter out useless instances (when it is replaced by the same name or by wildcard)
-            |> Seq.filter(fun (t1, t2) -> t1 <> t2 && t2 <> "_")
-            |> Map.ofSeq
-        // A simple hack to handle instantiation of type alias
-        if e.IsFSharpAbbreviation then
-            let typ = getNonAbbreviatedType e.AbbreviatedType
-            (typ.TypeDefinition.GenericParameters |> Seq.map getTypeParameterName,
-                typ.GenericArguments |> Seq.map (fun typ -> typ.Format(displayContext)))
-            ||> Seq.zip
-            |> Seq.fold (fun acc (x, y) -> Map.add x y acc) insts
-        else insts
-    let ctx = { Writer = writer; TypeInstantations = instantiations; ArgInstantiations = Seq.empty;
-                Indentation = indentation; ObjectIdent = objectIdent; MethodBody = lines; DisplayContext = displayContext }
-    let missingMembers =
-        getInterfaceMembers e
-        |> Seq.groupBy (fun (m, insts) ->
-            match m with
-            | _ when isEventMember m  ->
-                Some (normalizeEventName m)
-            | TypeOfMember typ ->
-                let signature = removeWhitespace (sprintf "%s:%s" m.DisplayName (formatType { ctx with ArgInstantiations = insts } typ))
-                Some signature
-            | _ ->
-                debug "FullType throws exceptions due to bugs in FCS."
-                None)
-        |> Seq.collect (fun (signature, members) ->
-            match signature with
-            | None ->
-                members
-            | Some signature when not (Set.contains signature excludedMemberSignatures) ->
-                // Return the first member from a group of members for a particular signature
-                Seq.truncate 1 members
-            | _ -> Seq.empty)
-
-    // All members have already been implemented
-    if Seq.isEmpty missingMembers then
-        String.Empty
+let private walkTypeDefn pos (SynTypeDefn.TypeDefn(info, repr, members, range)) =
+  members
+  |>List.tryPick (fun m ->
+    if rangeContainsPos m.Range pos
+    then
+      match m with
+      | SynMemberDefn.Interface(iface, members, _) ->
+        Some (InterfaceData.Interface(iface, members))
+      | _ -> None
     else
-        writer.Indent startColumn
-        writer.WriteLine("")
-        let duplicatedMembers =
-            missingMembers
-            |> Seq.countBy(fun (m, insts) -> m.DisplayName, insts |> Seq.length)
-            |> Seq.filter (snd >> (<) 1)
-            |> Seq.map (fst >> fst)
-            |> Set.ofSeq
+      None
+  )
 
-        let getReturnType v = snd (getArgTypes ctx v)
-        let rec formatMembers (members : (FSharpMemberOrFunctionOrValue * _) list) =
-            match members with
-            // Since there is no unified source of information for properties,
-            // we try to merge getters and setters when they seem to match.
-            // Assume that getter and setter come right after each other.
-            // They belong to the same property if names and return types are the same
-            | (getter as first, insts) :: (setter, _) :: otherMembers
-            | (setter as first, _) :: (getter, insts) :: otherMembers when
-                getter.IsPropertyGetterMethod && setter.IsPropertySetterMethod &&
-                normalizePropertyName getter = normalizePropertyName setter &&
-                getReturnType getter = getReturnType setter ->
-                let useVerboseMode = verboseMode || duplicatedMembers.Contains first.DisplayName
-                formatMember { ctx with ArgInstantiations = insts } (MemberInfo.PropertyGetSet(getter, setter)) useVerboseMode
-                formatMembers otherMembers
-            | (m, insts) :: otherMembers ->
-                let useVerboseMode = verboseMode || duplicatedMembers.Contains m.DisplayName
-                formatMember { ctx with ArgInstantiations = insts } (MemberInfo.Member m) useVerboseMode
-                formatMembers otherMembers
-            | [] -> ()
-
-        missingMembers
-        |> Seq.sortBy (fun (m, _) ->
-            // Sort by normalized name and return type so that getters and setters of the same properties
-            // are guaranteed to be neighboring.
-            normalizePropertyName m, getReturnType m)
-        |> Seq.toList
-        |> formatMembers
-        writer.Dump()
-
-/// Find corresponding interface declaration at a given position
-let private tryFindInterfaceDeclarationParsedInput (pos: pos) (parsedInput: ParsedInput) : InterfaceData option =
-    let rec walkImplFileInput (ParsedImplFileInput(_name, _isScript, _fileName, _scopedPragmas, _hashDirectives, moduleOrNamespaceList, _)) =
-        List.tryPick walkSynModuleOrNamespace moduleOrNamespaceList
-
-    and walkSynModuleOrNamespace(SynModuleOrNamespace(_, _, _, decls, _, _, _access, range)) =
-        if not <| rangeContainsPos range pos then
-            None
-        else
-            List.tryPick walkSynModuleDecl decls
-
-    and walkSynModuleDecl(decl: SynModuleDecl) =
-        if not <| rangeContainsPos decl.Range pos then
-            None
-        else
-            match decl with
-            | SynModuleDecl.Exception(SynExceptionDefn(_, synMembers, _), _) ->
-                List.tryPick walkSynMemberDefn synMembers
-            | SynModuleDecl.Let(_isRecursive, bindings, _range) ->
-                List.tryPick walkBinding bindings
-            | SynModuleDecl.ModuleAbbrev(_lhs, _rhs, _range) ->
-                None
-            | SynModuleDecl.NamespaceFragment(fragment) ->
-                walkSynModuleOrNamespace fragment
-            | SynModuleDecl.NestedModule(_, _, modules, _, _) ->
-                List.tryPick walkSynModuleDecl modules
-            | SynModuleDecl.Types(typeDefs, _range) ->
-                List.tryPick walkSynTypeDefn typeDefs
-            | SynModuleDecl.DoExpr (_, expr, _) ->
-                walkExpr expr
-            | SynModuleDecl.Attributes _
-            | SynModuleDecl.HashDirective _
-            | SynModuleDecl.Open _ ->
-                None
-
-    and walkSynTypeDefn(TypeDefn(_componentInfo, representation, members, range)) =
-        if not <| rangeContainsPos range pos then
-            None
-        else
-            walkSynTypeDefnRepr representation
-            |> Option.orElseWith (fun _ -> List.tryPick walkSynMemberDefn members)
-
-    and walkSynTypeDefnRepr(typeDefnRepr: SynTypeDefnRepr) =
-        if not <| rangeContainsPos typeDefnRepr.Range pos then
-            None
-        else
-            match typeDefnRepr with
-            | SynTypeDefnRepr.ObjectModel(_kind, members, _range) ->
-                List.tryPick walkSynMemberDefn members
-            | SynTypeDefnRepr.Simple(_repr, _range) ->
-                None
-            | SynTypeDefnRepr.Exception _ -> None
-
-    and walkSynMemberDefn (memberDefn: SynMemberDefn) =
-        if not <| rangeContainsPos memberDefn.Range pos then
-            None
-        else
-            match memberDefn with
-            | SynMemberDefn.AbstractSlot(_synValSig, _memberFlags, _range) ->
-                None
-            | SynMemberDefn.AutoProperty(_attributes, _isStatic, _id, _type, _memberKind, _memberFlags, _xmlDoc, _access, expr, _r1, _r2) ->
-                walkExpr expr
-            | SynMemberDefn.Interface(interfaceType, members, _range) ->
-                if rangeContainsPos interfaceType.Range pos then
-                    Some(InterfaceData.Interface(interfaceType, members))
-                else
-                    Option.bind (List.tryPick walkSynMemberDefn) members
-            | SynMemberDefn.Member(binding, _range) ->
-                walkBinding binding
-            | SynMemberDefn.NestedType(typeDef, _access, _range) ->
-                walkSynTypeDefn typeDef
-            | SynMemberDefn.ValField(_field, _range) ->
-                None
-            | SynMemberDefn.LetBindings(bindings, _isStatic, _isRec, _range) ->
-                List.tryPick walkBinding bindings
-            | SynMemberDefn.Open _
-            | SynMemberDefn.ImplicitCtor _
-            | SynMemberDefn.Inherit _ -> None
-            | SynMemberDefn.ImplicitInherit (_, expr, _, _) -> walkExpr expr
-
-    and walkBinding (Binding(_access, _bindingKind, _isInline, _isMutable, _attrs, _xmldoc, _valData, _headPat, _retTy, expr, _bindingRange, _seqPoint)) =
-        walkExpr expr
-
-    and walkExpr expr =
-        if not <| rangeContainsPos expr.Range pos then
-            None
-        else
-            match expr with
-            | SynExpr.Quote(synExpr1, _, synExpr2, _, _range) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-
-            | SynExpr.Const(_synConst, _range) ->
-                None
-
-            | SynExpr.Paren(synExpr, _, _, _parenRange) ->
-                walkExpr synExpr
-            | SynExpr.Typed(synExpr, _synType, _range) ->
-                walkExpr synExpr
-
-            | SynExpr.Tuple(_, synExprList, _, _range)
-            | SynExpr.ArrayOrList(_, synExprList, _range) ->
-                List.tryPick walkExpr synExprList
-
-            | SynExpr.Record(_inheritOpt, _copyOpt, fields, _range) ->
-                List.tryPick (fun (_, e, _) -> Option.bind walkExpr e) fields
-
-            | SynExpr.New(_, _synType, synExpr, _range) ->
-                walkExpr synExpr
-
-            | SynExpr.ObjExpr(ty, baseCallOpt, binds, ifaces, _range1, _range2) ->
+let tryFindInterfaceDeclAt (pos: pos) (tree: ParsedInput) =
+  AstTraversal.Traverse(pos, tree, {
+      new AstTraversal.AstVisitorBase<_>() with
+        member _.VisitExpr (_, _, defaultTraverse, expr) =
+          match expr with
+            SynExpr.ObjExpr(ty, baseCallOpt, binds, ifaces, _, _) ->
                 match baseCallOpt with
                 | None ->
                     if rangeContainsPos ty.Range pos then
                         Some (InterfaceData.ObjExpr(ty, binds))
                     else
-                        ifaces |> List.tryPick (fun (InterfaceImpl(ty, binds, range)) ->
+                        ifaces
+                        |> List.tryPick (fun (InterfaceImpl(ty, binds, range)) ->
                             if rangeContainsPos range pos then
                                 Some (InterfaceData.ObjExpr(ty, binds))
-                            else None)
-                | Some _ ->
-                    // Ignore object expressions of normal objects
-                    None
-
-            | SynExpr.While(_sequencePointInfoForWhileLoop, synExpr1, synExpr2, _range) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-            | SynExpr.ForEach(_sequencePointInfoForForLoop, _seqExprOnly, _isFromSource, _synPat, synExpr1, synExpr2, _range) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-
-            | SynExpr.For(_sequencePointInfoForForLoop, _ident, synExpr1, _, synExpr2, synExpr3, _range) ->
-                List.tryPick walkExpr [synExpr1; synExpr2; synExpr3]
-
-            | SynExpr.ArrayOrListOfSeqExpr(_, synExpr, _range) ->
-                walkExpr synExpr
-            | SynExpr.CompExpr(_, _, synExpr, _range) ->
-                walkExpr synExpr
-            | SynExpr.Lambda(_, _, _synSimplePats, synExpr, _, _range) ->
-                 walkExpr synExpr
-
-            | SynExpr.MatchLambda(_isExnMatch, _argm, synMatchClauseList, _spBind, _wholem) ->
-                synMatchClauseList |> List.tryPick (fun (Clause(_, _, e, _, _)) -> walkExpr e)
-            | SynExpr.Match(_sequencePointInfoForBinding, synExpr, synMatchClauseList, _range) ->
-                walkExpr synExpr
-                |> Option.orElseWith (fun _ -> synMatchClauseList |> List.tryPick (fun (Clause(_, _, e, _, _)) -> walkExpr e))
-
-            | SynExpr.Lazy(synExpr, _range) ->
-                walkExpr synExpr
-            | SynExpr.Do(synExpr, _range) ->
-                walkExpr synExpr
-            | SynExpr.Assert(synExpr, _range) ->
-                walkExpr synExpr
-
-            | SynExpr.App(_exprAtomicFlag, _isInfix, synExpr1, synExpr2, _range) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-
-            | SynExpr.TypeApp(synExpr, _, _synTypeList, _commas, _, _, _range) ->
-                walkExpr synExpr
-
-            | SynExpr.LetOrUse(_, _, synBindingList, synExpr, _range) ->
-                walkExpr synExpr
-                |> Option.orElseWith (fun _ -> List.tryPick walkBinding synBindingList)
-
-            | SynExpr.TryWith(synExpr, _range, _synMatchClauseList, _range2, _range3, _sequencePointInfoForTry, _sequencePointInfoForWith) ->
-                walkExpr synExpr
-
-            | SynExpr.TryFinally(synExpr1, synExpr2, _range, _sequencePointInfoForTry, _sequencePointInfoForFinally) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-
-            | Sequentials exprs  ->
-                List.tryPick walkExpr exprs
-
-            | SynExpr.IfThenElse(synExpr1, synExpr2, synExprOpt, _sequencePointInfoForBinding, _isRecovery, _range, _range2) ->
-                match synExprOpt with
-                | Some synExpr3 ->
-                    List.tryPick walkExpr [synExpr1; synExpr2; synExpr3]
-                | None ->
-                    List.tryPick walkExpr [synExpr1; synExpr2]
-
-            | SynExpr.Ident(_ident) ->
-                None
-            | SynExpr.LongIdent(_, _longIdent, _altNameRefCell, _range) ->
-                None
-
-            | SynExpr.LongIdentSet(_longIdent, synExpr, _range) ->
-                walkExpr synExpr
-            | SynExpr.DotGet(synExpr, _dotm, _longIdent, _range) ->
-                walkExpr synExpr
-
-            | SynExpr.DotSet(synExpr1, _longIdent, synExpr2, _range) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-
-            | SynExpr.DotIndexedGet(synExpr, IndexerArgList synExprList, _range, _range2) ->
-                synExprList
-                |> List.map fst
-                |> List.tryPick walkExpr
-                |> Option.orElseWith (fun _ -> walkExpr synExpr)
-
-            | SynExpr.DotIndexedSet(synExpr1, IndexerArgList synExprList, synExpr2, _, _range, _range2) ->
-                [ yield synExpr1
-                  yield! synExprList |> List.map fst
-                  yield synExpr2 ]
-                |> List.tryPick walkExpr
-
-            | SynExpr.JoinIn(synExpr1, _range, synExpr2, _range2) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-            | SynExpr.NamedIndexedPropertySet(_longIdent, synExpr1, synExpr2, _range) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-
-            | SynExpr.DotNamedIndexedPropertySet(synExpr1, _longIdent, synExpr2, synExpr3, _range) ->
-                List.tryPick walkExpr [synExpr1; synExpr2; synExpr3]
-
-            | SynExpr.TypeTest(synExpr, _synType, _range)
-            | SynExpr.Upcast(synExpr, _synType, _range)
-            | SynExpr.Downcast(synExpr, _synType, _range) ->
-                walkExpr synExpr
-            | SynExpr.InferredUpcast(synExpr, _range)
-            | SynExpr.InferredDowncast(synExpr, _range) ->
-                walkExpr synExpr
-            | SynExpr.AddressOf(_, synExpr, _range, _range2) ->
-                walkExpr synExpr
-            | SynExpr.TraitCall(_synTyparList, _synMemberSig, synExpr, _range) ->
-                walkExpr synExpr
-
-            | SynExpr.Null(_range)
-            | SynExpr.ImplicitZero(_range) ->
-                None
-
-            | SynExpr.YieldOrReturn(_, synExpr, _range)
-            | SynExpr.YieldOrReturnFrom(_, synExpr, _range)
-            | SynExpr.DoBang(synExpr, _range) ->
-                walkExpr synExpr
-
-            | SynExpr.LetOrUseBang(_sequencePointInfoForBinding, _, _, _synPat, synExpr1, ands, synExpr2, _range) ->
-                [ synExpr1
-                  yield! ands |> List.map (fun (_,_,_,_,body,_) -> body)
-                  synExpr2 ] |> List.tryPick walkExpr
-
-            | SynExpr.LibraryOnlyILAssembly _
-            | SynExpr.LibraryOnlyStaticOptimization _
-            | SynExpr.LibraryOnlyUnionCaseFieldGet _
-            | SynExpr.LibraryOnlyUnionCaseFieldSet _ ->
-                None
-            | SynExpr.ArbitraryAfterError(_debugStr, _range) ->
-                None
-
-            | SynExpr.FromParseError(synExpr, _range)
-            | SynExpr.DiscardAfterMissingQualificationAfterDot(synExpr, _range) ->
-                walkExpr synExpr
-
-            | _ -> None
-
-    match parsedInput with
-    | ParsedInput.SigFile _input ->
-        None
-    | ParsedInput.ImplFile input ->
-        walkImplFileInput input
+                            else None
+                          )
+                | Some _ -> None
+          | _ -> defaultTraverse expr
+        override _.VisitModuleDecl (defaultTraverse, decl) =
+          match decl with
+          | SynModuleDecl.Types(types, _) ->
+            List.tryPick (walkTypeDefn pos) types
+          | _ -> defaultTraverse decl
+    })
 
 let tryFindInterfaceExprInBufferAtPos (codeGenService: CodeGenerationService) (pos: pos) (document : Document) =
     asyncMaybe {
@@ -833,12 +84,8 @@ let tryFindInterfaceExprInBufferAtPos (codeGenService: CodeGenerationService) (p
 
         return!
             parseResults.ParseTree
-            |> Option.bind (tryFindInterfaceDeclarationParsedInput pos)
+            |> Option.bind (tryFindInterfaceDeclAt pos)
     }
-
-/// The code below is responsible for handling the code generation and determining the insert position
-let getLineIdent (lineStr: string) =
-    lineStr.Length - lineStr.TrimStart(' ').Length
 
 /// Return the interface identifier
 /// Useful, to determine the insert position when no `with` keyword has been found.
@@ -860,56 +107,7 @@ let getInterfaceIdentifier (interfaceData : InterfaceData) (tokens : FSharpToken
                     && token.TokenName = "INTERFACE"
             )
 
-    let rec findLastIdentifier (tokens : FSharpTokenInfo list) (lastValidToken : FSharpTokenInfo) =
-        match tokens with
-        // This rule try to move on step in the namespace declaration
-        // System.Collections.ICollection
-        //          ^
-        // { new System.Collections.ICollection }
-        //                 ^
-        | _::potentialDot::validIdentifier::tail
-            when potentialDot.CharClass = FSharpTokenCharKind.Delimiter
-                    && potentialDot.TokenName = "DOT"
-                    && validIdentifier.CharClass = FSharpTokenCharKind.Identifier
-                    && validIdentifier.TokenName = "IDENT" ->
-            findLastIdentifier tail validIdentifier
-        // This rule match when we are at the end of the namespace and there is some tokens left in the pile
-        // { new System.Collections.ICollection }
-        //                              ^
-        | potentialDot::validIdentifier::_
-            when potentialDot.CharClass = FSharpTokenCharKind.Delimiter
-                    && potentialDot.TokenName = "DOT"
-                    && validIdentifier.CharClass = FSharpTokenCharKind.Identifier
-                    && validIdentifier.TokenName = "IDENT" ->
-            validIdentifier
-        // This rule match when we are at the end of the namespace and there is no more tokens
-        // interface System.Collections.ICollection
-        //                              ^
-        | potentialDot::validIdentifier::[]
-            when potentialDot.CharClass = FSharpTokenCharKind.Delimiter
-                    && potentialDot.TokenName = "DOT"
-                    && validIdentifier.CharClass = FSharpTokenCharKind.Identifier
-                    && validIdentifier.TokenName = "IDENT" ->
-            validIdentifier
-        // If no special rule found, return the last valid token found
-        | _ -> lastValidToken
-
-    findLastIdentifier tokens.[newKeywordIndex + 2..] tokens.[newKeywordIndex + 2]
-
-let findLastGreaterOperator (tokens : FSharpTokenInfo list) =
-    tokens
-    |> List.findBack(fun token ->
-        token.CharClass = FSharpTokenCharKind.Operator
-            && token.TokenName = "GREATER"
-    )
-
-/// Return the greater multiple of `powerNumber` which is smaller than `value`
-/// Ex: roundToNearest 14 4 -> 12
-let findGreaterMultiple (value : int) (powerNumber : int) =
-    let mutable res = powerNumber
-    while res + powerNumber < value do
-        res <- res + powerNumber
-    res
+    CodeGenerationUtils.findLastIdentifier tokens.[newKeywordIndex + 2..] tokens.[newKeywordIndex + 2]
 
 /// Try to find the start column, so we know what the base indentation should be
 let inferStartColumn  (codeGenServer : CodeGenerationService) (pos : pos) (doc : Document) (lines: LineStr[]) (lineStr : string) (interfaceData : InterfaceData) (indentSize : int) =
@@ -970,38 +168,16 @@ let handleImplementInterface (codeGenServer : CodeGenerationService) (checkResul
 
             let insertInfo =
                 match codeGenServer.TokenizeLine(doc.FullName, pos.Line) with
-                | Some tokens ->
-                    let endPosOfWidth =
-                        tokens
-                        |> List.tryPick (fun (t: FSharpTokenInfo) ->
-                                if t.CharClass = FSharpTokenCharKind.Keyword && t.LeftColumn >= pos.Column && t.TokenName = "WITH" then
-                                    Some (Pos.fromZ (pos.Line - 1) (t.RightColumn + 1))
-                                else None)
-
-                    match endPosOfWidth with
-                    // If we found the position of `with` keyword, return it as it will serve as a reference position for insertion
-                    | Some pos -> Some (false, pos)
-                    // `with` not found, so we need to find the end position of the interface identifer
-                    | None ->
-                        let position =
-                            // If the interface doesn't use generic, returns the position after the identifer
-                            if entity.GenericParameters.Count = 0 then
-                                let token = getInterfaceIdentifier interfaceData tokens
-                                Pos.fromZ (pos.Line - 1) (token.RightColumn + 1)
-                            // Otherwise, returns the position after the last greater angle (>)
-                            else
-                                let token = findLastGreaterOperator tokens
-                                Pos.fromZ (pos.Line - 1) (token.RightColumn + 1)
-
-                        Some (true, position)
+                | Some tokens -> findLastPositionOfWithKeyword tokens entity pos (getInterfaceIdentifier interfaceData)
                 | None -> None
 
+            let desiredMemberNamesAndRanges = getMemberNameAndRanges interfaceData
             let! implementedSignatures =
-                getImplementedMemberSignatures getMemberByLocation displayContext interfaceData
+                getImplementedMemberSignatures getMemberByLocation displayContext desiredMemberNamesAndRanges
 
             let generatedString =
                 let formattedString =
-                    formatInterface
+                    formatMembersAt
                         (inferStartColumn codeGenServer pos doc lines lineStr interfaceData 4) // 4 here correspond to the indent size
                         4 // Should we make it a setting from the IDE ?
                         interfaceData.TypeParameters
@@ -1010,6 +186,7 @@ let handleImplementInterface (codeGenServer : CodeGenerationService) (checkResul
                         displayContext
                         implementedSignatures
                         entity
+                        getInterfaceMembers
                         true // Always generate the verbose version of the code
 
                 // If we are in a object expression, we remove the last new line, so the `}` stay on the same line

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -553,6 +553,16 @@ type ParseAndCheckResults
   member __.GetAllSymbolUsesInFile () = checkResults.GetAllUsesOfAllSymbolsInFile()
 
   member __.GetSemanticClassification = checkResults.GetSemanticClassification None
+
+  // member this.GetExpandedType (pos: pos) =
+  //   match parseResults.ParseTree with
+  //   | Some input ->
+  //     AstTraversal.Traverse(pos, input, {
+  //       new AstTraversal.AstVisitorBase<_>() with
+  //     })
+  //   | None -> None
+
+
   member __.GetAST = parseResults.ParseTree
   member __.GetCheckResults = checkResults
   member __.GetParseResults = parseResults

--- a/src/FsAutoComplete.Core/RecordStubGenerator.fs
+++ b/src/FsAutoComplete.Core/RecordStubGenerator.fs
@@ -6,6 +6,7 @@ open FSharp.Compiler.SyntaxTree
 open FSharp.Compiler.Range
 open FSharp.Compiler.SourceCodeServices
 open System.Diagnostics
+open FsAutoComplete.CodeGenerationUtils
 
 // Algorithm
 // [x] Make sure '}' is the last token of the expression

--- a/src/FsAutoComplete.Core/UnionPatternMatchCaseGenerator.fs
+++ b/src/FsAutoComplete.Core/UnionPatternMatchCaseGenerator.fs
@@ -8,6 +8,7 @@ open FSharp.Compiler.SyntaxTree
 open FSharp.Compiler.SyntaxTreeOps
 open FSharp.Compiler.Range
 open FSharp.Compiler.SourceCodeServices
+open FsAutoComplete.CodeGenerationUtils
 
 [<NoEquality; NoComparison>]
 type PatternMatchExpr = {

--- a/src/FsAutoComplete/CodeFixes.fs
+++ b/src/FsAutoComplete/CodeFixes.fs
@@ -270,6 +270,7 @@ module Fixes =
 
           let filePath =
             codeActionParameter.TextDocument.GetFilePath()
+
           match! getParseResultsForFile filePath pos with
           | Ok (tyRes, line, lines) ->
               match! getNamespaceSuggestions tyRes pos line with
@@ -404,7 +405,6 @@ module Fixes =
             FSharp.Compiler.Range.mkPos (caseLine + 1) (col + 1) //Must points on first case in 1-based system
 
           let! (tyRes, line, lines) = getParseResultsForFile fileName pos
-
           match! generateCases tyRes pos lines line |> Async.map Ok with
           | CoreResponse.Res (insertString: string, insertPosition) ->
               let range =
@@ -458,8 +458,7 @@ module Fixes =
   let mapAnalyzerDiagnostics = mapExternalDiagnostic "F# Analyzers"
 
   /// a codefix that generates member stubs for an interface declaration
-  let generateInterfaceStub (getFileLines: string -> Result<string [], _>)
-                            (getParseResultsForFile: string -> FSharp.Compiler.Range.pos -> Async<Result<ParseAndCheckResults * string * string array, 'e>>)
+  let generateInterfaceStub (getParseResultsForFile: string -> FSharp.Compiler.Range.pos -> Async<Result<ParseAndCheckResults * string * string array, 'e>>)
                             (genInterfaceStub: _ -> _ -> _ -> _ -> Async<CoreResponse<string * FSharp.Compiler.Range.pos>>)
                             (getTextReplacements: unit -> Map<string, string>)
                             : CodeFix =
@@ -468,13 +467,10 @@ module Fixes =
         let fileName =
           codeActionParams.TextDocument.GetFilePath()
 
-        let! (lines: string []) = getFileLines fileName
-
         let pos =
           protocolPosToPos codeActionParams.Range.Start
 
         let! (tyRes, line, lines) = getParseResultsForFile fileName pos
-
         match! genInterfaceStub tyRes pos lines line with
         | CoreResponse.Res (text, position) ->
             let replacements = getTextReplacements ()
@@ -497,8 +493,7 @@ module Fixes =
       |> AsyncResult.foldResult id (fun _ -> [])
 
   /// a codefix that generates member stubs for a record declaration
-  let generateRecordStub (getFileLines: string -> Result<string [], _>)
-                         (getParseResultsForFile: string -> FSharp.Compiler.Range.pos -> Async<Result<ParseAndCheckResults * string * string array, 'e>>)
+  let generateRecordStub (getParseResultsForFile: string -> FSharp.Compiler.Range.pos -> Async<Result<ParseAndCheckResults * string * string array, 'e>>)
                          (genRecordStub: _ -> _ -> _ -> _ -> Async<CoreResponse<string * FSharp.Compiler.Range.pos>>)
                          (getTextReplacements: unit -> Map<string, string>)
                          : CodeFix =
@@ -507,13 +502,10 @@ module Fixes =
         let fileName =
           codeActionParams.TextDocument.GetFilePath()
 
-        let! (lines: string []) = getFileLines fileName
-
         let pos =
           protocolPosToPos codeActionParams.Range.Start
 
         let! (tyRes, line, lines) = getParseResultsForFile fileName pos
-
         match! genRecordStub tyRes pos lines line with
         | CoreResponse.Res (text, position) ->
             let replacements = getTextReplacements ()
@@ -533,6 +525,41 @@ module Fixes =
         | _ -> return []
       }
       |> AsyncResult.foldResult id (fun _ -> [])
+
+  /// a codefix that generates stubs for required override members in abstract types
+  let generateAbstractClassStub (getParseResultsForFile: string -> FSharp.Compiler.Range.pos -> Async<Result<ParseAndCheckResults * string * string array, 'e>>)
+                                (genAbstractClassStub: _ -> _ -> _ -> _ -> Async<CoreResponse<string * FSharp.Compiler.Range.pos>>)
+                                (getTextReplacements: unit -> Map<string, string>)
+                                : CodeFix =
+    ifDiagnosticByCode
+      (fun diagnostic codeActionParams ->
+        asyncResult {
+          let fileName =
+            codeActionParams.TextDocument.GetFilePath()
+
+          let objExprRange = protocolRangeToRange fileName codeActionParams.Range
+
+          let! (tyRes, line, lines) = getParseResultsForFile fileName objExprRange.Start
+          match! genAbstractClassStub tyRes objExprRange lines line with
+          | CoreResponse.Res (text, position) ->
+              let replacements = getTextReplacements ()
+
+              let replaced =
+                (text, replacements)
+                ||> Seq.fold (fun text (KeyValue (key, replacement)) -> text.Replace(key, replacement))
+
+              return
+                [ { SourceDiagnostic = None
+                    Title = "Generate record stub"
+                    File = codeActionParams.TextDocument
+                    Edits =
+                      [| { Range = fcsPosToProtocolRange position
+                           NewText = replaced } |]
+                    Kind = Fix } ]
+          | _ -> return []
+        }
+        |> AsyncResult.foldResult id (fun _ -> [])
+      ) (Set.ofList ["365"])
 
   /// a codefix that adds in missing '=' characters in type declarations
   let addMissingEqualsToTypeDefinition (getFileLines: string -> Result<string [], _>) =

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -598,8 +598,8 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                         DocumentFormattingProvider = Some true
                         DocumentRangeFormattingProvider = Some false
                         SignatureHelpProvider = Some {
-                            TriggerCharacters = Some [| '('; ','; |]
-                            RetriggerCharacters = Some [| ')'; |]
+                            TriggerCharacters = Some [| '('; ','; ' ' |]
+                            RetriggerCharacters = Some [| ','; ')'; ' '|]
                         }
                         CompletionProvider =
                             Some {

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -468,6 +468,10 @@ type FSharpConfigDto = {
     FSICompilerToolLocations: string [] option
     TooltipMode : string option
     GenerateBinlog: bool option
+    AbstractClassStubGeneration: bool option
+    AbstractClassStubGenerationObjectIdentifier: string option
+    AbstractClassStubGenerationMethodBody: string option
+
 }
 
 type FSharpConfigRequest = {
@@ -486,6 +490,9 @@ type FSharpConfig = {
     UnionCaseStubGenerationBody: string
     RecordStubGeneration: bool
     RecordStubGenerationBody: string
+    AbstractClassStubGeneration: bool
+    AbstractClassStubGenerationObjectIdentifier: string
+    AbstractClassStubGenerationMethodBody: string
     InterfaceStubGeneration: bool
     InterfaceStubGenerationObjectIdentifier: string
     InterfaceStubGenerationMethodBody: string
@@ -519,6 +526,9 @@ with
             UnionCaseStubGenerationBody = "failwith \"Not Implemented\""
             RecordStubGeneration = false
             RecordStubGenerationBody = "failwith \"Not Implemented\""
+            AbstractClassStubGeneration = true
+            AbstractClassStubGenerationObjectIdentifier = "this"
+            AbstractClassStubGenerationMethodBody = "failwith \"Not Implemented\""
             InterfaceStubGeneration = false
             InterfaceStubGenerationObjectIdentifier = "this"
             InterfaceStubGenerationMethodBody = "failwith \"Not Implemented\""
@@ -542,7 +552,7 @@ with
             GenerateBinlog = false
         }
 
-    static member FromDto(dto: FSharpConfigDto) =
+    static member FromDto(dto: FSharpConfigDto): FSharpConfig =
         {
             AutomaticWorkspaceInit = defaultArg dto.AutomaticWorkspaceInit false
             WorkspaceModePeekDeepLevel = defaultArg dto.WorkspaceModePeekDeepLevel 2
@@ -579,6 +589,9 @@ with
             FSICompilerToolLocations = defaultArg dto.FSICompilerToolLocations FSharpConfig.Default.FSICompilerToolLocations
             TooltipMode = defaultArg dto.TooltipMode "full"
             GenerateBinlog = defaultArg dto.GenerateBinlog false
+            AbstractClassStubGeneration = defaultArg dto.AbstractClassStubGeneration false
+            AbstractClassStubGenerationObjectIdentifier = defaultArg dto.AbstractClassStubGenerationObjectIdentifier "this"
+            AbstractClassStubGenerationMethodBody = defaultArg dto.AbstractClassStubGenerationMethodBody "failwith \Not Implemented\""
         }
 
     /// called when a configuration change takes effect, so None-valued members here should revert options
@@ -586,6 +599,9 @@ with
     member x.AddDto(dto: FSharpConfigDto) =
         {
             AutomaticWorkspaceInit = defaultArg dto.AutomaticWorkspaceInit x.AutomaticWorkspaceInit
+            AbstractClassStubGeneration = defaultArg dto.AbstractClassStubGeneration x.AbstractClassStubGeneration
+            AbstractClassStubGenerationObjectIdentifier = defaultArg dto.AbstractClassStubGenerationObjectIdentifier x.AbstractClassStubGenerationObjectIdentifier
+            AbstractClassStubGenerationMethodBody = defaultArg dto.AbstractClassStubGenerationMethodBody x.AbstractClassStubGenerationMethodBody
             WorkspaceModePeekDeepLevel = defaultArg dto.WorkspaceModePeekDeepLevel x.WorkspaceModePeekDeepLevel
             ExcludeProjectDirectories = defaultArg dto.ExcludeProjectDirectories x.ExcludeProjectDirectories
             KeywordsAutocomplete = defaultArg dto.KeywordsAutocomplete x.KeywordsAutocomplete

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -99,7 +99,10 @@ let defaultConfigDto : FSharpConfigDto =
     FSIExtraParameters = None
     FSICompilerToolLocations = None
     TooltipMode = None
-    GenerateBinlog = None }
+    GenerateBinlog = None
+    AbstractClassStubGeneration = None
+    AbstractClassStubGenerationMethodBody = None
+    AbstractClassStubGenerationObjectIdentifier = None }
 
 let clientCaps : ClientCapabilities =
   let dynCaps : DynamicCapabilities = { DynamicRegistration = Some true}


### PR DESCRIPTION
This implements code generation similar to interface stub generation, but for abstract classes.

This works both on `inherit` syntax in 'full' type definitions as well as object expressions that implement an abstract class.

I factored out most of the core logic from the interface file to the code generation file, then patched up the interface generation and abstract class generation to use those shared members, because most of the content of the interface stub generation file was in logic that had little to do with interfaces specifically.