### PR TITLE
(mostly) implement explicit type annotation codefix

### DIFF
--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -21,7 +21,7 @@ type SourceTextExtensions =
   static member GetText(t: ISourceText, m: FSharp.Compiler.Text.Range): Result<string, string> =
     let allFileRange = Range.mkRange m.FileName Pos.pos0 (t.GetLastFilePosition())
     if not (Range.rangeContainsRange allFileRange m)
-    then Error "%A{m} is outside of the bounds of the file"
+    then Error $"%A{m} is outside of the bounds of the file"
     else
       if m.StartLine = m.EndLine then // slice of a single line, just do that
         let lineText = t.GetLineString (m.StartLine - 1)

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -397,6 +397,15 @@ module Array =
         | _ when n >= xs.Length || n < 0 -> xs, [||]
         | _ -> xs.[0..n-1], xs.[n..]
 
+    let partitionResults (xs: _ []) =
+      let oks = ResizeArray(xs.Length)
+      let errors = ResizeArray(xs.Length)
+      for x in xs do
+        match x with
+        | Ok ok -> oks.Add ok
+        | Error err -> errors.Add err
+      oks.ToArray(), errors.ToArray()
+
 module List =
 
     ///Returns the greatest of all elements in the list that is less than the threshold

--- a/src/FsAutoComplete/CodeFixes.fs
+++ b/src/FsAutoComplete/CodeFixes.fs
@@ -25,6 +25,7 @@ module Types =
   type GetParseResultsForFile = string<LocalPath> -> FSharp.Compiler.Text.Pos -> Async<ResultOrString<ParseAndCheckResults * string * FSharp.Compiler.Text.ISourceText>>
   type GetProjectOptionsForFile = string<LocalPath> -> ResultOrString<FSharp.Compiler.SourceCodeServices.FSharpProjectOptions>
 
+  [<RequireQualifiedAccess>]
   type FixKind =
     | Fix
     | Refactor
@@ -62,9 +63,9 @@ module Types =
         Kind =
           Some
             (match fixKind with
-             | Fix -> "quickfix"
-             | Refactor -> "refactor"
-             | Rewrite -> "refactor.rewrite")
+             | FixKind.Fix -> "quickfix"
+             | FixKind.Refactor -> "refactor"
+             | FixKind.Rewrite -> "refactor.rewrite")
         Diagnostics = diagnostic |> Option.map Array.singleton
         Edit = workspaceEdit
         Command = None }

--- a/src/FsAutoComplete/CodeFixes.fs
+++ b/src/FsAutoComplete/CodeFixes.fs
@@ -38,7 +38,7 @@ module Types =
       SourceDiagnostic: Diagnostic option
       Kind: FixKind }
 
-  type CodeFix = CodeActionParams -> Async<Fix list>
+  type CodeFix = CodeActionParams -> Async<Result<Fix list, string>>
 
   type CodeAction with
     static member OfFix getFileVersion clientCapabilities (fix: Fix) =
@@ -158,20 +158,16 @@ module Run =
   open Types
 
   let ifEnabled enabled codeFix: CodeFix =
-    fun codeActionParams -> if enabled () then codeFix codeActionParams else async.Return []
+    fun codeActionParams -> if enabled () then codeFix codeActionParams else AsyncResult.retn []
 
   let private runDiagnostics pred handler: CodeFix =
-    let logger = LogProvider.getLoggerByName "CodeFixes"
     fun codeActionParams ->
       codeActionParams.Context.Diagnostics
       |> Array.choose (fun d -> if pred d then Some d else None)
       |> Array.toList
       |> List.traverseAsyncResultM (fun d -> handler d codeActionParams)
       |> AsyncResult.map List.concat
-      |> AsyncResult.foldResult id (fun errs ->
-        logger.warn (Log.setMessage "CodeFix returned an error: {error}" >> Log.addContextDestructured "error" errs)
-        []
-      )
+
 
   let ifDiagnosticByMessage (checkMessage: string) handler : CodeFix =
     runDiagnostics (fun d -> d.Message.Contains checkMessage) handler

