### PR TITLE
Fix another case of line off-by-ones, this time in pipelineHints

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1556,12 +1556,12 @@ type Commands
     result {
       let! contents = state.TryGetFileSource tyRes.FileName
 
-      let getGenerics line (token: FSharpTokenInfo) =
+      let getSignatureAtPos pos =
         option {
-          let! lineStr = contents.GetLine (Position.mkPos line 0)
+          let! lineStr = contents.GetLine pos
 
           let! tip =
-            tyRes.TryGetToolTip(Position.fromZ line token.RightColumn) lineStr
+            tyRes.TryGetToolTip pos lineStr
             |> Option.ofResult
 
           return TipFormatter.extractGenericParameters tip
@@ -1608,7 +1608,8 @@ type Commands
         |> Array.fold folder (0, false, [])
         |> (fun (_, _, third) -> third |> Array.ofList)
         |> Array.Parallel.map (fun (lastExpressionLine, lastExpressionLineWasPipe, currentIndex, pipeToken) ->
-          let gens = getGenerics currentIndex pipeToken
+          let pipePos = Position.fromZ currentIndex pipeToken.RightColumn
+          let gens = getSignatureAtPos pipePos
 
           let previousNonPipeLine =
             if lastExpressionLineWasPipe then


### PR DESCRIPTION
Fixes https://github.com/ionide/ionide-vscode-fsharp/issues/1673

This was another off-by-one, this time on direct line indexing.  Since the `getGenerics` function was just constructing a `Position`, I pulled that out into a central area and used the same Position for both needs, so that the Position was always correctly calculated.

This is one of the 'stringy payload' members so it's rough to test. I have a plan for making this feature (and a few others) into FSAC-published decorations instead of Ionide-spawned decorations that might get around this and make it easier to test. 