### PR TITLE
Make file actions relative to project

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -360,49 +360,53 @@ type Commands (serialize : Serializer, backgroundServiceEnabled, toolsPath) =
       return CoreResponse.Res result
     }
 
-    member _.FsProjMoveFileUp (fsprojPath: string) (file: string) = async {
-      FsProjEditor.moveFileUp fsprojPath file
+    member _.FsProjMoveFileUp (fsprojPath: string) (fileVirtPath: string) = async {
+      FsProjEditor.moveFileUp fsprojPath fileVirtPath
       return CoreResponse.Res ()
     }
 
-    member _.FsProjMoveFileDown (fsprojPath: string) (file: string) = async {
-      FsProjEditor.moveFileDown fsprojPath file
+    member _.FsProjMoveFileDown (fsprojPath: string) (fileVirtPath: string) = async {
+      FsProjEditor.moveFileDown fsprojPath fileVirtPath
       return CoreResponse.Res ()
     }
 
-    member _.FsProjAddFileAbove (fsprojPath: string) (file: string) (newFileName: string) = async {
+    member _.FsProjAddFileAbove (fsprojPath: string) (fileVirtPath: string) (newFileName: string) = async {
       try
         let dir = Path.GetDirectoryName fsprojPath
-        let newFilePath = Path.Combine(dir, newFileName)
+        let virtPathDir = Path.GetDirectoryName fileVirtPath
+        let newFilePath = Path.Combine(dir, virtPathDir, newFileName)
         File.Create newFilePath |> ignore
 
-        FsProjEditor.addFileAbove fsprojPath file newFileName
+        let newVirtPath = Path.Combine(virtPathDir, newFileName)
+        FsProjEditor.addFileAbove fsprojPath fileVirtPath newVirtPath
         return CoreResponse.Res ()
       with
       | ex ->
         return CoreResponse.ErrorRes ex.Message
     }
 
-    member _.FsProjAddFileBelow (fsprojPath: string) (file: string) (newFileName: string) = async {
+    member _.FsProjAddFileBelow (fsprojPath: string) (fileVirtPath: string) (newFileName: string) = async {
       try
         let dir = Path.GetDirectoryName fsprojPath
-        let newFilePath = Path.Combine(dir, newFileName)
+        let virtPathDir = Path.GetDirectoryName fileVirtPath
+        let newFilePath = Path.Combine(dir, virtPathDir, newFileName)
         File.Create newFilePath |> ignore
 
-        FsProjEditor.addFileBelow fsprojPath file newFileName
+        let newVirtPath = Path.Combine(virtPathDir, newFileName)
+        FsProjEditor.addFileBelow fsprojPath fileVirtPath newVirtPath
         return CoreResponse.Res ()
       with
       | ex ->
         return CoreResponse.ErrorRes ex.Message
     }
 
-    member _.FsProjAddFile (fsprojPath: string) (file: string) = async {
+    member _.FsProjAddFile (fsprojPath: string) (fileVirtPath: string) = async {
       try
         let dir = Path.GetDirectoryName fsprojPath
-        let newFilePath = Path.Combine(dir, file)
+        let newFilePath = Path.Combine(dir, fileVirtPath)
         File.Create newFilePath |> ignore
 
-        FsProjEditor.addFile fsprojPath file
+        FsProjEditor.addFile fsprojPath fileVirtPath
         return CoreResponse.Res ()
       with
       | ex ->

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1572,7 +1572,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     member __.FsProjMoveFileUp(p: DotnetFileRequest) = async {
         logger.info (Log.setMessage "FsProjMoveFileUp Request: {parms}" >> Log.addContextDestructured "parms" p )
 
-        let! res = commands.FsProjMoveFileUp p.FsProj p.File
+        let! res = commands.FsProjMoveFileUp p.FsProj p.FileVirtualPath
         let res =
             match res with
             | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
@@ -1587,7 +1587,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     member __.FsProjMoveFileDown(p: DotnetFileRequest) = async {
         logger.info (Log.setMessage "FsProjMoveFileDown Request: {parms}" >> Log.addContextDestructured "parms" p )
 
-        let! res = commands.FsProjMoveFileDown p.FsProj p.File
+        let! res = commands.FsProjMoveFileDown p.FsProj p.FileVirtualPath
         let res =
             match res with
             | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
@@ -1602,7 +1602,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     member __.FsProjAddFileAbove(p: DotnetFile2Request) = async {
         logger.info (Log.setMessage "FsProjAddFileAbove Request: {parms}" >> Log.addContextDestructured "parms" p )
 
-        let! res = commands.FsProjAddFileAbove p.FsProj p.File p.NewFile
+        let! res = commands.FsProjAddFileAbove p.FsProj p.FileVirtualPath p.NewFile
         let res =
             match res with
             | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
@@ -1617,7 +1617,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     member __.FsProjAddFileBelow(p: DotnetFile2Request) = async {
         logger.info (Log.setMessage "FsProjAddFileBelow Request: {parms}" >> Log.addContextDestructured "parms" p )
 
-        let! res = commands.FsProjAddFileBelow p.FsProj p.File p.NewFile
+        let! res = commands.FsProjAddFileBelow p.FsProj p.FileVirtualPath p.NewFile
         let res =
             match res with
             | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
@@ -1632,7 +1632,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     member __.FsProjAddFile(p: DotnetFileRequest) = async {
         logger.info (Log.setMessage "FsProjAddFile Request: {parms}" >> Log.addContextDestructured "parms" p )
 
-        let! res = commands.FsProjAddFile p.FsProj p.File
+        let! res = commands.FsProjAddFile p.FsProj p.FileVirtualPath
         let res =
             match res with
             | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -430,9 +430,9 @@ type DotnetNewRunRequest = { Template: string; Output: string option; Name: stri
 
 type DotnetProjectRequest = { Target: string; Reference: string }
 
-type DotnetFileRequest = { FsProj: string; File: string }
+type DotnetFileRequest = { FsProj: string; FileVirtualPath: string }
 
-type DotnetFile2Request = { FsProj: string; File: string; NewFile: string }
+type DotnetFile2Request = { FsProj: string; FileVirtualPath: string; NewFile: string }
 
 type FSharpLiterateRequest = {FileName : string; }
 


### PR DESCRIPTION
In combination with: https://github.com/ionide/ionide-vscode-fsharp/pull/1472
This adjusts the logic of the fsproj file actions to support files in subdirectories by accepting a virtual path rather than just a filename.
This still fails when different separators are used in the command vs the fsproj file.