### PR TITLE
Fix & Enhancements for `AddExplicitTypeToParameter`

### DIFF
--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -140,7 +140,7 @@ type NamedText(fileName: string<LocalPath>, str: string) =
       if pos.Column = 0 then return! None
       else
         let lineIndex = pos.Column - 1
-        if lineText.Length < lineIndex
+        if lineText.Length <= lineIndex
         then
           return! None
         else

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests.fs
@@ -43,6 +43,7 @@ module CodeFix =
 
 let private addExplicitTypeToParameterTests state =
   serverTestList (nameof AddExplicitTypeToParameter) state defaultConfigDto None (fun server -> [
+    let selectCodeFix = CodeFix.withTitle AddExplicitTypeToParameter.title
     testCaseAsync "can suggest explicit parameter for record-typed function parameters" <|
       CodeFix.check server
         """
@@ -53,7 +54,7 @@ let private addExplicitTypeToParameterTests state =
             f.name
         """
         (Diagnostics.acceptAll)
-        (CodeFix.withTitle AddExplicitTypeToParameter.title)
+        selectCodeFix
         """
         type Foo =
             { name: string }
@@ -61,6 +62,343 @@ let private addExplicitTypeToParameterTests state =
         let name (f: Foo) =
             f.name
         """
+    testCaseAsync "can add type for int param" <|
+      CodeFix.check server
+        """
+        let f ($0x) = x + 1
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+        """
+        let f (x: int) = x + 1
+        """
+    testCaseAsync "can add type for generic param" <|
+      CodeFix.check server
+        """
+        let f ($0x) = ()
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+        """
+        let f (x: 'a) = ()
+        """
+    testCaseAsync "doesn't trigger when existing type" <|
+      CodeFix.checkNotApplicable server
+        """
+        let f ($0x: int) = ()
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+    testCaseAsync "can add type to tuple item" <|
+      CodeFix.check server
+        """
+        let f (a, $0b, c) = a + b + c + 1
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+        """
+        let f (a, b: int, c) = a + b + c + 1
+        """
+    testCaseAsync "doesn't trigger in tuple when existing type" <|
+      CodeFix.checkNotApplicable server
+        """
+        let f (a, $0b: int, c) = a + b + c + 1
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+    testCaseAsync "can add type to 2nd of 3 param" <|
+      CodeFix.check server
+        """
+        let f a $0b c = a + b + c + 1
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+        """
+        let f a (b: int) c = a + b + c + 1
+        """
+    testCaseAsync "doesn't trigger on 2nd of 3 param when existing type" <|
+      CodeFix.checkNotApplicable server
+        """
+        let f a ($0b: int) c = a + b + c + 1
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+    testCaseAsync "can add type to 2nd of 3 param when other params have types" <|
+      CodeFix.check server
+        """
+        let f (a: int) $0b (c: int) = a + b + c + 1
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+        """
+        let f (a: int) (b: int) (c: int) = a + b + c + 1
+        """
+    testCaseAsync "can add type to member param" <|
+      CodeFix.check server
+        """
+        type A() =
+          member _.F($0a) = a + 1
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+        """
+        type A() =
+          member _.F(a: int) = a + 1
+        """
+    testCaseAsync "doesn't trigger for member param when existing type" <|
+      CodeFix.checkNotApplicable server
+        """
+        type A() =
+          member _.F($0a: int) = a + 1
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+    testCaseAsync "can add type to ctor param" <|
+      CodeFix.check server
+        """
+        type A($0a) =
+          member _.F() = a + 1
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+        """
+        type A(a: int) =
+          member _.F() = a + 1
+        """
+    testCaseAsync "doesn't trigger for ctor param when existing type" <|
+      CodeFix.checkNotApplicable server
+        """
+        type A($0a: int) =
+          member _.F() = a + 1
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+    testCaseAsync "can add type to correct ctor param" <|
+      CodeFix.check server
+        """
+        type A(str, $0n, b) =
+          member _.FString() = sprintf "str=%s" str
+          member _.FInt() = n + 1
+          member _.FBool() = sprintf "b=%b" b
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+        """
+        type A(str, n: int, b) =
+          member _.FString() = sprintf "str=%s" str
+          member _.FInt() = n + 1
+          member _.FBool() = sprintf "b=%b" b
+        """
+    testCaseAsync "doesn't trigger for ctor param when existing type and multiple params" <|
+      CodeFix.checkNotApplicable server
+        """
+        type A(str, $0n: int, b) =
+          member _.FString() = sprintf "str=%s" str
+          member _.FInt() = a + 1
+          member _.FBool() = sprintf "b=%b" b
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+    testCaseAsync "can add type to secondary ctor param" <|
+      CodeFix.check server
+        """
+        type A(a) =
+          new($0a, b) = A(a+b)
+          member _.F() = a + 1
+        """
+        (Diagnostics.acceptAll)
+        selectCodeFix
+        """
+        type A(a) =
+          new(a: int, b) = A(a+b)
+          member _.F() = a + 1
+        """
+    testList "parens" [
+      testCaseAsync "single param without parens -> add parens" <|
+        CodeFix.check server
+          """
+          let f $0x = x + 1
+          """
+          (Diagnostics.acceptAll)
+          selectCodeFix
+          """
+          let f (x: int) = x + 1
+          """
+      testCaseAsync "single param with parens -> keep parens" <|
+        CodeFix.check server
+          """
+          let f ($0x) = x + 1
+          """
+          (Diagnostics.acceptAll)
+          selectCodeFix
+          """
+          let f (x: int) = x + 1
+          """
+      testCaseAsync "multi params without parens -> add parens" <|
+        CodeFix.check server
+          """
+          let f a $0x y = x + 1
+          """
+          (Diagnostics.acceptAll)
+          selectCodeFix
+          """
+          let f a (x: int) y = x + 1
+          """
+      testCaseAsync "multi params with parens -> keep parens" <|
+        CodeFix.check server
+          """
+          let f a ($0x) y = x + 1
+          """
+          (Diagnostics.acceptAll)
+          selectCodeFix
+          """
+          let f a (x: int) y = x + 1
+          """
+      testList "tuple params without parens -> no parens" [
+        testCaseAsync "start" <|
+          CodeFix.check server
+            """
+            let f ($0x, y, z) = x + y + z + 1
+            """
+            (Diagnostics.acceptAll)
+            selectCodeFix
+            """
+            let f (x: int, y, z) = x + y + z + 1
+            """
+        testCaseAsync "center" <|
+          CodeFix.check server
+            """
+            let f (x, $0y, z) = x + y + z + 1
+            """
+            (Diagnostics.acceptAll)
+            selectCodeFix
+            """
+            let f (x, y: int, z) = x + y + z + 1
+            """
+        testCaseAsync "end" <|
+          CodeFix.check server
+            """
+            let f (x, y, $0z) = x + y + z + 1
+            """
+            (Diagnostics.acceptAll)
+            selectCodeFix
+            """
+            let f (x, y, z: int) = x + y + z + 1
+            """
+      ]
+      testList "tuple params with parens -> keep parens" [
+        testCaseAsync "start" <|
+          CodeFix.check server
+            """
+            let f (($0x), y, z) = x + y + z + 1
+            """
+            (Diagnostics.acceptAll)
+            selectCodeFix
+            """
+            let f ((x: int), y, z) = x + y + z + 1
+            """
+        testCaseAsync "center" <|
+          CodeFix.check server
+            """
+            let f (x, ($0y), z) = x + y + z + 1
+            """
+            (Diagnostics.acceptAll)
+            selectCodeFix
+            """
+            let f (x, (y: int), z) = x + y + z + 1
+            """
+        testCaseAsync "end" <|
+          CodeFix.check server
+            """
+            let f (x, y, ($0z)) = x + y + z + 1
+            """
+            (Diagnostics.acceptAll)
+            selectCodeFix
+            """
+            let f (x, y, (z: int)) = x + y + z + 1
+            """
+      ]
+      testList "tuple params without parens but spaces -> no parens" [
+        testCaseAsync "start" <|
+          CodeFix.check server
+            """
+            let f (  $0x   ,   y   ,   z   ) = x + y + z + 1
+            """
+            (Diagnostics.acceptAll)
+            selectCodeFix
+            """
+            let f (  x: int   ,   y   ,   z   ) = x + y + z + 1
+            """
+        testCaseAsync "center" <|
+          CodeFix.check server
+            """
+            let f (  x   ,   $0y   ,   z   ) = x + y + z + 1
+            """
+            (Diagnostics.acceptAll)
+            selectCodeFix
+            """
+            let f (  x   ,   y: int   ,   z   ) = x + y + z + 1
+            """
+        testCaseAsync "end" <|
+          CodeFix.check server
+            """
+            let f (  x   ,   y   ,   $0z   ) = x + y + z + 1
+            """
+            (Diagnostics.acceptAll)
+            selectCodeFix
+            """
+            let f (  x   ,   y   ,   z: int   ) = x + y + z + 1
+            """
+      ]
+      testList "long tuple params without parens but spaces -> no parens" [
+        testCaseAsync "start" <|
+          CodeFix.check server
+            """
+            let f (  xV$0alue   ,   yAnotherValue   ,   zFinalValue   ) = xValue + yAnotherValue + zFinalValue + 1
+            """
+            (Diagnostics.acceptAll)
+            selectCodeFix
+            """
+            let f (  xValue: int   ,   yAnotherValue   ,   zFinalValue   ) = xValue + yAnotherValue + zFinalValue + 1
+            """
+        testCaseAsync "center" <|
+          CodeFix.check server
+            """
+            let f (  xValue   ,   yAn$0otherValue   ,   zFinalValue   ) = xValue + yAnotherValue + zFinalValue + 1
+            """
+            (Diagnostics.acceptAll)
+            selectCodeFix
+            """
+            let f (  xValue   ,   yAnotherValue: int   ,   zFinalValue   ) = xValue + yAnotherValue + zFinalValue + 1
+            """
+        testCaseAsync "end" <|
+          CodeFix.check server
+            """
+            let f (  xValue   ,   yAnotherValue   ,   zFina$0lValue   ) = xValue + yAnotherValue + zFinalValue + 1
+            """
+            (Diagnostics.acceptAll)
+            selectCodeFix
+            """
+            let f (  xValue   ,   yAnotherValue   ,   zFinalValue: int   ) = xValue + yAnotherValue + zFinalValue + 1
+            """
+      ]
+      testCaseAsync "never add parens to primary ctor param" <|
+        CodeFix.check server
+          """
+          type A (
+            $0a
+            ) =
+            member _.F(b) = a + b
+          """
+          (Diagnostics.acceptAll)
+          selectCodeFix
+          """
+          type A (
+            a: int
+            ) =
+            member _.F(b) = a + b
+          """
+    ]
   ])
 
 let private addMissingEqualsToTypeDefinitionTests state =

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -42,7 +42,8 @@ let lspTests =
     [ for (name, workspaceLoaderFactory) in loaders do
         testList
           name
-          [ Templates.tests ()
+          [ 
+            Templates.tests ()
             let testRunDir = Path.Combine(Path.GetTempPath(), "FsAutoComplete.Tests", Guid.NewGuid().ToString()) |> DirectoryInfo
             let state () =
               FsAutoComplete.State.Initial toolsPath testRunDir workspaceLoaderFactory


### PR DESCRIPTION
As promised in #917: Fix for `AddExplicitTypeToParameter`   
And some enhancements

<br/>

**Fix**: `AddExplicitTypeToParameter` triggers despite type already specified

**Enhancement**: Trigger for primary constructor
* secondary ctors (`new (...) = ...`) already worked 

**Enhancement**: Surround with parens less often
* prev: only don't add parens when already directly surrounded by parens (no spaces allowed) [[*1]](#footnote-1)
  ```fsharp
  let f1 (a) = a + 1
  //      ^
  let f2 (a ) = a + 1
  //      ^
  ```
  =>
  ```fsharp
  let f1 (a: int) = a + 1
  let f2 ((a: int) )
  ```
* now: don't add parens when surrounded by parens or `,` and spaces somewhere between are ok:
  ```fsharp
  let f1 (a) = a + 1
  //      ^
  let f2 (a ) = a + 1
  //      ^
  let f3 (a, b, c) = a + b + c + 1
  //         ^
  let f4 (a,  b  ) = a + b + 1
  //          ^
  ```
  =>
  ```fsharp
  let f1 (a: int) = a + 1
  let f2 (a: int ) = a + 1
  let f3 (a, b: int, c) = a + b + c + 1
  let f4 (a,  b: int  ) = a + b + 1
  ```

**Fix**: `NamedText.TryGetChar` throws exception when Position in last column

<br/>


--------

<br/>

hmpf...no code in footnotes allowed  
-> footnote substitute using custom separator, html and [*1]....  


<a name="footnote-1"></a>[*1]: Actually there were some more cases it didn't add parens: when other text directly adjacent to identifier and no spaces to next parens:
```fsharp
let f1 (a,b,c) = a + b + c + 1
//        ^
```
=> 
```fsharp
let f1 (a,b:int,c) = a + b + c + 1
```
But any spaces inside parens and param gets parens:
```fsharp
let f2 (a,b,c ) = a + b + c + 1
//        ^
let f3 (a ,b,c) = a + b + c + 1
//         ^
let f4 (a, b,c) = a + b + c + 1
//         ^
```
=>
```fsharp
let f2 (a,(b: int),c ) = a + b + c + 1
let f3 (a ,(b: int),c) = a + b + c + 1
let f4 (a, (b: int),c) = a + b + c + 1
```

With this PR neither of these cases gets parens
