### PR TITLE
file add - create subdirectories if missing

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -649,7 +649,7 @@ type Commands
         let dir = Path.GetDirectoryName fsprojPath
         let virtPathDir = Path.GetDirectoryName fileVirtPath
 
-        newFileName |> filePathContents |> createDirectoryIfMissing dir
+        newFileName |> Path.GetDirectoryName |> createDirectoryIfMissing dir
 
         let newFilePath =
           Path.Combine(dir, virtPathDir, newFileName)
@@ -670,7 +670,7 @@ type Commands
         let dir = Path.GetDirectoryName fsprojPath
         let virtPathDir = Path.GetDirectoryName fileVirtPath
 
-        newFileName |> filePathContents |> createDirectoryIfMissing dir
+        newFileName |> Path.GetDirectoryName |> createDirectoryIfMissing dir
 
         let newFilePath =
           Path.Combine(dir, virtPathDir, newFileName)
@@ -691,7 +691,7 @@ type Commands
         let dir = Path.GetDirectoryName fsprojPath
         let newFilePath = Path.Combine(dir, fileVirtPath)
 
-        fileVirtPath |> filePathContents |> createDirectoryIfMissing dir
+        fileVirtPath |> Path.GetDirectoryName |> createDirectoryIfMissing dir
 
         (File.Open(newFilePath, FileMode.OpenOrCreate))
           .Close()

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -649,6 +649,8 @@ type Commands
         let dir = Path.GetDirectoryName fsprojPath
         let virtPathDir = Path.GetDirectoryName fileVirtPath
 
+        newFileName |> filePathContents |> createDirectoryIfMissing dir
+
         let newFilePath =
           Path.Combine(dir, virtPathDir, newFileName)
 
@@ -668,6 +670,8 @@ type Commands
         let dir = Path.GetDirectoryName fsprojPath
         let virtPathDir = Path.GetDirectoryName fileVirtPath
 
+        newFileName |> filePathContents |> createDirectoryIfMissing dir
+
         let newFilePath =
           Path.Combine(dir, virtPathDir, newFileName)
 
@@ -686,6 +690,8 @@ type Commands
       try
         let dir = Path.GetDirectoryName fsprojPath
         let newFilePath = Path.Combine(dir, fileVirtPath)
+
+        fileVirtPath |> filePathContents |> createDirectoryIfMissing dir
 
         (File.Open(newFilePath, FileMode.OpenOrCreate))
           .Close()

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -648,8 +648,9 @@ type Commands
       try
         let dir = Path.GetDirectoryName fsprojPath
         let virtPathDir = Path.GetDirectoryName fileVirtPath
+        let newDir = Path.Combine(dir, virtPathDir)
 
-        newFileName |> Path.GetDirectoryName |> createDirectoryIfMissing dir
+        newFileName |> Path.GetDirectoryName |> createDirectoryIfMissing newDir
 
         let newFilePath =
           Path.Combine(dir, virtPathDir, newFileName)
@@ -669,8 +670,9 @@ type Commands
       try
         let dir = Path.GetDirectoryName fsprojPath
         let virtPathDir = Path.GetDirectoryName fileVirtPath
+        let newDir = Path.Combine(dir, virtPathDir)
 
-        newFileName |> Path.GetDirectoryName |> createDirectoryIfMissing dir
+        newFileName |> Path.GetDirectoryName |> createDirectoryIfMissing newDir
 
         let newFilePath =
           Path.Combine(dir, virtPathDir, newFileName)

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -737,23 +737,8 @@ type Debounce<'a>(timeout, fn) =
   /// Calls the function, after debouncing has been applied.
   member __.Bounce(arg) = mailbox.Post(arg)
 
-let filePathContents (path: string) =
-    Path.GetDirectoryName(path)
-        .Split(Path.DirectorySeparatorChar, System.StringSplitOptions.RemoveEmptyEntries)
-    |> Array.toList
+let createDirectoryIfMissing projPath dir =
+    let dir' = Path.Combine(projPath, dir)
+    if not <| Directory.Exists dir' then
+        Directory.CreateDirectory dir' |> ignore
 
-let createDirectoryIfMissing projPath dirs =
-    let rec create dirs =
-        match dirs with
-        | [] -> ()
-        | dir :: dirs ->
-            let dir' = Path.Combine(projPath, dir)
-            if not <| Directory.Exists dir' then
-                Directory.CreateDirectory dir' |> ignore
-            if List.isEmpty dirs then ()
-            else
-                let next = Path.Combine(dir, List.head dirs)
-                let rest = List.tail dirs
-                if List.isEmpty rest then create [ next ]
-                else create (next::rest)
-    create dirs

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -736,3 +736,24 @@ type Debounce<'a>(timeout, fn) =
 
   /// Calls the function, after debouncing has been applied.
   member __.Bounce(arg) = mailbox.Post(arg)
+
+let filePathContents (path: string) =
+    Path.GetDirectoryName(path)
+        .Split(Path.DirectorySeparatorChar, System.StringSplitOptions.RemoveEmptyEntries)
+    |> Array.toList
+
+let createDirectoryIfMissing projPath dirs =
+    let rec create dirs =
+        match dirs with
+        | [] -> ()
+        | dir :: dirs ->
+            let dir' = Path.Combine(projPath, dir)
+            if not <| Directory.Exists dir' then
+                Directory.CreateDirectory dir' |> ignore
+            if List.isEmpty dirs then ()
+            else
+                let next = Path.Combine(dir, List.head dirs)
+                let rest = List.tail dirs
+                if List.isEmpty rest then create [ next ]
+                else create (next::rest)
+    create dirs


### PR DESCRIPTION
https://github.com/ionide/ionide-vscode-fsharp/issues/1640

I wasn't sure where to add functions (Utils.fs, FileSystem.fs ...)

There is still at least one bug: trying to add **subdir/file.fs** above or below a file that's already in a subdirectory. Seems to work well from the project root, though.