--- a/src/FsAutoComplete/CodeFixes/AddExplicitTypeToParameter.fs
+++ b/src/FsAutoComplete/CodeFixes/AddExplicitTypeToParameter.fs
@@ -6,9 +6,61 @@ open FsAutoComplete.CodeFix.Types
 open LanguageServerProtocol.Types
 open FsAutoComplete
 open FsAutoComplete.LspHelpers
+open FSharp.Compiler.SourceCodeServices
+open FsAutoComplete.FCSPatches
 
-let fix : CodeFix =
+let fix (getParseResultsForFile: GetParseResultsForFile): CodeFix =
   fun codeActionParams ->
     asyncResult {
-      return []
+      let filePath = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
+      let fcsStartPos = protocolPosToPos codeActionParams.Range.Start
+      let! (parseAndCheck, lineStr, sourceText) = getParseResultsForFile filePath fcsStartPos
+      let parseFileResults = parseAndCheck.GetParseResults
+      let! (rightCol, idents) =
+        Lexer.findLongIdents(fcsStartPos.Column, lineStr)
+        |> Result.ofOption (fun _ -> $"Couldn't find long ident at %A{fcsStartPos} in file %s{codeActionParams.TextDocument.GetFilePath()}")
+      let! symbolUse =
+        parseAndCheck.GetCheckResults.GetSymbolUseAtLocation(fcsStartPos.Line, rightCol, lineStr, List.ofArray idents)
+        |> Result.ofOption (fun _ -> $"Couldn't find symbolUse at %A{(fcsStartPos.Line, rightCol)} in file %s{codeActionParams.TextDocument.GetFilePath()}")
+
+      let isValidParameterWithoutTypeAnnotation (funcOrValue: FSharpMemberOrFunctionOrValue) (symbolUse: FSharpSymbolUse) =
+        // TODO: remove patched functions and uncomment this boolean check after FCS 40 update
+        let isLambdaIfFunction =
+        //     funcOrValue.IsFunction &&
+             parseFileResults.IsBindingALambdaAtPositionPatched symbolUse.RangeAlternate.Start
+
+        (funcOrValue.IsValue || isLambdaIfFunction) &&
+        parseFileResults.IsPositionContainedInACurriedParameter symbolUse.RangeAlternate.Start &&
+        not (parseFileResults.IsTypeAnnotationGivenAtPositionPatched symbolUse.RangeAlternate.Start) &&
+        not funcOrValue.IsMember &&
+        not funcOrValue.IsMemberThisValue &&
+        not funcOrValue.IsConstructorThisValue &&
+        not (PrettyNaming.IsOperatorName funcOrValue.DisplayName)
+
+      match symbolUse.Symbol with
+      | :? FSharpMemberOrFunctionOrValue as v when isValidParameterWithoutTypeAnnotation v symbolUse ->
+        let typeString = v.FullType.Format symbolUse.DisplayContext
+        let title = "Add explicit type annotation"
+        let fcsSymbolRange = symbolUse.RangeAlternate
+        let protocolSymbolRange = fcsRangeToLsp fcsSymbolRange
+        let! symbolText = sourceText.GetText(fcsSymbolRange)
+
+        let alreadyWrappedInParens =
+          let hasLeftParen = Navigation.walkBackUntilConditionWithTerminal sourceText protocolSymbolRange.Start (fun c -> c = '(') System.Char.IsWhiteSpace
+          let hasRightParen = Navigation.walkForwardUntilConditionWithTerminal sourceText protocolSymbolRange.End (fun c -> c = ')') System.Char.IsWhiteSpace
+          hasLeftParen.IsSome && hasRightParen.IsSome
+
+        let changedText, changedRange =
+          if alreadyWrappedInParens
+          then ": " + typeString, { Start = protocolSymbolRange.End; End = protocolSymbolRange.End }
+          else "(" + symbolText + ": " + typeString + ")", protocolSymbolRange
+        return [ {
+          Edits = [| { Range = changedRange; NewText = changedText } |]
+          File = codeActionParams.TextDocument
+          Title = title
+          SourceDiagnostic = None
+          Kind = FixKind.Refactor
+          } ]
+      | _ ->
+        return []
     }

