### PR TITLE
do xml documentation generation inside the repo

### DIFF
--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -33,6 +33,17 @@ type FcsRange = FSharp.Compiler.Text.Range
 module FcsPos = FSharp.Compiler.Text.Position
 type FcsPos = FSharp.Compiler.Text.Position
 
+type OptionallyVersionedTextDocumentPositionParams =
+  {
+      /// The text document.
+      TextDocument: VersionedTextDocumentIdentifier
+      /// The position inside the text document.
+      Position: Ionide.LanguageServerProtocol.Types.Position
+  }
+  interface ITextDocumentPositionParams with
+      member this.TextDocument with get() = { Uri = this.TextDocument.Uri }
+      member this.Position with get() = this.Position
+
 module Result =
   let ofCoreResponse (r: CoreResponse<'a>) =
     match r with
@@ -2102,7 +2113,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
          |> success)
       |> async.Return)
 
-  member x.FSharpDocumentationGenerator(p: TextDocumentPositionParams) =
+  member x.FSharpDocumentationGenerator(p: OptionallyVersionedTextDocumentPositionParams) =
     logger.info (
       Log.setMessage "FSharpDocumentationGenerator Request: {parms}"
       >> Log.addContextDestructured "parms" p
@@ -2115,7 +2126,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
         Label = Some "Generate Xml Documentation"
         Edit = {
           DocumentChanges = Some [|
-            { TextDocument = { Uri = p.TextDocument.Uri; Version = None } //todo: can we verify version here?
+            { TextDocument = p.TextDocument
               Edits = [| { Range = fcsPosToProtocolRange insertPos; NewText = text } |] }
           |]
           Changes = None

--- a/test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
@@ -16,21 +16,8 @@
     <ProjectReference Include="..\FsAutoComplete.DependencyManager.Dummy\FsAutoComplete.DependencyManager.Dummy.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="TemplatesTests.fs" />
     <Compile Include="Helpers.fs" />
-    <Compile Include="CoreTests.fs" />
-    <Compile Include="ScriptTests.fs" />
-    <Compile Include="ExtensionsTests.fs" />
-    <Compile Include="InteractiveDirectivesTests.fs" />
-    <Compile Include="SignatureHelpTests.fs" />
-    <Compile Include="CodeFixTests.fs" />
-    <Compile Include="CompletionTests.fs" />
-    <Compile Include="RenameTests.fs" />
-    <Compile Include="GoToTests.fs" />
-    <Compile Include="FindReferencesTests.fs" />
-    <Compile Include="HighlightingTests.fs" />
-    <Compile Include="InfoPanelTests.fs" />
-    <Compile Include="DetectUnitTests.fs" />
+    <Compile Include="*Tests.fs" Exclude="Helpers.fs;Program.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -71,6 +71,7 @@ let tests =
         FindReferences.tests state
         InfoPanelTests.docFormattingTest state
         DetectUnitTests.tests state
+        XmlDocumentationGeneration.tests state
       ]
   ]
 

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/XmlDocGen/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/XmlDocGen/Script.fsx
@@ -1,0 +1,1 @@
+let add left right = left + right

--- a/test/FsAutoComplete.Tests.Lsp/XmlGenerationTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/XmlGenerationTests.fs
@@ -47,9 +47,9 @@ let tests state =
 
           let! result =
             server.FSharpDocumentationGenerator(
-              { TextDocument = { Uri = fileUri }
+              { TextDocument = { Uri = fileUri; Version = Some 1 }
                 // the start of the 'add' symbol name
-                Position = { Line = 0; Character = 5 } }: TextDocumentPositionParams
+                Position = { Line = 0; Character = 5 } }
             )
 
           match result with

--- a/test/FsAutoComplete.Tests.Lsp/XmlGenerationTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/XmlGenerationTests.fs
@@ -1,0 +1,71 @@
+module FsAutoComplete.Tests.XmlDocumentationGeneration
+
+open Expecto
+open Expecto.Tests
+open FsAutoComplete.Utils
+open FsToolkit.ErrorHandling
+open Helpers
+open Ionide.LanguageServerProtocol.Types
+open System.IO
+
+open type System.Environment
+
+let tests state =
+  let testPath = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "XmlDocGen")
+  let scriptPath = Path.Combine(testPath, "Script.fsx")
+
+  let server =
+    async {
+      let! (server, serverRequests) = serverInitialize testPath defaultConfigDto state
+      let tdop: DidOpenTextDocumentParams = { TextDocument = loadDocument scriptPath }
+
+      do! server.TextDocumentDidOpen tdop
+
+      match! waitForParseResultsForFile "Script.fsx" serverRequests with
+      | Ok () -> return server, scriptPath, serverRequests
+      | Error errors ->
+        let errorStrings =
+          errors
+          |> Array.map (fun e -> e.DebuggerDisplay)
+          |> String.concat "\n\t* "
+
+        return failtestf "Errors while parsing xml doc generation script:\n\t* %s" errorStrings
+    }
+    |> Async.Cache
+
+  testList
+    "xml doc comments"
+    [ testCaseAsync
+        "generate xml docs for function"
+        (async {
+          let! server, filePath, serverRequests = server
+          let fileUri = Path.FilePathToUri filePath
+
+          let! edits =
+            waitForEditsForFile filePath serverRequests
+            |> Async.StartChild
+
+          let! result =
+            server.FSharpDocumentationGenerator(
+              { TextDocument = { Uri = fileUri }
+                // the start of the 'add' symbol name
+                Position = { Line = 0; Character = 5 } }: TextDocumentPositionParams
+            )
+
+          match result with
+          | Error e -> failtestf "Couldn't generate xml docs: %A" e
+          | Ok () -> ()
+
+          let! edits = edits
+
+          let expectedXml =
+            $"""/// <summary></summary>{NewLine}/// <param name="left"></param>{NewLine}/// <param name="right"></param>{NewLine}/// <returns></returns>{NewLine}"""
+
+          let expectedEdits: TextEdit [] =
+            [| { Range =
+                   { Start = { Line = 0; Character = 0 }
+                     End = { Line = 0; Character = 0 } }
+                 NewText = expectedXml } |]
+
+          Expect.equal edits expectedEdits "Should have generated the xml docs at the start position"
+        }) ]


### PR DESCRIPTION
This internalizes the generation of the XML documentation for a value by using the newly-fixed `workspace/applyEdit` command. This makes the endpoint easier to use from non-ionide editors!  The payload has a slight tweak to add an optional version (for concurrency), but this now returns unit on success.

This is technically a breaking change for ionide, but a very simple one. We should get an ionide PR up with this change before merging this work, and I'll do just that tomorrow.  Once this is merged + release we could notify @cannorin to see if ionide-vim would care for this feature.
