### PR TITLE
Increase priority for properties in class constructor

### DIFF
--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -515,9 +515,17 @@ type ParseAndCheckResults
       let sortedDecls =
           decls
           |> Array.sortWith (fun x y ->
+              let transformKind (item: FSharpDeclarationListItem) =
+                if item.Kind = CompletionItemKind.Field && item.Glyph = FSharpGlyph.Method then
+                  CompletionItemKind.Method false
+                elif item.Kind = CompletionItemKind.Argument && item.Glyph = FSharpGlyph.Property then
+                  CompletionItemKind.Property
+                else
+                  item.Kind
+
               let mutable n = (not x.IsResolved).CompareTo(not y.IsResolved)
               if n <> 0 then n else
-                  n <- (getKindPriority x.Kind).CompareTo(getKindPriority y.Kind)
+                  n <- (getKindPriority <| transformKind x).CompareTo(getKindPriority <| transformKind y)
                   if n <> 0 then n else
                       n <- (not x.IsOwnMember).CompareTo(not y.IsOwnMember)
                       if n <> 0 then n else

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -379,6 +379,22 @@ let autocompleteTest =
           Expect.exists res.Items (fun n -> n.Label = "bar") "Autocomplete contains given symbol"
           Expect.exists res.Items (fun n -> n.Label = "baz") "Autocomplete contains given symbol"
       }))
+
+    testCaseAsync "Autocomplete class constructor with properties" (serverTest (fun server path ->
+      async {
+        let p : CompletionParams = {
+          TextDocument = { Uri = Path.FilePathToUri path }
+          Position = { Line = 32; Character = 26 }
+          Context = None
+        }
+        let! res = server.TextDocumentCompletion p
+        match res with
+        | Result.Error e -> failtestf "Request failed: %A" e
+        | Result.Ok None -> failtest "Request none"
+        | Result.Ok (Some res) ->
+          Expect.isTrue ((res.Items |> Seq.findIndex (fun n -> n.Label = "Bar")) < 2) "Autocomplete contains given symbol"
+          Expect.isTrue ((res.Items |> Seq.findIndex (fun n -> n.Label = "Baz")) < 2) "Autocomplete contains given symbol"
+      }))
   ]
 
   testSequenced (

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/AutocompleteScriptTest/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/AutocompleteScriptTest/Script.fsx
@@ -24,3 +24,10 @@ type Foo = {
 let foo = { bar = "bar"; baz = false }
 
 foo.
+
+type Stub() =
+    member val Foo = "" with get, set
+    member val Bar = "" with get, set
+    member val Baz = "" with get, set
+
+let s = Stub(Foo = "foo", )

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/AutocompleteTest/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/AutocompleteTest/Script.fsx
@@ -24,3 +24,10 @@ type Foo = {
 let foo = { bar = "bar"; baz = false }
 
 foo.
+
+type Stub() =
+    member val Foo = "" with get, set
+    member val Bar = "" with get, set
+    member val Baz = "" with get, set
+
+let s = Stub(Foo = "foo", )


### PR DESCRIPTION
Fixed problem causing functions to be most prioritized suggestion in most cases.

Imagine class
```fsharp
type Stub() =
    member val Foo = "" with get, set
    member val Bar = "" with get, set
    member val Baz = "" with get, set
```

You're trying to create instance with all properties set
```fsharp
let s = Stub(Foo = "foo", )
                         ^ press ctrl+space here
```
Before change you'll see `.. ..`, `abs`, `acos`, etc.
After change you'll see `Bar`, `Baz`, *others*

You're no longer need to remember all properties to effectively code with classes, e.g. Fabulous or XPlot

Needs to discuss solution, because it seems like a hack
Also needs to check behavior inside an editor, because I don't know how to do it