--- a/src/FsAutoComplete/CodeFixes/AddExplicitTypeToParameter.fs
+++ b/src/FsAutoComplete/CodeFixes/AddExplicitTypeToParameter.fs
@@ -1,0 +1,14 @@
+module FsAutoComplete.CodeFix.AddExplicitTypeToParameter
+
+open FsToolkit.ErrorHandling
+open FsAutoComplete.CodeFix.Navigation
+open FsAutoComplete.CodeFix.Types
+open LanguageServerProtocol.Types
+open FsAutoComplete
+open FsAutoComplete.LspHelpers
+
+let fix : CodeFix =
+  fun codeActionParams ->
+    asyncResult {
+      return []
+    }

--- a/src/FsAutoComplete/CodeFixes/AddMissingFunKeyword.fs
+++ b/src/FsAutoComplete/CodeFixes/AddMissingFunKeyword.fs
@@ -61,7 +61,7 @@ let fix (getFileLines: GetFileLines) (getLineText: GetLineText): CodeFix =
                       Edits =
                         [| { Range = symbolStartRange
                              NewText = "fun " } |]
-                      Kind = Fix } ]
+                      Kind = FixKind.Fix } ]
             | None -> return []
       }
       )

--- a/src/FsAutoComplete/CodeFixes/AddMissingRecKeyword.fs
+++ b/src/FsAutoComplete/CodeFixes/AddMissingRecKeyword.fs
@@ -67,7 +67,7 @@ let fix (getFileLines: GetFileLines) (getLineText: GetLineText): CodeFix =
                       Edits =
                         [| { Range = { Start = endOfError; End = endOfError }
                              NewText = " rec" } |]
-                      Kind = Fix } ]
+                      Kind = FixKind.Fix } ]
             | None -> return []
       }
       )

--- a/src/FsAutoComplete/CodeFixes/AddTypeToIndeterminateValue.fs
+++ b/src/FsAutoComplete/CodeFixes/AddTypeToIndeterminateValue.fs
@@ -50,7 +50,7 @@ let fix
                       Title = "Add explicit type annotation"
                       File = codeActionParams.TextDocument
                       SourceDiagnostic = Some diagnostic
-                      Kind = Fix
+                      Kind = FixKind.Fix
                       Edits = [| { Range = changedRange
                                    NewText = changedText } |] }]
         | _ -> return []

--- a/src/FsAutoComplete/CodeFixes/ChangeCSharpLambdaToFSharp.fs
+++ b/src/FsAutoComplete/CodeFixes/ChangeCSharpLambdaToFSharp.fs
@@ -38,7 +38,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getLineText: GetLineTe
                   Edits =
                     [| { Range = replacementRange
                          NewText = replacementText } |]
-                  Kind = Refactor } ]
+                  Kind = FixKind.Refactor } ]
         | None -> return []
       }
       )

--- a/src/FsAutoComplete/CodeFixes/ChangeComparisonToMutableAssignment.fs
+++ b/src/FsAutoComplete/CodeFixes/ChangeComparisonToMutableAssignment.fs
@@ -47,7 +47,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
                                  { Start = equalsPos
                                    End = (inc lines equalsPos) }
                                NewText = "<-" } |]
-                        Kind = Refactor } ]
+                        Kind = FixKind.Refactor } ]
               | None -> return []
           | _ -> return []
       }

--- a/src/FsAutoComplete/CodeFixes/ChangeTypeOfNameToNameOf.fs
+++ b/src/FsAutoComplete/CodeFixes/ChangeTypeOfNameToNameOf.fs
@@ -50,4 +50,3 @@ let fix (getParseResultsForFile: GetParseResultsForFile): CodeFix =
         SourceDiagnostic = None
         Kind = FixKind.Refactor }]
     }
-    |> AsyncResult.foldResult id (fun _ -> [])

--- a/src/FsAutoComplete/CodeFixes/ColonInFieldType.fs
+++ b/src/FsAutoComplete/CodeFixes/ColonInFieldType.fs
@@ -17,6 +17,6 @@ let fix: CodeFix =
                              Edits =
                                [| { Range = diagnostic.Range
                                     NewText = ":" } |]
