### PR TITLE
fix record stub generation off-by-one

### DIFF
--- a/src/FsAutoComplete.Core/CodeGeneration.fs
+++ b/src/FsAutoComplete.Core/CodeGeneration.fs
@@ -62,7 +62,7 @@ module CodeGenerationUtils =
 
     type ColumnIndentedTextWriter() =
         let stringWriter = new StringWriter()
-        let indentWriter = new IndentedTextWriter(stringWriter, " ")
+        let indentWriter = new IndentedTextWriter(stringWriter, " ", NewLine = "\n")
 
         member __.Write(s: string) =
             indentWriter.Write("{0}", s)

--- a/src/FsAutoComplete.Core/CodeGeneration.fs
+++ b/src/FsAutoComplete.Core/CodeGeneration.fs
@@ -19,7 +19,7 @@ type CodeGenerationService(checker : FSharpCompilerServiceChecker, state : State
       option {
         let! text = state.TryGetFileSource fileName |> Option.ofResult
         try
-            let! line = text.GetLine (Position.mkPos (i - 1) 0)
+            let! line = text.GetLine (Position.mkPos i 0)
             return Lexer.tokenizeLine [||] line
         with
         | _ -> return! None
@@ -117,7 +117,10 @@ module CodeGenerationUtils =
                 range
 
         let lineIdxAndTokenSeq = seq {
-            for lineIdx = range.StartLine to range.EndLine do
+            let lines =
+              if range.StartLine = range.EndLine then [range.StartLine]
+              else [range.StartLine..range.EndLine]
+            for lineIdx in lines do
               match codeGenService.TokenizeLine(document.FullName, lineIdx)
                     |> Option.map (List.map (fun tokenInfo -> lineIdx * 1<Line1>, tokenInfo)) with
               | Some xs -> yield! xs

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -439,12 +439,12 @@ type Commands
 
   let codeGenServer = CodeGenerationService(checker, state)
 
-  let docForText (lines: ISourceText) (tyRes: ParseAndCheckResults) : Document =
-    { LineCount = lines.Length
+  let docForText (lines: NamedText) (tyRes: ParseAndCheckResults) : Document =
+    { LineCount = lines.Lines.Length
       FullName = tyRes.FileName // from the compiler, assumed safe
       GetText = fun _ -> string lines
-      GetLineText0 = fun i -> lines.GetLineString i
-      GetLineText1 = fun i -> lines.GetLineString(i - 1) }
+      GetLineText0 = fun i -> (lines :> ISourceText).GetLineString i
+      GetLineText1 = fun i -> (lines :> ISourceText).GetLineString(i - 1) }
 
   let calculateNamespaceInsert (decl: DeclarationListItem) (pos: Position) getLine : CompletionNamespaceInsert option =
     let getLine (p: Position) =
@@ -1260,7 +1260,7 @@ type Commands
     |> x.AsCancellable tyRes.FileName
     |> AsyncResult.recoverCancellation
 
-  member x.GetRecordStub (tyRes: ParseAndCheckResults) (pos: Position) (lines: ISourceText) (line: LineStr) =
+  member x.GetRecordStub (tyRes: ParseAndCheckResults) (pos: Position) (lines: NamedText) (line: LineStr) =
     async {
       let doc = docForText lines tyRes
       let! res = tryFindRecordDefinitionFromPos codeGenServer pos doc
@@ -1283,7 +1283,7 @@ type Commands
     |> x.AsCancellable tyRes.FileName
     |> AsyncResult.recoverCancellation
 
-  member x.GetInterfaceStub (tyRes: ParseAndCheckResults) (pos: Position) (lines: ISourceText) (lineStr: LineStr) =
+  member x.GetInterfaceStub (tyRes: ParseAndCheckResults) (pos: Position) (lines: NamedText) (lineStr: LineStr) =
     async {
       let doc = docForText lines tyRes
       let! res = tryFindInterfaceExprInBufferAtPos codeGenServer pos doc
@@ -1303,7 +1303,7 @@ type Commands
   member x.GetAbstractClassStub
     (tyRes: ParseAndCheckResults)
     (objExprRange: Range)
-    (lines: ISourceText)
+    (lines: NamedText)
     (lineStr: LineStr)
     =
     asyncResult {

--- a/src/FsAutoComplete.Core/RecordStubGenerator.fs
+++ b/src/FsAutoComplete.Core/RecordStubGenerator.fs
@@ -20,6 +20,7 @@ type RecordExpr = {
     Expr: SynExpr
     CopyExprOption: option<SynExpr * BlockSeparator>
     FieldExprList: SynExprRecordField list
+    LastKnownGoodPosForSymbolLookup: Position
 }
 
 [<RequireQualifiedAccess>]
@@ -185,310 +186,27 @@ let formatRecord (insertionPos: RecordStubsInsertionParams) (fieldDefaultValue: 
 
     writer.Dump()
 
-let private tryFindRecordBindingInParsedInput (pos: Position) (parsedInput: ParsedInput) =
-    let inline getIfPosInRange range f =
-        if Range.rangeContainsPos range pos then f()
-        else None
 
-    let rec walkImplFileInput (ParsedImplFileInput(_name, _isScript, _fileName, _scopedPragmas, _hashDirectives, moduleOrNamespaceList, _)) =
-        List.tryPick walkSynModuleOrNamespace moduleOrNamespaceList
-
-    and walkSynModuleOrNamespace(SynModuleOrNamespace(_, _, _, decls, _, _, _, range)) =
-        getIfPosInRange range (fun () ->
-            List.tryPick walkSynModuleDecl decls
-        )
-
-    and walkSynModuleDecl(decl: SynModuleDecl) =
-        getIfPosInRange decl.Range (fun () ->
-            match decl with
-            | SynModuleDecl.Exception(exnDefn = SynExceptionDefn(members = synMembers)) ->
-                List.tryPick walkSynMemberDefn synMembers
-            | SynModuleDecl.Let(_isRecursive, bindings, _) ->
-                List.tryPick walkBinding bindings
-            | SynModuleDecl.ModuleAbbrev _ ->
-                None
-            | SynModuleDecl.NamespaceFragment(fragment) ->
-                walkSynModuleOrNamespace fragment
-            | SynModuleDecl.NestedModule(decls = modules) ->
-                List.tryPick walkSynModuleDecl modules
-            | SynModuleDecl.Types(typeDefs, _range) ->
-                List.tryPick walkSynTypeDefn typeDefs
-            | SynModuleDecl.DoExpr (_, expr, _) ->
-                walkExpr expr
-            | SynModuleDecl.Attributes _
-            | SynModuleDecl.HashDirective _
-            | SynModuleDecl.Open _ ->
-                None
-        )
-
-    and walkSynTypeDefn(SynTypeDefn(typeRepr = representation; members = members; implicitConstructor = implicitCtor; range = range)) =
-        getIfPosInRange range (fun () ->
-            walkSynTypeDefnRepr representation
-            |> Option.orElseWith (fun _ -> Option.bind walkSynMemberDefn implicitCtor)
-            |> Option.orElseWith (fun _ -> List.tryPick walkSynMemberDefn members)
-        )
-
-    and walkSynTypeDefnRepr(typeDefnRepr: SynTypeDefnRepr) =
-        getIfPosInRange typeDefnRepr.Range (fun () ->
-            match typeDefnRepr with
-            | SynTypeDefnRepr.ObjectModel(_kind, members, _range) ->
-                List.tryPick walkSynMemberDefn members
-            | SynTypeDefnRepr.Simple _
-            | SynTypeDefnRepr.Exception _ -> None
-        )
-
-    and walkSynMemberDefn (memberDefn: SynMemberDefn) =
-        getIfPosInRange memberDefn.Range (fun () ->
-            match memberDefn with
-            | SynMemberDefn.AbstractSlot(_synValSig, _memberFlags, _range) ->
-                None
-            | SynMemberDefn.AutoProperty(synExpr = expr) ->
-                walkExpr expr
-            | SynMemberDefn.Interface(members = members) ->
-                Option.bind (List.tryPick walkSynMemberDefn) members
-            | SynMemberDefn.Member(binding, _range) ->
-                walkBinding binding
-            | SynMemberDefn.NestedType(typeDef, _access, _range) ->
-                walkSynTypeDefn typeDef
-            | SynMemberDefn.ValField(_field, _range) ->
-                None
-            | SynMemberDefn.LetBindings(bindings, _isStatic, _isRec, _range) ->
-                List.tryPick walkBinding bindings
-            | SynMemberDefn.Open _
-            | SynMemberDefn.ImplicitInherit _
-            | SynMemberDefn.Inherit _
-            | SynMemberDefn.ImplicitCtor _ ->
-                None
-        )
-
-    and walkBinding (SynBinding(returnInfo = retTy; expr = expr) as binding) =
-        getIfPosInRange binding.RangeOfBindingWithRhs (fun () ->
-            match retTy with
-            | Some(SynBindingReturnInfo(_)) ->
-                match expr with
-                // Situation 1:
-                // NOTE: 'buggy' parse tree when a type annotation is given before the '=' (but workable corner case)
-                // Ex: let x: MyRecord = { f1 = e1; f2 = e2; ... }
-                | SynExpr.Typed(expr = SynExpr.Record(recordFields = fields; copyInfo = copyOpt;); targetType = synType) ->
-                    [
-                        // Get type annotation range
-                        yield synType.Range
-
-                        // Get all field identifiers ranges
-                        for (SynExprRecordField(fieldName = (recordFieldIdent, _))) in fields do
-                            yield recordFieldIdent.Range
-                    ]
-                    |> List.tryPick (fun range ->
-                        getIfPosInRange range (fun () ->
-                            Some { Expr = expr
-                                   CopyExprOption = copyOpt
-                                   FieldExprList = fields }
-                        )
-                    )
-                    |> Option.orElseWith (fun () ->
-                        fields
-                        |> List.tryPick walkRecordField
-                    )
-                | _ -> walkExpr expr
-            | None ->
-                walkExpr expr
-        )
-
-    and walkExpr expr =
-        getIfPosInRange expr.Range (fun () ->
-            match expr with
-            | SynExpr.Quote(synExpr1, _, synExpr2, _, _range) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-
-            | SynExpr.Const(_synConst, _range) ->
-                None
-
-            | SynExpr.Typed(synExpr, synType, _) ->
-                match synExpr with
-                // Situation 2: record is typed on the right
-                // { f1 = e1; f2 = e2; ... } : MyRecord
-                | SynExpr.Record(_inheritOpt, copyOpt, fields, _range) ->
-                    [
-                        // Get type annotation range
-                        yield synType.Range
-
-                        // Get all field identifiers ranges
-                        for (SynExprRecordField(fieldName = (recordFieldIdent, _))) in fields do
-                            yield recordFieldIdent.Range
-                    ]
-                    |> List.tryPick (fun range ->
-                        getIfPosInRange range (fun () ->
-                            Some { Expr = expr
-                                   CopyExprOption = copyOpt
-                                   FieldExprList = fields }
-                        )
-                    )
-                    |> Option.orElseWith (fun () ->
-                        fields
-                        |> List.tryPick walkRecordField
-                    )
-                | _ -> walkExpr synExpr
-
-            | SynExpr.Paren(synExpr, _, _, _)
-            | SynExpr.New(_, _, synExpr, _)
-            | SynExpr.ArrayOrListComputed(_, synExpr, _)
-            | SynExpr.ComputationExpr(_, synExpr, _)
-            | SynExpr.Lambda(body = synExpr)
-            | SynExpr.Lazy(synExpr, _)
-            | SynExpr.Do(synExpr, _)
-            | SynExpr.Assert(synExpr, _) ->
-                walkExpr synExpr
-
-            | SynExpr.Tuple(_, synExprList, _, _range)
-            | SynExpr.ArrayOrList(_, synExprList, _range) ->
-                List.tryPick walkExpr synExprList
-
-            | SynExpr.Record(_inheritOpt, copyOpt, fields, _range) ->
-                fields
-                |> List.tryPick (function
-                    | SynExprRecordField(fieldName = (recordFieldIdent, _))
-                        when Range.rangeContainsPos (recordFieldIdent.Range) pos ->
-                        Some { Expr = expr
-                               CopyExprOption = copyOpt
-                               FieldExprList = fields }
-                    | field -> walkRecordField field
-                )
-
-            | SynExpr.ObjExpr(bindings = binds; extraImpls = ifaces) ->
-                List.tryPick walkBinding binds
-                |> Option.orElseWith (fun _ -> List.tryPick walkSynInterfaceImpl ifaces)
-
-            | SynExpr.While(_sequencePointInfoForWhileLoop, synExpr1, synExpr2, _range) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-            | SynExpr.ForEach(enumExpr = synExpr1; bodyExpr = synExpr2) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-
-            | SynExpr.For(identBody = synExpr1; toBody = synExpr2; doBody = synExpr3) ->
-                List.tryPick walkExpr [synExpr1; synExpr2; synExpr3]
-
-            | SynExpr.MatchLambda(_isExnMatch, _argm, synMatchClauseList, _spBind, _wholem) ->
-                synMatchClauseList
-                |> List.tryPick (fun (SynMatchClause(resultExpr = e)) -> walkExpr e)
-            | SynExpr.Match(expr = synExpr; clauses = synMatchClauseList) ->
-                walkExpr synExpr
-                |> Option.orElseWith (fun _ -> synMatchClauseList |> List.tryPick (fun (SynMatchClause(resultExpr = e)) -> walkExpr e))
-
-            | SynExpr.App(_exprAtomicFlag, _isInfix, synExpr1, synExpr2, _range) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-
-            | SynExpr.TypeApp(synExpr, _, _synTypeList, _commas, _, _, _range) ->
-                walkExpr synExpr
-
-            | SynExpr.LetOrUse(bindings =  synBindingList; body = synExpr) ->
-                walkExpr synExpr
-                |> Option.orElseWith (fun _ -> List.tryPick walkBinding synBindingList)
-
-            | SynExpr.TryWith(tryExpr = synExpr) ->
-                walkExpr synExpr
-
-            | SynExpr.TryFinally(tryExpr = synExpr1; finallyExpr = synExpr2) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-
-            | Sequentials exprs ->
-                List.tryPick walkExpr exprs
-
-            | SynExpr.IfThenElse(ifExpr = synExpr1; thenExpr = synExpr2; elseExpr = synExprOpt) ->
-                match synExprOpt with
-                | Some synExpr3 ->
-                    List.tryPick walkExpr [synExpr1; synExpr2; synExpr3]
-                | None ->
-                    List.tryPick walkExpr [synExpr1; synExpr2]
-
-            | SynExpr.Ident(_ident) ->
-                None
-            | SynExpr.LongIdent(_, _longIdent, _altNameRefCell, _range) ->
-                None
-
-            | SynExpr.LongIdentSet(_longIdent, synExpr, _range) ->
-                walkExpr synExpr
-            | SynExpr.DotGet(synExpr, _dotm, _longIdent, _range) ->
-                walkExpr synExpr
-
-            | SynExpr.DotSet(synExpr1, _longIdent, synExpr2, _range) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-
-            | SynExpr.DotIndexedGet(synExpr, argList, _range, _range2) ->
-                walkExpr argList
-                |> Option.orElseWith (fun _ -> walkExpr synExpr)
-
-            | SynExpr.DotIndexedSet(synExpr1, argList, synExpr2, _, _range, _range2) ->
-                [ synExpr1
-                  argList
-                  synExpr2 ]
-                |> List.tryPick walkExpr
-
-            | SynExpr.JoinIn(synExpr1, _range, synExpr2, _range2) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-            | SynExpr.NamedIndexedPropertySet(_longIdent, synExpr1, synExpr2, _range) ->
-                List.tryPick walkExpr [synExpr1; synExpr2]
-
-            | SynExpr.DotNamedIndexedPropertySet(synExpr1, _longIdent, synExpr2, synExpr3, _range) ->
-                List.tryPick walkExpr [synExpr1; synExpr2; synExpr3]
-
-            | SynExpr.TypeTest(synExpr, _synType, _range)
-            | SynExpr.Upcast(synExpr, _synType, _range)
-            | SynExpr.Downcast(synExpr, _synType, _range) ->
-                walkExpr synExpr
-            | SynExpr.InferredUpcast(synExpr, _range)
-            | SynExpr.InferredDowncast(synExpr, _range) ->
-                walkExpr synExpr
-            | SynExpr.AddressOf(_, synExpr, _range, _range2) ->
-                walkExpr synExpr
-            | SynExpr.TraitCall(_synTyparList, _synMemberSig, synExpr, _range) ->
-                walkExpr synExpr
-
-            | SynExpr.Null(_range)
-            | SynExpr.ImplicitZero(_range) ->
-                None
-
-            | SynExpr.YieldOrReturn(_, synExpr, _range)
-            | SynExpr.YieldOrReturnFrom(_, synExpr, _range)
-            | SynExpr.DoBang(synExpr, _range) ->
-                walkExpr synExpr
-
-            | SynExpr.LetOrUseBang(rhs = synExpr1; andBangs = ands; body = synExpr2) ->
-                [ synExpr1
-                  yield! ands |> List.map (fun (SynExprAndBang(body = body)) -> body)
-                  synExpr2 ] |> List.tryPick walkExpr
-
-            | SynExpr.LibraryOnlyILAssembly _
-            | SynExpr.LibraryOnlyStaticOptimization _
-            | SynExpr.LibraryOnlyUnionCaseFieldGet _
-            | SynExpr.LibraryOnlyUnionCaseFieldSet _ ->
-                None
-            | SynExpr.ArbitraryAfterError(_debugStr, _range) ->
-                None
-
-            | SynExpr.FromParseError(synExpr, _range)
-            | SynExpr.DiscardAfterMissingQualificationAfterDot(synExpr, _range) ->
-                walkExpr synExpr
-
-            | _ -> None
-        )
-
-    and walkRecordField (SynExprRecordField(expr = synExprOpt)) =
-        match synExprOpt with
-        | Some synExpr when Range.rangeContainsPos synExpr.Range pos -> walkExpr synExpr
-        | _ -> None
-
-    and walkSynInterfaceImpl (SynInterfaceImpl(bindings = synBindings): SynInterfaceImpl) =
-        List.tryPick walkBinding synBindings
-
-    match parsedInput with
-    | ParsedInput.SigFile _input -> None
-    | ParsedInput.ImplFile input -> walkImplFileInput input
+let walkAndFindRecordBinding (pos, input) =
+  let walker = {
+      new SyntaxVisitorBase<RecordExpr>() with
+        member x.VisitExpr(path: SyntaxVisitorPath, traverseSynExpr: (SynExpr -> _ option), defaultTraverse: (SynExpr -> _ option), synExpr: SynExpr) =
+          match synExpr with
+          | SynExpr.Record (recordFields = recordFields; copyInfo = copyInfo) ->
+            Some { Expr = synExpr
+                   CopyExprOption = copyInfo
+                   FieldExprList = recordFields
+                   LastKnownGoodPosForSymbolLookup = recordFields |> List.tryLast |> Option.map (function SynExprRecordField(fieldName = (id, _)) -> id.Range.Start) |> Option.defaultValue synExpr.Range.Start }
+          | _ -> defaultTraverse synExpr
+    }
+  SyntaxTraversal.Traverse(pos, input, walker)
 
 let tryFindRecordExprInBufferAtPos (codeGenService: CodeGenerationService) (pos: Position) (document : Document) =
     asyncMaybe {
         let! parseResults = codeGenService.ParseFileInProject(document.FullName)
 
-        return!
-            tryFindRecordBindingInParsedInput pos parseResults.ParseTree
+        let! found = walkAndFindRecordBinding(pos, parseResults.ParseTree)
+        return found
     }
 
 let checkThatRecordExprEndsWithRBrace (codeGenService: CodeGenerationService) (document : Document) (expr: RecordExpr) =
@@ -542,7 +260,7 @@ let tryFindRecordDefinitionFromPos (codeGenService: CodeGenerationService) (pos:
             tryFindStubInsertionParamsAtPos codeGenService pos document
 
         let! symbol, symbolUse =
-            codeGenService.GetSymbolAndUseAtPositionOfKind(document.FullName, pos, SymbolKind.Ident)
+            codeGenService.GetSymbolAndUseAtPositionOfKind(document.FullName, recordExpression.LastKnownGoodPosForSymbolLookup, SymbolKind.Ident)
         let! symbolUse = symbolUse
         match symbolUse.Symbol with
         | :? FSharpEntity as entity when entity.IsFSharpRecord && entity.DisplayName = symbol.Text ->

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
@@ -168,8 +168,6 @@ let generateRecordStubTests state =
     }
     |> Async.Cache
 
-  let (|NormalizeNewlines|) (s: string) = s.Replace("\r\n", System.Environment.NewLine)
-
   testList
     "generate record stubs"
     [ testCaseAsync
@@ -192,7 +190,7 @@ let generateRecordStubTests state =
                                                                                                                                                  Character = 18 }
                                                                                                                                        End = { Line = 2
                                                                                                                                                Character = 18 } }
-                                                                                                                             NewText = NormalizeNewlines "\r\n           b = failwith \"Not Implemented\"" } |] } |] } } |])) ->
+                                                                                                                             NewText = "\n           b = failwith \"Not Implemented\"" } |] } |] } } |])) ->
               ()
             | Ok other ->
               failtestf

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
@@ -8,6 +8,17 @@ open FsAutoComplete.Utils
 
 let pos (line, character) = { Line = line; Character = character }
 let range st e = { Start = pos st; End = pos e }
