### PR TITLE
Render parameters that are function-typed with parens for accessibility

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1129,7 +1129,7 @@ type Commands (checker: FSharpCompilerServiceChecker, state: State, backgroundSe
         let parseOpts = Utils.projectOptionsToParseOptions opts
         let! ast = checker.ParseFile(file, text, parseOpts)
         match ast.ParseTree with
-        | None -> return! Error (ast.Errors |> Array.map string |> String.concat "\n")
+        | None -> return! Error (ast.Errors |> Array.map string |> String.concat Environment.NewLine)
         | Some ast' ->
             let ranges = Structure.getOutliningRanges (text.ToString().Split("\n")) ast'
             return ranges

--- a/src/FsAutoComplete.Core/DocumentationFormatter.fs
+++ b/src/FsAutoComplete.Core/DocumentationFormatter.fs
@@ -10,6 +10,7 @@ module DocumentationFormatter =
     open System
     open System.Text
 
+    let nl = Environment.NewLine
     let maxPadding = 200
 
     let mutable lastDisplayContext : FSharpDisplayContext = FSharpDisplayContext.Empty
@@ -295,14 +296,14 @@ module DocumentationFormatter =
                 |> List.map(fun (paramTypes, length) ->
                                 paramTypes
                                 |> List.map (formatParameterPadded length)
-                                |> String.concat (" *\n"))
-                |> String.concat ("->\n")
+                                |> String.concat $" *{nl}")
+                |> String.concat $"->{nl}"
 
             let typeArguments =
-                allParams +  "\n" + indent + (String.replicate (max (padLength-1) 0) " ") + "->" ++ retType ++ retTypeConstraint
+                allParams + nl + indent + (String.replicate (max (padLength-1) 0) " ") + "->" ++ retType ++ retTypeConstraint
 
             if isDelegate then typeArguments
-            else modifiers ++ functionName + ": \n" + typeArguments
+            else modifiers ++ $"{functionName}:{nl}{typeArguments}"
 
     let getFuncSignatureForTypeSignature displayContext (func: FSharpMemberOrFunctionOrValue) (getter: bool) (setter : bool) =
         let functionName =
@@ -478,25 +479,25 @@ module DocumentationFormatter =
             | _                         -> "type"
 
         let enumtip () =
-            " =\n  |" ++
+            $" ={nl}  |" ++
             (fse.FSharpFields
             |> Seq.filter (fun f -> not f.IsCompilerGenerated)
             |> Seq.sortBy (fun f -> match f.LiteralValue with | None -> -1 | Some lv -> Int32.Parse (string lv) )
             |> Seq.map (fun field -> match field.LiteralValue with
                                      | Some lv -> field.Name + " = " + (string lv)
                                      | None -> field.Name )
-            |> String.concat ("\n  | " ) )
+            |> String.concat $"{nl}  | ")
 
         let uniontip () =
-            " =\n  |" ++ (fse.UnionCases
+            $" ={nl}  |" ++ (fse.UnionCases
                           |> Seq.map (getUnioncaseSignature displayContext)
-                          |> String.concat ("\n  | " ) )
+                          |> String.concat ("{nl}  | " ) )
 
         let delegateTip () =
             let invoker =
                 fse.MembersFunctionsAndValues |> Seq.find (fun f -> f.DisplayName = "Invoke")
             let invokerSig = getFuncSignatureWithIdent displayContext invoker 6
-            " =\n   delegate of\n" + invokerSig
+            $" ={nl}   delegate of{nl}{invokerSig}"
 
         let typeTip () =
             let constrc =

--- a/src/FsAutoComplete.Core/DotnetNewTemplate.fs
+++ b/src/FsAutoComplete.Core/DotnetNewTemplate.fs
@@ -40,7 +40,7 @@ module DotnetNewTemplate =
       let mutable output = ""
       while not proc.StandardOutput.EndOfStream do
           let line = proc.StandardOutput.ReadLine()
