### PR TITLE
remove commas from old positional pattern parameters

### DIFF
--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -128,8 +128,8 @@ type NamedText(fileName: string<LocalPath>, str: string) =
   member x.GetLineLength(pos: FSharp.Compiler.Text.Position) =
     if pos.Line > getLines.Value.Length then None else Some (x.GetLineUnsafe pos).Length
 
-  member private x.GetCharUnsafe(pos: FSharp.Compiler.Text.Position): char =
-    x.GetLine(pos).Value[pos.Column]
+  member x.GetCharUnsafe(pos: FSharp.Compiler.Text.Position): char =
+    x.GetLine(pos).Value[pos.Column - 1]
 
   /// <summary>Provides safe access to a character of the file via FCS-provided Position.
   /// Also available in indexer form: <code lang="fsharp">x[pos]</code></summary>

--- a/src/FsAutoComplete/CodeFixes/ConvertPositionalDUToNamed.fs
+++ b/src/FsAutoComplete/CodeFixes/ConvertPositionalDUToNamed.fs
@@ -91,14 +91,14 @@ let private (|MatchedFields|UnmatchedFields|NotEnoughFields|) (astFields: SynPat
 let private createEdit (astField: SynPat, duField: string) : TextEdit list =
   let prefix = $"{duField} = "
   let startRange = astField.Range.Start |> fcsPosToProtocolRange
-  let suffix = "; "
+  let suffix = ";"
   let endRange = astField.Range.End |> fcsPosToProtocolRange
 
   [ { NewText = prefix; Range = startRange }
     { NewText = suffix; Range = endRange } ]
 
 let private createWildCard endRange (duField: string) : TextEdit =
-  let wildcard = $"{duField} = _; "
+  let wildcard = $"{duField} = _;"
   let range = endRange
   { NewText = wildcard; Range = range }
 
@@ -159,7 +159,9 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getRangeText: GetRange
       let removeCommaEdits =
         commasBetweenFields
         |> Seq.map (fun pos ->
-          { NewText = ""; Range = pos |> fcsPosToProtocolRange }
+          let startPos = fcsPosToLsp (FSharp.Compiler.Text.Position.mkPos pos.Line (pos.Column - 1))
+          let endPos = fcsPosToLsp pos
+          { NewText = ""; Range = { Start = startPos; End = endPos } }
         )
         |> Seq.toArray
 

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
@@ -686,6 +686,10 @@ let positionalToNamedDUTests state =
                     End = { Line = 2; Character = 8 } }
                 NewText = "; " }
               { Range =
+                  { Start = { Line = 2; Character = 9 }
+                    End = { Line = 2; Character = 9 } }
+                NewText = "" }
+              { Range =
                   { Start = { Line = 2; Character = 10 }
                     End = { Line = 2; Character = 10 } }
                 NewText = "b = " }
@@ -710,6 +714,10 @@ let positionalToNamedDUTests state =
                   { Start = { Line = 5; Character = 5 }
                     End = { Line = 5; Character = 5 } }
                 NewText = "; " }
+              { Range =
+                  { Start = { Line = 5; Character = 6 }
+                    End = { Line = 5; Character = 6 } }
+                NewText = "" }
               { Range =
                   { Start = { Line = 5; Character = 7 }
                     End = { Line = 5; Character = 7 } }
@@ -736,6 +744,10 @@ let positionalToNamedDUTests state =
                     End = { Line = 8; Character = 6 } }
                 NewText = "; " }
               { Range =
+                  { Start = { Line = 8; Character = 7 }
+                    End = { Line = 8; Character = 7 } }
+                NewText = "" }
+              { Range =
                   { Start = { Line = 8; Character = 8 }
                     End = { Line = 8; Character = 8 } }
                 NewText = "b = " }
@@ -760,6 +772,10 @@ let positionalToNamedDUTests state =
                   { Start = { Line = 12; Character = 29 }
                     End = { Line = 12; Character = 29 } }
                 NewText = "; " }
