### PR TITLE
Expand pipeline hints to final line and improve position

### DIFF
--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -338,6 +338,7 @@ module CommandResponse =
   type PieplineHint = {
     Line: int
     Types: string []
+    PrecedingNonPipeExprLine : int option
   }
 
   let private errorG (serialize : Serializer) (errorData: ErrorData) message =
@@ -545,10 +546,11 @@ module CommandResponse =
   let fsharpLiterate (serialize: Serializer) (content: string) =
     serialize { Kind = "fsharpLiterate"; Data = content}
 
-  let pipelineHint (serialize: Serializer) (content: (int * string list) []) =
+  let pipelineHint (serialize: Serializer) (content: (int * int option * string list) []) =
     let ctn =
-      content |> Array.map (fun (l, tt) -> {
+      content |> Array.map (fun (l, pnp, tt) -> {
         Line = l
         Types = Array.ofList tt
+        PrecedingNonPipeExprLine = pnp
       })
     serialize { Kind = "pipelineHint"; Data = ctn }


### PR DESCRIPTION
This is the FSAC side of implementing this improvement: https://github.com/ionide/ionide-vscode-fsharp/issues/1416

Currently, pipeline hints are done by finding each line starting with a pipe, and placing its incoming type on the previous line.

This PR attempts to make this a little more intelligent by:
- Tracking where the last meaningful preceding line was (Not whitespace or comment)
- Tracking if that last line was itself a pipe, and returning the meaningful line if it was not

This allows ionide to instead find each line starting with a pipe, and place its *outgoing* type on the current line. In addition, if the previous meaningful line was not a pipe (e.g. the starting expression), ionide can place the incoming type on that line.

Writing this up I realise it might not perfectly handle multi-line expressions between pipes, but I think it's still a solid improvement.

I haven't generally focused on code quality in my F# projects, so please be as critical of my approach and formatting as you'd like!

