### PR TITLE
LSP Server requests

### DIFF
--- a/src/FsAutoComplete.BackgroundServices/Program.fs
+++ b/src/FsAutoComplete.BackgroundServices/Program.fs
@@ -95,7 +95,7 @@ module Helpers =
             "file:///" + (uri.ToString()).TrimStart('/')
 
 
-type FsacClient(sendServerRequest: ClientNotificationSender) =
+type FsacClient(sendServerRequest: ClientNotificationSender, sendServerActualRequest: ClientRequestSender) =
     inherit LspClient ()
 
     member __.SendDiagnostics(p: PublishDiagnosticsParams) =

--- a/src/FsAutoComplete.BackgroundServices/Program.fs
+++ b/src/FsAutoComplete.BackgroundServices/Program.fs
@@ -95,14 +95,14 @@ module Helpers =
             "file:///" + (uri.ToString()).TrimStart('/')
 
 
-type FsacClient(sendServerRequest: ClientNotificationSender, sendServerActualRequest: ClientRequestSender) =
+type FsacClient(sendServerNotification: ClientNotificationSender, sendServerRequest: ClientRequestSender) =
     inherit LspClient ()
 
     member __.SendDiagnostics(p: PublishDiagnosticsParams) =
-        sendServerRequest "background/diagnostics" (box p) |> Async.Ignore
+        sendServerNotification "background/diagnostics" (box p) |> Async.Ignore
 
     member __.Notify(o: Msg) =
-        sendServerRequest "background/notify" o |> Async.Ignore
+        sendServerNotification "background/notify" o |> Async.Ignore
 
 type BackgroundServiceServer(state: State, client: FsacClient) =
     inherit LspServer()

--- a/src/FsAutoComplete.Core/BackgroundServices.fs
+++ b/src/FsAutoComplete.Core/BackgroundServices.fs
@@ -68,12 +68,12 @@ let start () =
 
 let updateFile(file, content, version) =
     let msg: UpdateFileParms = { File = file; Content = content; Version = version }
-    client.SendNotificatoin "background/update" msg
+    client.SendNotification "background/update" msg
 
 let updateProject(file, opts) =
     let msg = { File = file; Options = opts }
-    client.SendNotificatoin "background/project" msg
+    client.SendNotification "background/project" msg
 
 let saveFile(file) =
     let msg: FileParms = { File = file }
-    client.SendNotificatoin "background/save" msg
+    client.SendNotification "background/save" msg

--- a/src/FsAutoComplete.Core/BackgroundServices.fs
+++ b/src/FsAutoComplete.Core/BackgroundServices.fs
@@ -68,12 +68,12 @@ let start () =
 
 let updateFile(file, content, version) =
     let msg: UpdateFileParms = { File = file; Content = content; Version = version }
-    client.SendRequest "background/update" msg
+    client.SendNotificatoin "background/update" msg
 
 let updateProject(file, opts) =
     let msg = { File = file; Options = opts }
-    client.SendRequest "background/project" msg
+    client.SendNotificatoin "background/project" msg
 
 let saveFile(file) =
     let msg: FileParms = { File = file }
-    client.SendRequest "background/save" msg
+    client.SendNotificatoin "background/save" msg

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -28,42 +28,52 @@ module AsyncResult =
 
 open FSharp.Analyzers
 
-type FSharpLspClient(sendServerRequest: ClientNotificationSender, sendServerActualRequest: ClientRequestSender) =
+type FSharpLspClient(sendServerNotification: ClientNotificationSender, sendServerRequest: ClientRequestSender) =
     inherit LspClient ()
 
     override __.WindowShowMessage(p) =
-        sendServerRequest "window/showMessage" (box p) |> Async.Ignore
+        sendServerNotification "window/showMessage" (box p) |> Async.Ignore
 
     override __.WindowShowMessageRequest(p) =
