### PR TITLE
Add test and fix signature off-by-one

### DIFF
--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -213,7 +213,7 @@ type ParseAndCheckResults
   }
 
   member __.TryGetToolTip (pos: Pos) (lineStr: LineStr) =
-    match Lexer.findLongIdents(pos.Column - 1, lineStr) with
+    match Lexer.findLongIdents(pos.Column, lineStr) with
     | None -> ResultOrString.Error "Cannot find ident for tooltip"
     | Some(col,identIsland) ->
       let identIsland = Array.toList identIsland

--- a/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
@@ -379,7 +379,7 @@ let analyzerTests state =
 let signatureTests state =
   let server =
     async {
-      let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "Tooltips")
+      let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "Signature")
       let scriptPath = Path.Combine(path, "Script.fsx")
       let! (server, events) = serverInitialize path defaultConfigDto state
       do! waitForWorkspaceFinishedParsing events
@@ -394,27 +394,34 @@ let signatureTests state =
     }
     |> Async.Cache
 
-  let verifySignature line character expectedSignature =
-    testCaseAsync (sprintf "fsharp/signature for line %d character %d should be '%s'" line character expectedSignature) (async {
+  let verifySignature line (characterStart, characterEnd) expectedSignature =
+    let verifyAt character = async {
       let! server, scriptPath = server
       let pos: TextDocumentPositionParams = {
-        TextDocument =  { Uri = sprintf "file://%s" scriptPath }
+        TextDocument =  { Uri = Path.FilePathToUri scriptPath }
         Position = { Line = line; Character = character }
       }
       match! server.FSharpSignature pos with
       | Ok { Content = content } ->
         let r = JsonSerializer.readJson<CommandResponse.ResponseMsg<string>>(content)
         Expect.equal r.Kind "typesig" "Should have a kind of 'typesig'"
-        Expect.equal r.Data expectedSignature (sprintf "Should have a signature of '%s'" expectedSignature)
+        Expect.equal r.Data expectedSignature (sprintf "Should have a signature of '%s' at character %d" expectedSignature character)
       | Result.Error errors ->
         failtestf "Error while getting signature: %A" errors
-    })
+    }
+
+    testCaseAsync (sprintf "fsharp/signature for line %d characters [%d, %d] should be '%s'" line characterStart characterEnd expectedSignature) (
+      [ for c in characterStart .. characterEnd -> verifyAt c ]
+      |> Async.Sequential
+      |> Async.map (fun _ -> ())
+    )
 
   testSequenced <|
     testList "signature evaluation" [
       testList "tests" [
-        verifySignature 0 4 "val arrayOfTuples : (int * int) []"  // verify that even first letter of the signature triggers correctly
-        verifySignature 0 5 "val arrayOfTuples : (int * int) []"
+        verifySignature 0 (4, 16) "val arrayOfTuples : (int * int) []"
+        verifySignature 1 (4, 15) "val listOfTuples : (int * int) list"
+        verifySignature 2 (4, 15) "val someFunction : a:'a -> unit"
       ]
       testCaseAsync "cleanup" (async {
         let! server, _ = server

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -59,6 +59,7 @@ let tests =
         // fake isn't updated to FCS 39, disabling tests until that's resolved
         //fakeInteropTests toolsPath
         analyzerTests state
+        signatureTests state
         SignatureHelp.tests state
         CodeFixTests.tests state
         Completion.tests state

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Signature/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Signature/Script.fsx
@@ -1,0 +1,3 @@
+let arrayOfTuples = [| 1, 2 |]
+let listOfTuples = [ 1, 2 ]
+let someFunction a = ()


### PR DESCRIPTION
The `fsharp/signature` extension also seems to be a victim of the 'Great Offset Shift of 2021' (see #767, #774, #771).

The tests are basically the first tooltip tests from CoreTests.fs.  Not sure what is preferred, to have them there because they share logic (e.g. `server`), or if they should be in ExtensionTests because they test a custom endpoint.  Currently in the latter, should it have a separate TestCases file instead of reusing the TestCases/Tooltips.fs file?

(a quick search shows a few more places where `Lexer.findLongIdents(pos.Column - 1, lineStr)` is used, likely they are affected as well).