### PR TITLE
Use ISourceText for file contents instead of string[]

### DIFF
--- a/src/FsAutoComplete.Core/AbstractClassStubGenerator.fs
+++ b/src/FsAutoComplete.Core/AbstractClassStubGenerator.fs
@@ -96,10 +96,10 @@ let getMemberNameAndRanges (abstractClassData) =
   | AbstractClassData.ObjExpr (_, bindings, _) -> List.choose (|MemberNameAndRange|_|) bindings
 
 /// Try to find the start column, so we know what the base indentation should be
-let inferStartColumn  (codeGenServer : CodeGenerationService) (pos : Pos) (doc : Document) (lines: LineStr[]) (lineStr : string) (abstractClassData : AbstractClassData) (indentSize : int) =
+let inferStartColumn  (codeGenServer : CodeGenerationService) (pos : Pos) (doc : Document) (lines: ISourceText) (lineStr : string) (abstractClassData : AbstractClassData) (indentSize : int) =
     match getMemberNameAndRanges abstractClassData with
     | (_, range) :: _ ->
-        getLineIdent lines.[range.StartLine-1]
+        getLineIdent (lines.GetLineString(range.StartLine - 1))
     | [] ->
         match abstractClassData with
         | AbstractClassData.ExplicitImpl _ ->