-        sendServerActualRequest.f ("window/showMessageRequest") (box p)
+        sendServerRequest.f ("window/showMessageRequest") (box p)
 
     override __.WindowLogMessage(p) =
-        sendServerRequest "window/logMessage" (box p) |> Async.Ignore
+        sendServerNotification "window/logMessage" (box p) |> Async.Ignore
+
+    override __.TelemetryEvent(p) =
+        sendServerNotification "telemetry/event" (box p) |> Async.Ignore
+
+    override __.ClientRegisterCapability(p) =
+        sendServerRequest.f ("client/registerCapability") (box p)
+
+    override __.ClientUnregisterCapability(p) =
+        sendServerRequest.f ("client/unregisterCapability") (box p)
+
+    override __.WorkspaceWorkspaceFolders () =
+        sendServerRequest.f "workspace/workspaceFolders" ()
+
+    override __.WorkspaceConfiguration (p) =
+        sendServerRequest.f "workspace/configuration" (box p)
+
+    override __.WorkspaceApplyEdit (p) =
+        sendServerRequest.f "workspace/applyEdit" (box p)
 
     override __.TextDocumentPublishDiagnostics(p) =
-        sendServerRequest "textDocument/publishDiagnostics" (box p) |> Async.Ignore
+        sendServerNotification "textDocument/publishDiagnostics" (box p) |> Async.Ignore
 
     ///Custom notification for workspace/solution/project loading events
     member __.NotifyWorkspace (p: PlainNotification) =
-        sendServerRequest "fsharp/notifyWorkspace" (box p) |> Async.Ignore
+        sendServerNotification "fsharp/notifyWorkspace" (box p) |> Async.Ignore
 
     ///Custom notification for initial workspace peek
     member __.NotifyWorkspacePeek (p: PlainNotification) =
-        sendServerRequest "fsharp/notifyWorkspacePeek" (box p) |> Async.Ignore
+        sendServerNotification "fsharp/notifyWorkspacePeek" (box p) |> Async.Ignore
 
     member __.NotifyCancelledRequest (p: PlainNotification) =
-        sendServerRequest "fsharp/notifyCancel" (box p) |> Async.Ignore
+        sendServerNotification "fsharp/notifyCancel" (box p) |> Async.Ignore
 
     member __.NotifyFileParsed (p: PlainNotification) =
