### PR TITLE
Remove overly-broad document highlighting ranges

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -75,6 +75,45 @@ type Commands (serialize : Serializer, backgroundServiceEnabled, toolsPath) =
     let checkerLogger = LogProvider.getLoggerByName "CheckerEvents"
     let fantomasLogger = LogProvider.getLoggerByName "Fantomas"
 
+    // given an enveloping range and the sub-ranges it overlaps, split out the enveloping range into a
+    // set of range segments that are non-overlapping with the children
+    let segmentRanges (parentRange: range) (childRanges: range []): range [] =
+        let firstSegment = mkRange parentRange.FileName parentRange.Start childRanges.[0].Start // from start of parent to start of first child
+        let lastSegment = mkRange parentRange.FileName (Array.last childRanges).End parentRange.End // from end of last child to end of parent
+        // now we can go pairwise, emitting a new range for the area between each end and start
+        let innerSegments =
+            childRanges |> Array.pairwise |> Array.map (fun (left, right) -> mkRange parentRange.FileName left.End right.Start)
+
+        [|
+            firstSegment
+            yield! innerSegments
+            lastSegment
+        |]
+
+    /// because LSP doesn't know how to handle overlapping/nested ranges, we have to dedupe them here
+    let scrubRanges (highlights: struct(range * _) array): struct(range * _) array =
+        highlights
+        |> Array.sortBy(fun (struct(m, _)) -> m.Start.Line, m.Start.Column)
+        |> Array.groupBy (fun (struct(r, _)) -> r.StartLine)
+        |> Array.collect (fun (_, highlights) ->
+
+            // split out any ranges that contain other ranges on this line into the non-overlapping portions of that range
+            let expandParents (struct(parentRange, tokenType) as p) =
+                let children =
+                    highlights
+                    |> Array.except [p]
+                    |> Array.choose (fun (struct(childRange, _)) -> if rangeContainsRange parentRange childRange then Some childRange else None)
+                match children with
+                | [||] -> [| p |]
+                | children ->
+                    let sortedChildren = children |> Array.sortBy (fun r -> r.Start.Line, r.Start.Column)
+                    segmentRanges parentRange sortedChildren
+                    |> Array.map (fun subRange -> struct(subRange, tokenType))
+
+            highlights
+            |> Array.collect expandParents
+        )
+
     let analyzerHandler (file: string<LocalPath>, content, pt, tast, symbols, getAllEnts) =
           let ctx : SDK.Context = {
             FileName = UMX.untag file
@@ -1104,7 +1143,8 @@ type Commands (serialize : Serializer, backgroundServiceEnabled, toolsPath) =
           match res with
           | Some res ->
             let r = res.GetCheckResults.GetSemanticClassification(None)
-            Some r
+            let filteredRanges = scrubRanges r
+            Some filteredRanges
           | None ->
             None
         return CoreResponse.Res res

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -330,9 +330,7 @@ module CommandResponse =
     ParameterStr : string
   }
 
-  /// a type that has the same serialized shape as an FCS range, but that can be deserialized as well
-  type MiniRange = { StartLine: int; StartColumn: int; EndLine : int; EndColumn: int }
-  type HighlightingRange = { Range: MiniRange; TokenType: string }
+  type HighlightingRange = { Range: LanguageServerProtocol.Types.Range ; TokenType: string }
 
   type HighlightingResponse = {
     Highlights: HighlightingRange []
@@ -534,18 +532,6 @@ module CommandResponse =
 
   let fakeRuntime (serialize : Serializer) (runtimePath : string) =
      serialize { Kind = "fakeRuntime"; Data = runtimePath }
-
-  let highlighting (serialize: Serializer) ranges =
-    serialize {
-      Kind = "highlighting"
-      Data = {
-        Highlights =
-          ranges |> Array.map (fun struct ((r: range), tk) ->
-            { Range = { StartLine = r.StartLine; StartColumn = r.StartColumn; EndLine = r.EndLine; EndColumn = r.EndColumn }
-              TokenType = ClassificationUtils.map tk }
-          )
-      }
-    }
 
   let fsharpLiterate (serialize: Serializer) (content: string) =
     serialize { Kind = "fsharpLiterate"; Data = content}

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -330,7 +330,9 @@ module CommandResponse =
     ParameterStr : string
   }
 