+              { Range =
+                  { Start = { Line = 12; Character = 30 }
+                    End = { Line = 12; Character = 30 } }
+                NewText = "" }
               { Range =
                   { Start = { Line = 12; Character = 31 }
                     End = { Line = 12; Character = 31 } }

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
@@ -677,26 +677,31 @@ let positionalToNamedDUTests state =
             End = { Line = 2; Character = 10 } }
 
          let edits =
-           [| { Range =
-                  { Start = { Line = 2; Character = 7 }
-                    End = { Line = 2; Character = 7 } }
-                NewText = "a = " }
-              { Range =
-                  { Start = { Line = 2; Character = 8 }
-                    End = { Line = 2; Character = 8 } }
-                NewText = "; " }
-              { Range =
-                  { Start = { Line = 2; Character = 9 }
-                    End = { Line = 2; Character = 9 } }
-                NewText = "" }
-              { Range =
-                  { Start = { Line = 2; Character = 10 }
-                    End = { Line = 2; Character = 10 } }
-                NewText = "b = " }
-              { Range =
-                  { Start = { Line = 2; Character = 11 }
-                    End = { Line = 2; Character = 11 } }
-                NewText = "; " } |]
+           [| { Range = { Start = { Line = 2
+                                    Character = 7 }
+                          End = { Line = 2
+                                  Character = 7 } }
+                NewText = "a = " };
+              { Range = { Start = { Line = 2
+                                    Character = 8 }
+                          End = { Line = 2
+                                  Character = 8 } }
+                NewText = ";" };
+              { Range = { Start = { Line = 2
+                                    Character = 8 }
+                          End = { Line = 2
+                                  Character = 9 } }
+                NewText = "" };
+              { Range = { Start = { Line = 2
+                                    Character = 10 }
+                          End = { Line = 2
+                                  Character = 10 } }
+                NewText = "b = " };
+              { Range = { Start = { Line = 2
+                                    Character = 11 }
+                          End = { Line = 2
+                                  Character = 11 } }
+                NewText = ";" } |]
 
          expectEdits patternPos edits)
       testCaseAsync
@@ -706,26 +711,31 @@ let positionalToNamedDUTests state =
             End = { Line = 5; Character = 6 } }
 
          let edits =
-           [| { Range =
-                  { Start = { Line = 5; Character = 4 }
-                    End = { Line = 5; Character = 4 } }
-                NewText = "a = " }
-              { Range =
-                  { Start = { Line = 5; Character = 5 }
-                    End = { Line = 5; Character = 5 } }
-                NewText = "; " }
-              { Range =
-                  { Start = { Line = 5; Character = 6 }
-                    End = { Line = 5; Character = 6 } }
-                NewText = "" }
-              { Range =
-                  { Start = { Line = 5; Character = 7 }
-                    End = { Line = 5; Character = 7 } }
-                NewText = "b = " }
-              { Range =
-                  { Start = { Line = 5; Character = 8 }
-                    End = { Line = 5; Character = 8 } }
-                NewText = "; " } |]
+           [| { Range = { Start = { Line = 5
+                                    Character = 4 }
+                          End = { Line = 5
+                                  Character = 4 } }
+                NewText = "a = " };
+              { Range = { Start = { Line = 5
+                                    Character = 5 }
+                          End = { Line = 5
+                                  Character = 5 } }
+                NewText = ";" };
+              { Range = { Start = { Line = 5
+                                    Character = 5 }
+                          End = { Line = 5
+                                  Character = 6 } }
+                NewText = "" };
+              { Range = { Start = { Line = 5
+                                    Character = 7 }
+                          End = { Line = 5
+                                  Character = 7 } }
+                NewText = "b = " };
+              { Range = { Start = { Line = 5
+                                    Character = 8 }
+                          End = { Line = 5
+                                  Character = 8 } }
+                NewText = ";" } |]
 
          expectEdits patternPos edits)
       testCaseAsync
@@ -735,26 +745,31 @@ let positionalToNamedDUTests state =
             End = { Line = 8; Character = 8 } }
 
          let edits =
