### PR TITLE
add additional file path normalization for places where unnormalized file paths are passed in

### DIFF
--- a/src/FsAutoComplete.BackgroundServices/paket.references
+++ b/src/FsAutoComplete.BackgroundServices/paket.references
@@ -7,5 +7,5 @@ Microsoft.Data.Sqlite
 Ionide.ProjInfo
 Ionide.ProjInfo.FCS
 Ionide.ProjInfo.ProjectSystem
-
+FSharp.UMX
 Microsoft.NETFramework.ReferenceAssemblies

--- a/src/FsAutoComplete.Core/CodeGeneration.fs
+++ b/src/FsAutoComplete.Core/CodeGeneration.fs
@@ -7,6 +7,7 @@ open System.CodeDom.Compiler
 open FSharp.Compiler.SyntaxTree
 open FSharp.Compiler.Range
 open FSharp.Compiler.SourceCodeServices
+open FSharp.UMX
 
 [<Measure>] type Line0
 [<Measure>] type Line1

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -432,7 +432,7 @@ type Commands (serialize : Serializer, backgroundServiceEnabled, toolsPath) =
     /// if version of file in memory is grater than last type checked version.
     /// It also waits if there are no FSharpProjectOptions avaliable for given file
     member x.TryGetLatestTypeCheckResultsForFile(file) =
-        let file = Path.GetFullPath file
+        let file = Path.GetFullPath file |> Utils.normalizePath
         let stateVersion = state.TryGetFileVersion file
         let checkedVersion = state.TryGetLastCheckedVersion file
         commandsLogger.debug (Log.setMessage "TryGetLatestTypeCheckResultsFor {file}, State@{stateVersion}, Checked@{checkedVersion}"
@@ -482,7 +482,7 @@ type Commands (serialize : Serializer, backgroundServiceEnabled, toolsPath) =
     member x.TryGetFileVersion = state.TryGetFileVersion
 
     member x.Parse file lines version (isSdkScript: bool option) =
-        let file = Path.GetFullPath file
+        let file = Path.GetFullPath file |> Utils.normalizePath
         let tmf = isSdkScript |> Option.map (fun n -> if n then FSIRefs.NetCore else FSIRefs.NetFx) |> Option.defaultValue FSIRefs.NetFx
 
         do x.CancelQueue file

--- a/src/FsAutoComplete.Core/FakeSupport.fs
+++ b/src/FsAutoComplete.Core/FakeSupport.fs
@@ -2,6 +2,7 @@ namespace FsAutoComplete
 
 open Fake.Runtime
 open FsAutoComplete.Logging
+open FSharp.UMX
 
 module FakeSupport =
   let getFakeRuntime () =
@@ -20,9 +21,9 @@ module FakeSupport =
       Log.setMessage >> logger
     )
 
-  let detectFakeScript (file) =
+  let detectFakeScript (file: string<LocalPath>) =
     setupLogging()
-    Tooling.detectFakeScript file
+    Tooling.detectFakeScript (UMX.untag file)
 
   let getProjectOptions (detectionInfo:Tooling.DetectionInfo) =
     setupLogging()
@@ -32,6 +33,6 @@ module FakeSupport =
 
   type GetTargetsResult = Tooling.GetTargetsResult
 
-  let getTargets (file:string) (ctx:FakeContext) : Async<GetTargetsResult> =
+  let getTargets (file:string<LocalPath>) (ctx:FakeContext) : Async<GetTargetsResult> =
     setupLogging()
-    Tooling.getTargets file ctx
+    Tooling.getTargets (UMX.untag file) ctx

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -80,7 +80,7 @@ type ParseAndCheckResults
     let tryGetFullPath fileName =
       try
         // use the parsed file name directory as base path
-        let basePath = Path.GetDirectoryName(__.FileName)
+        let basePath = Path.GetDirectoryName(UMX.untag __.FileName)
         Some (Path.Combine(basePath, fileName))
       with
       | :? ArgumentException -> None
@@ -575,4 +575,4 @@ type ParseAndCheckResults
   member __.GetAST = parseResults.ParseTree
   member __.GetCheckResults = checkResults
   member __.GetParseResults = parseResults
-  member __.FileName: string = parseResults.FileName
+  member __.FileName: string<LocalPath> = UMX.tag parseResults.FileName

--- a/src/FsAutoComplete.Core/SymbolCache.fs
+++ b/src/FsAutoComplete.Core/SymbolCache.fs
@@ -8,6 +8,7 @@ open FSharp.Compiler.SourceCodeServices
 open System.Net
 open System.IO
 open Newtonsoft.Json
