### PR TITLE
Fix template list parsing on non-English systems

### DIFF
--- a/src/FsAutoComplete.Core/DotnetNewTemplate.fs
+++ b/src/FsAutoComplete.Core/DotnetNewTemplate.fs
@@ -36,6 +36,7 @@ module DotnetNewTemplate =
       si.UseShellExecute <- false
       si.RedirectStandardOutput <- true
       si.WorkingDirectory <- Environment.CurrentDirectory
+      si.EnvironmentVariables.["DOTNET_CLI_UI_LANGUAGE"] <- "en-us"
       let proc = System.Diagnostics.Process.Start(si)
       let mutable output = ""
       while not proc.StandardOutput.EndOfStream do

--- a/test/FsAutoComplete.Tests.Lsp/TemplatesTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TemplatesTests.fs
@@ -2,11 +2,24 @@ module FsAutoComplete.Tests.Templates
 
 open Expecto
 
+let withEnvironmentVariable (variable: string) (value: string) (f: unit -> unit) =
+  let priorValue = System.Environment.GetEnvironmentVariable variable
+  System.Environment.SetEnvironmentVariable(variable, value)
+  try
+    f ()
+  finally
+    // if the env variable was inexistant before, priorValue is null and the call will delete the variable
+    System.Environment.SetEnvironmentVariable(variable, priorValue)
+
 let tests() =
   testList "Templates Tests" [
     testCase "Templates are not empty" <| fun () ->
       FsAutoComplete.DotnetNewTemplate.installedTemplates()
       |> Expect.isNonEmpty <| "Templates are empty"
+    testCase "Listing doesn't fail when DOTNET_CLI_UI_LANGUAGE is set by the user" <| fun () ->
+      withEnvironmentVariable "DOTNET_CLI_UI_LANGUAGE" "fr-fr" <| fun () ->
+        FsAutoComplete.DotnetNewTemplate.installedTemplates()
+        |> Expect.isNonEmpty <| "Parsing failed"
     testCase "Detailed templates are not empty" <| fun () ->
       FsAutoComplete.DotnetNewTemplate.templateDetails()
       |> Expect.isNonEmpty <| "Detailed templates are empty"


### PR DESCRIPTION
To list the available templates, FSAC parses directly the output of `dotnet new --list`, looking for predefined English words. But if the configured display language / locale of the system is another language (e.g. French or German), this parsing fails and generates an out-of-bounds exception.

This commit takes the simplest route to fix the problem: forcing `dotnet` to print its output in English by setting a documented environment variable[1].

Fixes ionide/ionide-vscode-fsharp#1569

[1] https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_cli_ui_language