-          output <- output + "\n" + line
+          output <- output + Environment.NewLine + line
       output
 
     let parseTemplateOutput (x: string) =

--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -246,7 +246,11 @@ module SignatureFormatter =
             | _ -> false
 
         let formatParameter (p:FSharpParameter) =
-            try formatFSharpType displayContext p.Type
+            try
+              let formatted = formatFSharpType displayContext p.Type
+              if p.Type.IsFunctionType
+              then $"({formatted})"
+              else formatted
             with :? InvalidOperationException -> p.DisplayName
 
         match argInfos with
@@ -268,8 +272,8 @@ module SignatureFormatter =
 
             let allParamsLengths =
                 many |> List.map (List.map (fun p -> (formatParameter p).Length) >> List.sum)
-            let maxLength = (allParamsLengths |> List.maxUnderThreshold maxPadding)+1
 
+            let maxLength = (allParamsLengths |> List.maxUnderThreshold maxPadding)+1
 
             let formatParameterPadded length p =
                 let namePart = formatName indent padLength p
@@ -383,7 +387,10 @@ module SignatureFormatter =
             | many ->
                 let formatParameter (p:FSharpParameter) =
                     try
-                    formatFSharpType displayContext p.Type
+                      let formatted = formatFSharpType displayContext p.Type
+                      if p.Type.IsFunctionType
+                      then $"({formatted})"
+                      else formatted
                     with
                     | :? InvalidOperationException -> p.DisplayName
 

--- a/src/FsAutoComplete.Core/SignatureHelp.fs
+++ b/src/FsAutoComplete.Core/SignatureHelp.fs
@@ -46,7 +46,7 @@ let getText (lines: ISourceText) (range: Range) =
     let line = lineText lines range.Start
     line.Substring(range.StartColumn - 1, (range.End.Column - range.Start.Column))
   else
-    String.concat "\n" (seq {
+    String.concat Environment.NewLine (seq {
       let startLine = lineText lines range.Start
       yield startLine.Substring(range.StartColumn - 1, (startLine.Length - 1 - range.Start.Column))
       for lineNo in (range.Start.Line+1)..(range.End.Line-1) do

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -37,7 +37,7 @@ module private Section =
                         |> Seq.map (fun line ->
                             "> " + line.TrimStart()
                         )
-                        |> String.concat "\n"
+                        |> String.concat Environment.NewLine
                         |> (+) nl // Start the quote block on a new line
                     else
                         kv.Value
@@ -677,14 +677,14 @@ module private Format =
 
                         items
                         |> List.map (itemListToStringAsMarkdownList "*")
-                        |> String.concat "\n"
+                        |> String.concat Environment.NewLine
 
                     | Numbered ->
                         let items = extractItemList [] innerText
 
                         items
                         |> List.map (itemListToStringAsMarkdownList "1.")
-                        |> String.concat "\n"
+                        |> String.concat Environment.NewLine
 
                     | Tablered ->
                         let columnHeaders = extractColumnHeader [] innerText
@@ -728,13 +728,13 @@ module private Format =
                                 )
                                 |> String.concat ""
                             )
-                            |> String.concat "\n"
+                            |> String.concat Environment.NewLine
 
-                        "\n"
+                        Environment.NewLine
                         + columnHeadersText
-                        + "\n"
+                        + Environment.NewLine
                         + seprator
-                        + "\n"
+                        + Environment.NewLine
                         + itemsText
                     |> Some
         }
@@ -794,7 +794,7 @@ type private XmlDocMember(doc: XmlDocument, indentationSize : int, columnOffset 
                 else
                     line
             )
-            |> String.concat "\n"
+            |> String.concat Environment.NewLine
 
     let readChildren name (doc: XmlDocument) =
         doc.DocumentElement.GetElementsByTagName name
@@ -972,7 +972,7 @@ let private buildFormatComment cmt (formatStyle : FormatCommentStyle) (typeDoc: 
     match cmt with
     | FSharpXmlDoc.Text (unprocessed, processed) ->
         try
-            let document = processed |> String.concat "\n"
+            let document = processed |> String.concat Environment.NewLine
             // We create a "fake" XML document in order to use the same parser for both libraries and user code
             let xml = sprintf "<fake>%s</fake>" document
             let doc = XmlDocument()
@@ -1080,8 +1080,8 @@ let formatTipEnhanced (FSharpToolTipText tips) (signature : string) (footer : st
                       buildFormatComment i.XmlDoc formatCommentStyle typeDoc
                     else
                       buildFormatComment i.XmlDoc formatCommentStyle typeDoc
-                      + "\n\n**Generic Parameters**\n\n"
-                      + (i.TypeMapping |> List.map formatGenericParamInfo |> String.concat "\n")
+                      + nl + nl + "**Generic Parameters**" + nl + nl
+                      + (i.TypeMapping |> List.map formatGenericParamInfo |> String.concat nl)
                 (signature, comment, footer)))
         | FSharpToolTipElement.CompositionError (error) -> Some [("<Note>", error, "")]
         | _ -> None)
