### PR TITLE
apply a better comparison for finding specific workspace symbols

### DIFF
--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1052,7 +1052,7 @@ type FsharpLspServer(commands: Commands, lspClient: FSharpLspClient) =
                     let uri = Path.LocalPathToUri p
                     getSymbolInformations uri glyphToSymbolKind n)
                 |> Seq.collect id
-                |> Seq.filter(fun symbolInfo -> symbolInfo.Name.StartsWith(p.Query))
+                |> Seq.filter(fun symbolInfo -> applyQuery p.Query symbolInfo)
                 |> Seq.toArray
                 |> Some
                 |> success

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -134,6 +134,19 @@ module Conversions =
             yield! topLevel.Nested |> Seq.map (inner (Some topLevel.Declaration.Name))
         }
 
+    let applyQuery (query: string) (info: SymbolInformation) =
+      match query.Split([| '.' |], StringSplitOptions.RemoveEmptyEntries) with
+      | [|  |] -> false
+      | [| fullName |] -> info.Name = fullName
+      | [| moduleName; fieldName |] ->
+        info.Name = fieldName && info.ContainerName = Some moduleName
+      | parts ->
+        let containerName =
+          parts.[0..(parts.Length - 2)] |> String.concat "."
+        let fieldName =
+          Array.last parts
+        info.Name = fieldName && info.ContainerName = Some containerName
+
     let getCodeLensInformation (uri: DocumentUri) (typ: string) (topLevel: FSharpNavigationTopLevelDeclaration): CodeLens [] =
         let map (decl: FSharpNavigationDeclarationItem): CodeLens =
             {

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -137,15 +137,15 @@ module Conversions =
     let applyQuery (query: string) (info: SymbolInformation) =
       match query.Split([| '.' |], StringSplitOptions.RemoveEmptyEntries) with
       | [|  |] -> false
-      | [| fullName |] -> info.Name = fullName
+      | [| fullName |] -> info.Name.StartsWith fullName
       | [| moduleName; fieldName |] ->
-        info.Name = fieldName && info.ContainerName = Some moduleName
+        info.Name.StartsWith fieldName && info.ContainerName = Some moduleName
       | parts ->
         let containerName =
           parts.[0..(parts.Length - 2)] |> String.concat "."
         let fieldName =
           Array.last parts
-        info.Name = fieldName && info.ContainerName = Some containerName
+        info.Name.StartsWith fieldName && info.ContainerName = Some containerName
 
     let getCodeLensInformation (uri: DocumentUri) (typ: string) (topLevel: FSharpNavigationTopLevelDeclaration): CodeLens [] =
         let map (decl: FSharpNavigationDeclarationItem): CodeLens =


### PR DESCRIPTION
This fixes https://github.com/formulahendry/vscode-dotnet-test-explorer/issues/228 by making our querying logic for finding specific workspace symbols more intelligent.

Before, we were just checking if the symbol's name contains the entire string coming in, but it's possible for callers to send fully-qualified names as well, and so we have to do a bit of checking for what kind of name is coming in.

In general, if the name passed in isn't fully-qualified then we keep the old comparison logic (symbol name must start with the queried name). If the name is fully-qualified then the parent container(s) must match exactly, but the final name part can be variable as above.

This also pushes a filtering lambda down into the sequence generation for the results for this operation, because it can be quite a large set of symbols. 