### PR TITLE
Change codefix for "unused self reference" to single-underscore

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
     "sdk": {
-        "version": "5.0.301"
+        "version": "5.0.301",
+        "rollForward": "feature"
     }
 }

--- a/src/FsAutoComplete/CodeFixes/UnusedValue.fs
+++ b/src/FsAutoComplete/CodeFixes/UnusedValue.fs
@@ -6,16 +6,12 @@ open FsAutoComplete.CodeFix.Types
 open LanguageServerProtocol.Types
 open FsAutoComplete
 open FsAutoComplete.LspHelpers
-open FsAutoComplete.Logging
 
 /// a codefix that suggests prepending a _ to unused values
 let fix (getRangeText: GetRangeText) =
-  let logger = LogProvider.getLoggerByName "UnusedValue"
   Run.ifDiagnosticByMessage
     "is unused"
     (fun diagnostic codeActionParams ->
-      logger.info (Log.setMessage "HACK! INSIDE FIX: {dig}" >> Log.addContextDestructured "dig" diagnostic)
-      logger.info (Log.setMessage "HACK! INSIDE FIX: {cap}" >> Log.addContextDestructured "cap" codeActionParams)
       asyncResult {
         match getRangeText (codeActionParams.TextDocument.GetFilePath() |> normalizePath) diagnostic.Range with
         | Ok unusedExpression ->

--- a/src/FsAutoComplete/CodeFixes/UnusedValue.fs
+++ b/src/FsAutoComplete/CodeFixes/UnusedValue.fs
@@ -6,14 +6,18 @@ open FsAutoComplete.CodeFix.Types
 open LanguageServerProtocol.Types
 open FsAutoComplete
 open FsAutoComplete.LspHelpers
+open FsAutoComplete.Logging
 
 /// a codefix that suggests prepending a _ to unused values
 let fix (getRangeText: GetRangeText) =
+  let logger = LogProvider.getLoggerByName "UnusedValue"
   Run.ifDiagnosticByMessage
     "is unused"
     (fun diagnostic codeActionParams ->
+      logger.info (Log.setMessage "HACK! INSIDE FIX: {dig}" >> Log.addContextDestructured "dig" diagnostic)
+      logger.info (Log.setMessage "HACK! INSIDE FIX: {cap}" >> Log.addContextDestructured "cap" codeActionParams)
       asyncResult {
-        match getRangeText (codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath) diagnostic.Range with
+        match getRangeText (codeActionParams.TextDocument.GetFilePath() |> normalizePath) diagnostic.Range with
         | Ok unusedExpression ->
             match diagnostic.Code with
             | Some _ ->

--- a/src/FsAutoComplete/CodeFixes/UnusedValue.fs
+++ b/src/FsAutoComplete/CodeFixes/UnusedValue.fs
@@ -20,10 +20,10 @@ let fix (getRangeText: GetRangeText) =
                 return
                   [ { SourceDiagnostic = Some diagnostic
                       File = codeActionParams.TextDocument
-                      Title = "Replace with __"
+                      Title = "Replace with _"
                       Edits =
                         [| { Range = diagnostic.Range
-                             NewText = "__" } |]
+                             NewText = "_" } |]
                       Kind = Refactor } ]
             | None ->
                 let replaceSuggestion = "_"

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
@@ -252,11 +252,7 @@ let unusedValueTests state =
         Context = { Diagnostics = [| diagnostic |] }
     }
     match! server.TextDocumentCodeAction detected with
-    | Ok (Some (TextDocumentCodeActionResult.CodeActions actions)) ->
-        Expect.exists
-          actions
-          (function ActReplace -> true | _ -> false)
-          "Failed to 'Replace with _'"
+    | Ok (Some (TextDocumentCodeActionResult.CodeActions [| ActReplace |])) -> ()
     | Ok other ->
         failtestf $"Should have generated _, but instead generated %A{other}"
     | Error reason ->
@@ -277,36 +273,7 @@ let unusedValueTests state =
         Context = { Diagnostics = [| diagnostic |] }
     }
     match! server.TextDocumentCodeAction detected with
