### PR TITLE
Add support for inlay hints

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1600,6 +1600,9 @@ type Commands
   //     return CoreResponse.Res html
   //   }
 
+  member _.InlayHints (text, tyRes: ParseAndCheckResults, range) =
+    FsAutoComplete.Core.InlayHints.provideHints(text, tyRes, range)
+
   member __.PipelineHints(tyRes: ParseAndCheckResults) =
     result {
       let! contents = state.TryGetFileSource tyRes.FileName

--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -42,6 +42,7 @@
     <Compile Include="Fsdn.fs" />
     <!-- <Compile Include="Lint.fs" /> -->
     <Compile Include="SignatureHelp.fs" />
+    <Compile Include="InlayHints.fs" />
     <Compile Include="Commands.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/src/FsAutoComplete.Core/InlayHints.fs
+++ b/src/FsAutoComplete.Core/InlayHints.fs
@@ -1,0 +1,172 @@
+module FsAutoComplete.Core.InlayHints
+
+open System
+open FSharp.Compiler.Text
+open FSharp.Compiler.Syntax
+open FsToolkit.ErrorHandling
+open FsAutoComplete
+open FSharp.Compiler.Symbols
+open FSharp.UMX
+open System.Linq
+open System.Collections.Immutable
+open FSharp.Compiler.CodeAnalysis
+open System.Text
+
+type HintKind = Parameter | Type
+type Hint = { Text: string; Pos: Position; Kind: HintKind }
+
+let private getArgumentsFor (state: FsAutoComplete.State, p: ParseAndCheckResults, identText: Range) =
+  option {
+
+    let! contents =
+      state.TryGetFileSource p.FileName
+      |> Option.ofResult
+
+    let! line = contents.GetLine identText.End
+    let! symbolUse = p.TryGetSymbolUse identText.End line
+
+    match symbolUse.Symbol with
+    | :? FSharpMemberOrFunctionOrValue as mfv when
+      mfv.IsFunction
+      || mfv.IsConstructor
+      || mfv.CurriedParameterGroups.Count <> 0
+      ->
+      let parameters = mfv.CurriedParameterGroups
+
+      let formatted =
+        parameters
+        |> Seq.collect (fun pGroup -> pGroup |> Seq.map (fun p -> p.DisplayName + ":"))
+
+      return formatted |> Array.ofSeq
+    | _ -> return! None
+  }
+
+let private isSignatureFile (f: string<LocalPath>) =
+  System.IO.Path.GetExtension(UMX.untag f) = ".fsi"
+
+let getFirstPositionAfterParen (str: string) startPos =
+  match str with
+  | null -> -1
+  | str when startPos > str.Length -> -1
+  | str -> str.IndexOf('(') + 1
+
+let provideHints (text: NamedText, p: ParseAndCheckResults, range: Range) : Hint [] =
+  let parseFileResults, checkFileResults = p.GetParseResults, p.GetCheckResults
+
+  let symbolUses =
+    checkFileResults.GetAllUsesOfAllSymbolsInFile(System.Threading.CancellationToken.None)
+    |> Seq.filter (fun su -> Range.rangeContainsRange range su.Range)
+    |> Seq.toList
+
+  let typeHints = ImmutableArray.CreateBuilder()
+  let parameterHints = ImmutableArray.CreateBuilder()
+
+  let isValidForTypeHint (funcOrValue: FSharpMemberOrFunctionOrValue) (symbolUse: FSharpSymbolUse) =
+    let isLambdaIfFunction =
+      funcOrValue.IsFunction
+      && parseFileResults.IsBindingALambdaAtPosition symbolUse.Range.Start
+
+    (funcOrValue.IsValue || isLambdaIfFunction)
+    && not (parseFileResults.IsTypeAnnotationGivenAtPosition symbolUse.Range.Start)
+    && symbolUse.IsFromDefinition
+    && not funcOrValue.IsMember
+    && not funcOrValue.IsMemberThisValue
+    && not funcOrValue.IsConstructorThisValue
+    && not (PrettyNaming.IsOperatorDisplayName funcOrValue.DisplayName)
+
+  for symbolUse in symbolUses do
+    match symbolUse.Symbol with
+    | :? FSharpMemberOrFunctionOrValue as funcOrValue when isValidForTypeHint funcOrValue symbolUse ->
+      let layout =
+        ": "
+        + funcOrValue.ReturnParameter.Type.Format symbolUse.DisplayContext
+
+      let hint =
+        { Text = layout
+          Pos = symbolUse.Range.End
+          Kind = Type }
+
+      typeHints.Add(hint)
+
+    | :? FSharpMemberOrFunctionOrValue as func when func.IsFunction && not symbolUse.IsFromDefinition ->
+      let appliedArgRangesOpt =
+        parseFileResults.GetAllArgumentsForFunctionApplicationAtPostion symbolUse.Range.Start
+
+      match appliedArgRangesOpt with
+      | None -> ()
+      | Some [] -> ()
+      | Some appliedArgRanges ->
+        let parameters = func.CurriedParameterGroups |> Seq.concat
+        let appliedArgRanges = appliedArgRanges |> Array.ofList
+        let definitionArgs = parameters |> Array.ofSeq
+
+        for idx = 0 to appliedArgRanges.Length - 1 do
+          let appliedArgRange = appliedArgRanges.[idx]
+          let definitionArgName = definitionArgs.[idx].DisplayName
+
+          if not (String.IsNullOrWhiteSpace(definitionArgName)) then
+            let hint =
+              { Text = definitionArgName + " ="
+                Pos = appliedArgRange.Start
+                Kind = Parameter }
+
+            parameterHints.Add(hint)
+
+    | :? FSharpMemberOrFunctionOrValue as methodOrConstructor when methodOrConstructor.IsConstructor -> // TODO: support methods when this API comes into FCS
+      let endPosForMethod = symbolUse.Range.End
+      let line, _ = Position.toZ endPosForMethod
+
+      let afterParenPosInLine =
+        getFirstPositionAfterParen (text.Lines.[line].ToString()) (endPosForMethod.Column)
+
+      let tupledParamInfos =
+        parseFileResults.FindParameterLocations(Position.fromZ line afterParenPosInLine)
+
+      let appliedArgRanges =
+        parseFileResults.GetAllArgumentsForFunctionApplicationAtPostion symbolUse.Range.Start
+
+      match tupledParamInfos, appliedArgRanges with
+      | None, None -> ()
+
+      // Prefer looking at the "tupled" view if it exists, even if the other ranges exist.
+      // M(1, 2) can give results for both, but in that case we want the "tupled" view.
+      | Some tupledParamInfos, _ ->
+        let parameters =
+          methodOrConstructor.CurriedParameterGroups
+          |> Seq.concat
+          |> Array.ofSeq // TODO: need ArgumentLocations to be surfaced
+
+        for idx = 0 to parameters.Length - 1 do
+          // let paramLocationInfo = tupledParamInfos. .ArgumentLocations.[idx]
+          // let paramName = parameters.[idx].DisplayName
+          // if not paramLocationInfo.IsNamedArgument && not (String.IsNullOrWhiteSpace(paramName)) then
+          //     let hint = { Text = paramName + " ="; Pos = paramLocationInfo.ArgumentRange.Start; Kind = Parameter }
+          //     parameterHints.Add(hint)
+          ()
+
+      // This will only happen for curried methods defined in F#.
+      | _, Some appliedArgRanges ->
+        let parameters =
+          methodOrConstructor.CurriedParameterGroups
+          |> Seq.concat
+
+        let appliedArgRanges = appliedArgRanges |> Array.ofList
+        let definitionArgs = parameters |> Array.ofSeq
+
+        for idx = 0 to appliedArgRanges.Length - 1 do
+          let appliedArgRange = appliedArgRanges.[idx]
+          let definitionArgName = definitionArgs.[idx].DisplayName
+
+          if not (String.IsNullOrWhiteSpace(definitionArgName)) then
+            let hint =
+              { Text = definitionArgName + " ="
+                Pos = appliedArgRange.Start
+                Kind = Parameter }
+
+            parameterHints.Add(hint)
+    | _ -> ()
+
+  let typeHints = typeHints.ToImmutableArray()
+  let parameterHints = parameterHints.ToImmutableArray()
+
+  typeHints.AddRange(parameterHints).ToArray()

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -848,3 +848,9 @@ let encodeSemanticHighlightRanges (rangesAndHighlights: (struct(Ionide.LanguageS
       prev <- currentRange
       idx <- idx + 5
     Some finalArray
+
+
+type FSharpInlayHintsRequest = {
+  TextDocument: TextDocumentIdentifier
+  Range: Range
+}

--- a/test/FsAutoComplete.Tests.Lsp/InfoPanelTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InfoPanelTests.fs
@@ -4,19 +4,8 @@ open Expecto
 open System.IO
 open Ionide.LanguageServerProtocol.Types
 open FsAutoComplete
-open FsAutoComplete.LspHelpers
 open Helpers
 open FsToolkit.ErrorHandling
-
-let trySerialize (t: string): 't option =
-  try
-    JsonSerializer.readJson t |> Some
-  with _ -> None
-
-let (|As|_|) (m: PlainNotification): 't option =
-  match trySerialize m.Content with
-  | Some(r: FsAutoComplete.CommandResponse.ResponseMsg<'t>) -> Some r.Data
-  | None -> None
 
 let docFormattingTest state =
   let server =

--- a/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
@@ -1,0 +1,126 @@
+module FsAutoComplete.Tests.InlayHintTests
+
+open Expecto
+open System
+open System.IO
+open Ionide.LanguageServerProtocol.Types
+open FsAutoComplete
+open Helpers
+open FsToolkit.ErrorHandling
+
+let tests state =
+  let server =
+    async {
+      let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "InlayHints")
+      let config = defaultConfigDto
+      let! (server, events) = serverInitialize path config state
+      let path = Path.Combine(path, "Script.fsx")
+      let tdop: DidOpenTextDocumentParams = { TextDocument = loadDocument path }
+      do! server.TextDocumentDidOpen tdop
+
+      do!
+        waitForParseResultsForFile "Script.fsx" events
+        |> AsyncResult.bimap id (fun e -> failtest "should have not had check errors")
+
+      return (server, path)
+    }
+    |> Async.Cache
+
+  let expectedHintsForFile: FsAutoComplete.Lsp.LSPInlayHint [] =
+    [| "string", (3, 17), Lsp.InlayHintKind.Type
+       "FileInfo", (5, 9), Lsp.InlayHintKind.Type
+       "fileName", (5, 21), Lsp.InlayHintKind.Parameter |]
+    |> Array.map (fun (text, (line, char), kind) ->
+      { Text =
+          match kind with
+          | Lsp.InlayHintKind.Type -> ": " + text
+          | Lsp.InlayHintKind.Parameter -> text + " ="
+        Pos = { Line = line; Character = char }
+        Kind = kind })
+
+  testList
+    "Inlay Hints"
+    [ testCaseAsync
+        "Can return all inlay hints for a file"
+        (async {
+
+          let! (server, path) = server
+
+          let wholeFileRange: Range =
+            { Start = { Line = 0; Character = 0 }
+              End =
+                { Line = Int32.MaxValue
+                  Character = Int32.MaxValue } }
+
+          let! doc =
+            server.FSharpInlayHints
+              { TextDocument = { Uri = path }
+                Range = wholeFileRange }
+
+          match doc with
+          | Result.Error err -> failtest $"Doc error: {err.Message}"
+          | Result.Ok hints -> Expect.equal hints expectedHintsForFile "Can provide all of the hints"
+        })
+
+      testCaseAsync
+        "Filters hints returned when in a range of the file"
+        (async {
+
+          let! (server, path) = server
+
+          let partOfFileRange: Range =
+            { Start = { Line = 5; Character = 0 }
+              End =
+                { Line = Int32.MaxValue
+                  Character = Int32.MaxValue } }
+
+          let inRange = Range.rangeContainsPos partOfFileRange
+
+          let expectedHintsWithinRange =
+            expectedHintsForFile
+            |> Array.filter (fun h -> inRange h.Pos)
+
+          let! doc =
+            server.FSharpInlayHints
+              { TextDocument = { Uri = path }
+                Range = partOfFileRange }
+
+          match doc with
+          | Result.Error err -> failtest $"Doc error: {err.Message}"
+          | Result.Ok hints ->
+            Expect.isNonEmpty hints "Should have had some hints"
+            Expect.equal hints expectedHintsWithinRange "Can provide all of the hints that exist in the range"
+        })
+
+      testCaseAsync
+        "Returns no hints for nonexistent range"
+        (async {
+
+          let! (server, path) = server
+
+          let partOfFileRange: Range =
+            { Start =
+                { Line = Int32.MaxValue - 1
+                  Character = Int32.MaxValue - 1 }
+              End =
+                { Line = Int32.MaxValue
+                  Character = Int32.MaxValue } }
+
+          let inRange = Range.rangeContainsPos partOfFileRange
+
+          let! doc =
+            server.FSharpInlayHints
+              { TextDocument = { Uri = path }
+                Range = partOfFileRange }
+
+          match doc with
+          | Result.Error err -> failtest $"Doc error: {err.Message}"
+          | Result.Ok hints -> Expect.isEmpty hints "Should have had no hints"
+        })
+
+      testCaseAsync
+        "cleanup"
+        (async {
+          let! server, _ = server
+          do! server.Shutdown()
+        }) ]

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -72,6 +72,7 @@ let tests =
         InfoPanelTests.docFormattingTest state
         DetectUnitTests.tests state
         XmlDocumentationGeneration.tests state
+        InlayHintTests.tests state
       ]
   ]
 

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/InlayHints/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/InlayHints/Script.fsx
@@ -1,0 +1,12 @@
+open System.IO
+
+// shows function let-binding type annotations
+let tryFindFile p =
+    // shows value let-binding type annotations
+    let f = FileInfo p // constructor parameter name annotations
+
+    if f.Exists then Some f else None
+
+// when method parameter name annotations are enabled, this will cause a break in our tests
+System.Environment.GetEnvironmentVariable "Blah"
+|> ignore


### PR DESCRIPTION
This is most of the backend work necessary to support inlay hint display for parameter names and inferred types. It's based wholesale on @cartermp's work on https://github.com/dotnet/fsharp/pull/10295.
It doesn't currently work for methods with parameters, because there's not a public version of the changes to FCS he made in that PR yet.

Next steps:
* [x] add tests
* [ ] consider adding an inlayHint resolve method, since hints can have actions associated to them that may be difficult to perform
* [ ] consider adding an action to the type-style hints to explicitly type that expr, like we have a codeaction for already (essentially invoking that code action)