### PR TITLE
Fix: Occasionally `publishDiagnostics` is not sent

### DIFF
--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -111,6 +111,8 @@ type DiagnosticMessage =
 
 /// a type that handles bookkeeping for sending file diagnostics.  It will debounce calls and handle sending diagnostics via the configured function when safe
 type DiagnosticCollection(sendDiagnostics: DocumentUri -> Diagnostic [] -> Async<unit>) =
+  let logger = LogProvider.getLoggerByName "DiagnosticCollection"
+
   let send uri (diags: Map<string, Diagnostic []>) =
     Map.toArray diags
     |> Array.collect snd
@@ -147,10 +149,12 @@ type DiagnosticCollection(sendDiagnostics: DocumentUri -> Diagnostic [] -> Async
             async {
               match! inbox.Receive() with
               | Add (source, diags) ->
+                logger.info (Log.setMessage "-> Add({source})" >> Log.addContext "source" source)
                 let newState = state |> Map.add source diags
                 do! send uri newState
                 return! loop newState
               | Clear source ->
+                logger.info (Log.setMessage "-> Clear({source})" >> Log.addContext "source" source)
                 let newState = state |> Map.remove source
                 do! send uri newState
                 return! loop newState
@@ -171,6 +175,7 @@ type DiagnosticCollection(sendDiagnostics: DocumentUri -> Diagnostic [] -> Async
     mailbox
 
   and getOrAddAgent fileUri =
+    logger.info (Log.setMessage ":: getOrAdd({uri})" >> Log.addContext "uri" (UMX.untag fileUri))
     match agents.TryGetValue fileUri with
     | true, mailbox -> mailbox
     | false, _ ->
@@ -182,7 +187,9 @@ type DiagnosticCollection(sendDiagnostics: DocumentUri -> Diagnostic [] -> Async
         mailbox)
 
   member x.SetFor(fileUri: DocumentUri, kind: string, values: Diagnostic []) =
+    logger.info (Log.setMessage ">> setFor({kind}, {uri})" >> Log.addContext "kind" kind >> Log.addContext "uri" (UMX.untag fileUri))
     let mailbox = getOrAddAgent fileUri
+    logger.info (Log.setMessage "<< mailbox({kind}, {uri})" >> Log.addContext "kind" kind >> Log.addContext "uri" (UMX.untag fileUri))
 
     match values with
     | [||] -> mailbox.Post(Clear kind)

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -482,7 +482,12 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
 
           diagnosticCollections.SetFor(uri, "F# Analyzers", diags)
     with
-    | _ -> ()
+    | ex ->
+        logger.error (
+          Log.setMessage "Exception while handling command event {evt}: {ex}"
+          >> Log.addContextDestructured "evt" n
+          >> Log.addContext "ex" ex.Message
+        )
 
   /// centralize any state changes when the config is updated here
   let updateConfig (newConfig: FSharpConfig) =

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -62,69 +62,6 @@ let initTests state =
       failtest "Initialization failed"
   })
 
-let diagnosticsTests state =
-  testSequenced <| testList "diagnostics tests" [
-    let server =
-      async {
-        let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "Empty")
-        let config =
-          { defaultConfigDto with
-              UnusedOpensAnalyzer = Some true
-              UnusedDeclarationsAnalyzer = Some true
-              SimplifyNameAnalyzer = Some true
-          }
-        let! (server, events) = serverInitialize path config state
-        return (server, events, path)
-      }
-      |> Async.Cache
-
-    for i in 1..100 do
-      testCaseAsync $"can get all publishDiagnostics events {i}" <| async {
-        let logger = Expecto.Logging.Log.create $"diags tests {i}"
-
-        let! (server, events, _) = server
-        let uri = $"untitled:Untitled-{i}"
-        logger.info (eventX "Creating `{uri}`" >> setField "uri" uri)
-        // source doesn't really matter
-        let source = """
-  open System                   // unused open
-  open System.Diagnostics
-
-  let a = 42                    // unused decl
-  let b = 5
-
-  let f (v: System.String) = v  // simplify name
-        """
-        let tdop : DidOpenTextDocumentParams = {
-          TextDocument = {
-            Uri = uri
-            LanguageId = "fsharp"
-            Version = 0
-            Text = source
-          }
-        }
-
-        do! server.TextDocumentDidOpen tdop
-        // there should be 4 `textDocument/publishDiagnostics` events:
-        //   one for F# Compiler, one for each of the three (enabled) built-in analyzers
-        let! _ =
-          events
-          |> fileDiagnostics uri
-          |> Observable.take 4
-          |> Observable.last
-          |> Observable.timeoutSpan (TimeSpan.FromSeconds 3.0)
-          |> Async.AwaitObservable
-
-        let tdcp : DidCloseTextDocumentParams = {
-          TextDocument = {
-            Uri = uri
-          }
-        }
-        do! server.TextDocumentDidClose tdcp
-        ()
-      }
-  ]
-
 ///Tests for getting and resolving code(line) lenses with enabled reference code lenses
 let codeLensTest state =
   let server =

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -41,6 +41,7 @@ let tests =
         Templates.tests()
         let state = FsAutoComplete.State.Initial toolsPath workspaceLoaderFactory
         initTests state
