### PR TITLE
fix out-of-bounds checking for completions

### DIFF
--- a/src/FsAutoComplete.Core/KeywordList.fs
+++ b/src/FsAutoComplete.Core/KeywordList.fs
@@ -48,8 +48,9 @@ module KeywordList =
         |> Seq.toArray
 
     let allKeywords : string list =
-        FSharpKeywords.KeywordsWithDescription
-        |> List.map fst
+        keywordDescriptions
+        |> Seq.map ((|KeyValue|) >> fst)
+        |> Seq.toList
 
     let keywordCompletionItems =
         allKeywords

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1047,10 +1047,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
       let lineSegmentFCSRange = protocolRangeToRange (UMX.untag file) lineSegmentLSPRange
       let! lineStr = lines.GetText lineSegmentFCSRange |> Result.mapError JsonRpc.Error.InternalErrorMessage
 
-      if (lineStr.StartsWith "#"
-          && (KeywordList.hashDirectives.Keys
-              |> Seq.exists (fun k -> k.StartsWith lineStr)
-              || lineStr.Contains "\n")) then
+      if lineStr.StartsWith "#" then
         let completionList =
           { IsIncomplete = false
             Items = KeywordList.hashSymbolCompletionItems }

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Completion/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Completion/Script.fsx
@@ -2,3 +2,8 @@ async {
     return 1
 }
 |> Async. // completion at this `.` should not have a billion suggestions
+
+
+List.
+
+let tail = List.


### PR DESCRIPTION
Fixes #891 by correcting an off-by-one error when checking bounds for the line. We have a more safe way to get line text from FSC text ranges, so let's use that and sidestep some safety checks as a result (since they're included in the text helper).