-  type HighlightingRange = {Range: range; TokenType: string}
+  /// a type that has the same serialized shape as an FCS range, but that can be deserialized as well
+  type MiniRange = { StartLine: int; StartColumn: int; EndLine : int; EndColumn: int }
+  type HighlightingRange = { Range: MiniRange; TokenType: string }
 
   type HighlightingResponse = {
     Highlights: HighlightingRange []
@@ -538,8 +540,9 @@ module CommandResponse =
       Kind = "highlighting"
       Data = {
         Highlights =
-          ranges |> Array.map (fun struct (r, tk) ->
-            { Range = r; TokenType = ClassificationUtils.map tk }
+          ranges |> Array.map (fun struct ((r: range), tk) ->
+            { Range = { StartLine = r.StartLine; StartColumn = r.StartColumn; EndLine = r.EndLine; EndColumn = r.EndColumn }
+              TokenType = ClassificationUtils.map tk }
           )
       }
     }

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1761,7 +1761,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
             return LspResult.success ()
     }
 
-    member __.GetHighlighting(p : HighlightingRequest) = async {
+    member __.GetHighlighting(p : HighlightingRequest): AsyncLspResult<PlainNotification> = async {
       logger.info (Log.setMessage "GetHighlighting Request: {parms}" >> Log.addContextDestructured "parms" p )
 
       let fn = p.FileName |> Utils.normalizePath
@@ -1775,7 +1775,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
           | None -> LspResult.internalError "No highlights found"
           | Some res ->
             { Content = CommandResponse.highlighting FsAutoComplete.JsonSerializer.writeJson res }
-            |> success
+            |>  success
 
       return res
     }

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -398,6 +398,50 @@ module Structure =
           EndLine          = lsp.End.Line
           Kind             = kind }
 
+module ClassificationUtils =
+
+  // See https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#semantic-token-scope-map for the built-in scopes
+  // if new token-type strings are added here, make sure to update the 'legend' in any downstream consumers.
+  let map (t: SemanticClassificationType) : string =
+      match t with
+      | SemanticClassificationType.Operator -> "operator"
+      | SemanticClassificationType.ReferenceType
+      | SemanticClassificationType.Type
+      | SemanticClassificationType.TypeDef
+      | SemanticClassificationType.ConstructorForReferenceType -> "type"
+      | SemanticClassificationType.ValueType
+      | SemanticClassificationType.ConstructorForValueType -> "struct"
+      | SemanticClassificationType.UnionCase
+      | SemanticClassificationType.UnionCaseField -> "enumMember"
+      | SemanticClassificationType.Function
+      | SemanticClassificationType.Method
+      | SemanticClassificationType.ExtensionMethod -> "function"
+      | SemanticClassificationType.Property -> "property"
+      | SemanticClassificationType.MutableVar
+      | SemanticClassificationType.MutableRecordField -> "mutable"
+      | SemanticClassificationType.Module
+      | SemanticClassificationType.Namespace -> "namespace"
+      | SemanticClassificationType.Printf -> "regexp"
+      | SemanticClassificationType.ComputationExpression -> "cexpr"
+      | SemanticClassificationType.IntrinsicFunction -> "function"
+      | SemanticClassificationType.Enumeration -> "enum"
+      | SemanticClassificationType.Interface -> "interface"
+      | SemanticClassificationType.TypeArgument -> "typeParameter"
+      | SemanticClassificationType.DisposableTopLevelValue
+      | SemanticClassificationType.DisposableLocalValue
+      | SemanticClassificationType.DisposableType -> "disposable"
+      | SemanticClassificationType.Literal -> "variable.readonly.defaultLibrary"
+      | SemanticClassificationType.RecordField
+      | SemanticClassificationType.RecordFieldAsFunction -> "property.readonly"
+      | SemanticClassificationType.Exception
+      | SemanticClassificationType.Field
+      | SemanticClassificationType.Event
+      | SemanticClassificationType.Delegate
+      | SemanticClassificationType.NamedArgument -> "member"
+      | SemanticClassificationType.Value
+      | SemanticClassificationType.LocalValue -> "variable"
+      | SemanticClassificationType.Plaintext -> "text"
+
 type PlainNotification= { Content: string }
 
 type ProjectParms = {

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/HighlightingTest/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/HighlightingTest/Script.fsx
@@ -1,0 +1,8 @@
+let inline (|PeePee|) x = (^a : (member PeePee: string) x)
+let inline peepee (PeePee pp) = pp
+
+let inline (|PooPoo|) x = (^a : (member PooPoo: string) x)
+let inline poopoo (PooPoo pp) = pp
+
+let inline yeet ((PeePee pp & PooPoo pp') as toilet) =
+    peepee toilet = pp && poopoo toilet = pp'


### PR DESCRIPTION
Per https://github.com/ionide/ionide-vscode-fsharp/issues/1467, we think that the LSP protocol can't handle scenarios where the document highlight ranges reported can have overlapping ranges.

To trial this, this MR changes the documentation highlighting logic to remove these overly-broad ranges, leaving the hopefully more-useful inner ranges.

This logic is pretty rough, but we group the ranges by start line, and then iterate across each grouping, removing any range that contains another range in it.

I need to write a few more tests, but I opened this to track the issue and get an eye on the filtering logic/have others test it out.