+open FSharp.UMX
 
 [<CLIMutable>]
 type SymbolUseRange = {
@@ -155,11 +156,11 @@ let fromSymbolUse (su : FSharpSymbolUse) =
 let initCache dir =
     PersistenCacheImpl.initLazyCache dir
 
-let updateSymbols fn (symbols: FSharpSymbolUse[]) =
+let updateSymbols (fn: string<LocalPath>) (symbols: FSharpSymbolUse[]) =
     let sus = symbols |> Array.map(fromSymbolUse)
 
     PersistenCacheImpl.connection
-    |> Option.iter (fun con -> PersistenCacheImpl.insert(con.Value,fn,sus) )
+    |> Option.iter (fun con -> PersistenCacheImpl.insert(con.Value, UMX.untag fn, sus) )
 
 let getSymbols symbolName =
     async {

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -6,6 +6,7 @@ open FSharp.Compiler
 open FSharp.Compiler.SourceCodeServices
 open Ionide.ProjInfo.ProjectSystem
 open Ionide.ProjInfo.ProjectSystem.WorkspacePeek
+open FSharp.UMX
 
 module internal CompletionUtils =
   let getIcon (glyph : FSharpGlyph) =
@@ -491,11 +492,11 @@ module CommandResponse =
                 Data = { CommandName = commandName
                          ParameterStr = parameterStr} }
 
-  let declarations (serialize : Serializer) (decls : (FSharpNavigationTopLevelDeclaration * string) []) =
+  let declarations (serialize : Serializer) (decls : (FSharpNavigationTopLevelDeclaration * string<LocalPath>) []) =
      let decls' =
       decls |> Array.map (fun (d, fn) ->
-        { Declaration = Declaration.OfDeclarationItem (d.Declaration, fn);
-          Nested = d.Nested |> Array.map ( fun a -> Declaration.OfDeclarationItem(a,fn))
+        { Declaration = Declaration.OfDeclarationItem (d.Declaration, UMX.untag fn);
+          Nested = d.Nested |> Array.map ( fun a -> Declaration.OfDeclarationItem(a, UMX.untag fn))
         })
      serialize { Kind = "declarations"; Data = decls' }
 

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -76,6 +76,14 @@ let basicTests toolsPath =
     let (server, path) = serverStart.Value
     f server path
 
+  /// normalizes the line endings in returned markdown strings for cross-platform comparisons
+  let normalizeMarkedString = function | MarkedString.WithLanguage l -> MarkedString.WithLanguage l
+                                       | MarkedString.String s -> MarkedString.String (s.Replace("\r\n", "\n"))
+
+  let normalizeHoverContent = function | HoverContent.MarkedStrings strings -> MarkedStrings (strings |> Array.map normalizeMarkedString)
+                                       | HoverContent.MarkedString str -> MarkedString (normalizeMarkedString str)
+                                       | HoverContent.MarkupContent content -> MarkupContent content
+
   testSequenced <| testList "Basic Tests" [
       testSequenced <| testList "Hover Tests" [
 
@@ -95,7 +103,7 @@ let basicTests toolsPath =
                     MarkedString.String "*Full name: Script.t*"
                     MarkedString.String "*Assembly: BasicTest*"|]
 
-            Expect.equal res.Contents expected "Hover test - simple symbol"
+            Expect.equal (normalizeHoverContent res.Contents) expected "Hover test - simple symbol"
         ))
 
         testCase "Hover Tests - let keyword" (serverTest (fun server path ->
@@ -112,7 +120,7 @@ let basicTests toolsPath =
                 [|  MarkedString.WithLanguage {Language = "fsharp"; Value = "let"}
                     MarkedString.String "**Description**\n\n\nUsed to associate, or bind, a name to a value or function.\n"|]
 
-            Expect.equal res.Contents expected "Hover test - let keyword"
+            Expect.equal (normalizeHoverContent res.Contents) expected "Hover test - let keyword"
         ))
 
         testCase "Hover Tests - out of position" (serverTest (fun server path ->
@@ -144,7 +152,7 @@ let basicTests toolsPath =
                     MarkedString.String "*Full name: Script.( .>> )*"
                     MarkedString.String "*Assembly: BasicTest*"|]
 
-            Expect.equal res.Contents expected "Hover test - let keyword"
+            Expect.equal (normalizeHoverContent res.Contents) expected "Hover test - let keyword"
         ))
 
         //Test to reproduce: https://github.com/ionide/ionide-vscode-fsharp/issues/1203
@@ -164,7 +172,7 @@ let basicTests toolsPath =
                     MarkedString.String "*Full name: Script.( ^ )*"
                     MarkedString.String "*Assembly: BasicTest*"|]
 
-            Expect.equal res.Contents expected "Hover test - let keyword"
+            Expect.equal (normalizeHoverContent res.Contents) expected "Hover test - let keyword"
         ))
       ]
       testSequenced <| testList "Document Symbol Tests" [


### PR DESCRIPTION
Found some stuff while working on my windows box that started me down this path.

The idea is that we had some paths that weren't normalized coming into methods that call the compiler directly, so I started by layering the concept of `string<LocalPath>` into our dictionary caches and the compiler callsites.

Conversion to the new type is handled by `Utils.normalizePath`, and so that function is now much more prevalent.

When paths come directly from the compiler (ie on the parse results, symbol uses, etc) we can explicitly tag those and know that they are safe.

Everything else just flows out of that, up to the LSP layer, where we convert from the uris to an absolute local path and then normalize them to the `string<LocalPath>` concept.