### PR TITLE
Use triple-quoted interpolations when single-quoted ones give errors

### DIFF
--- a/src/FsAutoComplete.Core/FCSPatches.fs
+++ b/src/FsAutoComplete.Core/FCSPatches.fs
@@ -304,6 +304,15 @@ type FSharpParseFileResults with
                     None
             | _ -> defaultTraverse expr })
 
+  /// Attempts to find the range of the string interpolation that contains a given position.
+  member scope.TryRangeOfStringInterpolationContainingPos pos =
+     SyntaxTraversal.Traverse(pos, scope.ParseTree, { new SyntaxVisitorBase<_>() with
+            member _.VisitExpr(_, _, defaultTraverse, expr) =
+                match expr with
+                | SynExpr.InterpolatedString(range = range) when Range.rangeContainsPos range pos ->
+                    Some range
+                | _ -> defaultTraverse expr })
+
 module SyntaxTreeOps =
   open FSharp.Compiler.Syntax
   let rec synExprContainsError inpExpr =

--- a/src/FsAutoComplete/CodeFixes/UseTripleQuotedInterpolation.fs
+++ b/src/FsAutoComplete/CodeFixes/UseTripleQuotedInterpolation.fs
@@ -1,0 +1,37 @@
+module FsAutoComplete.CodeFix.UseTripleQuotedInterpolation
+
+open FsToolkit.ErrorHandling
+open FsAutoComplete.CodeFix.Types
+open Ionide.LanguageServerProtocol.Types
+open FsAutoComplete
+open FsAutoComplete.LspHelpers
+open FsAutoComplete.FCSPatches
+
+/// a codefix that replaces erroring single-quoted interpolations with triple-quoted interpolations
+let fix (getParseResultsForFile: GetParseResultsForFile) (getRangeText: GetRangeText) : CodeFix =
+  Run.ifDiagnosticByCode (Set.ofList [ "3373" ]) (fun diagnostic codeActionParams ->
+    asyncResult {
+      let pos = protocolPosToPos diagnostic.Range.Start
+
+      let filePath =
+        codeActionParams.TextDocument.GetFilePath()
+        |> Utils.normalizePath
+
+      let! tyRes, _, sourceText = getParseResultsForFile filePath pos
+
+      match tyRes.GetParseResults.TryRangeOfStringInterpolationContainingPos pos with
+      | Some range ->
+        let! interpolationText = sourceText.GetText range
+        // skip the leading '$' in the existing single-quoted interpolation
+        let newText = "$\"\"" + interpolationText.[1..] + "\"\""
+
+        return
+          [ { File = codeActionParams.TextDocument
+              SourceDiagnostic = Some diagnostic
+              Title = "Use triple-quoted string interpolation"
+              Edits =
+                [| { Range = fcsRangeToLsp range
+                     NewText = newText } |]
+              Kind = FixKind.Fix } ]
+      | None -> return []
+    })

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -868,7 +868,8 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
            ChangeTypeOfNameToNameOf.fix tryGetParseResultsForFile
            AddMissingInstanceMember.fix
            AddExplicitTypeToParameter.fix tryGetParseResultsForFile
-           ConvertPositionalDUToNamed.fix tryGetParseResultsForFile getRangeText |]
+           ConvertPositionalDUToNamed.fix tryGetParseResultsForFile getRangeText
+           UseTripleQuotedInterpolation.fix tryGetParseResultsForFile getRangeText |]
 
 
       match p.RootPath, c.AutomaticWorkspaceInit with

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/TripleQuotedInterpolation/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/TripleQuotedInterpolation/Script.fsx
@@ -1,0 +1,1 @@
+let a = $":^) {if true then "y" else "n"} d"


### PR DESCRIPTION
This is a pair of https://github.com/dotnet/fsharp/pull/12945, submitted by @kerams.  Same exact logic, just ported over so that we don't have to wait for FCS to release.