### PR TITLE
add codefix for mutually-recursive values where the initial let needs a 'rec'

### DIFF
--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -497,6 +497,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             Fixes.rewriteCSharpLambdaToFSharpLambda tryGetParseResultsForFile
             Fixes.addMissingFunKeyword getFileLines
             Fixes.makeOuterBindingRecursive tryGetParseResultsForFile
+            Fixes.addMissingRecToMutuallyRecFunctions getFileLines
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p


### PR DESCRIPTION
This is our implementation of https://github.com/dotnet/fsharp/pull/10678