### PR TITLE
Improve signature help for method calls and function applications

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -55,6 +55,14 @@ type NotificationEvent=
     | Diagnostics of LanguageServerProtocol.Types.PublishDiagnosticsParams
     | FileParsed of string<LocalPath>
 
+type SignatureHelpInfo = {
+  /// all potential overloads of the member at the position where signaturehelp was invoked
+  Methods: FSharpMethodGroupItem []
+  /// if present, the index of the method we think is the current one (will never be outside the bounds of the Methods array)
+  ActiveOverload: int option
+  /// if present, the index of the parameter on the active method (will never be outside the bounds of the Parameters array on the selected method)
+  ActiveParameter: int option}
+
 type Commands (checker: FSharpCompilerServiceChecker, state: State, backgroundService: BackgroundServices.BackgroundService, hasAnalyzers: bool) =
     let fileParsed = Event<FSharpParseFileResults>()
     let fileChecked = Event<ParseAndCheckResults * string<LocalPath> * int>()
@@ -795,9 +803,19 @@ type Commands (checker: FSharpCompilerServiceChecker, state: State, backgroundSe
         |> x.MapResult (CoreResponse.Res, CoreResponse.ErrorRes)
         |> x.AsCancellable tyRes.FileName |> AsyncResult.recoverCancellation
 
-    member x.Methods (tyRes : ParseAndCheckResults) (pos: Pos) (lines: LineStr[]) =
-        tyRes.TryGetMethodOverrides lines pos
-        |> AsyncResult.bimap CoreResponse.Res CoreResponse.ErrorRes
+    /// Attempts to identify member overloads and infer current parameter positions for signature help at a given location
+    member x.MethodsForSignatureHelp (tyRes : ParseAndCheckResults) (pos: Pos) (lines: LineStr[]) =
+      asyncResult {
+        let! methods, commas = tyRes.TryGetMethodOverrides lines pos
+        let overloadsByParameterCount = methods.Methods |> Array.sortBy (fun m -> m.Parameters.Length)
+        // naievely assume that the first overload with the same or greater number of parameters is our match
+        let activeSig = overloadsByParameterCount |> Array.tryFindIndex (fun m -> m.Parameters.Length >= commas)
+        return {
+          Methods = overloadsByParameterCount
+          ActiveOverload = activeSig
+          ActiveParameter = Some commas
+        }
+      }
 
     // member x.Lint (file: string<LocalPath>): Async<unit> =
     //     asyncResult {

--- a/src/FsAutoComplete.Core/FCSPatches.fs
+++ b/src/FsAutoComplete.Core/FCSPatches.fs
@@ -176,7 +176,7 @@ type FSharpParseFileResults with
       | None -> None
 
   /// Determines if the given position is inside a function or method application.
-  member scope.IsPosContainedInApplication pos =
+  member scope.IsPosContainedInApplicationPatched pos =
       match scope.ParseTree with
       | Some input ->
           let result =
@@ -195,7 +195,7 @@ type FSharpParseFileResults with
       | None -> false
 
   /// Attempts to find the range of a function or method that is being applied. Also accounts for functions in pipelines.
-  member scope.TryRangeOfFunctionOrMethodBeingApplied pos =
+  member scope.TryRangeOfFunctionOrMethodBeingAppliedPatched pos =
       let rec getIdentRangeForFuncExprInApp traverseSynExpr expr pos: Range option =
           match expr with
           | SynExpr.Ident ident -> Some ident.idRange

--- a/src/FsAutoComplete.Core/FCSPatches.fs
+++ b/src/FsAutoComplete.Core/FCSPatches.fs
@@ -181,51 +181,132 @@ type FSharpParseFileResults with
       | Some input ->
           let result =
               AstTraversal.Traverse(pos, input, { new AstTraversal.AstVisitorBase<_>() with
-                  member _.VisitExpr(_, _, defaultTraverse, expr) =
-                      match expr with
-                      | SynExpr.App (_, _, _, _, range) when Range.rangeContainsPos range pos ->
-                          Some range
-                      | _ -> defaultTraverse expr
+                  member _.VisitExpr(_, traverseSynExpr, defaultTraverse, expr) =
+                    match expr with
+                    | SynExpr.TypeApp (_, _, _, _, _, _, range) when Range.rangeContainsPos range pos ->
+                        Some range
+                    | SynExpr.App(_, _, _, SynExpr.CompExpr (_, _, expr, _), range) when Range.rangeContainsPos range pos ->
+                        traverseSynExpr expr
+                    | SynExpr.App (_, _, _, _, range) when Range.rangeContainsPos range pos ->
+                        Some range
+                    | _ -> defaultTraverse expr
               })
           result.IsSome
       | None -> false
 
   /// Attempts to find the range of a function or method that is being applied. Also accounts for functions in pipelines.
   member scope.TryRangeOfFunctionOrMethodBeingApplied pos =
-      let rec getIdentRangeForFuncExprInApp expr pos =
+      let rec getIdentRangeForFuncExprInApp traverseSynExpr expr pos: Range option =
           match expr with
-          | SynExpr.Ident ident -> ident.idRange
+          | SynExpr.Ident ident -> Some ident.idRange
 
-          | SynExpr.LongIdent(_, _, _, range) -> range
+          | SynExpr.LongIdent(_, _, _, range) -> Some range
 
           | SynExpr.Paren(expr, _, _, range) when Range.rangeContainsPos range pos ->
-              getIdentRangeForFuncExprInApp expr pos
+              getIdentRangeForFuncExprInApp traverseSynExpr expr pos
 
-          | SynExpr.App(_, _, funcExpr, argExpr, _) ->
+          | SynExpr.TypeApp (expr, _, _, _, _, _, _) ->
+              getIdentRangeForFuncExprInApp traverseSynExpr expr pos
+
+          | SynExpr.App (_, _, funcExpr, argExpr, _) ->
               match argExpr with
               | SynExpr.App (_, _, _, _, range) when Range.rangeContainsPos range pos ->
-                  getIdentRangeForFuncExprInApp argExpr pos
+                  getIdentRangeForFuncExprInApp traverseSynExpr argExpr pos
+
+              // Special case: `async { ... }` is actually a CompExpr inside of the argExpr of a SynExpr.App
+              | SynExpr.CompExpr (_, _, expr, range) when Range.rangeContainsPos range pos ->
+                  getIdentRangeForFuncExprInApp traverseSynExpr expr pos
+
+              | SynExpr.Paren (expr, _, _, range) when Range.rangeContainsPos range pos ->
+                  getIdentRangeForFuncExprInApp traverseSynExpr expr pos
+
               | _ ->
                   match funcExpr with
                   | SynExpr.App (_, true, _, _, _) when Range.rangeContainsPos argExpr.Range pos ->
                       // x |> List.map
                       // Don't dive into the funcExpr (the operator expr)
                       // because we dont want to offer sig help for that!
-                      getIdentRangeForFuncExprInApp argExpr pos
+                      getIdentRangeForFuncExprInApp traverseSynExpr argExpr pos
                   | _ ->
                       // Generally, we want to dive into the func expr to get the range
                       // of the identifier of the function we're after
-                      getIdentRangeForFuncExprInApp funcExpr pos
-          | expr -> expr.Range // Exhaustiveness, this shouldn't actually be necessary...right?
+                      getIdentRangeForFuncExprInApp traverseSynExpr funcExpr pos
+
+          | SynExpr.LetOrUse (_, _, bindings, body, range) when Range.rangeContainsPos range pos  ->
+                let binding =
+                    bindings
+                    |> List.tryFind (fun x -> Range.rangeContainsPos x.RangeOfBindingAndRhs pos)
+                match binding with
+                | Some(SynBinding.Binding(_, _, _, _, _, _, _, _, _, expr, _, _)) ->
+                    getIdentRangeForFuncExprInApp traverseSynExpr expr pos
+                | None ->
+                    getIdentRangeForFuncExprInApp traverseSynExpr body pos
+
+          | SynExpr.IfThenElse (ifExpr, thenExpr, elseExpr, _, _, _, range) when Range.rangeContainsPos range pos ->
+              if Range.rangeContainsPos ifExpr.Range pos then
+                  getIdentRangeForFuncExprInApp traverseSynExpr ifExpr pos
+              elif Range.rangeContainsPos thenExpr.Range pos then
+                  getIdentRangeForFuncExprInApp traverseSynExpr thenExpr pos
+              else
+                  match elseExpr with
+                  | None -> None
+                  | Some expr ->
+                      getIdentRangeForFuncExprInApp traverseSynExpr expr pos
+
+          | SynExpr.Match (_, expr, clauses, range) when Range.rangeContainsPos range pos ->
+              if Range.rangeContainsPos expr.Range pos then
+                  getIdentRangeForFuncExprInApp traverseSynExpr expr pos
+              else
+                  let clause = clauses |> List.tryFind (fun clause -> Range.rangeContainsPos clause.Range pos)
+                  match clause with
+                  | None -> None
+                  | Some clause ->
+                      match clause with
+                      | SynMatchClause.Clause (_, whenExpr, resultExpr, _, _) ->
+                          match whenExpr with
+                          | None ->
+                              getIdentRangeForFuncExprInApp traverseSynExpr resultExpr pos
+                          | Some whenExpr ->
+                              if Range.rangeContainsPos whenExpr.Range pos then
+                                  getIdentRangeForFuncExprInApp traverseSynExpr whenExpr pos
+                              else
+                                  getIdentRangeForFuncExprInApp traverseSynExpr resultExpr pos
+
+
+          // Ex: C.M(x, y, ...) <--- We want to find where in the tupled application the call is being made
+          | SynExpr.Tuple(_, exprs, _, tupRange) when Range.rangeContainsPos tupRange pos ->
+              let expr = exprs |> List.tryFind (fun expr -> Range.rangeContainsPos expr.Range pos)
+              match expr with
+              | None -> None
+              | Some expr ->
+                  getIdentRangeForFuncExprInApp traverseSynExpr expr pos
+
+          // Capture the body of a lambda, often nested in a call to a collection function
+          | SynExpr.Lambda(_, _, _args, body, _, _) when Range.rangeContainsPos body.Range pos ->
+              getIdentRangeForFuncExprInApp traverseSynExpr body pos
+
+          | SynExpr.Do(expr, range) when Range.rangeContainsPos range pos ->
+              getIdentRangeForFuncExprInApp traverseSynExpr expr pos
+
+          | SynExpr.Assert(expr, range) when Range.rangeContainsPos range pos ->
+              getIdentRangeForFuncExprInApp traverseSynExpr expr pos
+
+          | SynExpr.ArbitraryAfterError (_debugStr, range) when Range.rangeContainsPos range pos ->
+              Some range
+
+          | expr ->
+              traverseSynExpr expr
+              |> Option.map (fun expr -> expr)
 
       match scope.ParseTree with
       | Some input ->
           AstTraversal.Traverse(pos, input, { new AstTraversal.AstVisitorBase<_>() with
-              member _.VisitExpr(_, _, defaultTraverse, expr) =
+              member _.VisitExpr(_, traverseSynExpr, defaultTraverse, expr) =
                   match expr with
+                  | SynExpr.TypeApp (expr, _, _, _, _, _, range) when Range.rangeContainsPos range pos ->
+                    getIdentRangeForFuncExprInApp traverseSynExpr expr pos
                   | SynExpr.App (_, _, _funcExpr, _, range) as app when Range.rangeContainsPos range pos ->
-                      getIdentRangeForFuncExprInApp app pos
-                      |> Some
+                      getIdentRangeForFuncExprInApp traverseSynExpr app pos
                   | _ -> defaultTraverse expr
           })
       | None -> None

--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -40,6 +40,7 @@
     <Compile Include="BackgroundServices.fs" />
     <Compile Include="Fsdn.fs" />
     <Compile Include="Lint.fs" />
+    <Compile Include="SignatureHelp.fs" />
     <Compile Include="Commands.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -25,53 +25,6 @@ type ParseAndCheckResults
 
   let logger = LogProvider.getLoggerByName "ParseAndCheckResults"
 
-  member x.TryGetMethodOverrides (lines: LineStr[]) (pos: Pos) = async {
-    // Get the parameter locations
-    let paramLocations = parseResults.FindNoteworthyParamInfoLocations pos
-
-    match paramLocations with
-    | None ->
-      // if there were no parameter locations, try just the first position
-      let lineText = lines.[pos.Line - 1]
-      let nearestIdent = Lexer.findClosestIdent pos.Column lineText
-      match nearestIdent with
-      | Some (rightCol, names) ->
-        let meth = checkResults.GetMethods(pos.Line, rightCol, lineText, Some (List.ofArray names))
-        return Ok(meth, 0)
-      | None ->
-        return Error "No ident found for pos"
-    | Some nwpl ->
-      let names = nwpl.LongId
-      let lidEnd = nwpl.LongIdEndLocation
-      let meth = checkResults.GetMethods(lidEnd.Line, lidEnd.Column, lines.[lidEnd.Line - 1], Some names)
-      // Find the number of `,` in the current signature
-      let commas =
-        let lineCutoff = pos.Line - 6
-        let rec prevPos (line,col) =
-          match line, col with
-          | 1, 1
-          | _ when line < lineCutoff -> 1, 1
-          | _, 1 ->
-             let prevLine = lines.[line - 2]
-             if prevLine.Length = 0 then prevPos(line-1, 1)
-             else line - 1, prevLine.Length
-          | _    -> line, col - 1
-
-        let rec loop commas depth (line, col) =
-          if (line,col) <= (1,1) then (0, line, col) else
-          let ch = lines.[line - 1].[col - 1]
-          let commas = if depth = 0 && ch = ',' then commas + 1 else commas
-          if (ch = '(' || ch = '{' || ch = '[') && depth > 0 then loop commas (depth - 1) (prevPos (line,col))
-          elif ch = ')' || ch = '}' || ch = ']' then loop commas (depth + 1) (prevPos (line,col))
-          elif ch = '(' || ch = '<' then commas, line, col
-          else loop commas depth (prevPos (line,col))
-
-        match loop 0 0 (prevPos(pos.Line, pos.Column)) with
-        | _, 1, 1 -> 0
-        | commas, _, _ -> commas
-      return Ok(meth, commas)
-  }
-
   member __.TryFindDeclaration (pos: Pos) (lineStr: LineStr) = async {
     // try find identifier first
     let! identResult = __.TryFindIdentifierDeclaration pos lineStr

--- a/src/FsAutoComplete.Core/SignatureHelp.fs
+++ b/src/FsAutoComplete.Core/SignatureHelp.fs
@@ -59,8 +59,8 @@ let private getSignatureHelpForFunctionApplication (tyRes: ParseAndCheckResults,
   asyncMaybe {
     let lineStr = lineText lines endOfPreviousIdentPos
     let! possibleApplicationSymbolEnd = maybe {
-      if tyRes.GetParseResults.IsPosContainedInApplication endOfPreviousIdentPos then
-        let! funcRange = tyRes.GetParseResults.TryRangeOfFunctionOrMethodBeingApplied endOfPreviousIdentPos
+      if tyRes.GetParseResults.IsPosContainedInApplicationPatched endOfPreviousIdentPos then
+        let! funcRange = tyRes.GetParseResults.TryRangeOfFunctionOrMethodBeingAppliedPatched endOfPreviousIdentPos
         return funcRange.End
       else return endOfPreviousIdentPos
     }

--- a/src/FsAutoComplete.Core/SignatureHelp.fs
+++ b/src/FsAutoComplete.Core/SignatureHelp.fs
@@ -1,0 +1,141 @@
+module FsAutoComplete.SignatureHelp
+
+open FSharp.Compiler.Text
+open FSharp.Compiler.SourceCodeServices
+open FsToolkit.ErrorHandling
+open FsAutoComplete
+open System
+open FSharp.UMX
+
+type SignatureHelpKind = MethodCall | FunctionApplication
+
+type SignatureHelpInfo = {
+  /// all potential overloads of the member at the position where signaturehelp was invoked
+  Methods: FSharpMethodGroupItem []
+  /// if present, the index of the method we think is the current one (will never be outside the bounds of the Methods array)
+  ActiveOverload: int option
+  /// if present, the index of the parameter on the active method (will never be outside the bounds of the Parameters array on the selected method)
+  ActiveParameter: int option
+  SigHelpKind: SignatureHelpKind
+}
+
+let private lineText (lines: LineStr []) (pos: Pos) = lines.[pos.Line - 1]
+
+let private charAt (lines: LineStr []) (pos: Pos) =
+      (lineText lines pos).[pos.Column - 1]
+
+let private getSignatureHelpForFunctionApplication (tyRes: ParseAndCheckResults, caretPos: Pos, endOfPreviousIdentPos: Pos, lines: LineStr[]) : Async<SignatureHelpInfo option> =
+  asyncMaybe {
+    let lineStr = lineText lines endOfPreviousIdentPos
+    let! possibleApplicationSymbolEnd = maybe {
+      if tyRes.GetParseResults.IsPosContainedInApplication endOfPreviousIdentPos then
+        let! funcRange = tyRes.GetParseResults.TryRangeOfFunctionOrMethodBeingApplied endOfPreviousIdentPos
+        return funcRange.End
+      else return endOfPreviousIdentPos
+    }
+
+    let possibleApplicationSymbolLineStr = lineText lines possibleApplicationSymbolEnd
+    let! (endCol, names) = Lexer.findLongIdents(possibleApplicationSymbolEnd.Column, possibleApplicationSymbolLineStr)
+    let idents = List.ofArray names
+    let! symbolUse = tyRes.GetCheckResults.GetSymbolUseAtLocation(possibleApplicationSymbolEnd.Line, endCol, lineStr, idents)
+
+    let isValid (mfv: FSharpMemberOrFunctionOrValue) =
+      not (PrettyNaming.IsOperatorName mfv.DisplayName) &&
+      not mfv.IsProperty &&
+      mfv.CurriedParameterGroups.Count > 0
+
+    match symbolUse.Symbol with
+    | :? FSharpMemberOrFunctionOrValue as mfv when isValid mfv ->
+      let tooltip = tyRes.GetCheckResults.GetToolTipText(possibleApplicationSymbolEnd.Line, endCol, possibleApplicationSymbolLineStr, idents, FSharpTokenTag.IDENT)
+      match tooltip with
+      | FSharpToolTipText []
+      | FSharpToolTipText [FSharpToolTipElement.None] -> return! None
+      | _ ->
+        let symbolStart = symbolUse.RangeAlternate.Start
+        let possiblePipelineIdent = tyRes.GetParseResults.TryIdentOfPipelineContainingPosAndNumArgsApplied symbolStart
+        let numArgsAlreadyApplied = possiblePipelineIdent |> Option.map snd |> Option.defaultValue 0
+        let definedArgs = mfv.CurriedParameterGroups |> Array.ofSeq
+        let numDefinedArgs = definedArgs.Length
+        let curriedArgsInSource =
+            tyRes.GetParseResults.GetAllArgumentsForFunctionApplicationAtPostion symbolStart
+            |> Option.defaultValue []
+            |> Array.ofList
+        do! Option.guard (numDefinedArgs >= curriedArgsInSource.Length)
+
+        let! argumentIndex =
+          let possibleExactIndex =
+              curriedArgsInSource
+              |> Array.tryFindIndex(fun argRange -> Range.rangeContainsPos argRange caretPos)
+
+          match possibleExactIndex with
+          | Some index -> Some index
+          | None ->
+              let possibleNextIndex =
+                  curriedArgsInSource
+                  |> Array.tryFindIndex(fun argRange -> Pos.posGeq argRange.Start caretPos)
+
+              match possibleNextIndex with
+              | Some index -> Some index
+              | None ->
+                  if numDefinedArgs - numArgsAlreadyApplied > curriedArgsInSource.Length then
+                      Some (numDefinedArgs - (numDefinedArgs - curriedArgsInSource.Length))
+                  else
+                      None
+        let methods = tyRes.GetCheckResults.GetMethods(symbolStart.Line, symbolUse.RangeAlternate.End.Column, lineText lines symbolStart, None)
+
+        return {
+          ActiveParameter = Some argumentIndex
+          Methods = methods.Methods
+          ActiveOverload = None
+          SigHelpKind = FunctionApplication
+        }
+    | _ ->
+      return! None
+  }
+
+let getSignatureHelpFor (tyRes : ParseAndCheckResults, pos: Pos, lines: LineStr[], triggerChar, possibleSessionKind) =
+  asyncResult {
+    let charAt (pos: Pos) =
+      lines.[pos.Line - 1].[pos.Column - 1]
+
+    let previousNonWhitespaceCharPos =
+      let dec (pos: Pos): Pos =
+        if pos.Column = 0 then
+          let prevLine = lines.[pos.Line - 2]
+          // retreat to the end of the previous line
+          Pos.mkPos (pos.Line - 1) (prevLine.Length - 1)
+        else
+          Pos.mkPos (pos.Line) (pos.Column - 1)
+
+      let rec loop ch pos =
+        if Char.IsWhiteSpace ch then
+          let prevPos = dec pos
+          loop (charAt prevPos) prevPos
+        else
+          pos
+      let initialPos = dec pos
+      loop (charAt initialPos) initialPos
+
+    let previousNonWhitespaceChar = charAt previousNonWhitespaceCharPos
+    match triggerChar, possibleSessionKind with
+    // Generally ' ' indicates a function application, but it's also used commonly after a comma in a method call.
+    // This means that the adjusted position relative to the caret could be a ',' or a '(' or '<',
+    // which would mean we're already inside of a method call - not a function argument. So we bail if that's the case.
+    | (Some ' ', _) | (_, Some FunctionApplication) when previousNonWhitespaceChar <> ',' && previousNonWhitespaceChar <> '(' && previousNonWhitespaceChar <> '<' ->
+      return! getSignatureHelpForFunctionApplication (tyRes, pos, previousNonWhitespaceCharPos, lines)
+    | _ ->
+      let! methods, commas = tyRes.TryGetMethodOverrides lines pos
+      if methods.Methods.Length = 0 then
+        return None
+      else
+        let overloadsByParameterCount = methods.Methods |> Array.sortBy (fun m -> m.Parameters.Length)
+        // naievely assume that the first overload with the same or greater number of parameters is our match
+        let activeSig = overloadsByParameterCount |> Array.tryFindIndex (fun m -> m.Parameters.Length >= commas)
+        return Some {
+          Methods = overloadsByParameterCount
+          ActiveOverload = activeSig
+          ActiveParameter = Some commas
+          SigHelpKind = MethodCall
+        }
+  }
+

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -1053,8 +1053,20 @@ let formatTip (FSharpToolTipText tips) : (string * string) list list =
     tips
     |> List.choose (function
         | FSharpToolTipElement.Group items ->
-            let getRemarks (it : FSharpToolTipElementData<string>) = defaultArg (it.Remarks |> Option.map (fun n -> if String.IsNullOrWhiteSpace n then n else "\n\n" + n)) ""
-            Some (items |> List.map (fun (it) ->  (it.MainDescription + getRemarks it, buildFormatComment it.XmlDoc FormatCommentStyle.Legacy None)))
+            let getRemarks (it : FSharpToolTipElementData<string>) =
+              it.Remarks
+              |> Option.map (fun n -> if String.IsNullOrWhiteSpace n then n else "\n\n" + n)
+              |> Option.defaultValue ""
+
+            let makeTooltip (tipElement: FSharpToolTipElementData<string>) =
+              let header = tipElement.MainDescription + getRemarks tipElement
+              let body = buildFormatComment tipElement.XmlDoc FormatCommentStyle.Legacy None
+              header, body
+
+            items
+            |> List.map makeTooltip
+            |> Some
+
         | FSharpToolTipElement.CompositionError (error) -> Some [("<Note>", error)]
         | _ -> None)
 

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -97,6 +97,7 @@ let projectOptionsToParseOptions (checkOptions: FSharpProjectOptions) =
 module Option =
 
   let inline attempt (f: unit -> 'T) = try Some <| f() with _ -> None
+  let inline guard (b) = if b then Some () else None
 
 [<RequireQualifiedAccess>]
 module Result =

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -817,7 +817,12 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
         logger.info (Log.setMessage "TextDocumentSignatureHelp Request: {parms}" >> Log.addContextDestructured "parms" sigHelpParams )
         sigHelpParams |> x.positionHandlerWithLatest (fun sigHelpParams fcsPos tyRes lineStr lines ->
             asyncResult {
-                match! commands.MethodsForSignatureHelp(tyRes, fcsPos, lines, sigHelpParams.Context |> Option.bind (fun c -> c.TriggerCharacter), sigHelpKind) |> AsyncResult.ofStringErr with
+                let charAtCaret =
+                  sigHelpParams.Context
+                  |> Option.bind (fun c -> c.TriggerCharacter)
+                  |> Option.defaultWith (fun _ -> lineStr.[fcsPos.Column - 1])
+
+                match! commands.MethodsForSignatureHelp(tyRes, fcsPos, lines, Some charAtCaret, sigHelpKind) |> AsyncResult.ofStringErr with
                 | None ->
                   sigHelpKind <- None
                   return! success None

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -820,9 +820,8 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
                 let charAtCaret =
                   sigHelpParams.Context
                   |> Option.bind (fun c -> c.TriggerCharacter)
-                  |> Option.defaultWith (fun _ -> lineStr.[fcsPos.Column - 1])
 
-                match! commands.MethodsForSignatureHelp(tyRes, fcsPos, lines, Some charAtCaret, sigHelpKind) |> AsyncResult.ofStringErr with
+                match! commands.MethodsForSignatureHelp(tyRes, fcsPos, lines, charAtCaret, sigHelpKind) |> AsyncResult.ofStringErr with
                 | None ->
                   sigHelpKind <- None
                   return! success None

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -1119,11 +1119,10 @@ let signatureHelpTests state =
   })
 
   testSequenced <| testList "SignatureHelp" [
-    checkOverloadsAt (0, 36) "Can get overloads of MemoryStream with attached parens"
-    for c in 38..40 do
-      checkOverloadsAt (1, c) $"Can get overloads at whitespace position {c-38} of unattached parens"
+    for c in 37..39 do
+      checkOverloadsAt (0, c) $"Can get overloads at whitespace position {c-37} of unattached parens"
     for c in 39..41 do
-      checkOverloadsAt (2, c) $"Can get overloads at whitespace position {c-39} of attached parens"
+      checkOverloadsAt (1, c) $"Can get overloads at whitespace position {c-39} of attached parens"
 
     testCaseAsync "cleanup" (async {
       let! server, _ = server

--- a/test/FsAutoComplete.Tests.Lsp/FunctionApplicationTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/FunctionApplicationTests.fs
@@ -45,7 +45,7 @@ let testSignatureHelp title file (line, char) triggerType checkResp server =
 
 
 let test742 =
-  testSignatureHelp "issue 742 - signature help on piped functions counts the prior parameters" "742.fsx" (0, 7) (Char ' ') (fun resp ->
+  testSignatureHelp "issue 742 - signature help on piped functions counts the prior parameters" "742.fsx" (0, 6) (Char ' ') (fun resp ->
     Expect.isNone resp "there should be no sighelp on this location"
   )
 
@@ -100,7 +100,7 @@ let test750 =
 let tests state =
   let server = server state
   testSequenced <|
-    ptestList "function application" [
+    testList "function application" [
       testList "tests" ([
          test742
          test744

--- a/test/FsAutoComplete.Tests.Lsp/FunctionApplicationTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/FunctionApplicationTests.fs
@@ -45,7 +45,7 @@ let testSignatureHelp title file (line, char) triggerType checkResp server =
 
 
 let test742 =
-  testSignatureHelp "issue 742 - signature help on piped functions counts the prior parameters" "742.fsx" (0, 6) (Char ' ') (fun resp ->
+  testSignatureHelp "issue 742 - signature help on functions counts the prior parameters" "742.fsx" (0, 6) (Char ' ') (fun resp ->
     Expect.isNone resp "there should be no sighelp on this location"
   )
 
@@ -69,7 +69,7 @@ let test745 =
   )
 
 let test746 =
-  testSignatureHelp "issue 742 - signature help doesn't trigger when the function has all parameters" "746.fsx" (0, 23) Manual (fun resp ->
+  testSignatureHelp "issue 746 - signature help understands piping for parameter application" "746.fsx" (0, 22) (* the end of 'id' *)  Manual (fun resp ->
     Expect.isNone resp "there should be no suggestions at this position, since we've provided all parameters to List.map"
   )
 

--- a/test/FsAutoComplete.Tests.Lsp/FunctionApplicationTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/FunctionApplicationTests.fs
@@ -74,7 +74,7 @@ let test746 =
   )
 
 let test747 =
-  testSignatureHelp "issue 747 - signature help is provided for the most inner function" "747.fsx" (4, 5) Manual (fun resp ->
+  testSignatureHelp "issue 747 - signature help is provided for the most inner function" "747.fsx" (4, 4) Manual (fun resp ->
     Expect.isSome resp "should have provided signature help"
     let resp = resp.Value
     let methodsig = resp.Signatures.[0]

--- a/test/FsAutoComplete.Tests.Lsp/FunctionApplicationTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/FunctionApplicationTests.fs
@@ -16,10 +16,10 @@ let private server state =
   }
   |> Async.Cache
 
-let testSignatureHelp title file (line, char) triggerType checkResp server =
+let coreTestSignatureHelp hide title file (line, char) triggerType checkResp server =
 
-  testCaseAsync title ( async {
-    let! (server: Lsp.FSharpLspServer, event) = server
+  (if hide then ptestCaseAsync else testCaseAsync) title ( async {
+    let! (server: Lsp.FSharpLspServer, event: ClientEvents) = server
     let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "FunctionApplication")
     let path = Path.Combine(path, file)
     let tdop : DidOpenTextDocumentParams = { TextDocument = loadDocument path }
@@ -43,6 +43,8 @@ let testSignatureHelp title file (line, char) triggerType checkResp server =
     checkResp resp
   })
 
+let ptestSignatureHelp = coreTestSignatureHelp true
+let testSignatureHelp = coreTestSignatureHelp false
 
 let test742 =
   testSignatureHelp "issue 742 - signature help on functions counts the prior parameters" "742.fsx" (0, 6) (Char ' ') (fun resp ->
@@ -59,7 +61,7 @@ let test744 =
   )
 
 let test745 =
-  testSignatureHelp "issue 745 - signature help shows tuples in parens" "745.fsx" (2, 2) Manual (fun resp ->
+  ptestSignatureHelp "issue 745 - signature help shows tuples in parens" "745.fsx" (2, 2) Manual (fun resp ->
     match resp with
     | Some sigHelp ->
       Expect.equal sigHelp.ActiveSignature (Some 0) "should have suggested the first overload"

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/SignatureHelpTest/Script1.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/SignatureHelpTest/Script1.fsx
@@ -1,3 +1,2 @@
-let __ = new System.IO.MemoryStream()
 let ___ = new System.IO.MemoryStream (  )
 let _____ = new System.IO.MemoryStream(42)


### PR DESCRIPTION
This is largely a port of the code that @cartermp did in VF# a little while back, tweaked to our own structures and practices.

The gist is to be a bit more informed about the context of particular signature help calls for two cases in particular:
* function parameter applications
* method calls

the first move is to detect which case we're likely in, and then vary the logic based on that:

* for function applications:
	* use a new FCS method to get existing curried parameters for the function (including |> applications)
	* compare this count to the count of total function parameters
* for method calls
	* use something more like the pre-existing mechanism, just a bit more detailed

All in all, this is a huge jump in quality of life for signature help hints.

Fixes #750, #749, #748, #747, #746, #743, #742