@@ -122,7 +122,7 @@ let inferStartColumn  (codeGenServer : CodeGenerationService) (pos : Pos) (doc :
 /// Try to write any missing members of the given abstract type at the given location.
 /// If the destination type isn't an abstract class, or if there are no missing members to implement,
 /// nothing is written. Otherwise, a list of missing members is generated and written
-let writeAbstractClassStub (codeGenServer : CodeGenerationService) (checkResultForFile: ParseAndCheckResults) (doc : Document) (lines: LineStr[]) (lineStr : string) (abstractClassData : AbstractClassData) =
+let writeAbstractClassStub (codeGenServer : CodeGenerationService) (checkResultForFile: ParseAndCheckResults) (doc : Document) (lines: ISourceText) (lineStr : string) (abstractClassData : AbstractClassData) =
   asyncMaybe {
     let pos = Pos.mkPos abstractClassData.AbstractTypeIdentRange.Start.Line (abstractClassData.AbstractTypeIdentRange.End.Column)
     let! (_lexerSym, usages) = codeGenServer.GetSymbolAndUseAtPositionOfKind(doc.FullName, pos, SymbolKind.Ident)

--- a/src/FsAutoComplete.Core/CodeGeneration.fs
+++ b/src/FsAutoComplete.Core/CodeGeneration.fs
@@ -15,9 +15,9 @@ type CodeGenerationService(checker : FSharpCompilerServiceChecker, state : State
     member x.TokenizeLine(fileName, i) =
         match state.TryGetFileCheckerOptionsWithLines fileName with
         | ResultOrString.Error _ -> None
-        | ResultOrString.Ok (opts, lines) ->
+        | ResultOrString.Ok (opts, text) ->
             try
-                let line = lines.[ i - 1 ]
+                let line = text.GetLineString (i - 1)
                 Lexer.tokenizeLine [||] line |> Some
             with
             | _ -> None

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -4,20 +4,36 @@ open FSharp.Compiler.SourceCodeServices
 open System
 open FsAutoComplete.Logging
 open FSharp.UMX
+open FSharp.Compiler.Text
+open System.Runtime.CompilerServices
 
 type VolatileFile =
   { Touched: DateTime
-    Lines: string []
-    Version: int option}
+    Lines: ISourceText
+    Version: int option }
 
 open System.IO
+
+
+[<Extension>]
+type SourceTextExtensions =
+  [<Extension>]
+  static member inline GetText(t: ISourceText, m: FSharp.Compiler.Text.Range): string =
+    ""
+
+  [<Extension>]
+  static member inline GetText(t: ISourceText, r: LanguageServerProtocol.Types.Range): string =
+    ""
+
+  [<Extension>]
+  static member inline Lines(t: ISourceText) =
+    Array.init (t.GetLineCount()) t.GetLineString
 
 type FileSystem (actualFs: IFileSystem, tryFindFile: string<LocalPath> -> VolatileFile option) =
     let getContent (filename: string<LocalPath>) =
          filename
          |> tryFindFile
-         |> Option.map (fun file ->
-              System.Text.Encoding.UTF8.GetBytes (String.Join ("\n", file.Lines)))
+         |> Option.map (fun file -> file.Lines.ToString() |> System.Text.Encoding.UTF8.GetBytes)
 
     let fsLogger = LogProvider.getLoggerByName "FileSystem"
     /// translation of the BCL's Windows logic for Path.IsPathRooted.

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -18,16 +18,38 @@ open System.IO
 [<Extension>]
 type SourceTextExtensions =
   [<Extension>]
-  static member inline GetText(t: ISourceText, m: FSharp.Compiler.Text.Range): string =
-    ""
-
-  [<Extension>]
-  static member inline GetText(t: ISourceText, r: LanguageServerProtocol.Types.Range): string =
-    ""
+  static member GetText(t: ISourceText, m: FSharp.Compiler.Text.Range): Result<string, string> =
+    let allFileRange = Range.mkRange m.FileName Pos.pos0 (t.GetLastFilePosition())
+    if not (Range.rangeContainsRange allFileRange m)
+    then Error "%A{m} is outside of the bounds of the file"
+    else
+      if m.StartLine = m.EndLine then // slice of a single line, just do that
+        let lineText = t.GetLineString (m.StartLine - 1)
+        lineText.Substring(m.StartColumn, m.EndColumn - m.StartColumn) |> Ok
+      else
+        // multiline, use a builder
+        let builder = new System.Text.StringBuilder()
+        // slice of the first line
+        let firstLine = t.GetLineString (m.StartLine - 1)
+        builder.Append (firstLine.Substring(m.StartColumn)) |> ignore<System.Text.StringBuilder>
+        // whole intermediate lines
+        for line in (m.StartLine + 1)..(m.EndLine - 1) do
+          builder.AppendLine (t.GetLineString(line - 1)) |> ignore<System.Text.StringBuilder>
+        // final part, potential slice
+        let lastLine = t.GetLineString (m.EndLine - 1)
+        builder.Append (lastLine.Substring(0, m.EndColumn)) |> ignore<System.Text.StringBuilder>
+        Ok (builder.ToString())
 
   [<Extension>]
   static member inline Lines(t: ISourceText) =
     Array.init (t.GetLineCount()) t.GetLineString
+
+  [<Extension>]
+  /// a safe alternative to GetLastCharacterPosition, which returns untagged indexes. this version
+  /// returns a FCS Pos to prevent confusion about line index offsets
+  static member GetLastFilePosition(t: ISourceText): FSharp.Compiler.Text.Pos =
+    let endLine, endChar = t.GetLastCharacterPosition()
+    Pos.mkPos endLine endChar
 
 type FileSystem (actualFs: IFileSystem, tryFindFile: string<LocalPath> -> VolatileFile option) =
     let getContent (filename: string<LocalPath>) =

--- a/src/FsAutoComplete.Core/InterfaceStubGenerator.fs
+++ b/src/FsAutoComplete.Core/InterfaceStubGenerator.fs
@@ -108,10 +108,10 @@ let getInterfaceIdentifier (interfaceData : InterfaceData) (tokens : FSharpToken
     CodeGenerationUtils.findLastIdentifier tokens.[newKeywordIndex + 2..] tokens.[newKeywordIndex + 2]
 
 /// Try to find the start column, so we know what the base indentation should be
-let inferStartColumn  (codeGenServer : CodeGenerationService) (pos : Pos) (doc : Document) (lines: LineStr[]) (lineStr : string) (interfaceData : InterfaceData) (indentSize : int) =
+let inferStartColumn  (codeGenServer : CodeGenerationService) (pos : Pos) (doc : Document) (lines: ISourceText) (lineStr : string) (interfaceData : InterfaceData) (indentSize : int) =
     match getMemberNameAndRanges interfaceData with
     | (_, range) :: _ ->
-        getLineIdent lines.[range.StartLine-1]
+        getLineIdent (lines.GetLineString(range.StartLine - 1))
     | [] ->
         match interfaceData with
         | InterfaceData.Interface _ as iface ->
@@ -134,7 +134,7 @@ let inferStartColumn  (codeGenServer : CodeGenerationService) (pos : Pos) (doc :
 /// Return None, if we failed to handle the interface implementation
 /// Return Some (insertPosition, generatedString):
 /// `insertPosition`: representation the position where the editor should insert the `generatedString`
-let handleImplementInterface (codeGenServer : CodeGenerationService) (checkResultForFile: ParseAndCheckResults) (pos : Pos) (doc : Document) (lines: LineStr[]) (lineStr : string) (interfaceData : InterfaceData) =
+let handleImplementInterface (codeGenServer : CodeGenerationService) (checkResultForFile: ParseAndCheckResults) (pos : Pos) (doc : Document) (lines: ISourceText) (lineStr : string) (interfaceData : InterfaceData) =
     async {
         let! result = asyncMaybe {
             let! _symbol, symbolUse = codeGenServer.GetSymbolAndUseAtPositionOfKind(doc.FullName, pos, SymbolKind.Ident)

--- a/src/FsAutoComplete.Core/State.fs
+++ b/src/FsAutoComplete.Core/State.fs
@@ -143,7 +143,7 @@ type State =
       else
         let line = text.GetLineString (pos.Line - 1)
         let lineLength = line.Length
-        if pos.Column < 0 || pos.Column >= lineLength // since column is 0-based, lineLength is actually longer than the column is allowed to be
+        if pos.Column < 0 || pos.Column > lineLength // since column is 0-based, lineLength is actually longer than the column is allowed to be
         then Error "Position is out of range"
         else
           Ok (opts, text, line)

--- a/src/FsAutoComplete.Core/State.fs
+++ b/src/FsAutoComplete.Core/State.fs
@@ -46,10 +46,10 @@ type State =
       ScriptProjectOptions = ConcurrentDictionary()
       ColorizationOutput = false }
 
-  member x.GetCheckerOptions(file: string<LocalPath>, lines: LineStr[]) : FSharpProjectOptions option =
+  member x.RefreshCheckerOptions(file: string<LocalPath>, text: ISourceText) : FSharpProjectOptions option =
     x.ProjectController.GetProjectOptions (UMX.untag file)
     |> Option.map (fun opts ->
-        x.Files.[file] <- { Lines = lines; Touched = DateTime.Now; Version = None }
+        x.Files.[file] <- { Lines = text; Touched = DateTime.Now; Version = None }
         opts
     )
 
@@ -81,13 +81,13 @@ type State =
   member x.SetLastCheckedVersion (file: string<LocalPath>) (version: int) =
     x.LastCheckedVersion.[file] <- version
 
-  member x.AddFileTextAndCheckerOptions(file: string<LocalPath>, lines: LineStr[], opts, version) =
-    let fileState = { Lines = lines; Touched = DateTime.Now; Version = version }
+  member x.AddFileTextAndCheckerOptions(file: string<LocalPath>, text: ISourceText, opts, version) =
+    let fileState = { Lines = text; Touched = DateTime.Now; Version = version }
     x.Files.[file] <- fileState
     x.ProjectController.SetProjectOptions(UMX.untag file, opts)
 
-  member x.AddFileText(file: string<LocalPath>, lines: LineStr[], version) =
-    let fileState = { Lines = lines; Touched = DateTime.Now; Version = version }
+  member x.AddFileText(file: string<LocalPath>, text: ISourceText, version) =
+    let fileState = { Lines = text; Touched = DateTime.Now; Version = version }
     x.Files.[file] <- fileState
 
   member x.AddCancellationToken(file : string<LocalPath>, token: CancellationTokenSource) =
@@ -115,7 +115,7 @@ type State =
       ExtraProjectInfo = None
       Stamp = None}
 
-  member x.TryGetFileCheckerOptionsWithLines(file: string<LocalPath>) : ResultOrString<FSharpProjectOptions * LineStr[]> =
+  member x.TryGetFileCheckerOptionsWithLines(file: string<LocalPath>) : ResultOrString<FSharpProjectOptions * ISourceText> =
     match x.Files.TryFind(file) with
     | None -> ResultOrString.Error (sprintf "File '%s' not parsed" (UMX.untag file))
     | Some (volFile) ->
@@ -124,21 +124,26 @@ type State =
       | None -> Ok (State.FileWithoutProjectOptions(file), volFile.Lines)
       | Some opts -> Ok (opts, volFile.Lines)
 
-  member x.TryGetFileCheckerOptionsWithSource(file: string<LocalPath>) : ResultOrString<FSharpProjectOptions * string> =
+  member x.TryGetFileCheckerOptionsWithSource(file: string<LocalPath>) : ResultOrString<FSharpProjectOptions * ISourceText> =
     match x.TryGetFileCheckerOptionsWithLines(file) with
     | ResultOrString.Error x -> ResultOrString.Error x
-    | Ok (opts, lines) -> Ok (opts, String.concat "\n" lines)
+    | Ok (opts, lines) -> Ok (opts, lines)
 
-  member x.TryGetFileSource(file: string<LocalPath>) : ResultOrString<string[]> =
+  member x.TryGetFileSource(file: string<LocalPath>) : ResultOrString<ISourceText> =
     match x.Files.TryFind(file) with
     | None -> ResultOrString.Error (sprintf "File '%s' not parsed" (UMX.untag file))
-    | Some f -> Ok (f.Lines)
+    | Some f -> Ok f.Lines
 
-  member x.TryGetFileCheckerOptionsWithLinesAndLineStr(file: string<LocalPath>, pos : Pos) : ResultOrString<FSharpProjectOptions * LineStr[] * LineStr> =
+  member x.TryGetFileCheckerOptionsWithLinesAndLineStr(file: string<LocalPath>, pos : Pos) : ResultOrString<FSharpProjectOptions * ISourceText * LineStr> =
     match x.TryGetFileCheckerOptionsWithLines(file) with
-    | ResultOrString.Error x -> ResultOrString.Error x
-    | Ok (opts, lines) ->
-      let ok = pos.Line <= lines.Length && pos.Line >= 1 &&
-               pos.Column <= lines.[pos.Line - 1].Length + 1 && pos.Column >= 0
-      if not ok then ResultOrString.Error "Position is out of range"
-      else Ok (opts, lines, lines.[pos.Line - 1])
+    | Error x -> Error x
+    | Ok (opts, text) ->
+      let lineCount = text.GetLineCount()
+      if pos.Line < 1 || pos.Line > lineCount then Error "Position is out of range"
+      else
+        let line = text.GetLineString (pos.Line - 1)
+        let lineLength = line.Length
+        if pos.Column < 0 || pos.Column >= lineLength // since column is 0-based, lineLength is actually longer than the column is allowed to be
+        then Error "Position is out of range"
+        else
+          Ok (opts, text, line)

--- a/src/FsAutoComplete/CodeFixes/AddMissingFunKeyword.fs
+++ b/src/FsAutoComplete/CodeFixes/AddMissingFunKeyword.fs
@@ -17,13 +17,13 @@ let fix (getFileLines: GetFileLines) (getLineText: GetLineText): CodeFix =
           codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
 
         let! lines = getFileLines fileName
-        let errorText = getLineText lines diagnostic.Range
+        let! errorText = getLineText lines diagnostic.Range
         do! Result.guard (fun _ -> errorText = "->") "Expected error source code text not matched"
 
         let lineLen =
           lines.GetLineString(diagnostic.Range.Start.Line).Length
 
-        let line =
+        let! line =
           getLineText
             lines
             { Start =

--- a/src/FsAutoComplete/CodeFixes/AddMissingFunKeyword.fs
+++ b/src/FsAutoComplete/CodeFixes/AddMissingFunKeyword.fs
@@ -21,7 +21,7 @@ let fix (getFileLines: GetFileLines) (getLineText: GetLineText): CodeFix =
         do! Result.guard (fun _ -> errorText = "->") "Expected error source code text not matched"
 
         let lineLen =
-          lines.[diagnostic.Range.Start.Line].Length
+          lines.GetLineString(diagnostic.Range.Start.Line).Length
 
         let line =
           getLineText

--- a/src/FsAutoComplete/CodeFixes/AddMissingRecKeyword.fs
+++ b/src/FsAutoComplete/CodeFixes/AddMissingRecKeyword.fs
@@ -37,7 +37,7 @@ let fix (getFileLines: GetFileLines) (getLineText: GetLineText): CodeFix =
             let lineLen =
               lines.GetLineString(diagnostic.Range.Start.Line).Length
 
-            let line =
+            let! line =
               getLineText
                 lines
                 { Start =

--- a/src/FsAutoComplete/CodeFixes/AddMissingRecKeyword.fs
+++ b/src/FsAutoComplete/CodeFixes/AddMissingRecKeyword.fs
@@ -35,7 +35,7 @@ let fix (getFileLines: GetFileLines) (getLineText: GetLineText): CodeFix =
             let fcsPos = protocolPosToPos startOfBindingName
 
             let lineLen =
-              lines.[diagnostic.Range.Start.Line].Length
+              lines.GetLineString(diagnostic.Range.Start.Line).Length
 
             let line =
               getLineText

--- a/src/FsAutoComplete/CodeFixes/AddTypeToIndeterminateValue.fs
+++ b/src/FsAutoComplete/CodeFixes/AddTypeToIndeterminateValue.fs
@@ -25,7 +25,7 @@ let fix
       | FSharpFindDeclResult.DeclFound declRange when declRange.FileName = filename ->
         let! projectOptions = getProjectOptionsForFile typedFileName
         let protocolDeclRange = fcsRangeToLsp declRange
-        let declText = lines.GetText protocolDeclRange
+        let! declText = lines.GetText declRange
         let declTextLine = lines.GetLineString protocolDeclRange.Start.Line
         let! declLexerSymbol = Lexer.getSymbol declRange.Start.Line declRange.Start.Column declText SymbolLookupKind.ByLongIdent projectOptions.OtherOptions |> Result.ofOption (fun _ -> "No lexer symbol for declaration")
         let! declSymbolUse = tyRes.GetCheckResults.GetSymbolUseAtLocation(declRange.Start.Line, declRange.End.Column, declTextLine, declLexerSymbol.Text.Split('.') |> List.ofArray) |> Result.ofOption (fun _ -> "No lexer symbol")

--- a/src/FsAutoComplete/CodeFixes/AddTypeToIndeterminateValue.fs
+++ b/src/FsAutoComplete/CodeFixes/AddTypeToIndeterminateValue.fs
@@ -25,8 +25,8 @@ let fix
       | FSharpFindDeclResult.DeclFound declRange when declRange.FileName = filename ->
         let! projectOptions = getProjectOptionsForFile typedFileName
         let protocolDeclRange = fcsRangeToLsp declRange
-        let declText = getText lines protocolDeclRange
-        let declTextLine = lines.[protocolDeclRange.Start.Line] //TODO: check
+        let declText = lines.GetText protocolDeclRange
+        let declTextLine = lines.GetLineString protocolDeclRange.Start.Line
         let! declLexerSymbol = Lexer.getSymbol declRange.Start.Line declRange.Start.Column declText SymbolLookupKind.ByLongIdent projectOptions.OtherOptions |> Result.ofOption (fun _ -> "No lexer symbol for declaration")
         let! declSymbolUse = tyRes.GetCheckResults.GetSymbolUseAtLocation(declRange.Start.Line, declRange.End.Column, declTextLine, declLexerSymbol.Text.Split('.') |> List.ofArray) |> Result.ofOption (fun _ -> "No lexer symbol")
         match declSymbolUse.Symbol with

--- a/src/FsAutoComplete/CodeFixes/ChangeComparisonToMutableAssignment.fs
+++ b/src/FsAutoComplete/CodeFixes/ChangeComparisonToMutableAssignment.fs
@@ -24,7 +24,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
         | None -> return []
         | Some endPos ->
           let fcsPos = protocolPosToPos endPos
-          let line = getLine lines endPos
+          let line = lines.GetLineString endPos.Line
 
           let! symbol =
             tyRes.TryGetSymbolUse fcsPos line

--- a/src/FsAutoComplete/CodeFixes/GenerateUnionCases.fs
+++ b/src/FsAutoComplete/CodeFixes/GenerateUnionCases.fs
@@ -19,10 +19,10 @@ let fix (getFileLines: GetFileLines)
         let fileName =
           codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
 
-        let! (lines: string []) = getFileLines fileName
+        let! lines = getFileLines fileName
         // try to find the first case already written
         let caseLine = diagnostic.Range.Start.Line + 1
-        let caseCol = lines.[caseLine].IndexOf('|') + 3 // Find column of first case in patern matching
+        let caseCol = lines.GetLineString(caseLine).IndexOf('|') + 3 // Find column of first case in patern matching
         let casePos = { Line = caseLine; Character = caseCol }
         let casePosFCS = protocolPosToPos casePos
 

--- a/src/FsAutoComplete/CodeFixes/RemoveUnnecessaryReturnOrYield.fs
+++ b/src/FsAutoComplete/CodeFixes/RemoveUnnecessaryReturnOrYield.fs
@@ -24,8 +24,8 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getLineText: GetLineTe
         | None -> return []
         | Some exprRange ->
             let protocolExprRange = fcsRangeToLsp exprRange
-            let exprText = getLineText lines protocolExprRange
-            let errorText = getLineText lines diagnostic.Range
+            let! exprText = getLineText lines protocolExprRange
+            let! errorText = getLineText lines diagnostic.Range
 
             let! title =
               if errorText.StartsWith "return!"

--- a/src/FsAutoComplete/CodeFixes/ReplaceBangWithValueFunction.fs
+++ b/src/FsAutoComplete/CodeFixes/ReplaceBangWithValueFunction.fs
@@ -18,7 +18,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getLineText: GetLineTe
       let! exprRange = parseResults.GetParseResults.TryRangeOfExpressionBeingDereferencedContainingPos selectionRange.Start |> Result.ofOption (fun _ -> "No expr found at that pos")
       let combinedRange = FSharp.Compiler.Text.Range.unionRanges derefRange exprRange
       let protocolRange = fcsRangeToLsp combinedRange
-      let badString = getLineText lines protocolRange
+      let! badString = getLineText lines protocolRange
       let replacementString = badString.[1..] + ".Value"
       return [
         { Title = "Use `.Value` instead of dereference operator"

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -17,6 +17,7 @@ open System.IO
 open FsToolkit.ErrorHandling
 open FSharp.UMX
 open FSharp.Analyzers
+open FSharp.Compiler.Text
 
 module FcsRange = FSharp.Compiler.Text.Range
 type FcsRange = FSharp.Compiler.Text.Range
@@ -116,7 +117,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
                 match contentChange, doc.Version with
                 | Some contentChange, Some version ->
                     if contentChange.Range.IsNone && contentChange.RangeLength.IsNone then
-                        let content = contentChange.Text.Split('\n')
+                        let content = SourceText.ofString contentChange.Text
                         let tfmConfig = config.UseSdkScripts
                         logger.info (Log.setMessage "ParseFile - Parsing {file}" >> Log.addContextDestructured "file" filePath)
                         do! (commands.Parse filePath content version (Some tfmConfig) |> Async.Ignore)
@@ -352,7 +353,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
         commandDisposables.Add <| commands.Notify.Subscribe handleCommandEvents
 
     ///Helper function for handling Position requests using **recent** type check results
-    member x.positionHandler<'a, 'b when 'b :> ITextDocumentPositionParams> (f: 'b -> FcsPos -> ParseAndCheckResults -> string -> string [] ->  AsyncLspResult<'a>) (arg: 'b) : AsyncLspResult<'a> =
+    member x.positionHandler<'a, 'b when 'b :> ITextDocumentPositionParams> (f: 'b -> FcsPos -> ParseAndCheckResults -> string -> ISourceText ->  AsyncLspResult<'a>) (arg: 'b) : AsyncLspResult<'a> =
         async {
             let pos = arg.GetFcsPos()
             let file = arg.GetFilePath() |> Utils.normalizePath
@@ -382,7 +383,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
         }
 
     ///Helper function for handling Position requests using **latest** type check results
-    member x.positionHandlerWithLatest<'a, 'b when 'b :> ITextDocumentPositionParams> (f: 'b -> FcsPos -> ParseAndCheckResults -> string -> string [] ->  AsyncLspResult<'a>) (arg: 'b) : AsyncLspResult<'a> =
+    member x.positionHandlerWithLatest<'a, 'b when 'b :> ITextDocumentPositionParams> (f: 'b -> FcsPos -> ParseAndCheckResults -> string -> ISourceText ->  AsyncLspResult<'a>) (arg: 'b) : AsyncLspResult<'a> =
         async {
             let pos = arg.GetFcsPos()
             let file = arg.GetFilePath() |> Utils.normalizePath
@@ -418,7 +419,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
         }
 
     ///Helper function for handling file requests using **recent** type check results
-    member x.fileHandler<'a> (f: string<LocalPath> -> ParseAndCheckResults -> string [] -> AsyncLspResult<'a>) (file: string<LocalPath>) : AsyncLspResult<'a> =
+    member x.fileHandler<'a> (f: string<LocalPath> -> ParseAndCheckResults -> ISourceText -> AsyncLspResult<'a>) (file: string<LocalPath>) : AsyncLspResult<'a> =
         async {
 
             // logger.info (Log.setMessage "PositionHandler - Position request: {file} at {pos}" >> Log.addContextDestructured "file" file >> Log.addContextDestructured "pos" pos)
@@ -489,8 +490,8 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
 
 
         let getFileLines = commands.TryGetFileCheckerOptionsWithLines >> Result.map snd
-        let getRangeText fileName range = getFileLines fileName |> Result.map (fun lines -> getText lines range)
-        let getLineText lines range = getText lines range
+        let getRangeText fileName (range: LanguageServerProtocol.Types.Range) = getFileLines fileName |> Result.map (fun lines -> lines.GetText range)
+        let getLineText (lines: ISourceText) (range: LanguageServerProtocol.Types.Range) = lines.GetText range
         let getProjectOptsAndLines = commands.TryGetFileCheckerOptionsWithLinesAndLineStr
         let tryGetProjectOptions = commands.TryGetFileCheckerOptionsWithLines >> Result.map fst
 
@@ -669,7 +670,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
     override __.TextDocumentDidOpen(p: DidOpenTextDocumentParams) = async {
         let doc = p.TextDocument
         let filePath = doc.GetFilePath() |> Utils.normalizePath
-        let content = doc.Text.Split('\n')
+        let content = SourceText.ofString doc.Text
         let tfmConfig = config.UseSdkScripts
         logger.info (Log.setMessage "TextDocumentDidOpen Request: {parms}" >> Log.addContextDestructured "parms" filePath )
 
@@ -698,7 +699,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
         match contentChange, doc.Version with
         | Some contentChange, Some version ->
             if contentChange.Range.IsNone && contentChange.RangeLength.IsNone then
-                let content = contentChange.Text.Split('\n')
+                let content = SourceText.ofString contentChange.Text
                 commands.SetFileContent(filePath, content, Some version, config.ScriptTFM)
             else ()
         | _ -> ()
@@ -713,8 +714,8 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
     }
 
     override __.TextDocumentCompletion(p: CompletionParams) =
-      let ensureInBounds (lines: LineStr array) (line, col) =
-        let lineStr = lines.[line]
+      let ensureInBounds (lines: ISourceText) (line, col) =
+        let lineStr = lines.GetLineString line
         if line <= lines.Length && line >= 0 && col <= lineStr.Length + 1 && col >= 0
         then Ok ()
         else
@@ -732,7 +733,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
           let pos = p.GetFcsPos()
           let! (options, lines) = commands.TryGetFileCheckerOptionsWithLines file |> Result.mapError JsonRpc.Error.InternalErrorMessage
           let line, col = p.Position.Line, p.Position.Character
-          let lineStr = lines.[line]
+          let lineStr = lines.GetLineString line
           let word = lineStr.Substring(0, min col lineStr.Length)
 
           do! ensureInBounds lines (line, col)
@@ -1094,11 +1095,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
         | Some (lines, formatted) ->
             let range =
                 let zero = { Line = 0; Character = 0 }
-                let endLine = Array.length lines - 1
-                let endCharacter =
-                    Array.tryLast lines
-                    |> Option.map (fun line -> line.Length)
-                    |> Option.defaultValue 0
+                let endLine, endCharacter = lines.GetLastCharacterPosition()
                 { Start = zero; End = { Line = endLine; Character = endCharacter } }
 
             return LspResult.success(Some([| { Range = range; NewText = formatted  } |]))

--- a/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
@@ -273,7 +273,7 @@ let formattingTests state =
     { Range = { Start = start; End = ``end`` }; NewText = normalizeLineEndings expectedText }
 
   let verifyFormatting scenario document =
-    testCaseAsync $"{scenario} {document}" (async {
+    testCaseAsync $"{scenario}-{document}" (async {
     let! (server, events, rootPath) = server
     let sourceFile = Path.Combine(rootPath, sprintf "%s.input.fsx" document)
     let expectedFile = Path.Combine(rootPath, sprintf "%s.expected.fsx" document)


### PR DESCRIPTION
This changes the definition of `VolatileFile.Lines` from `string[]` for a few reasons:

* should reduce allocations somewhat due to us no longer re-creating the ISourceText to pass into compiler methods each time they are called
* makes it easier to port/unify logic for codefixes/editor features from dotnet/fsharp, since those work off of an ISourceText interface
* allows us to more easily experiment with different ISourceText implementations, potentially ones that allocate much less.