### PR TITLE
Clean FCS cache in Background Service when Background Service is just waiting

### DIFF
--- a/src/FsAutoComplete.BackgroundServices/Program.fs
+++ b/src/FsAutoComplete.BackgroundServices/Program.fs
@@ -256,10 +256,12 @@ type BackgroundServiceServer(state: State, client: FsacClient) =
             match msg, lst with
             //Empty
             | None, [] ->
+                checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients ()
                 do! Async.Sleep 300
                 return! loop (false, [])
             //Empty
             | Some (_,_,[]), [] ->
+                checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients ()
                 do! Async.Sleep 300
                 return! loop (false, [])
             //No request we just continue

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -66,7 +66,6 @@ type Commands (serialize : Serializer, backgroundServiceEnabled, toolsPath) =
     let mutable linterConfiguration: FSharpLint.Application.Lint.ConfigurationParam = FSharpLint.Application.Lint.ConfigurationParam.Default
     let mutable lastVersionChecked = -1
     let mutable lastCheckResult : ParseAndCheckResults option = None
-    let mutable analyzerHandler : ((string * string [] * FSharp.Compiler.SyntaxTree.ParsedInput * FSharpImplementationFileContents * FSharpEntity list * (bool -> AssemblySymbol list)) -> FSharp.Analyzers.SDK.Message []) option = None
 
     let notify = Event<NotificationEvent>()
 


### PR DESCRIPTION
Soo.... this is really interesting approach to "fixing" memory issues of Background Service (https://github.com/fsharp/FsAutoComplete/issues/686). Basically, whenever Background Service is done with its operation queue we clean all the FCS caches essentially resetting the state of FCS and dramatically decreasing current memory allocation.

However, this probably has a negative impact on the performance of Backogrund Service itself - I'd expect if users repeat operations on the same project. For example in following case:
1.  there was some operation that triggered background service, 
2. user did nothing for a while
3. Background service finished queue
4. User triggered background service again
the second round of background service (4) will be as slow as first one since all the caches were cleared.