+let rangeP st e = { Start = st; End = e }
+
+/// naive iteration, assumes start and end are on same line
+let iterateRange (r: Range) =
+  seq {
+    if r.Start = r.End then
+      yield r.Start
+    else
+      for c = r.Start.Character to r.End.Character do
+        yield pos (r.Start.Line, c)
+  }
 
 let (|Refactor|_|) title newText action =
   match action with
@@ -137,6 +148,58 @@ let generateMatchTests state =
           | Ok other -> failtestf $"Should have generated the rest of match cases, but instead generated %A{other}"
           | Error reason -> failtestf $"Should have succeeded, but failed with %A{reason}"
         }) ]
+
+let generateRecordStubTests state =
+  let server =
+    async {
+      let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "RecordStubGeneration")
+
+      let! (server, events) = serverInitialize path { defaultConfigDto with RecordStubGeneration = Some true } state
+      do! waitForWorkspaceFinishedParsing events
+      let path = Path.Combine(path, "Script.fsx")
+      let tdop: DidOpenTextDocumentParams = { TextDocument = loadDocument path }
+      do! server.TextDocumentDidOpen tdop
+
+      let! diagnostics =
+        waitForParseResultsForFile "Script.fsx" events
+        |> AsyncResult.bimap (fun _ -> failtest "Should have had errors") (fun e -> e)
+
+      return (server, path, diagnostics)
+    }
+    |> Async.Cache
+
+  let (|NormalizeNewlines|) (s: string) = s.Replace("\r\n", System.Environment.NewLine)
+
+  testList
+    "generate record stubs"
+    [ testCaseAsync
+        "can generate record stubs for every pos in the record as soon as one field is known"
+        (async {
+          let! server, file, diagnostics = server
+          let expectedDiagnostic = diagnostics.[0]
+          Expect.equal expectedDiagnostic.Code (Some "764") "Should have missing record field diagnostic"
+
+          for pos in iterateRange expectedDiagnostic.Range do
+            let! response =
+              server.TextDocumentCodeAction
+                { CodeActionParams.TextDocument = { Uri = Path.FilePathToUri file }
+                  Range = rangeP pos pos
+                  Context = { Diagnostics = [| expectedDiagnostic |] } }
+
+            match response with
+            | Ok (Some (TextDocumentCodeActionResult.CodeActions [| { Title = "Generate record stub"
+                                                                      Edit = Some { DocumentChanges = Some [| { Edits = [| { Range = { Start = { Line = 2
+                                                                                                                                                 Character = 18 }
+                                                                                                                                       End = { Line = 2
+                                                                                                                                               Character = 18 } }
+                                                                                                                             NewText = NormalizeNewlines "\r\n           b = failwith \"Not Implemented\"" } |] } |] } } |])) ->
+              ()
+            | Ok other ->
+              failtestf
+                $"Should have generated the rest of the record body at %d{pos.Line},%d{pos.Character}, but instead generated %A{other}"
+            | Error reason -> failtestf $"Should have succeeded, but failed with %A{reason}"
+        }) ]
+
 
 let missingFunKeywordTests state =
   let server =
