### PR TITLE
Push navigation and traversal into a new sourcetext implementation

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -6,7 +6,7 @@ NUGET
     Argu (5.2)
       FSharp.Core (>= 4.3.2)
       System.Configuration.ConfigurationManager (>= 4.4)
-    CliWrap (3.4)
+    CliWrap (3.4.1)
       Microsoft.Bcl.AsyncInterfaces (>= 6.0) - restriction: || (&& (== net5.0) (>= net461)) (&& (== net5.0) (< netstandard2.1)) (== netstandard2.0)
       System.Buffers (>= 4.5.1) - restriction: || (&& (== net5.0) (>= net461)) (&& (== net5.0) (< netstandard2.1)) (== netstandard2.0)
       System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (&& (== net5.0) (>= net461)) (&& (== net5.0) (< netstandard2.1)) (== netstandard2.0)

--- a/src/FsAutoComplete.BackgroundServices/Program.fs
+++ b/src/FsAutoComplete.BackgroundServices/Program.fs
@@ -395,7 +395,7 @@ type BackgroundServiceServer(state: State, client: FsacClient) =
             let file = Utils.normalizePath p.File.FilePath
 
             let vf =
-              { Lines = SourceText.ofString p.Content
+              { Lines = NamedText(file, p.Content)
                 Touched = DateTime.Now
                 Version = Some p.Version }
             state.Files.AddOrUpdate(file, (fun _ -> vf),( fun _ _ -> vf) ) |> ignore

--- a/src/FsAutoComplete.BackgroundServices/paket.references
+++ b/src/FsAutoComplete.BackgroundServices/paket.references
@@ -11,3 +11,4 @@ FSharp.UMX
 Microsoft.NETFramework.ReferenceAssemblies
 Ionide.LanguageServerProtocol
 Ionide.KeepAChangelog.Tasks
+FsToolkit.ErrorHandling

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -296,7 +296,7 @@ type FSharpCompilerServiceChecker(backgroundServiceEnabled, hasAnalyzers) =
     let path = UMX.untag fn
     checker.ParseFile(path, source, fpo)
 
-  member __.ParseAndCheckFileInProject(filePath: string<LocalPath>, version, source, options) =
+  member __.ParseAndCheckFileInProject(filePath: string<LocalPath>, version, source: NamedText, options) =
     async {
       let opName = sprintf "ParseAndCheckFileInProject - %A" filePath
       checkerLogger.info
@@ -329,7 +329,7 @@ type FSharpCompilerServiceChecker(backgroundServiceEnabled, hasAnalyzers) =
       | ex -> return ResultOrString.Error(ex.ToString())
     }
 
-  member __.TryGetRecentCheckResultsForFile(file: string<LocalPath>, options, source) =
+  member __.TryGetRecentCheckResultsForFile(file: string<LocalPath>, options, source: NamedText) =
     let opName = sprintf "TryGetRecentCheckResultsForFile - %A" file
 
     checkerLogger.info

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -6,27 +6,95 @@ open FsAutoComplete.Logging
 open FSharp.UMX
 open FSharp.Compiler.Text
 open System.Runtime.CompilerServices
-
-type VolatileFile =
-  { Touched: DateTime
-    Lines: ISourceText
-    Version: int option }
+open FsToolkit.ErrorHandling
 
 open System.IO
 open FSharp.Compiler.IO
 
+[<AutoOpen>]
+module PositionExtensions =
+  type FSharp.Compiler.Text.Position with
+    member x.LinesToBeginning() =
+      if x.Line <= 0 then Seq.empty
+      else seq {
+        for i = x.Line - 1 downto 0 do
+          yield Position.mkPos i 0
+      }
+    member x.IncLine() = Position.mkPos (x.Line + 1) x.Column
+    member x.DecLine() = Position.mkPos (x.Line - 1) x.Column
 
-[<Extension>]
-type SourceTextExtensions =
-  [<Extension>]
-  static member GetText(t: ISourceText, m: FSharp.Compiler.Text.Range) : Result<string, string> =
-    let allFileRange =
-      Range.mkRange m.FileName Position.pos0 (t.GetLastFilePosition())
+  let inline (|Pos|) (p: FSharp.Compiler.Text.Position) =
+    p.Line, p.Column
 
-    if not (Range.rangeContainsRange allFileRange m) then
+[<Sealed>]
+/// A copy of the StringText type from F#.Compiler.Text, which is private.
+/// Adds a UOM-typed filename to make range manipulation easier, as well as
+/// safer traversals
+type NamedText(fileName: string<LocalPath>, str: string) =
+
+  let getLines (str: string) =
+        use reader = new StringReader(str)
+        [|
+        let mutable line = reader.ReadLine()
+        while not (isNull line) do
+            yield line
+            line <- reader.ReadLine()
+        if str.EndsWith("\n", StringComparison.Ordinal) then
+            // last trailing space not returned
+            // http://stackoverflow.com/questions/19365404/stringreader-omits-trailing-linebreak
+            yield String.Empty
+        |]
+
+  let getLines =
+      // This requires allocating and getting all the lines.
+      // However, likely whoever is calling it is using a different implementation of ISourceText
+      // So, it's ok that we do this for now.
+      lazy getLines str
+
+  let lastCharPos = lazy (
+    let lines = getLines.Value
+    if lines.Length > 0 then
+        (lines.Length, lines.[lines.Length - 1].Length)
+    else
+        (0, 0)
+  )
+
+  let safeLastCharPos = lazy (
+    let (endLine, endChar) = lastCharPos.Value
+    Position.mkPos endLine endChar
+  )
+
+  member _.String = str
+
+  override _.GetHashCode() = str.GetHashCode()
+  override _.Equals(obj: obj) =
+      match obj with
+      | :? NamedText as other -> other.String.Equals(str)
+      | :? string as other -> other.Equals(str)
+      | _ -> false
+  override _.ToString() = str
+
+  /// The local absolute path of the file whose contents this NamedText represents
+  member x.FileName = fileName
+
+  /// The unwrapped local abolute path of the file whose contents this NamedText represents.
+  /// Should only be used when interoping with the Compiler/Serialization
+  member x.RawFileName = UMX.untag fileName
+
+  /// Cached representation of the final position in this file
+  member x.LastFilePosition = safeLastCharPos.Value
+
+  /// Cached representation of the entire contents of the file, for inclusion checks
+
+  member x.TotalRange =
+    Range.mkRange (UMX.untag fileName) Position.pos0 x.LastFilePosition
+
+  /// Provides safe access to a substring of the file via FCS-provided Range
+  member x.GetText(m: FSharp.Compiler.Text.Range) : Result<string, string> =
+    if not (Range.rangeContainsRange x.TotalRange m) then
       Error $"%A{m} is outside of the bounds of the file"
     else if m.StartLine = m.EndLine then // slice of a single line, just do that
-      let lineText = t.GetLineString(m.StartLine - 1)
+      let lineText = (x :> ISourceText).GetLineString(m.StartLine - 1)
 
       lineText.Substring(m.StartColumn, m.EndColumn - m.StartColumn)
       |> Ok
@@ -34,32 +102,185 @@ type SourceTextExtensions =
       // multiline, use a builder
       let builder = new System.Text.StringBuilder()
       // slice of the first line
-      let firstLine = t.GetLineString(m.StartLine - 1)
+      let firstLine = (x :> ISourceText).GetLineString(m.StartLine - 1)
 
       builder.Append(firstLine.Substring(m.StartColumn))
       |> ignore<System.Text.StringBuilder>
       // whole intermediate lines
       for line in (m.StartLine + 1) .. (m.EndLine - 1) do
-        builder.AppendLine(t.GetLineString(line - 1))
+        builder.AppendLine((x :> ISourceText).GetLineString(line - 1))
         |> ignore<System.Text.StringBuilder>
       // final part, potential slice
-      let lastLine = t.GetLineString(m.EndLine - 1)
+      let lastLine = (x :> ISourceText).GetLineString(m.EndLine - 1)
 
       builder.Append(lastLine.Substring(0, m.EndColumn))
       |> ignore<System.Text.StringBuilder>
 
       Ok(builder.ToString())
 
-  [<Extension>]
-  static member inline Lines(t: ISourceText) =
-    Array.init (t.GetLineCount()) t.GetLineString
+  member private x.GetLineUnsafe (pos: FSharp.Compiler.Text.Position) =
+    (x :> ISourceText).GetLineString(pos.Line - 1)
 
-  [<Extension>]
-  /// a safe alternative to GetLastCharacterPosition, which returns untagged indexes. this version
-  /// returns a FCS Pos to prevent confusion about line index offsets
-  static member GetLastFilePosition(t: ISourceText) : Position =
-    let endLine, endChar = t.GetLastCharacterPosition()
-    Position.mkPos endLine endChar
+  /// Provides safe access to a line of the file via FCS-provided Position
+  member x.GetLine(pos: FSharp.Compiler.Text.Position): string option =
+    if pos.Line > getLines.Value.Length then None else Some (x.GetLineUnsafe pos)
+
+  member x.GetLineLength(pos: FSharp.Compiler.Text.Position) =
+    if pos.Line > getLines.Value.Length then None else Some (x.GetLineUnsafe pos).Length
+
+  member private x.GetCharUnsafe(pos: FSharp.Compiler.Text.Position): char =
+    x.GetLine(pos).Value[pos.Column]
+
+  /// <summary>Provides safe access to a character of the file via FCS-provided Position.
+  /// Also available in indexer form: <code lang="fsharp">x[pos]</code></summary>
+  member x.TryGetChar(pos: FSharp.Compiler.Text.Position): char option =
+    option {
+      do! Option.guard (Range.rangeContainsPos (x.TotalRange) pos)
+      let lineText = x.GetLineUnsafe(pos)
+      if pos.Column = 0 then return! None
+      else
+        let lineIndex = pos.Column - 1
+        if lineText.Length < lineIndex
+        then
+          return! None
+        else
+          return lineText[lineIndex]
+    }
+
+  member x.NextLine(pos: FSharp.Compiler.Text.Position) =
+    if pos.Line < getLines.Value.Length then
+      Position.mkPos (pos.Line + 1) 0
+      |> Some
+    else
+      None
+
+  /// Provides safe incrementing of a position in the file via FCS-provided Position
+  member x.NextPos(pos: FSharp.Compiler.Text.Position): FSharp.Compiler.Text.Position option =
+    option {
+      let! currentLine = x.GetLine pos
+      if pos.Column - 1 = currentLine.Length then
+        if getLines.Value.Length > pos.Line
+        then
+          // advance to the beginning of the next line
+          return Position.mkPos (pos.Line + 1) 0
+        else
+          return! None
+      else
+        return Position.mkPos pos.Line (pos.Column + 1)
+    }
+
+  /// Provides safe incrementing of positions in a file while returning the character at the new position.
+  /// Intended use is for traversal loops.
+  member x.TryGetNextChar(pos: FSharp.Compiler.Text.Position): (FSharp.Compiler.Text.Position * char) option =
+    option {
+      let! np = x.NextPos pos
+      return np, x.GetCharUnsafe np
+    }
+
+  /// Provides safe decrementing of a position in the file via FCS-provided Position
+  member x.PrevPos(pos: FSharp.Compiler.Text.Position): FSharp.Compiler.Text.Position option =
+    option {
+      if pos.Column <> 0
+      then
+        return Position.mkPos pos.Line (pos.Column - 1)
+      else
+        if pos.Line = 0
+        then
+          return! None
+        else
+          if getLines.Value.Length > pos.Line - 2
+          then
+            let prevLine = (x :> ISourceText).GetLineString (pos.Line - 2)
+            // retreat to the end of the previous line
+            return Position.mkPos (pos.Line - 1) (prevLine.Length - 1)
+          else
+            return! None
+    }
+
+  /// Provides safe decrementing of positions in a file while returning the character at the new position.
+  /// Intended use is for traversal loops.
+  member x.TryGetPrevChar(pos: FSharp.Compiler.Text.Position): (FSharp.Compiler.Text.Position * char) option =
+    option {
+      let! np = x.PrevPos pos
+      return np, x.GetCharUnsafe np
+    }
+
+  /// Safe access to the contents of a file by Range
+  member x.Item with get (m: FSharp.Compiler.Text.Range) = x.GetText(m)
+  /// Safe access to the char in a file by Position
+  member x.Item with get (pos: FSharp.Compiler.Text.Position) = x.TryGetChar(pos)
+
+  member private x.Walk(start: FSharp.Compiler.Text.Position, (posChange: FSharp.Compiler.Text.Position -> FSharp.Compiler.Text.Position option), terminal, condition) =
+    /// if the condition is never met, return None
+
+    let firstPos = Position.pos0
+    let finalPos = x.LastFilePosition
+
+    let rec loop (pos: FSharp.Compiler.Text.Position): FSharp.Compiler.Text.Position option = option {
+      let! charAt = x[pos]
+      do! Option.guard (firstPos <> pos && finalPos <> pos)
+      do! Option.guard (not (terminal charAt))
+
+      if condition charAt
+      then
+        return pos
+      else
+        let! nextPos = posChange pos
+        return! loop nextPos
+    }
+
+    loop start
+
+  member x.WalkForward(start, terminal, condition) = x.Walk(start, x.NextPos, terminal, condition)
+  member x.WalkBackwards(start, terminal, condition) = x.Walk(start, x.PrevPos, terminal, condition)
+
+
+  /// Provides line-by-line access to the underlying text.
+  /// This can lead to unsafe access patterns, consider using one of the range or position-based
+  /// accessors instead
+  member x.Lines = getLines.Value
+
+  interface ISourceText with
+
+      member _.Item with get index = str.[index]
+
+      member _.GetLastCharacterPosition() = lastCharPos.Value
+
+      member _.GetLineString(lineIndex) =
+          getLines.Value.[lineIndex]
+
+      member _.GetLineCount() = getLines.Value.Length
+
+      member _.GetSubTextString(start, length) =
+          str.Substring(start, length)
+
+      member _.SubTextEquals(target, startIndex) =
+          if startIndex < 0 || startIndex >= str.Length then
+              invalidArg "startIndex" "Out of range."
+
+          if String.IsNullOrEmpty(target) then
+              invalidArg "target" "Is null or empty."
+
+          let lastIndex = startIndex + target.Length
+          if lastIndex <= startIndex || lastIndex >= str.Length then
+              invalidArg "target" "Too big."
+
+          str.IndexOf(target, startIndex, target.Length) <> -1
+
+      member _.Length = str.Length
+
+      member this.ContentEquals(sourceText) =
+          match sourceText with
+          | :? NamedText as sourceText when sourceText = this || sourceText.String = str -> true
+          | _ -> false
+
+      member _.CopyTo(sourceIndex, destination, destinationIndex, count) =
+          str.CopyTo(sourceIndex, destination, destinationIndex, count)
+
+type VolatileFile =
+  { Touched: DateTime
+    Lines: NamedText
+    Version: int option }
 
 type FileSystem(actualFs: IFileSystem, tryFindFile: string<LocalPath> -> VolatileFile option) =
   let fsLogger = LogProvider.getLoggerByName "FileSystem"

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -137,6 +137,7 @@ module Option =
     with
     | _ -> None
 
+  /// ensure the condition is true before continuing
   let inline guard (b) = if b then Some() else None
 
 [<RequireQualifiedAccess>]
@@ -151,6 +152,7 @@ module Result =
     | Some x -> Ok x
     | None -> Error(recover ())
 
+  /// ensure the condition is true before continuing
   let inline guard condition errorValue =
     if condition () then
       Ok()

--- a/src/FsAutoComplete/CodeFixes/AddExplicitTypeToParameter.fs
+++ b/src/FsAutoComplete/CodeFixes/AddExplicitTypeToParameter.fs
@@ -26,14 +26,13 @@ let fix (getParseResultsForFile: GetParseResultsForFile): CodeFix =
         |> Result.ofOption (fun _ -> $"Couldn't find symbolUse at %A{(fcsStartPos.Line, rightCol)} in file %s{codeActionParams.TextDocument.GetFilePath()}")
 
       let isValidParameterWithoutTypeAnnotation (funcOrValue: FSharpMemberOrFunctionOrValue) (symbolUse: FSharpSymbolUse) =
-        // TODO: remove patched functions and uncomment this boolean check after FCS 40 update
         let isLambdaIfFunction =
-        //     funcOrValue.IsFunction &&
-             parseFileResults.IsBindingALambdaAtPositionPatched symbolUse.Range.Start
+             funcOrValue.IsFunction &&
+             parseFileResults.IsBindingALambdaAtPosition symbolUse.Range.Start
 
         (funcOrValue.IsValue || isLambdaIfFunction) &&
         parseFileResults.IsPositionContainedInACurriedParameter symbolUse.Range.Start &&
-        not (parseFileResults.IsTypeAnnotationGivenAtPositionPatched symbolUse.Range.Start) &&
+        not (parseFileResults.IsTypeAnnotationGivenAtPosition symbolUse.Range.Start) &&
         not funcOrValue.IsMember &&
         not funcOrValue.IsMemberThisValue &&
         not funcOrValue.IsConstructorThisValue &&

--- a/src/FsAutoComplete/CodeFixes/AddTypeToIndeterminateValue.fs
+++ b/src/FsAutoComplete/CodeFixes/AddTypeToIndeterminateValue.fs
@@ -27,7 +27,7 @@ let fix
         let! projectOptions = getProjectOptionsForFile typedFileName
         let protocolDeclRange = fcsRangeToLsp declRange
         let! declText = lines.GetText declRange
-        let declTextLine = lines.GetLineString protocolDeclRange.Start.Line
+        let! declTextLine = lines.GetLine declRange.Start |> Result.ofOption (fun _ -> "No line found at pos")
         let! declLexerSymbol = Lexer.getSymbol declRange.Start.Line declRange.Start.Column declText SymbolLookupKind.ByLongIdent projectOptions.OtherOptions |> Result.ofOption (fun _ -> "No lexer symbol for declaration")
         let! declSymbolUse = tyRes.GetCheckResults.GetSymbolUseAtLocation(declRange.Start.Line, declRange.End.Column, declTextLine, declLexerSymbol.Text.Split('.') |> List.ofArray) |> Result.ofOption (fun _ -> "No lexer symbol")
         match declSymbolUse.Symbol with

--- a/src/FsAutoComplete/CodeFixes/ConvertInvalidRecordToAnonRecord.fs
+++ b/src/FsAutoComplete/CodeFixes/ConvertInvalidRecordToAnonRecord.fs
@@ -23,13 +23,15 @@ let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
         | Some recordExpressionRange ->
             let recordExpressionRange = fcsRangeToLsp recordExpressionRange
 
-            let startInsertRange =
-              let next = inc lines recordExpressionRange.Start
-              { Start = next; End = next }
+            let! startInsertRange =
+              inc lines recordExpressionRange.Start
+              |> Option.map (fun next -> { Start = next; End = next })
+              |> Result.ofOption (fun _ -> "No start insert range")
 
-            let endInsertRange =
-              let prev = dec lines recordExpressionRange.End
-              { Start = prev; End = prev }
+            let! endInsertRange =
+              dec lines recordExpressionRange.End
+              |> Option.map (fun prev -> { Start = prev; End = prev })
+              |> Result.ofOption (fun _ -> "No end insert range")
 
             return
               [ { Title = "Convert to anonymous record"

--- a/src/FsAutoComplete/CodeFixes/MissingEquals.fs
+++ b/src/FsAutoComplete/CodeFixes/MissingEquals.fs
@@ -19,10 +19,10 @@ let fix (getFileLines: GetFileLines) =
             codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
 
           let! lines = getFileLines fileName
-
-          match walkBackUntilCondition lines (dec lines diagnostic.Range.Start) (System.Char.IsWhiteSpace >> not) with
+          let! walkPos = dec lines diagnostic.Range.Start |> Result.ofOption (fun _ -> "No walk pos")
+          match walkBackUntilCondition lines walkPos (System.Char.IsWhiteSpace >> not) with
           | Some firstNonWhitespaceChar ->
-              let insertPos = inc lines firstNonWhitespaceChar
+              let! insertPos = inc lines firstNonWhitespaceChar |> Result.ofOption (fun _ -> "No insert pos")
 
               return
                 [ { SourceDiagnostic = Some diagnostic

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
@@ -637,10 +637,10 @@ let negationToSubstraction state =
                                                                           Range = {
                                                                             Start = {
                                                                               Line = 2;
-                                                                              Character = 16 };
+                                                                              Character = 15 };
                                                                             End = {
                                                                               Line = 2;
-                                                                              Character = 15 }
+                                                                              Character = 16 }
                                                                           };
                                                                           NewText = "- "
                                                                         }|] }|] } } |]))

--- a/test/FsAutoComplete.Tests.Lsp/paket.references
+++ b/test/FsAutoComplete.Tests.Lsp/paket.references
@@ -7,6 +7,7 @@ Microsoft.NET.Test.Sdk
 YoloDev.Expecto.TestSdk
 AltCover
 GitHubActionsTestLogger
+CliWrap
 
 Microsoft.Build copy_local:false
 Microsoft.Build.Framework copy_local:false


### PR DESCRIPTION
This PR covers a ton of error cases around line-by-line and character-by-character traversal. It involves pushing line and character traversal down into a new implementation of ISourceText I've called NamedText (since it has the filename associated with it), which allows for easily checking if tasks like incrementing/decrementing a position would take you out of bounds of the document.  It's inspired by a comment by a user recently that led to discovering that the SignatureHelp endpoint was throwing unhandled exceptions due to buggy character traversal code, and specifically some of the changes I made to the `FileSystem.fs` file [in this other recent PR](https://github.com/fsharp/FsAutoComplete/pull/894/files#diff-7c1d3328baa270a7e1450113731e5f1fe55cce453db26186a346965e4b66e981).  I figured I'd extract out the navigation changes on their own to minimize the diff there and make the changes to SignatureHelp in that PR more apparent.