### PR TITLE
Added FSharp.UMX to FsAutoComplete packages to correct build error.

### DIFF
--- a/src/FsAutoComplete/paket.references
+++ b/src/FsAutoComplete/paket.references
@@ -19,5 +19,6 @@ Serilog.Sinks.File
 Serilog.Sinks.Console
 Serilog.Sinks.Async
 Destructurama.FSharp
+FSharp.UMX
 
 Microsoft.NETFramework.ReferenceAssemblies


### PR DESCRIPTION
Would not build on my machine because of missing FSharp.UMX. I have added this to paket.references and now it builds properly.

This was on arch linux using dotnet-sdk-bin 5.0.1.sdk101-1 (AUR). 

The build output with the previous error is attached in [log.txt](https://github.com/fsharp/FsAutoComplete/files/5766936/log.txt).