+        diagnosticsTests state
         codeLensTest state
         documentSymbolTest state
         Completion.autocompleteTest state

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -41,7 +41,6 @@ let tests =
         Templates.tests()
         let state = FsAutoComplete.State.Initial toolsPath workspaceLoaderFactory
         initTests state
-        diagnosticsTests state
         codeLensTest state
         documentSymbolTest state
         Completion.autocompleteTest state


### PR DESCRIPTION
tl;dr: There's a lock issue in [`DiagnosticCollection`](https://github.com/fsharp/FsAutoComplete/blob/c9d481fca37f3a3c8c9c65c582dd30bca9c25ec6/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L174-L182) which results in an ignored exception (-> event `textDocument/publishDiagnostics` doesn't get sent)

### Description

(slightly verbose because I used this (at least to some extend) to structure my findings and detect where to look next)
<br/>

LSP-Event `textDocument/publishDiagnostics` is used to send Diagnostics. But sometimes it doesn't get sent when it should be.  
<br/>

In FSAC `publishDiagnostics` gets send after: [F# parsing](https://github.com/fsharp/FsAutoComplete/blob/c9d481fca37f3a3c8c9c65c582dd30bca9c25ec6/src/FsAutoComplete.Core/Commands.fs#L282-L295), after each [built-in Analyzer](https://github.com/fsharp/FsAutoComplete/blob/c9d481fca37f3a3c8c9c65c582dd30bca9c25ec6/src/FsAutoComplete.Core/Commands.fs#L1344-L1399), after [Custom Analyzers](https://github.com/fsharp/FsAutoComplete/blob/c9d481fca37f3a3c8c9c65c582dd30bca9c25ec6/src/FsAutoComplete.Core/Commands.fs#L317-L330) and (currently uncommented) after [Linting](https://github.com/fsharp/FsAutoComplete/blob/c9d481fca37f3a3c8c9c65c582dd30bca9c25ec6/src/FsAutoComplete.Core/Commands.fs#L1100-L1101).

When all three built-in analyzers (UnusedOpensAnalyzer, UnusedDeclarationsAnalyzer, SimplifyNameAnalyzer) are enabled, `publishDiagnostics` should occur four times: once for F# Compiler, and once for each Analyzer. (Sending happens in [`FsAutoComplete.Lsp.fs::DiagnosticCollection`](https://github.com/fsharp/FsAutoComplete/blob/c9d481fca37f3a3c8c9c65c582dd30bca9c25ec6/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L144-L157))


But occasionally an event doesn't get sent.  
It's not deterministic -> no simple test to reproduce error.

But by running a test quite often it's likely the failure emerges (at least on my PC):
* Checkout 3rd commit of this PR (4c79775ab37f561d43bbfc9f1452962ca62aca01)
* run 
  ```shell
  dotnet run --project ./test/FsAutoComplete.Tests.Lsp -- --filter "lsp.Ionide WorkspaceLoader.diagnostics tests" --exclude-from-log=Checker,CheckerEvents,Commands,Opts,Analyzers,LSP
  ```
* Quite likely (at least on my PC) at least one test will fail (if not: run again until a test fails...)

The [tests](https://github.com/Booksbaum/FsAutoComplete/blob/4c79775ab37f561d43bbfc9f1452962ca62aca01/test/FsAutoComplete.Tests.Lsp/CoreTests.fs#L65-L126) are all the same -- it just gets execute quite often (100 times).  
The [test](https://github.com/Booksbaum/FsAutoComplete/blob/4c79775ab37f561d43bbfc9f1452962ca62aca01/test/FsAutoComplete.Tests.Lsp/CoreTests.fs#L82-L125) itself is quite simple: (shortened)
```fsharp 
let tdop : DidOpenTextDocumentParams = {
  TextDocument = {
    Uri = $"untitled:Untitled-{i}"
    LanguageId = "fsharp"
    Version = 0
    Text = source
  }
}
do! server.TextDocumentDidOpen tdop
// there should be 4 `textDocument/publishDiagnostics` events:
//   one for F# Compiler, one for each of the three (enabled) built-in analyzers
let! _ =
  events
  |> fileDiagnostics uri
  |> Observable.take 4
  |> Observable.last
  |> Observable.timeoutSpan (TimeSpan.FromSeconds 3.0)
  |> Async.AwaitObservable
```
-> It just creates a new text document and waits for all `4` `publishDiagnostics` events. Fails when it doesn't get all `4` events in `3s`.

Note: I'm deliberately using `dotnet run` with quite some logging instead of `dotnet test`: Makes the Issue far more likely to emerge. In fact: with `dotnet test`, the new tests never failed on my PC. (Logging is quite important as it makes the issue more likely to appear.)

### Reason

Diagnostics are collected and sent in [`FsAutoComplete.Lsp.fs::DiagnosticsCollection`](https://github.com/fsharp/FsAutoComplete/blob/c9d481fca37f3a3c8c9c65c582dd30bca9c25ec6/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L113): It collects Diags for each file and each diag source (F# compiler, built-in analyzer, ...):
* [`SetFor(fileUri, kind, values: Diagnostic[])`](https://github.com/fsharp/FsAutoComplete/blob/c9d481fca37f3a3c8c9c65c582dd30bca9c25ec6/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L184-L189):  
  gets a mailbox for passed `fileUri` (-> [`getOrAddAgent (fileUri)`](https://github.com/fsharp/FsAutoComplete/blob/c9d481fca37f3a3c8c9c65c582dd30bca9c25ec6/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L173-L182)),  
  and then sends the diags and kind to the mailbox loop
  * `kind` is diag source like `F# compiler` or `F# Unused opens`
* mailbox loop in [`agentFor(uri)`](https://github.com/fsharp/FsAutoComplete/blob/c9d481fca37f3a3c8c9c65c582dd30bca9c25ec6/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L143-L161):  
  handles changed diagnostics for an uri: remembers diags for each kind and sends out all diags for that uri on every received mailbox message (-> every parse step).

Logging shows: Getting a mailbox in [`getOrAddAgent`](https://github.com/Booksbaum/FsAutoComplete/blob/4c79775ab37f561d43bbfc9f1452962ca62aca01/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L177-L188) blocks when two want a mailbox for the same uri at the same time, but the mailbox doesn't exist yet.  
In Log Messages:
``` text
[19:15:09 INF] Creating `untitled:Untitled-56` <diags tests 56>
[19:15:09 INF] waiting for events on file untitled:Untitled-56 <LSPTests>
[19:15:09 INF] [DiagnosticCollection] >> setFor(F# Compiler, untitled:Untitled-56)
[19:15:09 INF] [DiagnosticCollection] :: getOrAdd(untitled:Untitled-56)
[19:15:09 INF] [DiagnosticCollection] !! lock(agents, untitled:Untitled-56)
[19:15:09 INF] [DiagnosticCollection] >> setFor(F# Unused declarations, untitled:Untitled-56)
[19:15:09 INF] [DiagnosticCollection] :: getOrAdd(untitled:Untitled-56)
[19:15:09 INF] [DiagnosticCollection] !! lock(agents, untitled:Untitled-56)
[19:15:09 INF] [DiagnosticCollection] << mailbox(F# Compiler, untitled:Untitled-56)
[19:15:09 INF] [Diagnostics/untitled:Untitled-56] -> Clear(F# Compiler)
[19:15:09 INF] [DiagnosticCollection] -- Error(F# Unused declarations): An item with the same key has already been added. Key: untitled:Untitled-56
[19:15:09 INF] [DiagnosticCollection] >> setFor(F# simplify names, untitled:Untitled-56)
[19:15:09 INF] [DiagnosticCollection] :: getOrAdd(untitled:Untitled-56)
[19:15:09 INF] [DiagnosticCollection] << mailbox(F# simplify names, untitled:Untitled-56)
[19:15:09 INF] [Diagnostics/untitled:Untitled-56] -> Add(F# simplify names)
[19:15:09 INF] [DiagnosticCollection] >> setFor(F# Unused opens, untitled:Untitled-56)
[19:15:09 INF] [DiagnosticCollection] :: getOrAdd(untitled:Untitled-56)
[19:15:09 INF] [DiagnosticCollection] << mailbox(F# Unused opens, untitled:Untitled-56)
[19:15:09 INF] [Diagnostics/untitled:Untitled-56] -> Add(F# Unused opens)
[19:15:12 ERR] lsp.Ionide WorkspaceLoader.diagnostics tests.can get all publishDiagnostics events 56 errored in 00:00:03.0030000 <Expecto>
System.TimeoutException: The operation has timed out.
```
For every kind (`F# Compiler`, `F# Unused delcarations`, `F# simplify names`, `F# unused opens`) there should be:
```text
>> setFor(F# Compiler, untitled:Untitled-56)
:: getOrAdd(untitled:Untitled-56)
<< mailbox(F# Compiler, untitled:Untitled-56)
-> Clear(F# Compiler)           // or `-> Add(...)`
```
But: `F# Unused declarations` does never return from `getOrAdd` with a mailbox (no `<< mailbox(F# Unused declarations, ...)`)

[`getOrAddAgent`](https://github.com/Booksbaum/FsAutoComplete/blob/4c79775ab37f561d43bbfc9f1452962ca62aca01/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L177-L188):
```fsharp
and getOrAddAgent fileUri =
  logger.info (Log.setMessage ":: getOrAdd({uri})" >> Log.addContext "uri" (UMX.untag fileUri))
  match agents.TryGetValue fileUri with
  | true, mailbox -> mailbox
  | false, _ ->
    logger.info (Log.setMessage "!! lock(agents, {uri})" >> Log.addContext "uri" (UMX.untag fileUri))
    lock agents (fun _ ->
      let cts = new CancellationTokenSource()
      let mailbox = agentFor fileUri cts.Token
      agents.Add(fileUri, mailbox)
      ctoks.Add(fileUri, cts)
      mailbox)
```
-> Both `Compiler` and `Unused Declarations` want to create a mailbox because it doesn't yet exist. But only `Compiler` actually exits with a mailbox.  

The other one fails because `agents` already contains the key `fileUri` -> `ArgumentException` with Message `An item with the same key has already been added.`  (-> inserts a new mailbox for an already existing uri)
Further Complication: The exception doesn't surface, but instead gets [swallowed](https://github.com/fsharp/FsAutoComplete/blob/c9d481fca37f3a3c8c9c65c582dd30bca9c25ec6/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L470-L471).


In practice probably not really an issue:
* unlikely to happen
* can only happen for newly opened file. After first `publishDiagnostics` for that file, future parses/`publishDiags` for that file aren't affected any more.

### Fix
Use `ConcurrentDictionary` instead of `Dictionary` and custom locking

Note:  
I didn't add any tests (or removed the example tests again):  
Solution is something external (-> `ConcurrentDictionary`).  
Additional: issue was not deterministic but just: run this over and over again and MAYBE it will fail...


<br/>
<br/>

Additional:
* Add error logging to [`handleCommandEvents`](https://github.com/Booksbaum/FsAutoComplete/blob/6e8b1430ed222d9d37800ce3bc40d39040fae1c5/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L458-L464)

<br/>
<br/>

-----------------------------------

<br/>
<br/>

### Additional

I added two command line log filters for tests (via `dotnet run --project ./test/FsAutoComplete.Tests.Lsp -- ...`):
* `--log={level}`: Sets Log Level. `{level}` is something like `warn` or `info`.
  * (existing) `--debug` (= verbose logging) takes precedence over `--log={level}`
  * when multiple `--log=`: first occurrence is used
* `--exclude-from-log={logger names}`: Filters out loggers with the specified names
  * filters just serilog logging (-> used in `src`s; in `test`s Expecto is used for logging)
  * `{log sources}`: Comma-separated list with logger names. Like `--exclude-from-log=Checker,Commands,Opts,LSP`
    (-> doesn't support spaces)
  * can occur multiple times (-> `--exclude-from-log=Checker,Commands,Opts,LSP` = `--exclude-from-log=Checker,Commands --exclude-from-log=Opts,LSP`)


I implemented these to help me isolate the issue above (by reducing log clutter).
Might be useful for someone else too  
-> I left these command line options in this PR.


Notes:
* `xxx=y[,y,y]` because it's easy to parse (vs. separated by spaces)