-                             Kind = Fix } ]
+                             Kind = FixKind.Fix } ]
       else
         AsyncResult.retn [])

--- a/src/FsAutoComplete/CodeFixes/ConvertBangEqualsToInequality.fs
+++ b/src/FsAutoComplete/CodeFixes/ConvertBangEqualsToInequality.fs
@@ -18,7 +18,7 @@ let fix (getRangeText: GetRangeText): CodeFix =
         return [{ Title = "Use <> for inequality check"
                   File = codeActionParams.TextDocument
                   SourceDiagnostic = Some diag
-                  Kind = Fix
+                  Kind = FixKind.Fix
                   Edits = [| { Range = diag.Range
                                NewText = "<>" } |] }]
 

--- a/src/FsAutoComplete/CodeFixes/ConvertInvalidRecordToAnonRecord.fs
+++ b/src/FsAutoComplete/CodeFixes/ConvertInvalidRecordToAnonRecord.fs
@@ -40,7 +40,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
                          NewText = "|" }
                        { Range = endInsertRange
                          NewText = "|" } |]
-                  Kind = Refactor } ]
+                  Kind = FixKind.Refactor } ]
         | None -> return []
       }
       )

--- a/src/FsAutoComplete/CodeFixes/DoubleEqualsToSingleEquals.fs
+++ b/src/FsAutoComplete/CodeFixes/DoubleEqualsToSingleEquals.fs
@@ -23,7 +23,7 @@ let fix (getRangeText: GetRangeText) : CodeFix =
                   Edits =
                     [| { Range = diagnostic.Range
                          NewText = "=" } |]
-                  Kind = Fix } ]
+                  Kind = FixKind.Fix } ]
         | _ -> return []
       }
       )

--- a/src/FsAutoComplete/CodeFixes/ExternalSystemDiagnostics.fs
+++ b/src/FsAutoComplete/CodeFixes/ExternalSystemDiagnostics.fs
@@ -19,7 +19,7 @@ let private mapExternalDiagnostic diagnosticType =
                                  File = codeActionParams.TextDocument
                                  Title = $"Fix issue"
                                  Edits = fixes |> List.toArray
-                                 Kind = Fix } ]
+                                 Kind = FixKind.Fix } ]
 
           | _ -> AsyncResult.retn []
         )

--- a/src/FsAutoComplete/CodeFixes/GenerateAbstractClassStub.fs
+++ b/src/FsAutoComplete/CodeFixes/GenerateAbstractClassStub.fs
@@ -51,7 +51,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile)
                   Edits =
                     [| { Range = fcsPosToProtocolRange position
                          NewText = replaced } |]
-                  Kind = Fix } ]
+                  Kind = FixKind.Fix } ]
         | _ -> return []
       }
       )

--- a/src/FsAutoComplete/CodeFixes/GenerateInterfaceStub.fs
+++ b/src/FsAutoComplete/CodeFixes/GenerateInterfaceStub.fs
@@ -40,6 +40,4 @@ let fix (getParseResultsForFile: GetParseResultsForFile)
                        NewText = replaced } |]
                 Kind = FixKind.Fix } ]
       | _ -> return []
-
     }
-    |> AsyncResult.foldResult id (fun _ -> [])

--- a/src/FsAutoComplete/CodeFixes/GenerateInterfaceStub.fs
+++ b/src/FsAutoComplete/CodeFixes/GenerateInterfaceStub.fs
@@ -38,7 +38,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile)
                 Edits =
                   [| { Range = fcsPosToProtocolRange position
                        NewText = replaced } |]
-                Kind = Fix } ]
+                Kind = FixKind.Fix } ]
       | _ -> return []
 
     }

--- a/src/FsAutoComplete/CodeFixes/GenerateRecordStub.fs
+++ b/src/FsAutoComplete/CodeFixes/GenerateRecordStub.fs
@@ -39,4 +39,3 @@ let fix (getParseResultsForFile: GetParseResultsForFile)
                 Kind = FixKind.Fix } ]
       | _ -> return []
     }
-    |> AsyncResult.foldResult id (fun _ -> [])

