### PR TITLE
Simple completion in type hints/definitions

### DIFF
--- a/src/FsAutoComplete.Core/UntypedAstUtils.fs
+++ b/src/FsAutoComplete.Core/UntypedAstUtils.fs
@@ -1910,6 +1910,7 @@ module Completion =
   type Context =
   | StringLiteral
   | Unknown
+  | SynType
 
   let atPos (pos: Position, ast: ParsedInput): Context =
     let visitor =
@@ -1930,6 +1931,8 @@ module Completion =
                 )
               | _ -> defaultTraverse expr
           else None
+
+        member x.VisitType(path, defaultTraverse, synType) : Context option = Some Context.SynType
       }
     SyntaxTraversal.Traverse(pos, ast, visitor)
     |> Option.defaultValue Context.Unknown

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -113,6 +113,39 @@ let tests state =
               "first member should be List.Empty, since properties are preferred over functions"
           | Ok None -> failtest "Should have gotten some completion items"
           | Error e -> failtestf "Got an error while retrieving completions: %A" e
+        })
+      testCaseAsync
+        "completion in record defn field type"
+        (async {
+          let! server, path = server
+
+          let completionParams: CompletionParams =
+            { TextDocument = { Uri = Path.FilePathToUri path }
+              Position = { Line = 13; Character = 10 } // after str
+              Context =
+                Some
+                  { triggerKind = CompletionTriggerKind.Invoked
+                    triggerCharacter = None } }
+
+          let! response = server.TextDocumentCompletion completionParams
+
+          match response with
+          | Ok (Some completions) ->
+            Expect.isLessThan
+              completions.Items.Length
+              300
+              "shouldn't have a very long list of completion items that are only types"
+            Expect.isGreaterThan
+              completions.Items.Length
+              100
+              "should have a reasonable number of completion items that are only types"
+
+            Expect.exists
+              completions.Items
+              (fun item -> item.Label = "list")
+              "completion should contain the list type"
+          | Ok None -> failtest "Should have gotten some completion items"
+          | Error e -> failtestf "Got an error while retrieving completions: %A" e
         }) ]
 
 ///Tests for getting autocomplete

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -121,7 +121,7 @@ let tests state =
 
           let completionParams: CompletionParams =
             { TextDocument = { Uri = Path.FilePathToUri path }
-              Position = { Line = 13; Character = 10 } // after str
+              Position = { Line = 13; Character = 10 } // after Lis partial type name in Id record field declaration
               Context =
                 Some
                   { triggerKind = CompletionTriggerKind.Invoked

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Completion/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Completion/Script.fsx
@@ -7,3 +7,7 @@ async {
 List.
 
 let tail = List.
+
+type A = {
+  Id : Lis
+}


### PR DESCRIPTION
This adds a simple, flawed, but nevertheless useful, filter to completion results when the location is inside a `SynType`. This works in record fields and type hints. I haven't checked exhaustively, but I trust the AST walker and unless I've misunderstood we shouldn't find general expressions inside.

I tried to use this for Type parameters but it didn't work. I'm not very familiar with FCS's internals but I suspect it only uses getAllSymbols as a fallback and so doesn't need it in type pars. I imagine this means this feature will stop working with some future update of FCS.

This feature still suffers from the problem of the first few characters not triggering completion correctly.

Completion in a record field's type:
![image](https://user-images.githubusercontent.com/447391/161439315-bf5d669e-843d-4f60-98a0-d8264ead5bd4.png)

Completion in a normal expression:
![image](https://user-images.githubusercontent.com/447391/161439334-9b7444ff-b7de-48ca-b65c-abb6d2980a2a.png)

Completion in a type hint:
![image](https://user-images.githubusercontent.com/447391/161439352-e5acb673-f677-4db9-9e93-72e4c0a75805.png)

Q: Are there any other completion items that should be returned? Keywords?
