### PR TITLE
fix the formattingoptions type to not blow up on serialization

### DIFF
--- a/src/LanguageServerProtocol/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol/LanguageServerProtocol.fs
@@ -1163,17 +1163,16 @@ module Types =
     }
 
     /// Value-object describing what options formatting should use.
-    type FormattingOptions = {
+    type FormattingOptions() =
         /// Size of a tab in spaces.
-        TabSize: int
+        member val TabSize : int = 0 with get, set
 
         /// Prefer spaces over tabs.
-        InsertSpaces: bool
+        member val InsertSpaces: bool = false with get, set
 
         /// Further properties.
         [<JsonExtensionData>]
-        AdditionalData: System.Collections.Generic.IDictionary<string, JToken>
-    }
+        member val AdditionalData: System.Collections.Generic.IDictionary<string, JToken> = new System.Collections.Generic.Dictionary<_,_>() :> _ with get, set
 
     type DocumentFormattingParams = {
         /// The document to format.

--- a/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
@@ -279,9 +279,7 @@ let formattingTests toolsPath =
     match waitForParseResultsForFile (Path.GetFileName sourceFile) events with
     | Ok () ->
       match server.TextDocumentFormatting { TextDocument = { Uri = Path.FilePathToUri sourceFile }
-                                            Options = { TabSize = 4
-                                                        InsertSpaces = true
-                                                        AdditionalData = dict [] } } |> Async.RunSynchronously with
+                                            Options = FormattingOptions(TabSize = 4, InsertSpaces = true) } |> Async.RunSynchronously with
       | Ok (Some [|edit|]) ->
         let normalized = { edit with NewText = normalizeLineEndings edit.NewText }
         Expect.equal normalized expectedTextEdit "should replace the entire file range with the expected content"


### PR DESCRIPTION
Fixes #717 by changing the type to a class with auto-properties, which is fully supported by the `AdditionalData` mechanism in json.net.