@@ -1096,7 +1096,7 @@ let formatDocumentation (FSharpToolTipText tips) ((signature, (constructors, fie
                       buildFormatComment i.XmlDoc FormatCommentStyle.Documentation None
                     else
                       buildFormatComment i.XmlDoc FormatCommentStyle.Documentation None
-                      + "\n\n**Generic Parameters**\n\n"
+                      + nl + nl + "**Generic Parameters**" + nl + nl
                       + (i.TypeMapping |> List.map formatGenericParamInfo |> String.concat "\n")
 
                 (signature, constructors, fields, functions, interfaces, attrs, ts, comment, footer, cn)))

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -413,7 +413,7 @@ module CommandResponse =
                   yield! getMessageLines er |> Seq.map (fun line -> sprintf "    - %s" line)]) ]
       |Ionide.ProjInfo.Types.GenericError (_, errorMessage) -> [errorMessage]
       |Ionide.ProjInfo.Types.ProjectNotRestored _ -> ["Project not restored"]
-    let msg = getMessageLines errorDetails |> fun s -> String.Join("\n", s)
+    let msg = getMessageLines errorDetails |> String.concat Environment.NewLine
     match errorDetails with
     |Ionide.ProjInfo.Types.ProjectNotFound (project) -> errorG serialize (ErrorData.GenericProjectError { Project = project }) msg
     |Ionide.ProjInfo.Types.LanguageNotSupported (project) -> errorG serialize (ErrorData.GenericProjectError { Project = project }) msg
@@ -515,7 +515,7 @@ module CommandResponse =
 
   let formattedDocumentationForSymbol (serialize : Serializer) xml assembly (xmlDoc : string list) (signature, footer, cn) =
     let data = TipFormatter.formatDocumentationFromXmlSig xml assembly signature footer cn |> List.map(List.map(fun (n,cns, fds, funcs, intf, attrs, ts, m,f, cn) ->
-      let m = if String.IsNullOrWhiteSpace m then xmlDoc |> String.concat "\n" else m
+      let m = if String.IsNullOrWhiteSpace m then xmlDoc |> String.concat Environment.NewLine else m
       {XmlKey = cn; Constructors = cns |> Seq.toList; Fields = fds |> Seq.toList; Functions = funcs |> Seq.toList; Interfaces = intf |> Seq.toList; Attributes = attrs |> Seq.toList; Types = ts |> Seq.toList; Footer =f; Signature = n; Comment = m} ))
     serialize { Kind = "formattedDocumentation"; Data = data }
 

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -884,11 +884,11 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
                     | (sigCommentFooter::_)::_ ->
                         let signature, comment, footer = sigCommentFooter
                         let markStr lang (value:string) = MarkedString.WithLanguage { Language = lang ; Value = value }