--- a/src/FsAutoComplete/CodeFixes/GenerateRecordStub.fs
+++ b/src/FsAutoComplete/CodeFixes/GenerateRecordStub.fs
@@ -36,7 +36,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile)
                 Edits =
                   [| { Range = fcsPosToProtocolRange position
                        NewText = replaced } |]
-                Kind = Fix } ]
+                Kind = FixKind.Fix } ]
       | _ -> return []
     }
     |> AsyncResult.foldResult id (fun _ -> [])

--- a/src/FsAutoComplete/CodeFixes/GenerateUnionCases.fs
+++ b/src/FsAutoComplete/CodeFixes/GenerateUnionCases.fs
@@ -45,7 +45,7 @@ let fix (getFileLines: GetFileLines)
                   File = codeActionParams.TextDocument
                   Title = "Generate union pattern match cases"
                   Edits = [| { Range = range; NewText = replaced } |]
-                  Kind = Fix } ]
+                  Kind = FixKind.Fix } ]
 
           | _ -> return []
         }

--- a/src/FsAutoComplete/CodeFixes/MakeDeclarationMutable.fs
+++ b/src/FsAutoComplete/CodeFixes/MakeDeclarationMutable.fs
@@ -40,7 +40,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile)
                                  { Start = lspRange.Start
                                    End = lspRange.Start }
                                NewText = "mutable " } |]
-                        Kind = Refactor } ]
+                        Kind = FixKind.Refactor } ]
             | _ -> return []
         | None -> return []
       }

--- a/src/FsAutoComplete/CodeFixes/MakeOuterBindingRecursive.fs
+++ b/src/FsAutoComplete/CodeFixes/MakeOuterBindingRecursive.fs
@@ -34,7 +34,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getLineText: GetLineTe
           [ { Title = "Make outer binding recursive"
               File = codeActionParams.TextDocument
               SourceDiagnostic = Some diagnostic
-              Kind = Fix
+              Kind = FixKind.Fix
               Edits =
                 [| { Range =
                        { Start = lspOuterBindingRange.Start

--- a/src/FsAutoComplete/CodeFixes/MissingEquals.fs
+++ b/src/FsAutoComplete/CodeFixes/MissingEquals.fs
@@ -31,7 +31,7 @@ let fix (getFileLines: GetFileLines) =
                     Edits =
                       [| { Range = { Start = insertPos; End = insertPos }
                            NewText = " =" } |]
-                    Kind = Fix } ]
+                    Kind = FixKind.Fix } ]
           | None -> return []
         else
           return []

--- a/src/FsAutoComplete/CodeFixes/NegationToSubtraction.fs
+++ b/src/FsAutoComplete/CodeFixes/NegationToSubtraction.fs
@@ -27,7 +27,7 @@ let fix (getFileLines: GetFileLines): CodeFix =
                   Edits =
                     [| { Range = { Start = dash; End = inc lines dash }
                          NewText = "- " } |]
-                  Kind = Fix } ]
+                  Kind = FixKind.Fix } ]
         | None -> return []
       }
       )

--- a/src/FsAutoComplete/CodeFixes/NewWithDisposables.fs
+++ b/src/FsAutoComplete/CodeFixes/NewWithDisposables.fs
@@ -20,5 +20,5 @@ let fix (getRangeText: GetRangeText) =
                                Edits =
                                  [| { Range = diagnostic.Range
                                       NewText = $"new %s{errorText}" } |]
-                               Kind = Refactor } ]
+                               Kind = FixKind.Refactor } ]
       | Error _ -> AsyncResult.retn [])

--- a/src/FsAutoComplete/CodeFixes/ParenthesizeExpression.fs
+++ b/src/FsAutoComplete/CodeFixes/ParenthesizeExpression.fs
@@ -19,5 +19,5 @@ let fix (getRangeText: GetRangeText): CodeFix =
                                Edits =
                                  [| { Range = diagnostic.Range
                                       NewText = $"(%s{erroringExpression})" } |]
-                               Kind = Fix } ]
+                               Kind = FixKind.Fix } ]
       | Error _ -> AsyncResult.retn [])

