### PR TITLE
add option to specify the location to store workspace-specific state

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -573,7 +573,7 @@ type Commands
       commandsLogger.info (
         Log.setMessage "Workspace ready - sending init request to background service"
       )
-      backgroundService.InitWorkspace())
+      backgroundService.InitWorkspace(state.WorkspaceStateDirectory.FullName))
 
 
   member __.Notify = notify.Publish

--- a/src/FsAutoComplete.Core/State.fs
+++ b/src/FsAutoComplete.Core/State.fs
@@ -33,10 +33,12 @@ type State =
     ScriptProjectOptions: ConcurrentDictionary<string<LocalPath>, int * FSharpProjectOptions>
 
     mutable ColorizationOutput: bool
+
+    WorkspaceStateDirectory: System.IO.DirectoryInfo
   }
   member x.DebugString = $"{x.Files.Count} Files, {x.ProjectController.ProjectOptions |> Seq.length} Projects"
 
-  static member Initial toolsPath workspaceLoaderFactory =
+  static member Initial toolsPath workspaceStateDir workspaceLoaderFactory =
     { Files = ConcurrentDictionary()
       LastCheckedVersion = ConcurrentDictionary()
       ProjectController = new ProjectController(toolsPath, workspaceLoaderFactory)
@@ -47,7 +49,8 @@ type State =
       CancellationTokens = ConcurrentDictionary()
       NavigationDeclarations = ConcurrentDictionary()
       ScriptProjectOptions = ConcurrentDictionary()
-      ColorizationOutput = false }
+      ColorizationOutput = false
+      WorkspaceStateDirectory = workspaceStateDir }
 
   member x.RefreshCheckerOptions(file: string<LocalPath>, text: NamedText) : FSharpProjectOptions option =
     x.ProjectController.GetProjectOptions (UMX.untag file)

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -216,7 +216,7 @@ type DiagnosticCollection(sendDiagnostics: DocumentUri -> Diagnostic [] -> Async
       for (_, cts) in agents.Values do
         cts.Cancel()
 
-type FSharpLspServer(backgroundServiceEnabled: bool, state: State, stateDirectory: DirectoryInfo, lspClient: FSharpLspClient) =
+type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FSharpLspClient) =
   inherit LspServer()
 
   let logger = LogProvider.getLoggerByName "LSP"
@@ -771,7 +771,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, stateDirector
 
       rootPath <- actualRootPath
       commands.SetWorkspaceRoot actualRootPath
-      backgroundService.Start(stateDirectory.FullName)
+      backgroundService.Start()
 
       let c =
         p.InitializationOptions
@@ -2758,7 +2758,7 @@ let startCore backgroundServiceEnabled toolsPath stateStorageDir workspaceLoader
     |> Map.add "fsharp/inlayHints" (requestHandling (fun s p -> s.FSharpInlayHints(p)))
 
   let state =
-    State.Initial toolsPath workspaceLoaderFactory
+    State.Initial toolsPath stateStorageDir workspaceLoaderFactory
 
   let originalFs =
     FSharp.Compiler.IO.FileSystemAutoOpens.FileSystem
@@ -2766,7 +2766,7 @@ let startCore backgroundServiceEnabled toolsPath stateStorageDir workspaceLoader
   FSharp.Compiler.IO.FileSystemAutoOpens.FileSystem <- FsAutoComplete.FileSystem(originalFs, state.Files.TryFind)
 
   Ionide.LanguageServerProtocol.Server.start requestsHandlings input output FSharpLspClient (fun lspClient ->
-    new FSharpLspServer(backgroundServiceEnabled, state, stateStorageDir, lspClient))
+    new FSharpLspServer(backgroundServiceEnabled, state, lspClient))
 
 let start backgroundServiceEnabled toolsPath stateStorageDir workspaceLoaderFactory =
   let logger = LogProvider.getLoggerByName "Startup"

--- a/src/FsAutoComplete/Parser.fs
+++ b/src/FsAutoComplete/Parser.fs
@@ -67,7 +67,7 @@ module Parser =
 
   let waitForDebuggerOption =
     Option<bool>(
-      "--wait-for-debugger",
+      [|"--wait-for-debugger"; "--attachdebugger"|],
       "Stop execution on startup until an external debugger to attach to this process"
     )
     |> zero
@@ -87,7 +87,7 @@ module Parser =
     |> zero
 
   let stateLocationOption =
