### PR TITLE
Update 'comparisonToMutableAssignment' code fix to account for properties and qualified names

### DIFF
--- a/src/FsAutoComplete/CodeFixes.fs
+++ b/src/FsAutoComplete/CodeFixes.fs
@@ -803,13 +803,14 @@ module Fixes =
             codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
 
           let fcsPos = protocolPosToPos diagnostic.Range.Start
-          let! (_, _, lines) = getParseResultsForFile fileName fcsPos
+          let! (tyRes, line, lines) = getParseResultsForFile fileName fcsPos
 
           match walkForwardUntilCondition lines diagnostic.Range.Start System.Char.IsWhiteSpace with
           | None -> return []
-          | Some col ->
-            let fcsPos = protocolPosToPos col
-            let! (tyRes, line, lines) = getParseResultsForFile fileName fcsPos
+          | Some endPos ->
+            let fcsPos = protocolPosToPos endPos
+            let line = getLine lines endPos
+            // let! (tyRes, line, lines) = getParseResultsForFile fileName fcsPos
 
             let! symbol =
               tyRes.TryGetSymbolUse fcsPos line

--- a/src/FsAutoComplete/CodeFixes.fs
+++ b/src/FsAutoComplete/CodeFixes.fs
@@ -803,32 +803,38 @@ module Fixes =
             codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
 
           let fcsPos = protocolPosToPos diagnostic.Range.Start
-          let! (tyRes, line, lines) = getParseResultsForFile fileName fcsPos
+          let! (_, _, lines) = getParseResultsForFile fileName fcsPos
 
-          let! symbol =
-            tyRes.TryGetSymbolUse fcsPos line
-            |> AsyncResult.ofOption (fun _ -> "No symbol found at position")
+          match walkForwardUntilCondition lines diagnostic.Range.Start System.Char.IsWhiteSpace with
+          | None -> return []
+          | Some col ->
+            let fcsPos = protocolPosToPos col
+            let! (tyRes, line, lines) = getParseResultsForFile fileName fcsPos
 
-          match symbol.Symbol with
-          // only do anything if the value is mutable
-          | :? FSharpMemberOrFunctionOrValue as mfv when mfv.IsValue && mfv.IsMutable ->
-              // try to find the '=' at from the start of the range
-              let endOfMutableValue = fcsPosToLsp symbol.RangeAlternate.End
+            let! symbol =
+              tyRes.TryGetSymbolUse fcsPos line
+              |> AsyncResult.ofOption (fun _ -> "No symbol found at position")
 
-              match walkForwardUntilCondition lines endOfMutableValue (fun c -> c = '=') with
-              | Some equalsPos ->
-                  return
-                    [ { File = codeActionParams.TextDocument
-                        Title = "Use '<-' to mutate value"
-                        SourceDiagnostic = Some diagnostic
-                        Edits =
-                          [| { Range =
-                                 { Start = equalsPos
-                                   End = (inc lines equalsPos) }
-                               NewText = "<-" } |]
-                        Kind = Refactor } ]
-              | None -> return []
-          | _ -> return []
+            match symbol.Symbol with
+            // only do anything if the value is mutable
+            | :? FSharpMemberOrFunctionOrValue as mfv when mfv.IsMutable || mfv.HasSetterMethod ->
+                // try to find the '=' at from the start of the range
+                let endOfMutableValue = fcsPosToLsp symbol.RangeAlternate.End
+
+                match walkForwardUntilCondition lines endOfMutableValue (fun c -> c = '=') with
+                | Some equalsPos ->
+                    return
+                      [ { File = codeActionParams.TextDocument
+                          Title = "Use '<-' to mutate value"
+                          SourceDiagnostic = Some diagnostic
+                          Edits =
+                            [| { Range =
+                                   { Start = equalsPos
+                                     End = (inc lines equalsPos) }
+                                 NewText = "<-" } |]
+                          Kind = Refactor } ]
+                | None -> return []
+            | _ -> return []
         }
         |> AsyncResult.foldResult id (fun _ -> []))
       (Set.ofList [ "20" ])

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -158,6 +158,9 @@ module Conversions =
         )
         |> Array.map map
 
+    let getLine (lines: string[]) (pos: Lsp.Position) =
+      lines.[pos.Line]
+
     let getText (lines: string []) (r: Lsp.Range) =
         lines.[r.Start.Line].Substring(r.Start.Character, r.End.Character - r.Start.Character)
 


### PR DESCRIPTION
Dunno if this is the right way to go about doing it, but the gist of this is:

* Walk forward until we're at the end of the LongIdent
* Account for properties

Mirror (to the best of my limited abilities) of https://github.com/dotnet/fsharp/pull/10977


Sample code is

```fsharp
type C () = 
    member val P = 0 with get, set

module M = 
    let mutable x = "yeet"

let f() = 
    let c = C()
    c.P <- 12

    printfn "yeet"
```