### PR TITLE
Improved project add

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -375,7 +375,7 @@ type Commands (serialize : Serializer, backgroundServiceEnabled, toolsPath) =
         let dir = Path.GetDirectoryName fsprojPath
         let virtPathDir = Path.GetDirectoryName fileVirtPath
         let newFilePath = Path.Combine(dir, virtPathDir, newFileName)
-        File.Create newFilePath |> ignore
+        (File.Create newFilePath).Close()
 
         let newVirtPath = Path.Combine(virtPathDir, newFileName)
         FsProjEditor.addFileAbove fsprojPath fileVirtPath newVirtPath
@@ -390,7 +390,7 @@ type Commands (serialize : Serializer, backgroundServiceEnabled, toolsPath) =
         let dir = Path.GetDirectoryName fsprojPath
         let virtPathDir = Path.GetDirectoryName fileVirtPath
         let newFilePath = Path.Combine(dir, virtPathDir, newFileName)
-        File.Create newFilePath |> ignore
+        (File.Create newFilePath).Close()
 
         let newVirtPath = Path.Combine(virtPathDir, newFileName)
         FsProjEditor.addFileBelow fsprojPath fileVirtPath newVirtPath
@@ -404,7 +404,7 @@ type Commands (serialize : Serializer, backgroundServiceEnabled, toolsPath) =
       try
         let dir = Path.GetDirectoryName fsprojPath
         let newFilePath = Path.Combine(dir, fileVirtPath)
-        File.Create newFilePath |> ignore
+        (File.Create newFilePath).Close()
 
         FsProjEditor.addFile fsprojPath fileVirtPath
         return CoreResponse.Res ()

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -375,7 +375,7 @@ type Commands (serialize : Serializer, backgroundServiceEnabled, toolsPath) =
         let dir = Path.GetDirectoryName fsprojPath
         let virtPathDir = Path.GetDirectoryName fileVirtPath
         let newFilePath = Path.Combine(dir, virtPathDir, newFileName)
-        (File.Create newFilePath).Close()
+        (File.Open(newFilePath, FileMode.OpenOrCreate)).Close()
 
         let newVirtPath = Path.Combine(virtPathDir, newFileName)
         FsProjEditor.addFileAbove fsprojPath fileVirtPath newVirtPath
@@ -390,7 +390,7 @@ type Commands (serialize : Serializer, backgroundServiceEnabled, toolsPath) =
         let dir = Path.GetDirectoryName fsprojPath
         let virtPathDir = Path.GetDirectoryName fileVirtPath
         let newFilePath = Path.Combine(dir, virtPathDir, newFileName)
-        (File.Create newFilePath).Close()
+        (File.Open(newFilePath, FileMode.OpenOrCreate)).Close()
 
         let newVirtPath = Path.Combine(virtPathDir, newFileName)
         FsProjEditor.addFileBelow fsprojPath fileVirtPath newVirtPath
@@ -404,7 +404,7 @@ type Commands (serialize : Serializer, backgroundServiceEnabled, toolsPath) =
       try
         let dir = Path.GetDirectoryName fsprojPath
         let newFilePath = Path.Combine(dir, fileVirtPath)
-        (File.Create newFilePath).Close()
+        (File.Open(newFilePath, FileMode.OpenOrCreate)).Close()
 
         FsProjEditor.addFile fsprojPath fileVirtPath
         return CoreResponse.Res ()

--- a/src/FsAutoComplete.Core/FsprojEdit.fs
+++ b/src/FsAutoComplete.Core/FsprojEdit.fs
@@ -31,6 +31,11 @@ module FsProjEditor =
       itemGroup.InsertAfter(node, downNode) |> ignore
       xdoc.Save fsprojPath
 
+  let private createNewCompileNode (doc: System.Xml.XmlDocument) (includePath: string) =
+    let node = doc.CreateElement("Compile")
+    node.SetAttribute("Include", includePath)
+    node
+
   let addFileAbove (fsprojPath: string) (aboveFile: string) (newFileName: string) =
     let xdoc = System.Xml.XmlDocument()
     xdoc.Load fsprojPath
@@ -38,9 +43,7 @@ module FsProjEditor =
     let itemGroup = xdoc.SelectSingleNode(xpath)
     let childXPath = sprintf "//Compile[@Include='%s']" aboveFile
     let aboveNode = itemGroup.SelectSingleNode(childXPath)
-    let node = aboveNode.Clone ()
-    let attr = node.Attributes.GetNamedItem "Include"
-    attr.Value <- newFileName
+    let node = createNewCompileNode xdoc newFileName
     itemGroup.InsertBefore(node, aboveNode) |> ignore
     xdoc.Save fsprojPath
 
@@ -51,9 +54,7 @@ module FsProjEditor =
     let itemGroup = xdoc.SelectSingleNode(xpath)
     let childXPath = sprintf "//Compile[@Include='%s']" belowFile
     let aboveNode = itemGroup.SelectSingleNode(childXPath)
-    let node = aboveNode.Clone ()
-    let attr = node.Attributes.GetNamedItem "Include"
-    attr.Value <- newFileName
+    let node = createNewCompileNode xdoc newFileName
     itemGroup.InsertAfter(node, aboveNode) |> ignore
     xdoc.Save fsprojPath
 
@@ -62,8 +63,6 @@ module FsProjEditor =
     xdoc.Load fsprojPath
     let itemGroup = xdoc.SelectSingleNode("//Compile/.." )
     let x = itemGroup.FirstChild
-    let node = x.Clone ()
-    let attr = node.Attributes.GetNamedItem "Include"
-    attr.Value <- newFileName
+    let node = createNewCompileNode xdoc newFileName
     itemGroup.InsertBefore(node, x) |> ignore
     xdoc.Save fsprojPath


### PR DESCRIPTION
Note: This depends on https://github.com/fsharp/FsAutoComplete/pull/695

This makes a few small improvements to the three File add actions.
- It no longer intermittently locks new files
- It creates a new "Compile" element rather than cloning another element
- It finds the first appropriate `ItemGroup`, or creates one at the end if none exist