--- a/src/FsAutoComplete/CodeFixes/RedundantQualifier.fs
+++ b/src/FsAutoComplete/CodeFixes/RedundantQualifier.fs
@@ -16,4 +16,4 @@ let fix =
                            File = codeActionParams.TextDocument
                            Title = "Remove redundant qualifier"
                            SourceDiagnostic = Some diagnostic
-                           Kind = Refactor } ])
+                           Kind = FixKind.Refactor } ])

--- a/src/FsAutoComplete/CodeFixes/RefCellAccessToNot.fs
+++ b/src/FsAutoComplete/CodeFixes/RefCellAccessToNot.fs
@@ -27,7 +27,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile): CodeFix =
                   Edits =
                     [| { Range = fcsRangeToLsp derefRange
                          NewText = "not " } |]
-                  Kind = Fix } ]
+                  Kind = FixKind.Fix } ]
         | None -> return []
       }
       )

--- a/src/FsAutoComplete/CodeFixes/RemoveUnnecessaryReturnOrYield.fs
+++ b/src/FsAutoComplete/CodeFixes/RemoveUnnecessaryReturnOrYield.fs
@@ -45,7 +45,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getLineText: GetLineTe
                   Edits =
                     [| { Range = diagnostic.Range
                          NewText = exprText } |]
-                  Kind = Refactor } ]
+                  Kind = FixKind.Refactor } ]
 
       }
       )

--- a/src/FsAutoComplete/CodeFixes/RemoveUnusedBinding.fs
+++ b/src/FsAutoComplete/CodeFixes/RemoveUnusedBinding.fs
@@ -64,5 +64,5 @@ let fix (getParseResults: GetParseResultsForFile): CodeFix =
                  Edits = [| { Range = replacementRange; NewText = "" } |]
                  File = codeActionParams.TextDocument
                  SourceDiagnostic = Some diagnostic
-                 Kind = Refactor } ]
+                 Kind = FixKind.Refactor } ]
     })

--- a/src/FsAutoComplete/CodeFixes/ReplaceBangWithValueFunction.fs
+++ b/src/FsAutoComplete/CodeFixes/ReplaceBangWithValueFunction.fs
@@ -24,7 +24,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getLineText: GetLineTe
         { Title = "Use `.Value` instead of dereference operator"
           File = codeActionParams.TextDocument
           SourceDiagnostic = None
-          Kind = Refactor
+          Kind = FixKind.Refactor
           Edits = [| { Range = protocolRange
                        NewText = replacementString } |] }
       ]

--- a/src/FsAutoComplete/CodeFixes/ReplaceBangWithValueFunction.fs
+++ b/src/FsAutoComplete/CodeFixes/ReplaceBangWithValueFunction.fs
@@ -29,4 +29,3 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getLineText: GetLineTe
                        NewText = replacementString } |] }
       ]
     }
-    |> AsyncResult.foldResult id (fun _ -> [])

--- a/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
+++ b/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
@@ -53,7 +53,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getNamespaceSuggestion
              NewText = qual } |]
       File = file
       Title = $"Use %s{qual}"
-      Kind = Fix }
+      Kind = FixKind.Fix }
 
   let openFix (text: ISourceText) file diagnostic (word: string) (ns, name: string, ctx, multiple): Fix =
     let insertPoint = adjustInsertionPoint text ctx
@@ -86,7 +86,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getNamespaceSuggestion
       File = file
       SourceDiagnostic = Some diagnostic
       Title = $"open %s{actualOpen}"
-      Kind = Fix }
+      Kind = FixKind.Fix }
 
   Run.ifDiagnosticByMessage
     "is not defined"

--- a/src/FsAutoComplete/CodeFixes/SuggestedIdentifier.fs
+++ b/src/FsAutoComplete/CodeFixes/SuggestedIdentifier.fs
@@ -27,6 +27,6 @@ let fix =
                Title = $"Replace with %s{suggestion}"
                File = codeActionParams.TextDocument
                SourceDiagnostic = Some diagnostic
-               Kind = Fix })
+               Kind = FixKind.Fix })
       |> Array.toList
       |> AsyncResult.retn)

