### PR TITLE
Add two new codefixes

### DIFF
--- a/src/FsAutoComplete/CodeFixes/AddMissingInstanceMember.fs
+++ b/src/FsAutoComplete/CodeFixes/AddMissingInstanceMember.fs
@@ -1,0 +1,16 @@
+module FsAutoComplete.CodeFix.AddMissingInstanceMember
+
+open FsToolkit.ErrorHandling
+open FsAutoComplete.CodeFix.Types
+open LanguageServerProtocol.Types
+
+let fix =
+    Run.ifDiagnosticByCode (Set.ofList [ "673" ]) (fun diagnostic codeActionParams -> asyncResult {
+      return [{
+        Title = "Add missing instance member parameter"
+        File = codeActionParams.TextDocument
+        Kind = FixKind.Fix
+        SourceDiagnostic = Some diagnostic
+        Edits = [| { Range = { Start = diagnostic.Range.Start; End = diagnostic.Range.Start }; NewText = "x." } |]
+      }]
+    })

--- a/src/FsAutoComplete/CodeFixes/ChangeTypeOfNameToNameOf.fs
+++ b/src/FsAutoComplete/CodeFixes/ChangeTypeOfNameToNameOf.fs
@@ -1,0 +1,53 @@
+/// a codefix that replaces typeof<'t>.Name with nameof('t)
+module FsAutoComplete.CodeFix.ChangeTypeOfNameToNameOf
+
+open FsToolkit.ErrorHandling
+open FsAutoComplete.CodeFix.Types
+open LanguageServerProtocol.Types
+open FsAutoComplete
+open FsAutoComplete.LspHelpers
+open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.SyntaxTree
+
+type FSharpParseFileResults with
+  member this.TryRangeOfTypeofWithNameAndTypeExpr pos =
+    this.ParseTree
+    |> Option.bind (fun pt ->
+      AstTraversal.Traverse(pos, pt , { new AstTraversal.AstVisitorBase<_>() with
+              member _.VisitExpr(_path, _, defaultTraverse, expr) =
+                  match expr with
+                  | SynExpr.DotGet(expr, _, _, range) ->
+                      match expr with
+                      | SynExpr.TypeApp(SynExpr.Ident(ident), _, typeArgs, _, _, _, _) ->
+                          let onlyOneTypeArg =
+                              match typeArgs with
+                              | [] -> false
+                              | [_] -> true
+                              | _ -> false
+                          if ident.idText = "typeof" && onlyOneTypeArg then
+                              Some {| NamedIdentRange = typeArgs.Head.Range; FullExpressionRange = range |}
+                          else
+                              defaultTraverse expr
+                      | _ -> defaultTraverse expr
+                  | _ -> defaultTraverse expr })
+    )
+
+let fix (getParseResultsForFile: GetParseResultsForFile): CodeFix =
+  fun codeActionParams ->
+    asyncResult {
+      let fileName = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
+      let pos = protocolPosToPos codeActionParams.Range.Start
+
+      let! (tyRes, line, sourceText) = getParseResultsForFile fileName pos
+      let! results = tyRes.GetParseResults.TryRangeOfTypeofWithNameAndTypeExpr(pos) |> Result.ofOption (fun _ -> "no typeof expr found")
+      let! typeName = sourceText.GetText results.NamedIdentRange
+      let replacement = $"nameof({typeName})"
+
+      return [{
+        Edits = [| { Range = fcsRangeToLsp results.FullExpressionRange; NewText = replacement } |]
+        File = codeActionParams.TextDocument
+        Title = "Use 'nameof'"
+        SourceDiagnostic = None
+        Kind = FixKind.Refactor }]
+    }
+    |> AsyncResult.foldResult id (fun _ -> [])

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -571,6 +571,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
             ReplaceBangWithValueFunction.fix tryGetParseResultsForFile getLineText
             RemoveUnusedBinding.fix tryGetParseResultsForFile
             AddTypeToIndeterminateValue.fix tryGetParseResultsForFile tryGetProjectOptions
+            ChangeTypeOfNameToNameOf.fix tryGetParseResultsForFile
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -572,6 +572,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
             RemoveUnusedBinding.fix tryGetParseResultsForFile
             AddTypeToIndeterminateValue.fix tryGetParseResultsForFile tryGetProjectOptions
             ChangeTypeOfNameToNameOf.fix tryGetParseResultsForFile
+            AddMissingInstanceMember.fix
           |]
           |> Array.map (fun fixer -> async {
               let! fixes = fixer p

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/MissingInstanceMember/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/MissingInstanceMember/Script.fsx
@@ -1,0 +1,2 @@
+type C () =
+  member Foo() = ()

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/NameofInsteadOfTypeofName/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/NameofInsteadOfTypeofName/Script.fsx
@@ -1,0 +1,1 @@
+let x = typeof<Async<string>>.Name


### PR DESCRIPTION
Adds two new codefixes from dotnet/fsharp:

* [Add missing instance self identifier](https://github.com/dotnet/fsharp/pull/11567)
* [Refactor `typeof<'t>.Name` to `nameof('t)`](https://github.com/dotnet/fsharp/pull/11566)