### PR TITLE
Actually pack and publish the fsautocomplete dotnet tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      username:
+        description: Github username of the person triggering the release
+        default: "Krzysztof-Cieslak"
+        required: true
+      email:
+        description: Email of the person triggering the release
+        default: "krzysztof_cieslak@windowslive.com"
+        required: true
+
+jobs:
+  release:
+    strategy:
+      matrix:
+        dotnet: [5.0.200]
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ matrix.dotnet }}
+    - name: Restore tools
+      run: dotnet tool restore
+    - name: Run Build
+      run: dotnet fake build -t Build
+    - name: upload artifact package
+      uses: actions/upload-artifact@v2
+      with:
+        name: fsautocomplete
+        path: bin/pkgs
+    - name: Publish Release
+      env:
+        nuget-key: ${{ secrets.NUGET_KEY }}
+        github-token: ${{ secrets.USER_TOKEN }}
+      run: dotnet fake build -t Release

--- a/build.fsx
+++ b/build.fsx
@@ -78,15 +78,15 @@ Target.create "LocalRelease" (fun _ ->
            OutputPath = Some (__SOURCE_DIRECTORY__ </> "bin/release_netcore")
            Framework = Some "net5.0"
            Configuration = DotNet.BuildConfiguration.fromString configuration
-           MSBuildParams = { MSBuild.CliArguments.Create () with Properties =  [ "SourceLinkCreate","true"; "Version", release.AssemblyVersion ] } }) "src/FsAutoComplete"
+           MSBuildParams = { MSBuild.CliArguments.Create () with Properties =  [ "Version", release.AssemblyVersion ] } }) "src/FsAutoComplete"
 
 
     Shell.cleanDirs [ "bin/release_as_tool" ]
-    DotNet.publish (fun p ->
+    DotNet.pack (fun p ->
        { p with
            OutputPath = Some (__SOURCE_DIRECTORY__ </> "bin/release_as_tool")
            Configuration = DotNet.BuildConfiguration.fromString configuration
-           MSBuildParams = { MSBuild.CliArguments.Create () with Properties =  [ "SourceLinkCreate","true"; "Version", release.AssemblyVersion; "PackAsTool", "true" ] } }) "src/FsAutoComplete"
+           MSBuildParams = { MSBuild.CliArguments.Create () with Properties =  [ "Version", release.AssemblyVersion; "PackAsTool", "true" ] } }) "src/FsAutoComplete"
 )
 
 Target.create "Clean" (fun _ ->
@@ -101,7 +101,7 @@ Target.create "Build" (fun _ ->
   DotNet.build (fun p ->
      { p with
          Configuration = DotNet.BuildConfiguration.fromString configuration
-         MSBuildParams = { MSBuild.CliArguments.Create () with Properties =  [ "SourceLinkCreate","true"; "Version", release.AssemblyVersion ] } }) "FsAutoComplete.sln"
+         MSBuildParams = { MSBuild.CliArguments.Create () with Properties =  [ "Version", release.AssemblyVersion ] } }) "FsAutoComplete.sln"
 )
 
 Target.create "ReplaceFsLibLogNamespaces" <| fun _ ->


### PR DESCRIPTION
This PR adds packaging of the fsautocomplete dotnet tool, as well as publishing and automated releases using a manual trigger similar to what we've done for Ionide.

After this, users should be able to install fsautocomplete either globally or locally to a project with `dotnet tool install fsautocomplete` (adding `-g` for global if they require) and then be able to invoke the tool with `dotnet fsautocomplete` as one would expect.

This seems to be working in my local testing (`dotnet tool install fsautocomplete --add-source <path to directory with nupkg`).

Once a user has done this, it can even be made to work in ionide easily (as a hack/workaround/test) by using `"FSharp.fsac.netcoreDllPath" : "fsautocomplete"`, which will cause Ionide to run `dotnet fsautocomplete` as a user might expect :D We can of course make this better, but it sufficed for testing.