--- a/src/FsAutoComplete/CodeFixes/UnusedOpens.fs
+++ b/src/FsAutoComplete/CodeFixes/UnusedOpens.fs
@@ -23,6 +23,6 @@ let fix : CodeFix =
           File = codeActionParams.TextDocument
           Title = "Remove unused open"
           SourceDiagnostic = Some d
-          Kind = Refactor }
+          Kind = FixKind.Refactor }
 
       AsyncResult.retn [ fix ])

--- a/src/FsAutoComplete/CodeFixes/UnusedValue.fs
+++ b/src/FsAutoComplete/CodeFixes/UnusedValue.fs
@@ -24,7 +24,7 @@ let fix (getRangeText: GetRangeText) =
                       Edits =
                         [| { Range = diagnostic.Range
                              NewText = "_" } |]
-                      Kind = Refactor } ]
+                      Kind = FixKind.Refactor } ]
             | None ->
                 let replaceSuggestion = "_"
                 let prefixSuggestion = $"_%s{unusedExpression}"
@@ -36,13 +36,13 @@ let fix (getRangeText: GetRangeText) =
                       Edits =
                         [| { Range = diagnostic.Range
                              NewText = replaceSuggestion } |]
-                      Kind = Refactor }
+                      Kind = FixKind.Refactor }
                     { SourceDiagnostic = Some diagnostic
                       File = codeActionParams.TextDocument
                       Title = "Prefix with _"
                       Edits =
                         [| { Range = diagnostic.Range
                              NewText = prefixSuggestion } |]
-                      Kind = Refactor } ]
+                      Kind = FixKind.Refactor } ]
         | Error _ -> return []
       })

--- a/src/FsAutoComplete/CodeFixes/UseSafeCastInsteadOfUnsafe.fs
+++ b/src/FsAutoComplete/CodeFixes/UseSafeCastInsteadOfUnsafe.fs
@@ -27,7 +27,7 @@ let fix (getRangeText: GetRangeText): CodeFix =
                                    Edits =
                                     [| { Range = diagnostic.Range
                                          NewText = expressionText.Replace(":?>", ":>") } |]
-                                   Kind = Refactor } ]
+                                   Kind = FixKind.Refactor } ]
           | false, true ->
               AsyncResult.retn [ { File = codeActionParams.TextDocument
                                    SourceDiagnostic = Some diagnostic
@@ -35,5 +35,5 @@ let fix (getRangeText: GetRangeText): CodeFix =
                                    Edits =
                                       [| { Range = diagnostic.Range
                                            NewText = expressionText.Replace("downcast", "upcast") } |]
-                                   Kind = Refactor } ]
+                                   Kind = FixKind.Refactor } ]
       | Error _ -> AsyncResult.retn [])

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -648,7 +648,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
             AddTypeToIndeterminateValue.fix tryGetParseResultsForFile tryGetProjectOptions
             ChangeTypeOfNameToNameOf.fix tryGetParseResultsForFile
             AddMissingInstanceMember.fix
-            AddExplicitTypeToParameter.fix
+            AddExplicitTypeToParameter.fix tryGetParseResultsForFile
           |]
 
 

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
@@ -294,7 +294,7 @@ let unusedValueTests state =
         Context = { Diagnostics = [| diagnostic |] }
     }
     match! server.TextDocumentCodeAction detected with
-    | Ok (Some (TextDocumentCodeActionResult.CodeActions [| ActReplace; ActPrefix "three" |])) -> ()
+    | Ok (Some (TextDocumentCodeActionResult.CodeActions [| ActReplace; ActPrefix "three"; _ (* explicit type annotation codefix *) |])) -> ()
     | Ok other ->
         failtestf $"Should have generated _, but instead generated %A{other}"
     | Error reason ->

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/ExplicitTypeAnnotations/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/ExplicitTypeAnnotations/Script.fsx
@@ -1,0 +1,5 @@
+type Foo =
+    { name: string }
+
+let name f =
+    f.name


### PR DESCRIPTION
Closes #806 

Ports over most of the implementation from upstream, but currently doesn't handle function-typed parameters at all due to missing fields on the FCS data types.