### PR TITLE
Improve detection and replacement logic for 'remove binding' codefix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,7 @@
             "enableStepFiltering": false,
             "args": [
               "--filter",
-              "lsp.Ionide WorkspaceLoader.Go to definition tests.GoTo Tests.Go-to-type-definition on first char of identifier"
+              "lsp.Ionide WorkspaceLoader.codefix tests.remove unused binding"
             ]
         },
         {

--- a/src/FsAutoComplete/CodeFixes/RemoveUnusedBinding.fs
+++ b/src/FsAutoComplete/CodeFixes/RemoveUnusedBinding.fs
@@ -16,28 +16,53 @@ let posBetween (range: Range) tester =
   Pos.posGeq tester range.Start // positions on this one are flipped to simulate Pos.posLte, because that doesn't exist
   && Pos.posGeq range.End tester
 
+type private ReplacmentRangeResult =
+| FullBinding of bindingRange: Range
+| Pattern of patternRange: Range
+
 type FSharpParseFileResults with
-  member this.TryRangeOfBindingWithHeadPatternWithPos pos =
+  member private this.TryRangeOfBindingWithHeadPatternWithPos (diagnosticRange: range) =
       this.ParseTree
       |> Option.bind (fun input ->
-        AstTraversal.Traverse(pos, input, { new AstTraversal.AstVisitorBase<_>() with
+        AstTraversal.Traverse(diagnosticRange.Start, input, { new AstTraversal.AstVisitorBase<_>() with
             member _.VisitExpr(_, _, defaultTraverse, expr) =
                 defaultTraverse expr
+            override _.VisitPat(defaultTraverse, pat: SynPat) =
+              // if the diagnostic was for this specific pattern in its entirety, then we're don
+              if Range.equals pat.Range diagnosticRange then Some (Pattern diagnosticRange)
+              else
+                match pat with
+                | SynPat.Paren (inner, m) ->
+                  // otherwise if the pattern inside a parens
+                  if Range.rangeContainsRange m diagnosticRange
+                  then
+                    // explicitly matches
+                    if Range.equals inner.Range diagnosticRange
+                    // then return the range of the parens, so the entire pattern gets removed
+                    then Some (Pattern m)
+                    else defaultTraverse inner
+                  else defaultTraverse inner
+                | pat -> defaultTraverse pat
 
             override _.VisitBinding(defaultTraverse, binding) =
                 match binding with
                 | SynBinding.Binding(_, SynBindingKind.NormalBinding, _, _, _, _, _, pat, _, _, _, _) as binding ->
-                    if posBetween binding.RangeOfHeadPat pos then
-                        Some binding.RangeOfBindingAndRhs
-                    else
-                        // Check if it's an operator
-                        match pat with
-                        | SynPat.LongIdent(LongIdentWithDots([id], _), _, _, _, _, _) when id.idText.StartsWith("op_") ->
-                            if posBetween id.idRange pos then
-                                Some binding.RangeOfBindingAndRhs
-                            else
-                                defaultTraverse binding
-                        | _ -> defaultTraverse binding
+                    // walk the patterns in the binding first, to allow the parameter traversal a chance to fire
+                    match defaultTraverse binding with
+                    | None ->
+                      // otherwise if the diagnostic was in this binding's head pattern then do teh replacement
+                      if Range.rangeContainsRange binding.RangeOfHeadPat diagnosticRange then
+                          Some (FullBinding binding.RangeOfBindingAndRhs)
+                      else
+                          // Check if it's an operator
+                          match pat with
+                          | SynPat.LongIdent(LongIdentWithDots([id], _), _, _, _, _, _) when id.idText.StartsWith("op_") ->
+                              if Range.rangeContainsRange id.idRange diagnosticRange then
+                                  Some (FullBinding binding.RangeOfBindingAndRhs)
+                              else
+                                  defaultTraverse binding
+                          | _ -> defaultTraverse binding
+                    | Some range -> Some range
                 | _ -> defaultTraverse binding })
       )
 
@@ -48,21 +73,36 @@ let fix (getParseResults: GetParseResultsForFile): CodeFix =
       let fileName = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
       let fcsRange = protocolRangeToRange (codeActionParams.TextDocument.GetFilePath()) diagnostic.Range
       let! tyres, line, lines = getParseResults fileName fcsRange.Start
-      let! rangeOfBinding = tyres.GetParseResults.TryRangeOfBindingWithHeadPatternWithPos(fcsRange.Start) |> Result.ofOption (fun () -> "no binding range found")
+      let! rangeOfBinding = tyres.GetParseResults.TryRangeOfBindingWithHeadPatternWithPos(fcsRange) |> Result.ofOption (fun () -> "no binding range found")
 
-      let protocolRange = fcsRangeToLsp rangeOfBinding
+      match rangeOfBinding with
+      | Pattern rangeOfPattern ->
+        let protocolRange = fcsRangeToLsp rangeOfPattern
 
-      // the pos at the end of the keyword
-      let! endOfPrecedingKeyword =
-        Navigation.walkBackUntilCondition lines (dec lines protocolRange.Start) (System.Char.IsWhiteSpace)
-        |> Result.ofOption (fun _ -> "failed to walk")
+        // the pos at the end of the previous token
+        let! endOfPrecedingToken =
+          Navigation.walkBackUntilCondition lines protocolRange.Start (System.Char.IsWhiteSpace >> not)
+          |> Result.ofOption (fun _ -> "failed to walk")
+        // replace from there to the end of the pattern's range
+        let replacementRange = { Start = endOfPrecedingToken; End = protocolRange.End }
+        return [ { Title = "Remove unused parameter"
+                   Edits = [| { Range = replacementRange; NewText = "" } |]
+                   File = codeActionParams.TextDocument
+                   SourceDiagnostic = Some diagnostic
+                   Kind = FixKind.Refactor } ]
+      | FullBinding bindingRangeWithPats ->
+        let protocolRange = fcsRangeToLsp bindingRangeWithPats
+        // the pos at the end of the previous keyword
+        let! endOfPrecedingKeyword =
+          Navigation.walkBackUntilCondition lines (dec lines protocolRange.Start) (System.Char.IsWhiteSpace >> not)
+          |> Result.ofOption (fun _ -> "failed to walk")
 
-      // walk back to the start of the keyword, which is always `let` or `use`
-      let keywordStartColumn = decMany lines endOfPrecedingKeyword 3
-      let replacementRange = { Start = keywordStartColumn; End = protocolRange.End }
-      return [ { Title = "Remove unused binding"
-                 Edits = [| { Range = replacementRange; NewText = "" } |]
-                 File = codeActionParams.TextDocument
-                 SourceDiagnostic = Some diagnostic
-                 Kind = FixKind.Refactor } ]
+        // walk back to the start of the keyword, which is always `let` or `use`
+        let keywordStartColumn = decMany lines endOfPrecedingKeyword 3
+        let replacementRange = { Start = keywordStartColumn; End = protocolRange.End }
+        return [ { Title = "Remove unused binding"
+                   Edits = [| { Range = replacementRange; NewText = "" } |]
+                   File = codeActionParams.TextDocument
+                   SourceDiagnostic = Some diagnostic
+                   Kind = FixKind.Refactor } ]
     })

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -614,7 +614,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
             Run.ifEnabled (fun _ -> config.ResolveNamespaces) (ResolveNamespace.fix tryGetParseResultsForFile commands.GetNamespaceSuggestions)
             SuggestedIdentifier.fix
             RedundantQualifier.fix
-            UnusedValue.fix getRangeText
+            Run.ifEnabled (fun _ -> config.UnusedDeclarationsAnalyzer) (UnusedValue.fix getRangeText)
             NewWithDisposables.fix getRangeText
             Run.ifEnabled (fun _ -> config.UnionCaseStubGeneration)
               (GenerateUnionCases.fix getFileLines tryGetParseResultsForFile commands.GetUnionPatternMatchCases getUnionCaseStubReplacements)

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -413,6 +413,10 @@ let fsacDiagnostics file =
   fileDiagnostics file
   >> diagnosticsFromSource "FSAC"
 
+let compilerDiagnostics file =
+  fileDiagnostics file
+  >> diagnosticsFromSource "F# Compiler"
+
 let diagnosticsToResult =
   Observable.map (function | [||] -> Ok () | diags -> Core.Error diags)
 
@@ -423,6 +427,11 @@ let waitForParseResultsForFile file =
 
 let waitForFsacDiagnosticsForFile file =
   fsacDiagnostics file
+  >> diagnosticsToResult
+  >> Async.AwaitObservable
+
+let waitForCompilerDiagnosticsForFile file =
+  compilerDiagnostics file
   >> diagnosticsToResult
   >> Async.AwaitObservable
 

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/RemoveUnusedBinding/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/RemoveUnusedBinding/Script.fsx
@@ -1,0 +1,7 @@
+let incr i x = 2
+
+let incr2 (i) = 2
+
+let container () =
+  let incr x = 2
+  ()


### PR DESCRIPTION
Closes #811 

The logic here is to dive into the SynPat of a Binding first to see if we can find a more specific pattern replacement instead of the entire binding.  If we can, then the replacement logic (tokens to look for, etc) is slightly different for an entire pattern, but structurally quite similar.

I added tests for several cases, and I do think this is a better way to go. We should consider upstreaming this as well.