-    | Ok (Some (TextDocumentCodeActionResult.CodeActions actions)) ->
-        Expect.exists
-          actions
-          (function ActReplace -> true | _ -> false)
-          "Failed to 'Replace with _'"
-    | Ok other ->
-        failtestf $"Should have generated _, but instead generated %A{other}"
-    | Error reason ->
-        failtestf $"Should have succeeded, but failed with %A{reason}"
-  })
-
-  let canPrefixUnusedBinding = testCaseAsync "can prefix unused binding" (async {
-    let! server, file, diagnostics = server
-    let diagnostic =
-      diagnostics
-      |> Array.tryFind (fun d ->
-          d.Range.Start = { Line = 9; Character = 4 } &&
-          d.Range.End   = { Line = 9; Character = 7 }
-      ) |> Option.defaultWith (fun () -> failwith "could not find diagnostic with expected range")
-    let detected = {
-        CodeActionParams.TextDocument = { Uri = Path.FilePathToUri file }
-        Range = diagnostic.Range
-        Context = { Diagnostics = [| diagnostic |] }
-    }
-    match! server.TextDocumentCodeAction detected with
-    | Ok (Some (TextDocumentCodeActionResult.CodeActions actions)) ->
-        Expect.exists
-          actions
-          (function ActPrefix "six" -> true | _ -> false)
-          "Failed to 'Prefix with _'"
+    | Ok (Some (TextDocumentCodeActionResult.CodeActions [| ActReplace; ActPrefix "six" |])) -> ()
     | Ok other ->
         failtestf $"Should have generated _, but instead generated %A{other}"
     | Error reason ->
@@ -327,36 +294,7 @@ let unusedValueTests state =
         Context = { Diagnostics = [| diagnostic |] }
     }
     match! server.TextDocumentCodeAction detected with
-    | Ok (Some (TextDocumentCodeActionResult.CodeActions actions)) ->
-        Expect.exists
-          actions
-          (function ActReplace -> true | _ -> false)
-          "Failed to 'Replace with _'"
-    | Ok other ->
-        failtestf $"Should have generated _, but instead generated %A{other}"
-    | Error reason ->
-        failtestf $"Should have succeeded, but failed with %A{reason}"
-  })
-
-  let canPrefixUnusedParameter = testCaseAsync "can prefix unused parameter" (async {
-    let! server, file, diagnostics = server
-    let diagnostic =
-      diagnostics
-      |> Array.tryFind (fun d ->
-          d.Range.Start = { Line = 15; Character = 16 } &&
-          d.Range.End   = { Line = 15; Character = 21 }
-      ) |> Option.defaultWith (fun () -> failwith "could not find diagnostic with expected range")
-    let detected = {
-        CodeActionParams.TextDocument = { Uri = Path.FilePathToUri file }
-        Range = diagnostic.Range
-        Context = { Diagnostics = [| diagnostic |] }
-    }
-    match! server.TextDocumentCodeAction detected with
-    | Ok (Some (TextDocumentCodeActionResult.CodeActions actions)) ->
-        Expect.exists
-          actions
-          (function ActPrefix "three" -> true | _ -> false)
-          "Failed to 'Prefix with _'"
+    | Ok (Some (TextDocumentCodeActionResult.CodeActions [| ActReplace; ActPrefix "three" |])) -> ()
     | Ok other ->
         failtestf $"Should have generated _, but instead generated %A{other}"
     | Error reason ->
@@ -366,9 +304,7 @@ let unusedValueTests state =
   testList "unused value" [
     canReplaceUnusedSelfReference
     canReplaceUnusedBinding
-    canPrefixUnusedBinding
     canReplaceUnusedParameter
-    canPrefixUnusedParameter
   ]
 
 let tests state = testList "codefix tests" [

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
@@ -209,7 +209,7 @@ let unusedValueTests state =
   let server =
     async {
       let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "UnusedValue")
-      let! (server, events) = serverInitialize path defaultConfigDto state
+      let! (server, events) = serverInitialize path { defaultConfigDto with UnusedDeclarationsAnalyzer = Some true }  state
       do! waitForWorkspaceFinishedParsing events
       let path = Path.Combine(path, "Script.fsx")
       let tdop : DidOpenTextDocumentParams = { TextDocument = loadDocument path }

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -421,6 +421,11 @@ let waitForParseResultsForFile file =
   >> diagnosticsToResult
   >> Async.AwaitObservable
 
+let waitForFsacDiagnosticsForFile file =
+  fsacDiagnostics file
+  >> diagnosticsToResult
+  >> Async.AwaitObservable
+
 let waitForParsedScript (event: ClientEvents) =
   event
   |> typedEvents<LanguageServerProtocol.Types.PublishDiagnosticsParams> "textDocument/publishDiagnostics"

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/UnusedValue/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/UnusedValue/Script.fsx
@@ -1,4 +1,16 @@
-let x = typeof<Async<string>>.Name
+(* unused self reference *)
+type MyClass() =
+  member this.DoAThing() = ()
 
-// type MyClass() =
-//   member this.DoAThing() = ()
+
+(*
+  replace usused binding with _
+  prefix _ to unused binding
+*)
+let six = 6
+
+(*
+  replace usused function parameter with _
+  prefix _ to unused function parameter
+*)
+let add one two three = one + two

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/UnusedValue/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/UnusedValue/Script.fsx
@@ -1,0 +1,4 @@
+let x = typeof<Async<string>>.Name
+
+// type MyClass() =
+//   member this.DoAThing() = ()


### PR DESCRIPTION
+ Codefix now emits single underscore (`_`) instead of double (`__`)
+ Added "rollForward" to global.json
+ Added MSBuild.StructuredLogger as direct dependency (was transitive)