### PR TITLE
Fix unit of measure displays in tooltips

### DIFF
--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -945,12 +945,13 @@ let tooltipTests state =
       testList "tests" [
         verifyTooltip 0 4 "val arrayOfTuples : (int * int) array"
         verifyTooltip 1 4 "val listOfTuples : list<int * int>"
-        verifyTooltip 2 4 "val listOfStructTuples : list<struct(int * int)>"
+        verifyTooltip 2 4 "val listOfStructTuples : list<struct (int * int)>"
         verifyTooltip 3 4 "val floatThatShouldHaveGenericReportedInTooltip : float" //<MeasureOne>
         //verifyDescription 4 4 """**Description**\n\nPrint to a string using the given format.\n\n**Parameters**\n\n* `format`: The formatter.\n\n**Returns**\n\nThe formatted result.\n\n**Generic parameters**\n\n* `'T` is `string`"""
         verifyDescription 13 10 (concatLines ["**Description**"; ""; "\nMy super summary\n "; ""; "**Parameters**"; ""; "* `c`: foo"; "* `b`: bar"; "* `a`: baz"; ""; "**Returns**"; ""; ""])
         verifyTooltip 14 4 "val nestedTuples : int * ((int * int) * int)"
-        verifyTooltip 15 4 "val nestedStructTuples : int * struct(int * int)"
+        verifyTooltip 15 4 "val nestedStructTuples : int * struct (int * int)"
+        verifyTooltip 21 8 "val speed : float<m/s>"
       ]
       testCaseAsync "cleanup" (async {
         let! server, _ = server

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -14,3 +14,9 @@ sprintf "asd"
 let someFunction (a) (b) (c) = ()
 let nestedTuples = (1, ((2, 3), 4))
 let nestedStructTuples = 1, struct(2, 3)
+
+type [<Measure>]s
+type [<Measure>]m
+let distance = 5.<m>
+let time = 1.<s>
+let speed = distance/time


### PR DESCRIPTION
Fixes #758 by not hijacking this specific part of type formatting when we detect a unit of measure is being formatted.

New tooltip tests with the source from that issue verify that they reduce (like `val speed : float<m/s>`)