### PR TITLE
roll forward to latest major if present

### DIFF
--- a/src/FsAutoComplete.BackgroundServices/FsAutoComplete.BackgroundServices.fsproj
+++ b/src/FsAutoComplete.BackgroundServices/FsAutoComplete.BackgroundServices.fsproj
@@ -6,6 +6,7 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
     <IsPackable>false</IsPackable>
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\LanguageServerProtocol\LanguageServerProtocol.fsproj">

--- a/src/FsAutoComplete.BackgroundServices/runtimeconfig.template.json
+++ b/src/FsAutoComplete.BackgroundServices/runtimeconfig.template.json
@@ -1,3 +1,0 @@
-{
-    "rollForwardOnNoCandidateFx": 2
-}

--- a/src/FsAutoComplete/FsAutoComplete.fsproj
+++ b/src/FsAutoComplete/FsAutoComplete.fsproj
@@ -13,6 +13,10 @@
     <PackageIcon>logo.png</PackageIcon>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <Authors>FsAutoComplete contributors</Authors>
+    <!-- This rollforward enables us to actually run on the .net 6 runtime without
+         retargeting the whole app, minimizing packaged binary size. -->
+    <RollForward>LatestMajor</RollForward>
+
   </PropertyGroup>
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="\"/>
@@ -40,9 +44,6 @@
     <AssemblyName>dotnet-fsautocomplete</AssemblyName>
     <PackageId>fsautocomplete</PackageId>
     <PackageType>DotnetTool</PackageType>
-    <!-- This rollforward enables us to actually run on the .net 6 runtime without
-         retargeting the whole app, minimizing packaged binary size. -->
-    <RollForward>Major</RollForward>
     <!-- workaround for not being able to have p2p dependencies in tool output dir https://github.com/nuget/home/issues/3891#issuecomment-377319939 -->
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>

--- a/src/FsAutoComplete/runtimeconfig.template.json
+++ b/src/FsAutoComplete/runtimeconfig.template.json
@@ -1,3 +1,0 @@
-{
-    "rollForward": "major"
-}


### PR DESCRIPTION
Changes the rollforward policy from `major` to `latest major`.  The difference is that `major` only rolls forward is the desired TFM is not found, while `latest major` rolls forward as long as there's a stable newer major available.

This can be further expanded upon by setting the `DOTNET_ROLL_FORWARD_TO_PRERELEASE=1` env variable, which allows prerelease versions to be taken into consideration.

I'm not sure we want to take this, but knowing about this rollforward flag gives us another option. 