### PR TITLE
Fix completion on first character

### DIFF
--- a/src/FsAutoComplete.Core/Lexer.fs
+++ b/src/FsAutoComplete.Core/Lexer.fs
@@ -22,7 +22,6 @@ type LexerSymbol =
 [<RequireQualifiedAccess>]
 type SymbolLookupKind =
     | Fuzzy
-    | ByRightColumn
     | ByLongIdent
     | Simple
 
@@ -135,8 +134,6 @@ module Lexer =
             match lookupKind with
             | SymbolLookupKind.Simple | SymbolLookupKind.Fuzzy ->
                 tokens |> List.filter (fun x -> x.Token.LeftColumn <= col && x.RightColumn + 1 >= col)
-            | SymbolLookupKind.ByRightColumn ->
-                tokens |> List.filter (fun x -> x.RightColumn = col)
             | SymbolLookupKind.ByLongIdent ->
                 tokens |> List.filter (fun x -> x.Token.LeftColumn <= col)
 
@@ -172,8 +169,7 @@ module Lexer =
                       LeftColumn = leftCol
                       RightColumn = first.RightColumn + 1
                       Text = lineStr.[leftCol..first.RightColumn] })
-        | SymbolLookupKind.Fuzzy
-        | SymbolLookupKind.ByRightColumn ->
+        | SymbolLookupKind.Fuzzy ->
             // Select IDENT token. If failed, select OPERATOR token.
             tokensUnderCursor
             |> List.tryFind (fun { DraftToken.Kind = k } ->

--- a/src/FsAutoComplete.Core/Lexer.fs
+++ b/src/FsAutoComplete.Core/Lexer.fs
@@ -24,6 +24,7 @@ type SymbolLookupKind =
     | Fuzzy
     | ByLongIdent
     | Simple
+    | ForCompletion
 
 type private DraftToken =
     { Kind: SymbolKind
@@ -134,6 +135,8 @@ module Lexer =
             match lookupKind with
             | SymbolLookupKind.Simple | SymbolLookupKind.Fuzzy ->
                 tokens |> List.filter (fun x -> x.Token.LeftColumn <= col && x.RightColumn + 1 >= col)
+            | SymbolLookupKind.ForCompletion ->
+                tokens |> List.filter (fun x -> x.Token.LeftColumn <= col && x.RightColumn >= col)
             | SymbolLookupKind.ByLongIdent ->
                 tokens |> List.filter (fun x -> x.Token.LeftColumn <= col)
 
@@ -185,6 +188,7 @@ module Lexer =
                   LeftColumn = token.Token.LeftColumn
                   RightColumn = token.RightColumn + 1
                   Text = lineStr.Substring(token.Token.LeftColumn, token.Token.FullMatchedLength) })
+        | SymbolLookupKind.ForCompletion
         | SymbolLookupKind.Simple ->
             tokensUnderCursor
             |> List.tryLast

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -576,7 +576,7 @@ type ParseAndCheckResults
               && entity.FullName.Contains "."
               && not (PrettyNaming.IsOperatorDisplayName entity.Symbol.DisplayName))
 
-          let token = Lexer.getSymbol pos.Line (pos.Column - 1) lineStr SymbolLookupKind.Simple [||]
+          let token = Lexer.getSymbol pos.Line (pos.Column - 1) lineStr SymbolLookupKind.ForCompletion [||]
 
           logger.info (
             Log.setMessage "TryGetCompletions - token: {token}"


### PR DESCRIPTION
This fixes completion on the first character (or no characters) of a new expression. This substantially improves the suggestions workflow in VS Code.

This is done by adding another lookup kind for the Lexer which doesn't allow too many tokens from the left to get picked up. This prevents an operator or whitespace being picked as the current token which breaks later parts of the completion logic.

![Code_akGSS5ANOL](https://user-images.githubusercontent.com/447391/161600246-0f9d0273-05bc-4eb9-9f16-119c8f1d2d7c.gif)


This is still a workaround, as I still don't fully understand the whole `TryGetCompletions` process. It doesn't fix completion everywhere either. For example, after the `<` of a type param. However, `<` isn't a trigger character so it isn't as much of a problem.