### PR TITLE
Fix dependent file checking for scripts and files in the same project

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -23,7 +23,6 @@ type FSharpCompilerServiceChecker(backgroundServiceEnabled, hasAnalyzers) =
       enableBackgroundItemKeyStoreAndSemanticClassification = true
     )
 
-  do checker.BeforeBackgroundFileCheck.Add ignore
 
   // we only want to let people hook onto the underlying checker event if there's not a background service actually compiling things for us
   let safeFileCheckedEvent =

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -665,28 +665,23 @@ type ParseAndCheckResults
 
   member __.GetAllEntities(publicOnly: bool) : AssemblySymbol list =
     try
-      let res =
-        [ yield!
-            AssemblyContent.GetAssemblySignatureContent
-              AssemblyContentType.Full
-              checkResults.PartialAssemblySignature
-          let ctx = checkResults.ProjectContext
+      [ yield!
+          AssemblyContent.GetAssemblySignatureContent
+            AssemblyContentType.Full
+            checkResults.PartialAssemblySignature
+        let ctx = checkResults.ProjectContext
 
-          let assembliesByFileName =
-            ctx.GetReferencedAssemblies()
-            |> List.groupBy (fun asm -> asm.FileName)
-            |> List.rev // if mscorlib.dll is the first then FSC raises exception when we try to
-          // get Content.Entities from it.
+        let assembliesByFileName =
+          ctx.GetReferencedAssemblies()
+          |> List.groupBy (fun asm -> asm.FileName)
+          |> List.rev // if mscorlib.dll is the first then FSC raises exception when we try to
+        // get Content.Entities from it.
 
-          for fileName, signatures in assembliesByFileName do
-            let contentType = if publicOnly then AssemblyContentType.Public else AssemblyContentType.Full
+        let contentType = if publicOnly then AssemblyContentType.Public else AssemblyContentType.Full
+        for fileName, signatures in assembliesByFileName do
+            yield! AssemblyContent.GetAssemblyContent entityCache.Locking contentType fileName signatures
 
-            let content =
-              AssemblyContent.GetAssemblyContent entityCache.Locking contentType fileName signatures
-
-            yield! content ]
-
-      res
+        ]
     with
     | _ -> []
 

--- a/src/FsAutoComplete.Core/State.fs
+++ b/src/FsAutoComplete.Core/State.fs
@@ -20,7 +20,7 @@ type State =
     Files : ConcurrentDictionary<string<LocalPath>, VolatileFile>
     LastCheckedVersion: ConcurrentDictionary<string<LocalPath>, int>
     ProjectController: ProjectController
-
+    ProjectDerivedInformation: ConcurrentDictionary<string<LocalPath>, ProjectResult>
     HelpText : ConcurrentDictionary<DeclName, ToolTipText>
     Declarations: ConcurrentDictionary<DeclName, DeclarationListItem * Position * string<LocalPath>>
     CompletionNamespaceInsert : ConcurrentDictionary<DeclName, CompletionNamespaceInsert>
@@ -46,7 +46,8 @@ type State =
       CancellationTokens = ConcurrentDictionary()
       NavigationDeclarations = ConcurrentDictionary()
       ScriptProjectOptions = ConcurrentDictionary()
-      ColorizationOutput = false }
+      ColorizationOutput = false
+      ProjectDerivedInformation = ConcurrentDictionary() }
 
   member x.RefreshCheckerOptions(file: string<LocalPath>, text: ISourceText) : FSharpProjectOptions option =
     x.ProjectController.GetProjectOptions (UMX.untag file)


### PR DESCRIPTION
Part of https://github.com/ionide/ionide-vscode-fsharp/issues/1652

This changes the `Parse` command to trigger re-checking of dependent files when a file is checked.  It also unifies a bit of code duplication around the built-in analyzers that run when a file is checked. It _does not_ tackle project-to-project live updates, because that requires implemented `tryGetMetadataReader` with an appropriate implementation, which we haven't worked through at this time.