@@ -677,30 +740,25 @@ let positionalToNamedDUTests state =
             End = { Line = 2; Character = 10 } }
 
          let edits =
-           [| { Range = { Start = { Line = 2
-                                    Character = 7 }
-                          End = { Line = 2
-                                  Character = 7 } }
-                NewText = "a = " };
-              { Range = { Start = { Line = 2
-                                    Character = 8 }
-                          End = { Line = 2
-                                  Character = 8 } }
-                NewText = ";" };
-              { Range = { Start = { Line = 2
-                                    Character = 8 }
-                          End = { Line = 2
-                                  Character = 9 } }
-                NewText = "" };
-              { Range = { Start = { Line = 2
-                                    Character = 10 }
-                          End = { Line = 2
-                                  Character = 10 } }
-                NewText = "b = " };
-              { Range = { Start = { Line = 2
-                                    Character = 11 }
-                          End = { Line = 2
-                                  Character = 11 } }
+           [| { Range =
+                  { Start = { Line = 2; Character = 7 }
+                    End = { Line = 2; Character = 7 } }
+                NewText = "a = " }
+              { Range =
+                  { Start = { Line = 2; Character = 8 }
+                    End = { Line = 2; Character = 8 } }
+                NewText = ";" }
+              { Range =
+                  { Start = { Line = 2; Character = 8 }
+                    End = { Line = 2; Character = 9 } }
+                NewText = "" }
+              { Range =
+                  { Start = { Line = 2; Character = 10 }
+                    End = { Line = 2; Character = 10 } }
+                NewText = "b = " }
+              { Range =
+                  { Start = { Line = 2; Character = 11 }
+                    End = { Line = 2; Character = 11 } }
                 NewText = ";" } |]
 
          expectEdits patternPos edits)
@@ -711,30 +769,25 @@ let positionalToNamedDUTests state =
             End = { Line = 5; Character = 6 } }
 
          let edits =
