### PR TITLE
Add codefix for adding 'rec' to a binding

### DIFF
--- a/src/FsAutoComplete/CodeFixes.fs
+++ b/src/FsAutoComplete/CodeFixes.fs
@@ -949,10 +949,10 @@ module Fixes =
       (Set.ofList [ "39" // undefined value
                     "43" ]) // operator not defined
 
+  /// a codefix that adds a missing 'fun' keyword to a lambda
   let rec addMissingFunKeyword
     (getFileLines: string -> Result<string [], _>)
     : CodeFix =
-    let logger = LogProvider.getLoggerByName (nameof addMissingFunKeyword)
     ifDiagnosticByCode (
       fun diagnostic codeActionParams ->
       asyncResult {
@@ -969,11 +969,6 @@ module Fixes =
         | Some firstNonWhitespacePos ->
           let pos2Range = ({ Start = firstNonWhitespacePos; End = inc lines firstNonWhitespacePos })
           let charAtPos2 = getText lines pos2Range
-          logger.info (Log.setMessage "walked pack from {pos}@{char} to {pos2}@{char2}"
-                       >> Log.addContextDestructured "pos" diagnostic.Range.Start
-                       >> Log.addContextDestructured "char" charAtPos
-                       >> Log.addContextDestructured "pos2" firstNonWhitespacePos
-                       >> Log.addContextDestructured "char2" charAtPos2)
           let fcsPos = protocolPosToPos firstNonWhitespacePos
           match Lexer.getSymbol fcsPos.Line fcsPos.Column line SymbolLookupKind.Fuzzy [||] with
           | Some lexSym ->

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -496,6 +496,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             Fixes.removeUnnecessaryReturnOrYield tryGetParseResultsForFile
             Fixes.rewriteCSharpLambdaToFSharpLambda tryGetParseResultsForFile
             Fixes.addMissingFunKeyword getFileLines
+            Fixes.makeOuterBindingRecursive tryGetParseResultsForFile
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p


### PR DESCRIPTION
Implements https://github.com/dotnet/fsharp/pull/10666 in FSAC.

The sample code used to test was:

```fsharp
let mySum xs acc =
    match xs with
    | [] -> acc
    | _ :: tail ->
        mySum tail (acc + 1)

let f x = 
    let h x = 
        h x
    
    let z = 12
    g x
```

which gives fixable errors on the inner `mySum` and the inner `h` but no other locations.