-        sendServerRequest "fsharp/fileParsed" (box p) |> Async.Ignore
-
-    override __.WorkspaceApplyEdit (p) =
-        sendServerActualRequest.f "workspace/applyEdit" (box p)
-
-    override __.WorkspaceWorkspaceFolders () =
-        sendServerActualRequest.f "workspace/workspaceFolders" ()
-    // TODO: Add the missing notifications
-    // TODO: Implement requests
+        sendServerNotification "fsharp/fileParsed" (box p) |> Async.Ignore
 
 type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     inherit LspServer()

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -35,7 +35,7 @@ type FSharpLspClient(sendServerNotification: ClientNotificationSender, sendServe
         sendServerNotification "window/showMessage" (box p) |> Async.Ignore
 
     override __.WindowShowMessageRequest(p) =
-        sendServerRequest.f ("window/showMessageRequest") (box p)
+        sendServerRequest.Send "window/showMessageRequest" (box p)
 
     override __.WindowLogMessage(p) =
         sendServerNotification "window/logMessage" (box p) |> Async.Ignore
@@ -44,19 +44,19 @@ type FSharpLspClient(sendServerNotification: ClientNotificationSender, sendServe
         sendServerNotification "telemetry/event" (box p) |> Async.Ignore
 
     override __.ClientRegisterCapability(p) =
-        sendServerRequest.f ("client/registerCapability") (box p)
+        sendServerRequest.Send "client/registerCapability" (box p)
 
     override __.ClientUnregisterCapability(p) =
-        sendServerRequest.f ("client/unregisterCapability") (box p)
+        sendServerRequest.Send "client/unregisterCapability" (box p)
 
     override __.WorkspaceWorkspaceFolders () =
-        sendServerRequest.f "workspace/workspaceFolders" ()
+        sendServerRequest.Send "workspace/workspaceFolders" ()
 
     override __.WorkspaceConfiguration (p) =
-        sendServerRequest.f "workspace/configuration" (box p)
+        sendServerRequest.Send "workspace/configuration" (box p)
 
     override __.WorkspaceApplyEdit (p) =
-        sendServerRequest.f "workspace/applyEdit" (box p)
+        sendServerRequest.Send "workspace/applyEdit" (box p)
 
     override __.TextDocumentPublishDiagnostics(p) =
         sendServerNotification "textDocument/publishDiagnostics" (box p) |> Async.Ignore

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1650,26 +1650,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
     member __.FsProjAddFile(p: DotnetFileRequest) = async {
         logger.info (Log.setMessage "FsProjAddFile Request: {parms}" >> Log.addContextDestructured "parms" p )
 
-        let! workspacesResponse = lspClient.WorkspaceWorkspaceFolders()
-        let extra =
-            match workspacesResponse with
-            | LspResult.Ok (Some xs) -> xs.[0].Name
-            | _ -> "nothing"
-
-        let messageParams = {
-          ShowMessageRequestParams.Type = MessageType.Warning
-          Message = ("Select a suffix " + extra)
-          Actions = Some [| {MessageActionItem.Title = "Give me A"}; {MessageActionItem.Title = "Give me B"} |]
-        }
-
-        let! response = lspClient.WindowShowMessageRequest(messageParams)
-        let newFileVirtualPath =
-          match response with
-          | LspResult.Ok (Some {Title = "Give me A"}) -> p.FileVirtualPath + "A.fs"
-          | LspResult.Ok (Some {Title = "Give me B"}) -> p.FileVirtualPath + "B.fs"
-          | _ -> p.FileVirtualPath
-
-        let! res = commands.FsProjAddFile p.FsProj newFileVirtualPath
+        let! res = commands.FsProjAddFile p.FsProj p.FileVirtualPath
         let res =
             match res with
             | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -27,22 +27,10 @@ module AsyncResult =
 
 
 open FSharp.Analyzers
-type Test = string -> obj -> AsyncLspResult<obj>
-
-
-// let y (w: Wrapper) =
-//    let a = w.f 1
-//    let b = w.f 2L
-//    (a, b)
-
-// let genericFn x = x
-
-// // Calling y:
-// y { new Wrapper with member __.f x = genericFn x }
 
 type FSharpLspClient(sendServerRequest: ClientNotificationSender, sendServerActualRequest: ClientRequestSender) =
     inherit LspClient ()
-    // member __.Inner<'response> = sendServerActualRequest<'response>
+
     override __.WindowShowMessage(p) =
         sendServerRequest "window/showMessage" (box p) |> Async.Ignore
 

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -28,11 +28,14 @@ module AsyncResult =
 
 open FSharp.Analyzers
 
-type FSharpLspClient(sendServerRequest: ClientNotificationSender) =
+type FSharpLspClient(sendServerRequest: ClientNotificationSender, sendServerActualRequest: ClientRequestSender) =
     inherit LspClient ()
 
     override __.WindowShowMessage(p) =
         sendServerRequest "window/showMessage" (box p) |> Async.Ignore
+
+    override __.WindowShowMessageRequest(p) =
+        sendServerActualRequest "window/showMessageRequest" (box p)
 
     override __.WindowLogMessage(p) =
         sendServerRequest "window/logMessage" (box p) |> Async.Ignore

--- a/src/LanguageServerProtocol/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol/LanguageServerProtocol.fs
@@ -2458,7 +2458,7 @@ module Server =
         let sendServerRequest (rpcMethod: string) (requestObj: obj): AsyncLspResult<MessageActionItem option> =
             async {
               let serializedResponse = JToken.FromObject(requestObj, jsonSerializer)
-              let req = JsonRpc.Request.Create(rpcMethod, serializedResponse)
+              let req = JsonRpc.Request.Create(10000, rpcMethod, serializedResponse)
               let reqString = JsonConvert.SerializeObject(req, jsonSettings)
               sender.Post(reqString)
               let! response = responseAgent.PostAndAsyncReply((fun replyChannel -> Request(req.Id.Value, replyChannel)))

--- a/src/LanguageServerProtocol/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol/LanguageServerProtocol.fs
@@ -1908,6 +1908,7 @@ module JsonRpc =
         Result: JToken option
     }
     with
+        member x.ShouldSerializeResult() = x.Error.IsNone
         static member Success(id: int, result: JToken option) =
             { Version = "2.0"; Id = Some id; Result = result; Error = None }
         static member Failure(id: int, error: Error) =

--- a/src/LanguageServerProtocol/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol/LanguageServerProtocol.fs
@@ -1908,6 +1908,7 @@ module JsonRpc =
         Result: JToken option
     }
     with
+        /// Json.NET conditional property serialization, controlled by naming convention
         member x.ShouldSerializeResult() = x.Error.IsNone
         static member Success(id: int, result: JToken option) =
             { Version = "2.0"; Id = Some id; Result = result; Error = None }
@@ -2720,7 +2721,7 @@ module Client =
             |> Async.StartAsTask
             |> ignore
 
-        member __.SendNotificatoin (rpcMethod: string) (requestObj: obj) =
+        member __.SendNotification (rpcMethod: string) (requestObj: obj) =
             let serializedResponse = JToken.FromObject(requestObj, jsonSerializer)
             let notification = JsonRpc.Notification.Create(rpcMethod, Some serializedResponse)
             let notString = JsonConvert.SerializeObject(notification, jsonSettings)

--- a/src/LanguageServerProtocol/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol/LanguageServerProtocol.fs
@@ -2253,10 +2253,6 @@ module Server =
         Run: 'server -> JToken option -> AsyncLspResult<JToken option>
     }
 
-    type ResponseHandling = {
-        Run: JToken option -> AsyncLspResult<JToken option>
-    }
-
     let deserialize<'t> (token: JToken) = token.ToObject<'t>(jsonSerializer)
 
     let serialize<'t> (o: 't) = JToken.FromObject(o, jsonSerializer)