-                        let fsharpBlock (lines: string[]) = lines |> String.concat "\n" |> markStr "fsharp"
+                        let fsharpBlock (lines: string[]) = lines |> String.concat Environment.NewLine |> markStr "fsharp"
 
                         let sigContent =
                             let lines =
-                                signature.Split '\n'
+                                signature.Split Environment.NewLine
                                 |> Array.filter (not << String.IsNullOrWhiteSpace)
 
                             match lines |> Array.splitAt (lines.Length - 1) with
@@ -903,7 +903,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
                             |> MarkedString.String
 
                         let footerContent =
-                            footer.Split '\n'
+                            footer.Split Environment.NewLine
                             |> Array.filter (not << String.IsNullOrWhiteSpace)
                             |> Array.map (fun n -> MarkedString.String ("*" + n + "*"))
 

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -267,7 +267,7 @@ let tooltipTests state =
 
 
   testSequenced <|
-    ftestList "tooltip evaluation" [
+    testList "tooltip evaluation" [
       testList "tests" [
         verifyDescription 0 2 ["**Description**";"";"";"Used to associate, or bind, a name to a value or function.";""] // `let` keyword
         verifySignature 0 4 "val arrayOfTuples : (int * int) array" // verify that even the first letter of the tooltip triggers correctly

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -74,7 +74,7 @@ let basicTests state =
     |> Async.Cache
 
   /// normalizes the line endings in returned markdown strings for cross-platform comparisons
-  let normalizeMarkedString = function | MarkedString.WithLanguage l -> MarkedString.WithLanguage l
+  let normalizeMarkedString = function | MarkedString.WithLanguage { Language = lang; Value = v } -> MarkedString.WithLanguage { Language = lang; Value = v.Replace("\r\n", "\n") }
                                        | MarkedString.String s -> MarkedString.String (s.Replace("\r\n", "\n"))
 
   let normalizeHoverContent = function | HoverContent.MarkedStrings strings -> MarkedStrings (strings |> Array.map normalizeMarkedString)
@@ -82,28 +82,7 @@ let basicTests state =
                                        | HoverContent.MarkupContent content -> MarkupContent content
 
   testSequenced <| testList "Basic Tests" [
-      testSequenced <| testList "Hover Tests" [
-
-        testCaseAsync "simple symbol" (async {
-          let! (server, path) = server
-          let p : TextDocumentPositionParams =
-            { TextDocument = { Uri = Path.FilePathToUri path}
-              Position = { Line = 0; Character = 5 } }
-          let! res = server.TextDocumentHover p
-          match res with
-          | Result.Error e -> failtestf "Request failed: %A" e
-          | Result.Ok None -> failtest "Request none"
-          | Result.Ok (Some res) ->
-            let expected =
-              MarkedStrings
-                [|  MarkedString.WithLanguage {Language = "fsharp"; Value = "val t : int"}
-                    MarkedString.String ""
-                    MarkedString.String "*Full name: Script.t*"
-                    MarkedString.String "*Assembly: Script*"|]
-
-            Expect.equal (normalizeHoverContent res.Contents) expected "Hover test - simple symbol"
-        })
-
+      testSequenced <| ftestList "Hover Tests" [
         testCaseAsync "Hover Tests - let keyword" (async {
           let! server, path = server
           let p : TextDocumentPositionParams =
@@ -133,92 +112,6 @@ let basicTests state =
           | Result.Ok None -> failtest "Request none"
           | Result.Ok (Some res) ->
             failtest "Expected failure"
-        })
-
-        //Test to reproduce: https://github.com/ionide/ionide-vscode-fsharp/issues/1203
-        testCaseAsync "Hover Tests - operator" (async {
-          let! server, path = server
-          let p : TextDocumentPositionParams =
-            { TextDocument = { Uri = Path.FilePathToUri path}
-              Position = { Line = 2; Character = 7}}
-          let! res = server.TextDocumentHover p
-          match res with
-          | Result.Error e -> ()
-          | Result.Ok None -> failtest "Request none"
-          | Result.Ok (Some res) ->
-            let expected =
-              MarkedStrings
-                [|  MarkedString.WithLanguage {Language = "fsharp"; Value = "val ( .>> ): \n   x: int ->\n   y: int \n   -> int"}
-                    MarkedString.String ""
-                    MarkedString.String "*Full name: Script.( .>> )*"
-                    MarkedString.String "*Assembly: Script*"|]
-
-            Expect.equal (normalizeHoverContent res.Contents) expected "Hover test - let keyword"
-        })
-
-        //Test to reproduce: https://github.com/ionide/ionide-vscode-fsharp/issues/1203
-        testCaseAsync "Hover Tests - operator ^" (async {
-          let! server, path = server
-          let p : TextDocumentPositionParams =
-            { TextDocument = { Uri = Path.FilePathToUri path}
-              Position = { Line = 4; Character = 6}}
-          let! res = server.TextDocumentHover p
-          match res with
-          | Result.Error e -> ()
-          | Result.Ok None -> failtest "Request none"
-          | Result.Ok (Some res) ->
-            let expected =
-              MarkedStrings
-                [|  MarkedString.WithLanguage {Language = "fsharp"; Value = "val ( ^ ): \n   x: int ->\n   y: int \n   -> int"}
-                    MarkedString.String ""
-                    MarkedString.String "*Full name: Script.( ^ )*"
-                    MarkedString.String "*Assembly: Script*"|]
-
-            return Expect.equal (normalizeHoverContent res.Contents) expected "Hover test - let keyword"
-        })
-
-        testCaseAsync "Hover Tests - inline function with open generics" (async {
-          let! server, path = server
-          let p : TextDocumentPositionParams =
-            { TextDocument = { Uri = Path.FilePathToUri path}
-              Position = { Line = 6; Character = 13}} // middle of the `add` function
-          let! res = server.TextDocumentHover p
-          match res with
-          | Result.Error e -> ()
-          | Result.Ok None -> failtest "Request none"
-          | Result.Ok (Some res) ->
-            let expected =
-              MarkedStrings
-                [|  MarkedString.WithLanguage {Language = "fsharp"; Value = "val add: \n   x: ^a (requires static member ( + ) )->\n   y: ^b (requires static member ( + ) )\n   -> ^c"}
-                    MarkedString.String ""
-                    MarkedString.String "*Full name: Script.add*"
-                    MarkedString.String "*Assembly: Script*"|]
-
-            return Expect.equal (normalizeHoverContent res.Contents) expected "should have rendered the inline generics"
-        })
-
-        testCaseAsync "Hover Tests - use of generic function renders fixed generic parameters" (async {
-          let! server, path = server
-          let p : TextDocumentPositionParams =
-            { TextDocument = { Uri = Path.FilePathToUri path}
-              Position = { Line = 8; Character = 14 } } // middle of the use of the `add` function, where generics are fixed
-          let! res = server.TextDocumentHover p
-          match res with
-          | Result.Error e -> ()
-          | Result.Ok None -> failtest "Request none"
-          | Result.Ok (Some res) ->
-            let expected =
-              MarkedStrings
-                [|  MarkedString.WithLanguage {Language = "fsharp"; Value = "val add: \n   x: ^a (requires static member ( + ) )->\n   y: ^b (requires static member ( + ) )\n   -> ^c"}
-                    MarkedString.String "\n\n**Generic Parameters**\n\n* `'a` is `int`\n* `'b` is `int`\n* `'c` is `int`"
-                    MarkedString.String "*Full name: Script.add*"
-                    MarkedString.String "*Assembly: Script*"|]
-
-            return Expect.equal (normalizeHoverContent res.Contents) expected "should have rendered the inline generics"
-        })
-        testCaseAsync "cleanup" (async {
-          let! server, _ = server
-          do! server.Shutdown()
         })
       ]
   ]
@@ -366,13 +259,14 @@ let foldingTests state =
 
 
 let tooltipTests state =
-  let (|Tooltip|_|) (hover: Hover) =
+  let (|Signature|_|) (hover: Hover) =
     match hover with
     | { Contents = MarkedStrings [| MarkedString.WithLanguage { Language = "fsharp"; Value = tooltip }; MarkedString.String newline; MarkedString.String fullname; MarkedString.String assembly |] } -> Some tooltip
     | _ -> None
 
   let (|Description|_|) (hover: Hover) =
     match hover with
+    | { Contents = MarkedStrings [| MarkedString.WithLanguage { Language = "fsharp"; Value = tooltip }; MarkedString.String description; |] } -> Some description
     | { Contents = MarkedStrings [| MarkedString.WithLanguage { Language = "fsharp"; Value = tooltip }; MarkedString.String description; MarkedString.String fullname; MarkedString.String assembly |] } -> Some description
     | _ -> None
 
@@ -393,53 +287,72 @@ let tooltipTests state =
     }
     |> Async.Cache
 
-  let verifyTooltip line character expectedTooltip =
-    testCaseAsync (sprintf "tooltip for line %d character %d should be '%s'" line character expectedTooltip) (async {
+  let verifySignature line character expectedSignature =
+    testCaseAsync (sprintf "tooltip for line %d character %d should be '%s'" line character expectedSignature) (async {
       let! server, scriptPath = server
       let pos: TextDocumentPositionParams = {
         TextDocument =  { Uri = sprintf "file://%s" scriptPath }
         Position = { Line = line; Character = character }
       }
       match! server.TextDocumentHover pos with
-      | Ok (Some (Tooltip tooltip)) ->
-        Expect.equal tooltip expectedTooltip (sprintf "Should have a tooltip of '%s'" expectedTooltip)
+      | Ok (Some (Signature signature)) ->
+        Expect.equal signature expectedSignature (sprintf "Should have a signature of '%s'" expectedSignature)
       | Ok response ->
-        failtestf "Should have gotten tooltip but got %A" response
+        failtestf "Should have gotten signature but got %A" response
       | Result.Error errors ->
-        failtestf "Error while getting tooltip: %A" errors
+        failtestf "Error while getting signature: %A" errors
     })
 
-  let verifyDescription line character expectedTooltip =
-    testCaseAsync (sprintf "description for line %d character %d should be '%s" line character expectedTooltip) (async {
+  let concatLines = String.concat Environment.NewLine
+
+  let verifyDescription line character expectedDescription =
+    let expectedDescription = concatLines expectedDescription
+    testCaseAsync (sprintf "description for line %d character %d should be '%s" line character expectedDescription) (async {
       let! server, scriptPath = server
       let pos: TextDocumentPositionParams = {
         TextDocument =  { Uri = sprintf "file://%s" scriptPath }
         Position = { Line = line; Character = character }
       }
       match! server.TextDocumentHover pos with
-      | Ok (Some (Description tooltip)) ->
-        Expect.equal tooltip expectedTooltip (sprintf "Should have a tooltip of '%s'" expectedTooltip)
+      | Ok (Some (Description description)) ->
+        Expect.equal description expectedDescription (sprintf "Should have a description of '%s'" expectedDescription)
       | Ok response ->
         failtestf "Should have gotten description but got %A" response
       | Result.Error errors ->
         failtestf "Error while getting description: %A" errors
     })
 
-  let concatLines = String.concat Environment.NewLine
 
   testSequenced <|
-    testList "tooltip evaluation" [
+    ftestList "tooltip evaluation" [
       testList "tests" [
-        verifyTooltip 0 4 "val arrayOfTuples : (int * int) array" // verify that even the first letter of the tooltip triggers correctly
-        verifyTooltip 0 5 "val arrayOfTuples : (int * int) array"
-        verifyTooltip 1 5 "val listOfTuples : list<int * int>"
-        verifyTooltip 2 5 "val listOfStructTuples : list<struct (int * int)>"
-        verifyTooltip 3 5 "val floatThatShouldHaveGenericReportedInTooltip : float" //<MeasureOne>
-        //verifyDescription 4 4 """**Description**\n\nPrint to a string using the given format.\n\n**Parameters**\n\n* `format`: The formatter.\n\n**Returns**\n\nThe formatted result.\n\n**Generic parameters**\n\n* `'T` is `string`"""
-        verifyDescription 13 11 (concatLines ["**Description**"; ""; "\nMy super summary\n "; ""; "**Parameters**"; ""; "* `c`: foo"; "* `b`: bar"; "* `a`: baz"; ""; "**Returns**"; ""; ""])
-        verifyTooltip 14 5 "val nestedTuples : int * ((int * int) * int)"
-        verifyTooltip 15 5 "val nestedStructTuples : int * struct (int * int)"
-        verifyTooltip 21 9 "val speed : float<m/s>"
+        verifyDescription 0 2 ["**Description**";"";"";"Used to associate, or bind, a name to a value or function.";""] // `let` keyword
+        verifySignature 0 4 "val arrayOfTuples : (int * int) array" // verify that even the first letter of the tooltip triggers correctly
+        verifySignature 0 5 "val arrayOfTuples : (int * int) array" // inner positions trigger
+        verifySignature 1 5 "val listOfTuples : list<int * int>" // verify we default to prefix-generics style
+        verifySignature 2 5 "val listOfStructTuples : list<struct (int * int)>" // verify we render struct tuples in a round-tripabble format
+        verifySignature 3 5 "val floatThatShouldHaveGenericReportedInTooltip : float" // verify we strip <MeasureOne> measure annotations
+        verifyDescription 4 4 ["**Description**";"";"Print to a string using the given format.";"";"**Parameters**";"";"* `format`: The formatter.";"";"**Returns**";"";"The formatted result.";"";"**Generic Parameters**";"";"* `'T` is `string`"]
+        verifyDescription 13 11 ["**Description**"; ""; ""; "My super summary"; " "; ""; "**Parameters**"; ""; "* `c`: foo"; "* `b`: bar"; "* `a`: baz"; ""; "**Returns**"; ""; ""]
+        verifySignature 14 5 "val nestedTuples : int * ((int * int) * int)" // verify that tuples render correctly (parens, etc)
+        verifySignature 15 5 "val nestedStructTuples : int * struct (int * int)" // verify we can differentiate between struct and non-struct tuples
+        verifySignature 21 9 "val speed : float<m/s>" // verify we nicely-render measure annotations
+        // verify formatting of function-parameters to values. NOTE: we want to wrap them in parens for user clarity eventually.
+        verifySignature 26 5 (concatLines ["val funcWithFunParam:"; "   f: int -> unit ->"; "   i: int";"   -> unit"])
+        // verify formatting of tuple args.  NOTE: we want to wrap tuples in parens for user clarify eventually.
+        verifySignature 30 12 (concatLines ["val funcWithTupleParam:";"   : int *"; "   : int";"   -> int * int"])
+        // verify formatting of struct tuple args in parameter tooltips.
+        verifySignature 32 12 (concatLines ["val funcWithStructTupleParam:";"   f: struct (int * int)";"   -> struct (int * int)"])
+        verifySignature 36 15 (concatLines ["member Foo:"; "   stuff: int * int * int"; "       -> int"])
+        verifySignature 37 15 (concatLines ["member Bar:"; "   a: int *";"   b: int *";"   c: int";"   -> int"])
+        // verify formatting for multi-char operators
+        verifySignature 39 7  (concatLines ["val ( .>> ):"; "   x: int ->"; "   y: int";"   -> int"])
+        // verify formatting for single-char operators
+        verifySignature 41 6  (concatLines ["val ( ^ ):"; "   x: int ->"; "   y: int"; "   -> int"])
+        // verify rendeirng of generic constraints
+        verifySignature 43 13 (concatLines ["val add:"; "   x: ^a (requires static member ( + ) ) ->"; "   y: ^b (requires static member ( + ) )"; "   -> ^c"])
+        // verify rendering of solved generic constraints in tooltips for members where they are solved
+        verifyDescription 45 15 ["";"";"**Generic Parameters**";"";"* `'a` is `int`";"* `'b` is `int`";"* `'c` is `int`"]
       ]
       testCaseAsync "cleanup" (async {
         let! server, _ = server

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -338,7 +338,7 @@ let tooltipTests state =
         verifySignature 15 5 "val nestedStructTuples : int * struct (int * int)" // verify we can differentiate between struct and non-struct tuples
         verifySignature 21 9 "val speed : float<m/s>" // verify we nicely-render measure annotations
         // verify formatting of function-parameters to values. NOTE: we want to wrap them in parens for user clarity eventually.
-        verifySignature 26 5 (concatLines ["val funcWithFunParam:"; "   f: int -> unit ->"; "   i: int";"   -> unit"])
+        verifySignature 26 5 (concatLines ["val funcWithFunParam:"; "   f: (int -> unit) ->"; "   i: int";"   -> unit"])
         // verify formatting of tuple args.  NOTE: we want to wrap tuples in parens for user clarify eventually.
         verifySignature 30 12 (concatLines ["val funcWithTupleParam:";"   : int *"; "   : int";"   -> int * int"])
         // verify formatting of struct tuple args in parameter tooltips.

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -111,6 +111,6 @@ let main args =
   let config =
     { defaultConfig
       with runInParallel = false
-          //  failOnFocusedTests = true
+           failOnFocusedTests = true
            printer = Expecto.Impl.TestPrinters.summaryPrinter defaultConfig.printer }
   runTestsWithArgsAndCancel cts.Token config args tests

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -37,7 +37,6 @@ let tests =
       testSequenced <| testList name [
         let state = FsAutoComplete.State.Initial toolsPath workspaceLoaderFactory
         initTests state
-        basicTests state
         codeLensTest state
         documentSymbolTest state
         Completion.autocompleteTest state

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -112,6 +112,6 @@ let main args =
   let config =
     { defaultConfig
       with runInParallel = false
-           failOnFocusedTests = true
+          //  failOnFocusedTests = true
            printer = Expecto.Impl.TestPrinters.summaryPrinter defaultConfig.printer }
   runTestsWithArgsAndCancel cts.Token config args tests

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -20,3 +20,27 @@ type [<Measure>]m
 let distance = 5.<m>
 let time = 1.<s>
 let speed = distance/time
+
+// The purpose of this function is to test rendering of function parameters that are themselves functions.
+// In the before times, `f` would be rendered as `int -> unit` on a single line.
+// After the fix, we want `f` to be rendered as `(int -> unit)` on a single line, to emphasize the single-parameter nature of the function parameter
+let funcWithFunParam (f: int->unit) (i: int) = ()
+
+/// <summary>does a thing</summary>
+/// <param name="f">the inputs</param>
+let funcWithTupleParam (f: (int * int)) = snd f, fst f
+
+let funcWithStructTupleParam (f: struct(int * int)) = match f with struct(x, y) -> struct(y, x)
+
+
+type X() =
+    member x.Foo(stuff: (int * int * int)) = match stuff with a, b, c -> a + b + c
+    member x.Bar(a,b,c) = a + b + c
+
+let (.>>) x y = x + y
+
+let (^) x y = x + y
+
+let inline add x y = x + y
+
+let result = add 5 5


### PR DESCRIPTION
Someone in slack asked for functions (and tuples) to be wrapped in parens in tooltips for easy visibility, and I thought it was a good idea.

The fix itself was easy enough, but I started this fix on Windows, where I found a bunch of newline-dependent tests failing on that platform, so as part of this work I also fixed that issue. The tests should now work on Windows as well as they do on *nix.