### PR TITLE
[WIP] Add semantic highlighting modifiers based on symbol declaration location

### DIFF
--- a/src/FsAutoComplete.Core/DeclarationLocationClassifier.fs
+++ b/src/FsAutoComplete.Core/DeclarationLocationClassifier.fs
@@ -1,0 +1,31 @@
+namespace FsAutoComplete
+
+open FsAutoComplete
+open FSharp.Compiler.Symbols
+open FSharp.Compiler.CodeAnalysis
+open System.Collections.Generic
+
+module DeclarationLocationClassifier =
+    type DeclarationLocation =
+        | Unknown
+        | Local
+        | ProjectReference
+        | FSharpCore
+        | External
+
+    let getDeclarationLocationClassification (symbolsUses: FSharpSymbolUse seq) =
+        symbolsUses
+        |> Seq.map (fun n ->
+            if n.IsPrivateToFile then
+                n.Range, Local
+            elif n.Symbol.IsInternalToProject then
+                n.Range, Local
+            elif n.Symbol.Assembly.SimpleName = "FSharp.Core" then
+                n.Range, FSharpCore
+            else
+                //TODO: Make ProjectReference vs External vs Local [in case of public symbols] decision
+                //based on the assembly name or something
+                n.Range, External
+            )
+
+

--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -25,6 +25,7 @@
     <Compile Include="FileSystem.fs" />
     <Compile Include="KeywordList.fs" />
     <Compile Include="UnusedDeclarationsAnalyzer.fs" />
+    <Compile Include="DeclarationLocationClassifier.fs" />
     <Compile Include="Decompiler.fs" />
     <Compile Include="Sourcelink.fs" />
     <!-- <Compile Include="FakeSupport.fs" /> -->

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -155,7 +155,8 @@ let defaultConfigDto : FSharpConfigDto =
     GenerateBinlog = Some true
     AbstractClassStubGeneration = None
     AbstractClassStubGenerationMethodBody = None
-    AbstractClassStubGenerationObjectIdentifier = None }
+    AbstractClassStubGenerationObjectIdentifier = None
+    DeclarationLocationClassification = Some true }
 
 let clientCaps : ClientCapabilities =
   let dynCaps : DynamicCapabilities = { DynamicRegistration = Some true}


### PR DESCRIPTION
Requires bunch of more work which I'm not sure I'm bothered enough to do:
- [ ] Write actual classifier rather than proof of concept I've done (TODO in `DeclarationLocationClassifier.fs` file)
- [ ] Disable feature by default (TODO in `LspHelpers.fs` file)
- [ ] Support setting multiple declaration locations qualifiers at the same time (something may be external and FSharpCore at the same time, we can send both modifiers to the client so users have control over how they want it displayed)

Example usage - symbols coming from FSharpCore are underlined:
<img width="825" alt="Screenshot 2022-01-13 230953" src="https://user-images.githubusercontent.com/5427083/149418340-d0608b8d-3332-4e19-9c8c-8b947cca0784.png">