-           [| { Range =
-                  { Start = { Line = 8; Character = 5 }
-                    End = { Line = 8; Character = 5 } }
-                NewText = "a = " }
-              { Range =
-                  { Start = { Line = 8; Character = 6 }
-                    End = { Line = 8; Character = 6 } }
-                NewText = "; " }
-              { Range =
-                  { Start = { Line = 8; Character = 7 }
-                    End = { Line = 8; Character = 7 } }
-                NewText = "" }
-              { Range =
-                  { Start = { Line = 8; Character = 8 }
-                    End = { Line = 8; Character = 8 } }
-                NewText = "b = " }
-              { Range =
-                  { Start = { Line = 8; Character = 9 }
-                    End = { Line = 8; Character = 9 } }
-                NewText = "; " } |]
+           [| { Range = { Start = { Line = 8
+                                    Character = 5 }
+                          End = { Line = 8
+                                  Character = 5 } }
+                NewText = "a = " };
+              { Range = { Start = { Line = 8
+                                    Character = 6 }
+                          End = { Line = 8
+                                  Character = 6 } }
+                NewText = ";" };
+              { Range = { Start = { Line = 8
+                                    Character = 6 }
+                          End = { Line = 8
+                                  Character = 7 } }
+                NewText = "" };
+              { Range = { Start = { Line = 8
+                                    Character = 8 }
+                          End = { Line = 8
+                                  Character = 8 } }
+                NewText = "b = " };
+              { Range = { Start = { Line = 8
+                                    Character = 9 }
+                          End = { Line = 8
+                                  Character = 9 } }
+                NewText = ";" } |]
 
          expectEdits patternPos edits)
       testCaseAsync
@@ -764,30 +779,36 @@ let positionalToNamedDUTests state =
             End = { Line = 12; Character = 30 } }
 
          let edits =
-           [| { Range =
-                  { Start = { Line = 12; Character = 28 }
-                    End = { Line = 12; Character = 28 } }
-                NewText = "a = " }
-              { Range =
-                  { Start = { Line = 12; Character = 29 }
-                    End = { Line = 12; Character = 29 } }
-                NewText = "; " }
-              { Range =
-                  { Start = { Line = 12; Character = 30 }
-                    End = { Line = 12; Character = 30 } }
-                NewText = "" }
-              { Range =
-                  { Start = { Line = 12; Character = 31 }
-                    End = { Line = 12; Character = 31 } }
-                NewText = "b = " }
-              { Range =
-                  { Start = { Line = 12; Character = 32 }
-                    End = { Line = 12; Character = 32 } }
-                NewText = "; " }
-              { Range =
-                  { Start = { Line = 12; Character = 32 }
-                    End = { Line = 12; Character = 32 } }
-                NewText = "c = _; " } |]
+           [| { Range = { Start = { Line = 12
+                                    Character = 28 }
+                          End = { Line = 12
+                                  Character = 28 } }
+                NewText = "a = " };
+              { Range = { Start = { Line = 12
+                                    Character = 29 }
+                          End = { Line = 12
+                                  Character = 29 } }
+                NewText = ";" };
+              { Range = { Start = { Line = 12
+                                    Character = 29 }
+                          End = { Line = 12
+                                  Character = 30 } }
+                NewText = "" }; { Range = { Start = { Line = 12
+                                                      Character = 31 }
+                                            End = { Line = 12
+                                                    Character = 31 } }
+                                  NewText = "b = " };
+              { Range = { Start = { Line = 12
+                                    Character = 32 }
+                          End = { Line = 12
+                                  Character = 32 } }
+                NewText = ";" };
+              { Range = { Start = { Line = 12
+                                    Character = 32 }
+                          End = { Line = 12
+                                  Character = 32 } }
+                NewText = "c = _;" }
+            |]
 
          expectEdits patternPos edits) ]
 


### PR DESCRIPTION
Manual testing of the new codefix for structural DU matches didn't remove the commas from the old positional patterns, so the codefix would result in code that wouldn't compile. Now we remove those.