### PR TITLE
Fix renames and reenable tests

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -24,7 +24,7 @@ open FSharp.Compiler.Tokenization
 [<RequireQualifiedAccess>]
 type LocationResponse<'a, 'b> =
   | Use of 'a
-  | UseRange of 'b
+  | UseRange of FSharpSymbolUse * 'b
 
 [<RequireQualifiedAccess>]
 type HelpText =
@@ -1086,7 +1086,7 @@ type Commands
             else
               let! symbols = checker.GetUsesOfSymbol(tyRes.FileName, state.FSharpProjectOptions, sym.Symbol)
               return CoreResponse.Res(LocationResponse.Use(sym, symbols))
-          | Some res -> return CoreResponse.Res(LocationResponse.UseRange res)
+          | Some res -> return CoreResponse.Res(LocationResponse.UseRange(sym, res))
       | Error x -> return CoreResponse.ErrorRes x
     }
     |> x.AsCancellable tyRes.FileName
@@ -1118,7 +1118,7 @@ type Commands
               let! symbols = checker.GetUsesOfSymbol(tyRes.FileName, state.FSharpProjectOptions, sym.Symbol)
               let symbols = filterSymbols symbols
               return CoreResponse.Res(LocationResponse.Use(sym, filterSymbols symbols))
-          | Some res -> return CoreResponse.Res(LocationResponse.UseRange res)
+          | Some res -> return CoreResponse.Res(LocationResponse.UseRange(sym, res))
       | Error e -> return CoreResponse.ErrorRes e
     }
     |> x.AsCancellable tyRes.FileName

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -26,10 +26,10 @@ module PositionExtensions =
   let inline (|Pos|) (p: FSharp.Compiler.Text.Position) =
     p.Line, p.Column
 
-[<Sealed>]
 /// A copy of the StringText type from F#.Compiler.Text, which is private.
 /// Adds a UOM-typed filename to make range manipulation easier, as well as
 /// safer traversals
+[<Sealed>]
 type NamedText(fileName: string<LocalPath>, str: string) =
 
   let getLines (str: string) =

--- a/src/FsAutoComplete.Core/Lexer.fs
+++ b/src/FsAutoComplete.Core/Lexer.fs
@@ -179,8 +179,6 @@ module Lexer =
                 match k with
                 | Ident | GenericTypeParameter | StaticallyResolvedTypeParameter | Keyword -> true
                 | _ -> false)