@@ -2402,12 +2398,9 @@ module Server =
         }
 
     type ClientNotificationSender = string -> obj -> AsyncLspResult<unit>
-    // type ClientRequestSender = Type -> (string -> obj -> -> AsyncLspResult<'t>)
-    // type ClientRequestSender(asd) =
-    //   member __.Asd<'t>() = asd
+
     type ClientRequestSender =
         abstract member f<'a> : string -> obj -> AsyncLspResult<'a>
-
 
     type private RequestHandlingResult =
         | Normal
@@ -2427,22 +2420,6 @@ module Server =
       fun () ->
         counter <- counter + 1
         counter
-
-    // let sendServerRequest<'response> (rpcMethod: string) (requestObj: obj) =
-    //     fun (sender : MailboxProcessor<string>) (responseAgent : MailboxProcessor<msg>) ->
-    //       async {
-    //         let serializedResponse = JToken.FromObject(requestObj, jsonSerializer)
-    //         let req = JsonRpc.Request.Create(getNextRequestId(), rpcMethod, serializedResponse)
-    //         let reqString = JsonConvert.SerializeObject(req, jsonSettings)
-    //         sender.Post(reqString)
-    //         let! response = responseAgent.PostAndAsyncReply((fun replyChannel -> Request(req.Id.Value, replyChannel)))
-    //         match responseHandling response with
-    //         | Some result -> return (LspResult.Ok result)
-    //         | None -> return (LspResult.notImplemented)
-    //         // TODO: Really wait for the client answer if not a notification (Necessary to implement requests)
-    //         // return (LspResult.Ok response)
-    //       }
-
 
     let start<'a, 'b when 'a :> LspClient and 'b :> LspServer> (requestHandlings : Map<string,RequestHandling<'b>>) (input: Stream) (output: Stream) (clientCreator: (ClientNotificationSender * ClientRequestSender) -> 'a) (serverCreator: 'a -> 'b) =
         let sender = MailboxProcessor<string>.Start(fun inbox ->

--- a/src/LanguageServerProtocol/LanguageServerProtocol.fsproj
+++ b/src/LanguageServerProtocol/LanguageServerProtocol.fsproj
@@ -7,5 +7,9 @@
   <ItemGroup>
     <Compile Include="LanguageServerProtocol.fs" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FsAutoComplete.Logging\FsAutoComplete.Logging.fsproj" />
+  </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -63,7 +63,7 @@ let logger = Expecto.Logging.Log.create "LSPTests"
 let createServer (toolsPath) =
 
   let event = Event<string * obj> ()
-  let client = FSharpLspClient ((fun name o -> event.Trigger (name,o); AsyncLspResult.success ()), { new LanguageServerProtocol.Server.ClientRequestSender with member __.f _ _ = AsyncLspResult.notImplemented})
+  let client = FSharpLspClient ((fun name o -> event.Trigger (name,o); AsyncLspResult.success ()), { new LanguageServerProtocol.Server.ClientRequestSender with member __.Send _ _ = AsyncLspResult.notImplemented})
   let commands = Commands(FsAutoComplete.JsonSerializer.writeJson, false, toolsPath)
   let originalFs = FSharp.Compiler.AbstractIL.Internal.Library.Shim.FileSystem
   let fs = FsAutoComplete.FileSystem(originalFs, commands.Files.TryFind)

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -63,7 +63,7 @@ let logger = Expecto.Logging.Log.create "LSPTests"
 let createServer (toolsPath) =
 
   let event = Event<string * obj> ()
-  let client = FSharpLspClient ((fun name o -> event.Trigger (name,o); AsyncLspResult.success ()), (fun _ _ -> AsyncLspResult.notImplemented))
+  let client = FSharpLspClient ((fun name o -> event.Trigger (name,o); AsyncLspResult.success ()), { new LanguageServerProtocol.Server.ClientRequestSender with member __.f _ _ = AsyncLspResult.notImplemented})
   let commands = Commands(FsAutoComplete.JsonSerializer.writeJson, false, toolsPath)
   let originalFs = FSharp.Compiler.AbstractIL.Internal.Library.Shim.FileSystem
   let fs = FsAutoComplete.FileSystem(originalFs, commands.Files.TryFind)

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -63,7 +63,7 @@ let logger = Expecto.Logging.Log.create "LSPTests"
 let createServer (toolsPath) =
 
   let event = Event<string * obj> ()
-  let client = FSharpLspClient (fun name o -> event.Trigger (name,o); AsyncLspResult.success () )
+  let client = FSharpLspClient ((fun name o -> event.Trigger (name,o); AsyncLspResult.success ()), (fun _ _ -> AsyncLspResult.notImplemented))
   let commands = Commands(FsAutoComplete.JsonSerializer.writeJson, false, toolsPath)
   let originalFs = FSharp.Compiler.AbstractIL.Internal.Library.Shim.FileSystem
   let fs = FsAutoComplete.FileSystem(originalFs, commands.Files.TryFind)


### PR DESCRIPTION
This extends the LSP server to explicitly handle Requests, Responses and Notifications, as well as send requests to the client.

Main outstanding concerns:
1. Is the response mailbox processor deadlock safe?
2. Does it need to better handle failed requests to the client?
3. What should it do when there's an error in a response or notification?