-           [| { Range = { Start = { Line = 5
-                                    Character = 4 }
-                          End = { Line = 5
-                                  Character = 4 } }
-                NewText = "a = " };
-              { Range = { Start = { Line = 5
-                                    Character = 5 }
-                          End = { Line = 5
-                                  Character = 5 } }
-                NewText = ";" };
-              { Range = { Start = { Line = 5
-                                    Character = 5 }
-                          End = { Line = 5
-                                  Character = 6 } }
-                NewText = "" };
-              { Range = { Start = { Line = 5
-                                    Character = 7 }
-                          End = { Line = 5
-                                  Character = 7 } }
-                NewText = "b = " };
-              { Range = { Start = { Line = 5
-                                    Character = 8 }
-                          End = { Line = 5
-                                  Character = 8 } }
+           [| { Range =
+                  { Start = { Line = 5; Character = 4 }
+                    End = { Line = 5; Character = 4 } }
+                NewText = "a = " }
+              { Range =
+                  { Start = { Line = 5; Character = 5 }
+                    End = { Line = 5; Character = 5 } }
+                NewText = ";" }
+              { Range =
+                  { Start = { Line = 5; Character = 5 }
+                    End = { Line = 5; Character = 6 } }
+                NewText = "" }
+              { Range =
+                  { Start = { Line = 5; Character = 7 }
+                    End = { Line = 5; Character = 7 } }
+                NewText = "b = " }
+              { Range =
+                  { Start = { Line = 5; Character = 8 }
+                    End = { Line = 5; Character = 8 } }
                 NewText = ";" } |]
 
          expectEdits patternPos edits)
@@ -745,30 +798,25 @@ let positionalToNamedDUTests state =
             End = { Line = 8; Character = 8 } }
 
          let edits =
