### PR TITLE
Add a codefix to add a missing 'fun' keyword when appropriate

### DIFF
--- a/src/FsAutoComplete.Core/CodeGeneration.fs
+++ b/src/FsAutoComplete.Core/CodeGeneration.fs
@@ -39,12 +39,7 @@ type CodeGenerationService(checker : FSharpCompilerServiceChecker, state : State
                 | ResultOrString.Error _ -> return! None
                 | ResultOrString.Ok (opts, _, line) ->
                     let! result = checker.TryGetRecentCheckResultsForFile(fileName, opts)
-                    let symbolUse = async {
-                      let! r = result.TryGetSymbolUse pos line
-                      match r with
-                      | ResultOrString.Error _ -> return None
-                      | ResultOrString.Ok (suse, _) -> return Some suse
-                    }
+                    let symbolUse = result.TryGetSymbolUse pos line
                     return! Some (symbol, symbolUse)
             else
                 return! None

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -92,6 +92,12 @@ module Option =
   let inline attempt (f: unit -> 'T) = try Some <| f() with _ -> None
 
 [<RequireQualifiedAccess>]
+module Result =
+  let inline bimap okF errF r = match r with | Ok x -> okF x | Error y -> errF y
+  let inline ofOption recover o = match o with | Some x -> Ok x | None -> Error (recover ())
+  let inline guard condition errorValue = if condition () then Ok () else Error errorValue
+
+[<RequireQualifiedAccess>]
 module Async =
     /// Transforms an Async value using the specified function.
     [<CompiledName("Map")>]
@@ -136,7 +142,12 @@ module Async =
 
                 // Return the completed results.
                 return result
-}
+            }
+
+[<RequireQualifiedAccess>]
+module AsyncResult =
+  let inline bimap okF errF r = Async.map (Result.bimap okF errF) r
+  let inline ofOption recover o = Async.map (Result.ofOption recover) o
 
 // Maybe computation expression builder, copied from ExtCore library
 /// https://github.com/jack-pappas/ExtCore/blob/master/ExtCore/Control.fs

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -432,6 +432,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
         }
 
         let getFileLines = commands.TryGetFileCheckerOptionsWithLines >> Result.map snd
+        let getProjectOptsAndLines = commands.TryGetFileCheckerOptionsWithLinesAndLineStr
         let tryGetProjectOptions = commands.TryGetFileCheckerOptionsWithLines >> Result.map fst
 
         let interfaceStubReplacements =
@@ -494,6 +495,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             Fixes.partialOrInvalidRecordExpressionToAnonymousRecord tryGetParseResultsForFile
             Fixes.removeUnnecessaryReturnOrYield tryGetParseResultsForFile
             Fixes.rewriteCSharpLambdaToFSharpLambda tryGetParseResultsForFile
+            Fixes.addMissingFunKeyword getFileLines
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p


### PR DESCRIPTION
![nofun](https://user-images.githubusercontent.com/573979/101720342-fc5f9900-3a6a-11eb-853b-cb5f9ca2f366.gif)
