### PR TITLE
Misc. diagnostics additions

### DIFF
--- a/src/FsAutoComplete.BackgroundServices/Program.fs
+++ b/src/FsAutoComplete.BackgroundServices/Program.fs
@@ -59,6 +59,9 @@ module Helpers =
         | FSharpDiagnosticSeverity.Hidden -> None
         | FSharpDiagnosticSeverity.Info -> Some DiagnosticSeverity.Information
 
+    let urlForCompilerCode (number: int) =
+      $"https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-messages/fs%04d{number}"
+
     let fcsErrorToDiagnostic (error: FSharpDiagnostic) =
         {
             Range =
@@ -72,6 +75,10 @@ module Helpers =
             Code = Some (string error.ErrorNumber)
             RelatedInformation = Some [||]
             Tags = None
+            Data = None
+            CodeDescription = Some {
+              Href = Some (Uri (urlForCompilerCode error.ErrorNumber))
+            }
         }
 
     /// Algorithm from https://stackoverflow.com/a/35734486/433393 for converting file paths to uris,

--- a/src/FsAutoComplete/CodeFixes/ExternalSystemDiagnostics.fs
+++ b/src/FsAutoComplete/CodeFixes/ExternalSystemDiagnostics.fs
@@ -5,31 +5,27 @@ open FsAutoComplete.CodeFix
 open FsAutoComplete.CodeFix.Types
 open LanguageServerProtocol.Types
 open FsAutoComplete
-open FsAutoComplete.LspHelpers
-open System.IO
 
-let private mapExternalDiagnostic diagnosticType getFixesForFile =
+let private mapExternalDiagnostic diagnosticType =
     Run.ifDiagnosticByType
       diagnosticType
       (fun diagnostic codeActionParams ->
-        let fileName =
-          codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
 
-        let normalizedUri = Path.LocalPathToUri fileName
-
-        match getFixesForFile normalizedUri
-              |> Option.bind
-                   (fun fixes ->
-                     fixes
-                     |> List.tryFind (fun (range, textEdit) -> range = diagnostic.Range)) with
-        | Some (range, textEdit) ->
-            AsyncResult.retn [ { SourceDiagnostic = Some diagnostic
-                                 File = codeActionParams.TextDocument
-                                 Title = $"Replace with %s{textEdit.NewText}"
-                                 Edits = [| textEdit |]
-                                 Kind = Fix } ]
-        | None -> AsyncResult.retn [])
-
+        match diagnostic.Data with
+        | None -> AsyncResult.retn []
+        | Some fixes ->
+          match fixes with
+          | :? list<Range * TextEdit> as fixes ->
+            match fixes |> List.tryFind (fun (range, textEdit) -> range = diagnostic.Range) with
+            | Some (_range, textEdit) ->
+                AsyncResult.retn [ { SourceDiagnostic = Some diagnostic
+                                     File = codeActionParams.TextDocument
+                                     Title = $"Replace with %s{textEdit.NewText}"
+                                     Edits = [| textEdit |]
+                                     Kind = Fix } ]
+            | None -> AsyncResult.retn []
+          | _ -> AsyncResult.retn []
+        )
 
 /// a codefix that generates fixes reported by FSharpLint
 let linter = mapExternalDiagnostic "F# Linter"

--- a/src/FsAutoComplete/CodeFixes/ExternalSystemDiagnostics.fs
+++ b/src/FsAutoComplete/CodeFixes/ExternalSystemDiagnostics.fs
@@ -10,20 +10,17 @@ let private mapExternalDiagnostic diagnosticType =
     Run.ifDiagnosticByType
       diagnosticType
       (fun diagnostic codeActionParams ->
-
         match diagnostic.Data with
         | None -> AsyncResult.retn []
         | Some fixes ->
           match fixes with
-          | :? list<Range * TextEdit> as fixes ->
-            match fixes |> List.tryFind (fun (range, textEdit) -> range = diagnostic.Range) with
-            | Some (_range, textEdit) ->
-                AsyncResult.retn [ { SourceDiagnostic = Some diagnostic
-                                     File = codeActionParams.TextDocument
-                                     Title = $"Replace with %s{textEdit.NewText}"
-                                     Edits = [| textEdit |]
-                                     Kind = Fix } ]
-            | None -> AsyncResult.retn []
+          | :? list<TextEdit> as fixes ->
+            AsyncResult.retn [ { SourceDiagnostic = Some diagnostic
+                                 File = codeActionParams.TextDocument
+                                 Title = $"Fix issue"
+                                 Edits = fixes |> List.toArray
+                                 Kind = Fix } ]
+
           | _ -> AsyncResult.retn []
         )
 

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -101,6 +101,9 @@ module Conversions =
         | FSharpDiagnosticSeverity.Hidden -> None
         | FSharpDiagnosticSeverity.Info -> Some DiagnosticSeverity.Information
 
+    let urlForCompilerCode (number: int) =
+      $"https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-messages/fs%04d{number}"
+
     let fcsErrorToDiagnostic (error: FSharpDiagnostic) =
         {
             Range =
@@ -114,6 +117,8 @@ module Conversions =
             Code = Some (string error.ErrorNumber)
             RelatedInformation = Some [||]
             Tags = None
+            Data = None
+            CodeDescription = Some { Href = Some (Uri (urlForCompilerCode error.ErrorNumber))}
         }
 
     let getSymbolInformations (uri: DocumentUri) (glyphToSymbolKind: FSharpGlyph -> SymbolKind option) (topLevel: FSharpNavigationTopLevelDeclaration) (symbolFilter: SymbolInformation -> bool): SymbolInformation [] =

