### PR TITLE
initial stab at completion context for string literals

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0.301",
+        "version": "5.0.100",
         "rollForward": "major"
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0.100",
+        "version": "5.0.301",
         "rollForward": "major"
     }
 }

--- a/src/FsAutoComplete.Core/UntypedAstUtils.fs
+++ b/src/FsAutoComplete.Core/UntypedAstUtils.fs
@@ -1895,19 +1895,20 @@ module Completion =
       { new SourceCodeServices.AstTraversal.AstVisitorBase<Context>() with
 
         member x.VisitExpr(path, traverseExpr, defaultTraverse, expr): Context option =
-          match expr with
-          | SynExpr.InterpolatedString (parts, m) ->
-            if Range.rangeContainsPos m pos
-            then
-              parts
-              |> List.tryPick (
-                function | SynInterpolatedStringPart.String(s, m) when Range.rangeContainsPos m pos -> Some Context.StringLiteral
-                         | SynInterpolatedStringPart.String _ -> None
-                         | SynInterpolatedStringPart.FillExpr(e, _) when Range.rangeContainsPos e.Range pos -> traverseExpr e
-                         | SynInterpolatedStringPart.FillExpr _ -> None
-              )
-            else None
-          | _ ->  None
+          if Range.rangeContainsPos expr.Range pos
+          then
+              match expr with
+              | SynExpr.Const(SynConst.String _, _) -> Some Context.StringLiteral
+              | SynExpr.InterpolatedString (parts, _) ->
+                parts
+                |> List.tryPick (
+                  function | SynInterpolatedStringPart.String(s, m) when Range.rangeContainsPos m pos -> Some Context.StringLiteral
+                           | SynInterpolatedStringPart.String _ -> None
+                           | SynInterpolatedStringPart.FillExpr(e, _) when Range.rangeContainsPos e.Range pos -> defaultTraverse e // gotta dive into the expr to see if we're in a literal inside the expr
+                           | SynInterpolatedStringPart.FillExpr _ -> None
+                )
+              | _ -> defaultTraverse expr
+          else None
       }
     FSharp.Compiler.SourceCodeServices.AstTraversal.Traverse(pos, ast, visitor)
     |> Option.defaultValue Context.Unknown

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -950,7 +950,9 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
                 | CoreResponse.InfoRes msg | CoreResponse.ErrorRes msg ->
                     LspResult.internalError msg
                     |> async.Return
-                | CoreResponse.Res(tip, signature, footer, typeDoc) ->
+                | CoreResponse.Res None ->
+                  async.Return (success None)
+                | CoreResponse.Res(Some(tip, signature, footer, typeDoc)) ->
                     let formatCommentStyle =
                         if config.TooltipMode = "full" then
                             TipFormatter.FormatCommentStyle.FullEnhanced

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -872,7 +872,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
                 return! success (Some completionList)
             | _ ->
               logger.info (Log.setMessage "TextDocumentCompletion - no completion results")
-              return! success (Some { IsIncomplete = true; Items = [||] })
+              return! success (Some { IsIncomplete = false; Items = [||] })
       }
 
     override __.CompletionItemResolve(ci: CompletionItem) = async {


### PR DESCRIPTION
This is an initial attempt at satisfying https://github.com/ionide/ionide-vscode-fsharp/issues/1575.

The idea is to use the parsetree to determine if we're inside a literal (either actual string literal or a string portion of an interpolated string) and if so short-circuit and return no completion entries (or no hover text as appropriate).  This seems to allow the other extension to take over easily enough.