### PR TITLE
make signaturehelp traverse characters safely

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1071,7 +1071,7 @@ type Commands
     (
       tyRes: ParseAndCheckResults,
       pos: Position,
-      lines: ISourceText,
+      lines: NamedText,
       triggerChar,
       possibleSessionKind
     ) =

--- a/src/FsAutoComplete.Core/FCSPatches.fs
+++ b/src/FsAutoComplete.Core/FCSPatches.fs
@@ -95,7 +95,7 @@ type FSharpParseFileResults with
       function | SynExpr.App(ExprAtomicFlag.NonAtomic, false, SynExpr.App(ExprAtomicFlag.NonAtomic, true, Ident "op_EqualsGreater", actualParamListExpr, _), actualLambdaBodyExpr, _) -> Some (actualParamListExpr, actualLambdaBodyExpr)
                | _ -> None
 
-    
+
     let visitor = {
         new SyntaxVisitorBase<_>() with
           member _.VisitExpr(_, _, defaultTraverse, expr) =
@@ -277,7 +277,7 @@ type FSharpParseFileResults with
               traverseSynExpr expr
               |> Option.map (fun expr -> expr)
 
-      
+
       SyntaxTraversal.Traverse(pos, scope.ParseTree, { new SyntaxVisitorBase<_>() with
           member _.VisitExpr(_, traverseSynExpr, defaultTraverse, expr) =
               match expr with
@@ -303,50 +303,6 @@ type FSharpParseFileResults with
                 else
                     None
             | _ -> defaultTraverse expr })
-
-  member scope.IsTypeAnnotationGivenAtPositionPatched pos =
-      let result =
-          SyntaxTraversal.Traverse(pos, scope.ParseTree, { new SyntaxVisitorBase<_>() with
-              member _.VisitExpr(_path, _traverseSynExpr, defaultTraverse, expr) =
-                  match expr with
-                  | SynExpr.Typed (_expr, _typeExpr, range) when Position.posEq range.Start pos ->
-                      Some range
-                  | _ -> defaultTraverse expr
-
-              override _.VisitSimplePats(_, pats) =
-                  match pats with
-                  | [] -> None
-                  | _ ->
-                      let exprFunc pat =
-                          match pat with
-                          | SynSimplePat.Typed (_pat, _targetExpr, range) when Position.posEq range.Start pos ->
-                              Some range
-                          | _ ->
-                              None
-
-                      pats |> List.tryPick exprFunc
-
-              override _.VisitPat(_, defaultTraverse, pat) =
-                  match pat with
-                  | SynPat.Typed (_pat, _targetType, range) when Position.posEq range.Start pos ->
-                      Some range
-                  | _ -> defaultTraverse pat })
-      result.IsSome
-
-  member scope.IsBindingALambdaAtPositionPatched pos =
-      let result =
-          SyntaxTraversal.Traverse(pos, scope.ParseTree, { new SyntaxVisitorBase<_>() with
-              member _.VisitExpr(_path, _traverseSynExpr, defaultTraverse, expr) =
-                  defaultTraverse expr
-
-              override _.VisitBinding(_, defaultTraverse, binding) =
-                  match binding with
-                  | SynBinding(_, _, _, _, _, _, _, _, _, expr, range, _) when Position.posEq range.Start pos ->
-                      match expr with
-                      | SynExpr.Lambda _ -> Some range
-                      | _ -> None
-                  | _ -> defaultTraverse binding })
-      result.IsSome
 
 module SyntaxTreeOps =
   open FSharp.Compiler.Syntax

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -8,11 +8,6 @@ open FSharp.Compiler.Text
 open System.Runtime.CompilerServices
 open FsToolkit.ErrorHandling
 
-type VolatileFile =
-  { Touched: DateTime
-    Lines: ISourceText
-    Version: int option }
-
 open System.IO
 open FSharp.Compiler.IO
 
@@ -281,6 +276,11 @@ type NamedText(fileName: string<LocalPath>, str: string) =
 
       member _.CopyTo(sourceIndex, destination, destinationIndex, count) =
           str.CopyTo(sourceIndex, destination, destinationIndex, count)
+
+type VolatileFile =
+  { Touched: DateTime
+    Lines: NamedText
+    Version: int option }
 
 type FileSystem(actualFs: IFileSystem, tryFindFile: string<LocalPath> -> VolatileFile option) =
   let fsLogger = LogProvider.getLoggerByName "FileSystem"

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -8,6 +8,11 @@ open FSharp.Compiler.Text
 open System.Runtime.CompilerServices
 open FsToolkit.ErrorHandling
 
+type VolatileFile =
+  { Touched: DateTime
+    Lines: ISourceText
+    Version: int option }
+
 open System.IO
 open FSharp.Compiler.IO
 
@@ -276,11 +281,6 @@ type NamedText(fileName: string<LocalPath>, str: string) =
 
       member _.CopyTo(sourceIndex, destination, destinationIndex, count) =
           str.CopyTo(sourceIndex, destination, destinationIndex, count)
-
-type VolatileFile =
-  { Touched: DateTime
-    Lines: NamedText
-    Version: int option }
 
 type FileSystem(actualFs: IFileSystem, tryFindFile: string<LocalPath> -> VolatileFile option) =
   let fsLogger = LogProvider.getLoggerByName "FileSystem"

--- a/src/FsAutoComplete.Core/SignatureHelp.fs
+++ b/src/FsAutoComplete.Core/SignatureHelp.fs
@@ -23,7 +23,7 @@ type SignatureHelpInfo = {
   SigHelpKind: SignatureHelpKind
 }
 
-let private getSignatureHelpForFunctionApplication (tyRes: ParseAndCheckResults, caretPos: Position, endOfPreviousIdentPos: Position, lines: ISourceText) : Async<SignatureHelpInfo option> =
+let private getSignatureHelpForFunctionApplication (tyRes: ParseAndCheckResults, caretPos: Position, endOfPreviousIdentPos: Position, lines: NamedText) : Async<SignatureHelpInfo option> =
   asyncMaybe {
     let! lineStr = lines.GetLine endOfPreviousIdentPos
     let! possibleApplicationSymbolEnd = maybe {
@@ -93,7 +93,7 @@ let private getSignatureHelpForFunctionApplication (tyRes: ParseAndCheckResults,
       return! None
   }
 
-let private getSignatureHelpForMethod (tyRes: ParseAndCheckResults, caretPos: Position, lines: ISourceText, triggerChar) =
+let private getSignatureHelpForMethod (tyRes: ParseAndCheckResults, caretPos: Position, lines: NamedText, triggerChar) =
   asyncMaybe {
     let! paramLocations = tyRes.GetParseResults.FindParameterLocations caretPos
     let names = paramLocations.LongId
@@ -167,7 +167,7 @@ let private getSignatureHelpForMethod (tyRes: ParseAndCheckResults, caretPos: Po
       }
   }
 
-let getSignatureHelpFor (tyRes : ParseAndCheckResults, pos: Position, lines: ISourceText, triggerChar, possibleSessionKind) =
+let getSignatureHelpFor (tyRes : ParseAndCheckResults, pos: Position, lines: NamedText, triggerChar, possibleSessionKind) =
   asyncResult {
     let previousNonWhitespaceChar =
       let rec loop ch pos =

--- a/src/FsAutoComplete/CodeFixes/ChangeCSharpLambdaToFSharp.fs
+++ b/src/FsAutoComplete/CodeFixes/ChangeCSharpLambdaToFSharp.fs
@@ -22,10 +22,10 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getLineText: GetLineTe
 
         match tyRes.GetParseResults.TryRangeOfParenEnclosingOpEqualsGreaterUsage fcsPos with
         | Some (fullParenRange, lambdaArgRange, lambdaBodyRange) ->
-            let argExprText =
+            let! argExprText =
               getLineText lines (fcsRangeToLsp lambdaArgRange)
 
-            let bodyExprText =
+            let! bodyExprText =
               getLineText lines (fcsRangeToLsp lambdaBodyRange)
 
             let replacementText = $"fun {argExprText} -> {bodyExprText}"

--- a/src/FsAutoComplete/CodeFixes/MakeOuterBindingRecursive.fs
+++ b/src/FsAutoComplete/CodeFixes/MakeOuterBindingRecursive.fs
@@ -17,14 +17,14 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getLineText: GetLineTe
 
         let errorRangeStart = protocolPosToPos diagnostic.Range.Start
         let! (tyres, _line, lines) = getParseResultsForFile fileName errorRangeStart
-        let missingMemberName = getLineText lines diagnostic.Range
+        let! missingMemberName = getLineText lines diagnostic.Range
 
         let! outerBindingRange =
           tyres.GetParseResults.TryRangeOfNameOfNearestOuterBindingContainingPos errorRangeStart
           |> Result.ofOption (fun _ -> "No outer binding found at pos")
 
         let lspOuterBindingRange = fcsRangeToLsp outerBindingRange
-        let outerBindingName = getLineText lines lspOuterBindingRange
+        let! outerBindingName = getLineText lines lspOuterBindingRange
 
         do! Result.guard
               (fun _ -> missingMemberName = outerBindingName)

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1007,25 +1007,6 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
     }
 
   override __.TextDocumentCompletion(p: CompletionParams) =
-    let ensureInBounds (lines: ISourceText) (line, col) =
-      let lineStr = lines.GetLineString line
-
-      if line <= lines.Length
-         && line >= 0
-         && col <= lineStr.Length + 1
-         && col >= 0 then
-        Ok()
-      else
-        logger.info (
-          Log.setMessage
-            "TextDocumentCompletion Not OK:\n COL: {col}\n LINE_STR: {lineStr}\n LINE_STR_LENGTH: {lineStrLength}"
-          >> Log.addContextDestructured "col" col
-          >> Log.addContextDestructured "lineStr" lineStr
-          >> Log.addContextDestructured "lineStrLength" lineStr.Length
-        )
-
-        Error(JsonRpc.Error.InternalErrorMessage "not ok")
-
     asyncResult {
       logger.info (
         Log.setMessage "TextDocumentCompletion Request: {context}"


### PR DESCRIPTION
While investigating https://github.com/fsharp/FsAutoComplete/issues/891#issuecomment-1065958740, @quantum-booty had a log line that suggested `textDocument/signatureHelp` wasn't traversing positions safely. This turned out to be the case, so I've pushed helper functions for safe incrementing and decrementing of positions down into the SourceText extensions, then updated the implementation of SignatureHelp to use these.