### PR TITLE
Remove FSharp.Data

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -22,7 +22,6 @@ nuget Microsoft.Build.Framework copy_local:false
 nuget Microsoft.Build.Utilities.Core copy_local:false
 nuget Microsoft.Build.Tasks.Core copy_local: false
 nuget FSharp.Analyzers.SDK
-nuget FSharp.Data 3.0.1
 nuget ICSharpCode.Decompiler
 nuget Mono.Cecil >= 0.10.0-beta7
 nuget Newtonsoft.Json

--- a/paket.lock
+++ b/paket.lock
@@ -85,8 +85,6 @@ NUGET
       System.Threading.Thread (>= 4.3)
       System.Threading.ThreadPool (>= 4.3)
     FSharp.Core (5.0)
-    FSharp.Data (3.0.1)
-      FSharp.Core (>= 4.3.4)
     FSharp.Formatting (7.2.9)
       FSharp.Compiler.Service (>= 36.0.3)
     FSharp.UMX (1.0)
@@ -270,7 +268,7 @@ NUGET
       NETStandard.Library (>= 1.6)
       SQLitePCLRaw.core (>= 1.1.14)
     System.Buffers (4.5.1)
-    System.CodeDom (5.0)
+    System.CodeDom (5.0) - copy_local: false
     System.Collections (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
@@ -342,7 +340,9 @@ NUGET
       System.Runtime (>= 4.3)
     System.Drawing.Common (5.0) - restriction: || (== net50) (&& (== netstandard2.0) (>= netcoreapp3.0))
       Microsoft.Win32.SystemEvents (>= 5.0) - restriction: || (== net50) (&& (== netstandard2.0) (>= netcoreapp2.0)) (&& (== netstandard2.0) (>= netcoreapp3.0))
-    System.Formats.Asn1 (5.0)
+    System.Formats.Asn1 (5.0) - copy_local: false
+      System.Buffers (>= 4.5.1) - restriction: || (&& (== net50) (>= monotouch)) (&& (== net50) (>= net461)) (&& (== net50) (< netcoreapp2.0)) (&& (== net50) (>= xamarinios)) (&& (== net50) (>= xamarinmac)) (&& (== net50) (>= xamarintvos)) (&& (== net50) (>= xamarinwatchos)) (== netstandard2.0)
+      System.Memory (>= 4.5.4) - restriction: || (&& (== net50) (>= net461)) (&& (== net50) (< netcoreapp2.0)) (&& (== net50) (< netcoreapp2.1)) (&& (== net50) (>= uap10.1)) (== netstandard2.0)
     System.Globalization (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
@@ -526,7 +526,7 @@ NUGET
       Microsoft.NETCore.Targets (>= 1.1)
       System.Runtime (>= 4.3)
     System.Reflection.TypeExtensions (4.7)
-    System.Resources.Extensions (5.0)
+    System.Resources.Extensions (5.0) - copy_local: false
       System.Memory (>= 4.5.4) - restriction: || (&& (== net50) (>= net461)) (&& (== net50) (< netcoreapp2.1)) (== netstandard2.0)
     System.Resources.ResourceManager (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
@@ -596,7 +596,7 @@ NUGET
       System.Security.Cryptography.Encoding (>= 4.3)
       System.Security.Cryptography.Primitives (>= 4.3)
       System.Text.Encoding (>= 4.3)
-    System.Security.Cryptography.Cng (5.0)
+    System.Security.Cryptography.Cng (5.0) - copy_local: false
       System.Formats.Asn1 (>= 5.0) - restriction: || (== net50) (&& (== netstandard2.0) (>= netcoreapp3.0))
     System.Security.Cryptography.Csp (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
@@ -627,7 +627,7 @@ NUGET
       System.Text.Encoding (>= 4.3)
     System.Security.Cryptography.OpenSsl (5.0)
       System.Formats.Asn1 (>= 5.0) - restriction: || (== net50) (&& (== netstandard2.0) (>= netcoreapp3.0))
-    System.Security.Cryptography.Pkcs (5.0.1)
+    System.Security.Cryptography.Pkcs (5.0.1) - copy_local: false
       System.Buffers (>= 4.5.1) - restriction: || (&& (== net50) (< netcoreapp2.0) (< netstandard2.1)) (== netstandard2.0)
       System.Formats.Asn1 (>= 5.0)
       System.Memory (>= 4.5.4) - restriction: || (&& (== net50) (< netcoreapp2.0) (< netstandard2.1)) (&& (== net50) (< netcoreapp2.1) (< netstandard2.1)) (&& (== net50) (>= uap10.1)) (== netstandard2.0)
@@ -668,7 +668,7 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3)
       System.Text.Encoding (>= 4.3)
       System.Threading (>= 4.3)
-    System.Security.Cryptography.Xml (5.0)
+    System.Security.Cryptography.Xml (5.0) - copy_local: false
       System.Memory (>= 4.5.4) - restriction: || (&& (== net50) (< netcoreapp2.1)) (== netstandard2.0)
       System.Security.Cryptography.Pkcs (>= 5.0)
       System.Security.Permissions (>= 5.0)

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -328,7 +328,7 @@ type Commands (serialize : Serializer, backgroundServiceEnabled, toolsPath) =
         x.MapResultAsync ((fun x -> successToString x |> async.Return), ?failureToString = failureToString)
 
     member x.Fsdn (querystr) = async {
-            let results = Fsdn.query querystr
+            let! results = Fsdn.query querystr
             return CoreResponse.Res results
         }
 

--- a/src/FsAutoComplete.Core/paket.references
+++ b/src/FsAutoComplete.Core/paket.references
@@ -8,7 +8,6 @@ Newtonsoft.Json
 Fake.Runtime
 ICSharpCode.Decompiler
 Microsoft.SourceLink.GitHub
-FSharp.Data
 Dapper
 Microsoft.Data.Sqlite
 System.Configuration.ConfigurationManager

--- a/src/FsAutoComplete/paket.references
+++ b/src/FsAutoComplete/paket.references
@@ -9,7 +9,6 @@ Ionide.ProjInfo
 Ionide.ProjInfo.ProjectSystem
 Fake.Runtime
 Dapper
-FSharp.Data
 Microsoft.Data.Sqlite
 ICSharpCode.Decompiler
 Fantomas


### PR DESCRIPTION
This decreases FSAC memory footprint by about 10%. I have no idea why FSharp.Data is allocating so much stuff related to TPs even if no actual TPs were used in this codebase (we had it as a dependency for easy HTTP request + JSON parsing) 

Memory dump pre-change:
![image](https://user-images.githubusercontent.com/5427083/103216108-820d9080-4915-11eb-943b-5a5742d2f363.png)

Memory dump post-change:
![image](https://user-images.githubusercontent.com/5427083/103216130-90f44300-4915-11eb-942c-b94232e631c7.png)
