### PR TITLE
when analyzers are explicitly loaded, do the rescan/reregister flow

### DIFF
--- a/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
@@ -329,7 +329,7 @@ let analyzerTests state =
   let server =
     async {
       let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "Analyzers")
-      // because the analyzer is a project this project has a reference, the analyzer can ber
+      // because the analyzer is a project this project has a reference, the analyzer can be
       // found in alongside this project, so we can use the directory this project is in
       let analyzerPath = System.IO.Path.GetDirectoryName (System.Reflection.Assembly.GetExecutingAssembly().Location)
       let analyzerEnabledConfig =

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -24,7 +24,8 @@ let testTimeout =
 
 let loaders = [
   "Ionide WorkspaceLoader",  WorkspaceLoader.Create
-  "MSBuild Project Graph WorkspaceLoader", WorkspaceLoaderViaProjectGraph.Create
+  // These are commented out because of https://github.com/ionide/proj-info/issues/109
+  // "MSBuild Project Graph WorkspaceLoader", WorkspaceLoaderViaProjectGraph.Create
 ]
 
 ///Global list of tests


### PR DESCRIPTION
Closes #781 

We already had logic for dynamically enabling/disabling analyzers, but for this use endpoint specifically we didn't hook into the existing flow.

Here we call the config-update function as a shortcut for doing the re-initialization that triggers the FSharpChecker flip if necessary.

This is all a bit hairy, and I think we could have a much better level of state tracking here, eg. with FSharp.Data.Adaptive.