-                /// Gets the option if Some x, otherwise try to get another value
-
             |> Option.orElseWith (fun _ -> tokensUnderCursor |> List.tryFind (fun { DraftToken.Kind = k } -> k = Operator))
             |> Option.map (fun token ->
                 { Kind = token.Kind

--- a/src/FsAutoComplete.Core/SymbolCache.fs
+++ b/src/FsAutoComplete.Core/SymbolCache.fs
@@ -172,7 +172,9 @@ let getSymbols symbolName =
         match PersistentCacheImpl.connection with
         | Some conn ->
             let! res = PersistentCacheImpl.loadSymbolUses conn.Value symbolName
-            return Some res
+            match res with
+            | [||] -> return None
+            | res -> return Some res
         | None -> return None
     }
 

--- a/src/FsAutoComplete.Core/TypedAstPatterns.fs
+++ b/src/FsAutoComplete.Core/TypedAstPatterns.fs
@@ -216,8 +216,8 @@ module SymbolUse =
         | Entity (entity, _) when entity.IsAttributeType -> Some entity
         | _ -> None
 
-[<AutoOpen>]
 /// Active patterns over `FSharpSymbol`.
+[<AutoOpen>]
 module SymbolPatterns =
 
     let private attributeSuffixLength = "Attribute".Length

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -843,8 +843,8 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
       let getAbstractClassStubReplacements () = abstractClassStubReplacements ()
 
       codeFixes <-
-        [| Run.ifEnabled 
-             (fun _ -> config.UnusedOpensAnalyzer) 
+        [| Run.ifEnabled
+             (fun _ -> config.UnusedOpensAnalyzer)
              (RemoveUnusedOpens.fix getFileLines)
            Run.ifEnabled
              (fun _ -> config.ResolveNamespaces)
@@ -1326,15 +1326,6 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
                 symbols
                 |> Array.map (fun sym ->
                   let range = fcsRangeToLsp sym.Range
-
-                  let range =
-                    { range with
-                        Start =
-                          { Line = range.Start.Line
-                            Character =
-                              range.End.Character
-                              - sym.Symbol.DisplayName.Length } }
-
                   { Range = range; NewText = p.NewName })
                 |> Array.distinct
 
@@ -1356,13 +1347,6 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
                 symbols
                 |> Array.map (fun sym ->
                   let range = symbolUseRangeToLsp sym
-
-                  let range =
-                    { range with
-                        Start =
-                          { Line = range.Start.Line
-                            Character = range.End.Character - sym.SymbolDisplayName.Length } }
-
                   { Range = range; NewText = p.NewName })
                 |> Array.distinct
 

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -523,9 +523,9 @@ type PlainNotification= { Content: string }
 
 /// Notification when a `TextDocument` is completely analyzed:
 /// F# Compiler checked file & all Analyzers (like `UnusedOpensAnalyzer`) are done.
-/// 
+///
 /// Used to signal all Diagnostics for this `TextDocument` are collected and sent.
-/// -> For tests to get all Diagnostics of `TextDocument` 
+/// -> For tests to get all Diagnostics of `TextDocument`
 type DocumentAnalyzedNotification = {
     TextDocument: VersionedTextDocumentIdentifier
 }
@@ -836,7 +836,7 @@ let encodeSemanticHighlightRanges (rangesAndHighlights: (struct(Ionide.LanguageS
 
   match rangesAndHighlights.Length with
   | 0 -> None
-  /// only 1 entry, so compute the line from the 0 position
+  // only 1 entry, so compute the line from the 0 position
   | 1 ->
     Some (
       computeLine fileStart rangesAndHighlights.[0]

--- a/test/FsAutoComplete.DependencyManager.Dummy/Library.fs
+++ b/test/FsAutoComplete.DependencyManager.Dummy/Library.fs
@@ -36,8 +36,8 @@ type ScriptExtension = string
 type HashRLines = string seq
 type TFM = string
 
-[<DependencyManager>]
 /// the type _must_ take an optional output directory
+[<DependencyManager>]
 type DummyDependencyManager(outputDir: string option) =
 
     /// Name of the dependency manager

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -44,7 +44,6 @@ let rec private copyDirectory sourceDir destDir =
 type DisposableDirectory(directory: string) =
   static member Create() =
     let tempPath = IO.Path.Combine(IO.Path.GetTempPath(), Guid.NewGuid().ToString("n"))
-    printfn "Creating directory %s" tempPath
     IO.Directory.CreateDirectory tempPath |> ignore
     new DisposableDirectory(tempPath)
 
@@ -57,7 +56,6 @@ type DisposableDirectory(directory: string) =
 
   interface IDisposable with
     member x.Dispose() =
-      printfn "Deleting directory %s" x.DirectoryInfo.FullName
       IO.Directory.Delete(x.DirectoryInfo.FullName, true)
 
 type Async =


### PR DESCRIPTION
Fixes https://github.com/ionide/ionide-vscode-fsharp/issues/1690

Does three things:
* fix xmldoc warnings from the compiler about invalid placements
* fixes the replacement ranges - we can just mark the entire symbol range as replaced and the editor will handle the rest
* reenables tests for renames (which some are failing as expected).


I _think_ I'm running into a behavior difference with the backgroundservices enabled vs disabled. When I turn them off, these changes work as expected. When I turn them on, only the declaration symbol use is renamed, none of the dependent uses. So we might have a problem in the background services, will need to inspect the generated tables.