--- a/src/LanguageServerProtocol/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol/LanguageServerProtocol.fs
@@ -1575,6 +1575,13 @@ module Types =
         Message: string
     }
 
+    // Structure to capture a description for an error code.
+    type CodeDescription =
+      {
+        // An URI to open with more information about the diagnostic error.
+        Href: Uri option
+      }
+
     /// Represents a diagnostic, such as a compiler error or warning. Diagnostic objects are only valid in the
     /// scope of a resource.
     [<DebuggerDisplay("{DebuggerDisplay}")>]
@@ -1589,6 +1596,8 @@ module Types =
 
           /// The diagnostic's code. Can be omitted.
           Code: string option
+          /// An optional property to describe the error code.
+          CodeDescription: CodeDescription option
 
           /// A human-readable string describing the source of this
           /// diagnostic, e.g. 'typescript' or 'super lint'.
@@ -1598,6 +1607,11 @@ module Types =
           Message: string
           RelatedInformation: DiagnosticRelatedInformation [] option
           Tags: DiagnosticTag[] option
+          /// A data entry field that is preserved between a
+          /// `textDocument/publishDiagnostics` notification and
+          /// `textDocument/codeAction` request.
+          Data: obj option
+
       }
       [<DebuggerBrowsable(DebuggerBrowsableState.Never)>]
       member x.DebuggerDisplay = $"[{defaultArg x.Severity DiagnosticSeverity.Error}] ({x.Range.DebuggerDisplay}) {x.Message} ({defaultArg x.Code String.Empty})"

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -199,8 +199,8 @@ let autoOpenTests state =
 
     let tdop: DidOpenTextDocumentParams = { TextDocument = loadDocument scriptPath }
     do! server.TextDocumentDidOpen tdop
-    do! 
-      waitForParseResultsForFile scriptName events 
+    do!
+      waitForParseResultsForFile scriptName events
       |> AsyncResult.bimap (fun _ -> failtest "Should have had errors") id
       |> Async.Ignore
 
@@ -225,8 +225,10 @@ let autoOpenTests state =
           Source = "F# Compiler"
           RelatedInformation = None
           Tags = None
+          Data = None
+          CodeDescription = None
         }
-      |] } 
+      |] }
     }
     let (|ContainsOpenAction|_|) (codeActions: CodeAction []) =
       codeActions
@@ -240,12 +242,12 @@ let autoOpenTests state =
         let openPos = calcOpenPos edit
         return (edit, ns, openPos)
     | Ok _ -> return failtest $"Quick fix on `{word}` doesn't contain open action"
-  } 
+  }
   let test (compareWithQuickFix: bool) (name: string option) (server: Async<FSharpLspServer * string>) (word: string, ns: string) (cursor: Position) (expectedOpen: Position) =
     let name = name |> Option.defaultWith (fun _ -> sprintf "completion on `Regex` at (%i, %i) should `open System.Text.RegularExpressions` at (%i, %i) (0-based)" (cursor.Line) (cursor.Character) (expectedOpen.Line) (expectedOpen.Character))
     testCaseAsync name <| async {
       let! server, path = server
-      
+
       let p : CompletionParams = { TextDocument = { Uri = Path.FilePathToUri path}
                                    // Line AND Column are ZERO-based!
                                    Position = cursor
@@ -256,7 +258,7 @@ let autoOpenTests state =
       | Ok (Some res) ->
           Expect.isFalse res.IsIncomplete "Result is incomplete"
           let ci = res.Items |> Array.find (fun c -> c.Label = word)
-          
+
           // now get details: `completionItem/resolve` (previous request was `textDocument/completion` -> List of all completions, but without details)
           match! server.CompletionItemResolve ci with
           | Error e -> failtestf "Request failed: %A" e
@@ -280,10 +282,10 @@ let autoOpenTests state =
     }
 
   /// In passed file: Cursor positions are marked with comments (multi-line comments: `(*...*)`)
-  /// Cursor: 
+  /// Cursor:
   /// * before start of open comment (before the leading `(`)
   /// * Completion is executed here -> expected to be `Regex`
-  /// In comment: 
+  /// In comment:
   /// * Expected position of generated `open ...`. Column marks the the position of the leading `o` of `open` (-> Column is indentation)
   ///
   /// Format of position: `Line,Column`
@@ -324,7 +326,7 @@ let autoOpenTests state =
           | '+' | '-' ->
             // relative to current position
             current + int n
-          | _ -> 
+          | _ ->
             // absolute
             int n
 

--- a/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
@@ -328,7 +328,7 @@ let analyzerTests state =
                           End = { Line = 3
                                   Character = 31 } }
                 Severity = Some DiagnosticSeverity.Warning
-                Code = None
+                Code = Some "OV001"
                 Source = "F# Analyzers (Option.Value analyzer)"
                 Message = "Option.Value shouldn't be used"
                 RelatedInformation = None


### PR DESCRIPTION
This adds

* helper combinators for the observable event streams to allow for waiting for specific sources of diagnostics, as well as a few pre-baked
* the ability to add urls and data to the diagnostics, which is immediately used to flow through linter help urls and compiler error code documentation urls.