-           [| { Range = { Start = { Line = 8
-                                    Character = 5 }
-                          End = { Line = 8
-                                  Character = 5 } }
-                NewText = "a = " };
-              { Range = { Start = { Line = 8
-                                    Character = 6 }
-                          End = { Line = 8
-                                  Character = 6 } }
-                NewText = ";" };
-              { Range = { Start = { Line = 8
-                                    Character = 6 }
-                          End = { Line = 8
-                                  Character = 7 } }
-                NewText = "" };
-              { Range = { Start = { Line = 8
-                                    Character = 8 }
-                          End = { Line = 8
-                                  Character = 8 } }
-                NewText = "b = " };
-              { Range = { Start = { Line = 8
-                                    Character = 9 }
-                          End = { Line = 8
-                                  Character = 9 } }
+           [| { Range =
+                  { Start = { Line = 8; Character = 5 }
+                    End = { Line = 8; Character = 5 } }
+                NewText = "a = " }
+              { Range =
+                  { Start = { Line = 8; Character = 6 }
+                    End = { Line = 8; Character = 6 } }
+                NewText = ";" }
+              { Range =
+                  { Start = { Line = 8; Character = 6 }
+                    End = { Line = 8; Character = 7 } }
+                NewText = "" }
+              { Range =
+                  { Start = { Line = 8; Character = 8 }
+                    End = { Line = 8; Character = 8 } }
+                NewText = "b = " }
+              { Range =
+                  { Start = { Line = 8; Character = 9 }
+                    End = { Line = 8; Character = 9 } }
                 NewText = ";" } |]
 
          expectEdits patternPos edits)
@@ -779,36 +827,30 @@ let positionalToNamedDUTests state =
             End = { Line = 12; Character = 30 } }
 
          let edits =
