### PR TITLE
Don't store untyped AST in state

### DIFF
--- a/src/FsAutoComplete.BackgroundServices/Program.fs
+++ b/src/FsAutoComplete.BackgroundServices/Program.fs
@@ -105,7 +105,7 @@ type FsacClient(sendServerRequest: ClientNotificationSender) =
 type BackgroundServiceServer(state: State, client: FsacClient) =
     inherit LspServer()
 
-    let checker = FSharpChecker.Create(projectCacheSize = 1, keepAllBackgroundResolutions = false, suggestNamesForErrors = true)
+    let checker = FSharpChecker.Create(projectCacheSize = 1, keepAllBackgroundResolutions = false, suggestNamesForErrors = false)
 
     do checker.ImplicitlyStartBackgroundWork <- false
     let mutable latestSdkVersion = lazy None

--- a/src/FsAutoComplete.Core/State.fs
+++ b/src/FsAutoComplete.Core/State.fs
@@ -22,7 +22,6 @@ type State =
     mutable CurrentAST: FSharp.Compiler.SyntaxTree.ParsedInput option
 
     NavigationDeclarations : ConcurrentDictionary<SourceFilePath, FSharpNavigationTopLevelDeclaration[]>
-    ParseResults: ConcurrentDictionary<SourceFilePath, FSharpParseFileResults>
     CancellationTokens: ConcurrentDictionary<SourceFilePath, CancellationTokenSource list>
 
     ScriptProjectOptions: ConcurrentDictionary<SourceFilePath, int * FSharpProjectOptions>
@@ -40,7 +39,6 @@ type State =
       CompletionNamespaceInsert = ConcurrentDictionary()
       CancellationTokens = ConcurrentDictionary()
       NavigationDeclarations = ConcurrentDictionary()
-      ParseResults = ConcurrentDictionary()
       ScriptProjectOptions = ConcurrentDictionary()
       ColorizationOutput = false }
 

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1291,7 +1291,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
 
         let file = selectionRangeP.TextDocument.GetFilePath()
         let poss = selectionRangeP.Positions |> Array.map protocolPosToPos |> Array.toList
-        let res = commands.GetRangesAtPosition file poss
+        let! res = commands.GetRangesAtPosition file poss
         match res with
         | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
             return internalError msg


### PR DESCRIPTION
This significantly reduces memory usage, especially on big projects. On `FSharp.sln` I observed reducing memory usage in main FSAC process from 2800 MB to 2100 MB in similar usage scenario (initial load, wait for background service to stabilize, do some small operations in a file from `FSharp.Compiler.Service.fsproj`)

Memory dump pre-change: (notice super high allocations for objects from AST)
![image](https://user-images.githubusercontent.com/5427083/103221773-b425ef00-4923-11eb-8b55-22a8b092c5e3.png)

Memory dump post-change:
![image](https://user-images.githubusercontent.com/5427083/103221888-01a25c00-4924-11eb-91cf-bc57bc51ca49.png)
