### PR TITLE
Add in support for range-based highlighting

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+### 0.42.0 - 03.02.2021
+
+* Many large changes, .Net 5 is required now
+* Support for LSP semantic highlighting
+* Fantomas upgrade to 4.4.0-beta-003
+* FCS 38.0.2 upgrade
+* Use Ionide.ProjInfo for the project system instead of the oen built into this repo
+* Use local hosted msbuild to crack projects instead of managing builds ourselves
+
 #### 0.41.1 - 23.03.2020
 
 * Fix `PublishDiagnosticsCapabilities` type [#574](https://github.com/fsharp/FsAutoComplete/pull/574) by [@Gastove](https://github.com/Gastove)

--- a/build.fsx
+++ b/build.fsx
@@ -116,17 +116,13 @@ Target.create "ReleaseGitHub" (fun _ ->
     Git.Branches.pushTag "" remote release.NugetVersion
 
     let client =
-        let user =
-            match Environment.environVarOrNone "github-user" with
+        let token =
+            match Environment.environVarOrNone "github-token" with
             | Some s when not (String.isNullOrWhiteSpace s) -> s
-            | _ -> UserInput.getUserInput "Username: "
-        let pw =
-            match Environment.environVarOrNone "github-pw" with
-            | Some s when not (String.isNullOrWhiteSpace s) -> s
-            | _ -> UserInput.getUserPassword "Password: "
+            | _ -> UserInput.getUserInput "Token: "
 
-        // Git.createClient user pw
-        GitHub.createClient user pw
+        GitHub.createClientWithToken token
+
     let files = !! (pkgsDir </> "*.*")
 
     let notes =

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -167,8 +167,8 @@ let clientCaps : ClientCapabilities =
       {
         DynamicRegistration = Some true
         Requests = {
-          Range = None
-          Full = None
+          Range = Some (U2.First true)
+          Full = Some (U2.First true)
         }
         TokenTypes = [| |]
         TokenModifiers = [| |]


### PR DESCRIPTION
Small followup for the last MR to add in support for getting encodings for just a specific range, along with a test to show that it works