-    Option<DirectoryInfo>("--state-directory", getDefaultValue = Func<_> (fun () -> DirectoryInfo(Environment.CurrentDirectory)),  description = "Set the directory to store the state of the server. This should be a per-workspace location, not a shared-workspace location.")
+    Option<DirectoryInfo>("--state-directory", getDefaultValue = Func<_> (fun () -> DirectoryInfo("C:\\Users\\chusk")),  description = "Set the directory to store the state of the server. This should be a per-workspace location, not a shared-workspace location.")
 
   let rootCommand =
     let rootCommand = RootCommand("An F# LSP server implementation")

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -18,7 +18,8 @@ let initTests state =
   testCaseAsync
     "InitTest"
     (async {
-      let (server, event) = createServer state
+      let tempDir = Path.Combine(Path.GetTempPath(), "FsAutoComplete.Tests", Guid.NewGuid().ToString())
+      let (server, event) = createServer (DirectoryInfo(tempDir)) state
 
       let p: InitializeParams =
         { ProcessId = Some 1

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -19,7 +19,7 @@ let initTests state =
     "InitTest"
     (async {
       let tempDir = Path.Combine(Path.GetTempPath(), "FsAutoComplete.Tests", Guid.NewGuid().ToString())
-      let (server, event) = createServer (DirectoryInfo(tempDir)) state
+      let (server, event) = createServer state
 
       let p: InitializeParams =
         { ProcessId = Some 1

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -153,7 +153,7 @@ let record (cacher: Cacher<_>) =
     cacher.OnNext(name, payload)
     AsyncLspResult.success Unchecked.defaultof<_>
 
-let createServer workingDir (state: unit -> State) =
+let createServer (state: unit -> State) =
   let serverInteractions = new Cacher<_>()
   let recordNotifications = record serverInteractions
 
@@ -166,7 +166,7 @@ let createServer workingDir (state: unit -> State) =
   let originalFs = FSharp.Compiler.IO.FileSystemAutoOpens.FileSystem
   let fs = FsAutoComplete.FileSystem(originalFs, innerState.Files.TryFind)
   FSharp.Compiler.IO.FileSystemAutoOpens.FileSystem <- fs
-  let server = new FSharpLspServer(false, innerState, workingDir, client)
+  let server = new FSharpLspServer(false, innerState, client)
   server, serverInteractions :> ClientEvents
 
 let defaultConfigDto: FSharpConfigDto =
@@ -387,8 +387,7 @@ let serverInitialize path (config: FSharpConfigDto) state =
        |> Seq.exists (fun p -> p.EndsWith ".fsproj") then
       do! dotnetRestore path
 
-    let tempDir = Path.Combine(Path.GetTempPath(), "FsAutoComplete.Tests", Guid.NewGuid().ToString()) |> DirectoryInfo
-    let server, clientNotifications = createServer tempDir state
+    let server, clientNotifications = createServer state
 
     clientNotifications |> Observable.add logEvent
 

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -14,6 +14,7 @@ open FsAutoComplete.Tests.InteractiveDirectivesTests
 open Ionide.ProjInfo
 open System.Threading
 open Serilog.Filters
+open System.IO
 
 let testTimeout =
   Environment.GetEnvironmentVariable "TEST_TIMEOUT_MINUTES"
@@ -41,10 +42,10 @@ let lspTests =
     [ for (name, workspaceLoaderFactory) in loaders do
         testList
           name
-          [ 
-            Templates.tests ()
+          [ Templates.tests ()
+            let testRunDir = Path.Combine(Path.GetTempPath(), "FsAutoComplete.Tests", Guid.NewGuid().ToString()) |> DirectoryInfo
             let state () =
-              FsAutoComplete.State.Initial toolsPath workspaceLoaderFactory
+              FsAutoComplete.State.Initial toolsPath testRunDir workspaceLoaderFactory
 
             initTests state
 
@@ -82,7 +83,7 @@ let lspTests =
             InfoPanelTests.docFormattingTest state
             DetectUnitTests.tests state
             XmlDocumentationGeneration.tests state
-            InlayHintTests.tests state 
+            InlayHintTests.tests state
           ]
     ]
 


### PR DESCRIPTION
This is part 1 of #912: it adds the option to specify where workspace-local state should be stored.

This value is defaulted to the current directory (which preserves the current behavior).  The idea would be for a client host like Ionide to get a workspace-local value from the host IDE (in the VSCode context this comes from the extension's context during activation), and then flow that value down to FSAC.

The net user-facing benefit here would be to get the `.ionide` directory out of user view, since it doesn't contain anything that a user can actually do anything with.