### PR TITLE
fix lsp types to allow workspace/applyEdit to work

### DIFF
--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -26,9 +26,16 @@ type FcsRange = FSharp.Compiler.Text.Range
 module FcsPos = FSharp.Compiler.Text.Pos
 type FcsPos = FSharp.Compiler.Text.Pos
 
+module Result =
+  let ofCoreResponse (r: CoreResponse<'a>) =
+    match r with
+    | CoreResponse.Res a -> Ok a
+    | CoreResponse.ErrorRes msg
+    | CoreResponse.InfoRes msg -> Error (JsonRpc.Error.InternalErrorMessage msg)
+
 module AsyncResult =
   let ofCoreResponse (ar: Async<CoreResponse<'a>>) =
-    ar |> Async.map (function | CoreResponse.Res a -> Ok a | CoreResponse.ErrorRes msg | CoreResponse.InfoRes msg -> Error (JsonRpc.Error.InternalErrorMessage msg))
+    ar |> Async.map Result.ofCoreResponse
 
   let ofStringErr (ar: Async<Result<'a, string>>) =
     ar |> AsyncResult.mapError JsonRpc.Error.InternalErrorMessage

--- a/src/LanguageServerProtocol/LanguageServerProtocol.fs
+++ b/src/LanguageServerProtocol/LanguageServerProtocol.fs
@@ -226,6 +226,8 @@ module Types =
             /// (the server has not received an open notification before) the server can send
             /// `null` to indicate that the version is known and the content on disk is the
             /// truth (as speced with document content ownership)
+            /// Explicitly include the null value here.
+            [<JsonProperty(NullValueHandling = NullValueHandling.Include)>]
             Version: int option
         }
         interface ITextDocumentIdentifier with
@@ -321,10 +323,29 @@ module Types =
         DynamicRegistration: bool option
     }
 
+    type ResourceOperationKind = Create | Rename | Delete
+
+    type FailureHandlingKind = Abort | Transactional | Undo | TextOnlyTransactional
+
+    type ChangeAnnotationSupport = {
+      GroupsOnLabel: bool option
+    }
+
     /// Capabilities specific to `WorkspaceEdit`s
     type WorkspaceEditCapabilities = {
         /// The client supports versioned document changes in `WorkspaceEdit`s
         DocumentChanges: bool option
+        /// The resource operations the client supports. Clients should at least
+        /// support 'create', 'rename' and 'delete' files and folders.
+        ResourceOperations: ResourceOperationKind [] option
+        /// The failure handling strategy of a client if applying the workspace edit fails.
+        FailureHandling: FailureHandlingKind option
+        /// Whether the client normalizes line endings to the client specific setting.
+        /// If set to `true` the client will normalize line ending characters
+        /// in a workspace edit to the client specific new line character(s).
+        NormalizesLineEndings: bool option
+        /// Whether the client in general supports change annotations on text edits, create file, rename file and delete file changes.
+        ChangeAnnotationSupport: ChangeAnnotationSupport option
     }
 
     /// Specific capabilities for the `SymbolKind` in the `workspace/symbol` request.

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -160,7 +160,11 @@ let defaultConfigDto : FSharpConfigDto =
 let clientCaps : ClientCapabilities =
   let dynCaps : DynamicCapabilities = { DynamicRegistration = Some true}
   let workspaceCaps : WorkspaceClientCapabilities =
-    let weCaps : WorkspaceEditCapabilities = { DocumentChanges = Some true}
+    let weCaps : WorkspaceEditCapabilities = { DocumentChanges = Some true
+                                               ResourceOperations = None
+                                               FailureHandling = None
+                                               NormalizesLineEndings = None
+                                               ChangeAnnotationSupport = None }
     let symbolCaps: SymbolCapabilities = { DynamicRegistration = Some true
                                            SymbolKind = None}
     let semanticTokenCaps: SemanticTokensWorkspaceClientCapabilities = { RefreshSupport = Some true }


### PR DESCRIPTION
This adds explicit null value handling to the `Version` property of the `VersionedTextDocumentIdentififer` type, so that `workspace/applyEdit` works.

This endpoint, unlike many other endpoints, requires the property to be present and explicitly null if empty. Rust-analyzer had [the same issue](https://github.com/rust-analyzer/rust-analyzer/issues/6654#issuecomment-735980787).

I also took the opportunity to add some additional clientCapabilities based on the LSP spec.