-           [| { Range = { Start = { Line = 12
-                                    Character = 28 }
-                          End = { Line = 12
-                                  Character = 28 } }
-                NewText = "a = " };
-              { Range = { Start = { Line = 12
-                                    Character = 29 }
-                          End = { Line = 12
-                                  Character = 29 } }
-                NewText = ";" };
-              { Range = { Start = { Line = 12
-                                    Character = 29 }
-                          End = { Line = 12
-                                  Character = 30 } }
-                NewText = "" }; { Range = { Start = { Line = 12
-                                                      Character = 31 }
-                                            End = { Line = 12
-                                                    Character = 31 } }
-                                  NewText = "b = " };
-              { Range = { Start = { Line = 12
-                                    Character = 32 }
-                          End = { Line = 12
-                                  Character = 32 } }
-                NewText = ";" };
-              { Range = { Start = { Line = 12
-                                    Character = 32 }
-                          End = { Line = 12
-                                  Character = 32 } }
-                NewText = "c = _;" }
-            |]
+           [| { Range =
+                  { Start = { Line = 12; Character = 28 }
+                    End = { Line = 12; Character = 28 } }
+                NewText = "a = " }
+              { Range =
+                  { Start = { Line = 12; Character = 29 }
+                    End = { Line = 12; Character = 29 } }
+                NewText = ";" }
+              { Range =
+                  { Start = { Line = 12; Character = 29 }
+                    End = { Line = 12; Character = 30 } }
+                NewText = "" }
+              { Range =
+                  { Start = { Line = 12; Character = 31 }
+                    End = { Line = 12; Character = 31 } }
+                NewText = "b = " }
+              { Range =
+                  { Start = { Line = 12; Character = 32 }
+                    End = { Line = 12; Character = 32 } }
+                NewText = ";" }
+              { Range =
+                  { Start = { Line = 12; Character = 32 }
+                    End = { Line = 12; Character = 32 } }
+                NewText = "c = _;" } |]
 
          expectEdits patternPos edits) ]
 
@@ -816,6 +858,7 @@ let tests state =
   testList
     "codefix tests"
     [ abstractClassGenerationTests state
+      generateRecordStubTests state
       generateMatchTests state
       missingFunKeywordTests state
       outerBindingRecursiveTests state

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/RecordStubGeneration/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/RecordStubGeneration/Script.fsx
@@ -1,0 +1,3 @@
+type R = { a: string; b: int }
+
+let a = {  a = "";  }


### PR DESCRIPTION
Fixes https://github.com/ionide/ionide-vscode-fsharp/issues/1674 by

* addressing an off-by-one line read error introduced by the move to NamedText vs raw ISourceText, and
* cleans up the record stub code by moving it to the core Syntax Tree Walker mechanism, and
* fixes an edge case where stub generation wouldn't work if you were outside a field range, and
* adds some basic testing