### PR TITLE
Some restrictions for Parameter Hints

### DIFF
--- a/src/FsAutoComplete.Core/InlayHints.fs
+++ b/src/FsAutoComplete.Core/InlayHints.fs
@@ -253,6 +253,15 @@ module private ShouldCreate =
     parameterName <> userArgumentText
     && not (userArgumentText.StartsWith parameterName)
 
+  let private isParamNamePostfixOfFuncName
+    (func: FSharpMemberOrFunctionOrValue)
+    (paramName: string)
+    =
+    let funcName = func.DisplayName.AsSpan()
+    let paramName = removeLeadingUnderscore (paramName.AsSpan())
+
+    isPostfixOf funcName paramName
+
   /// </summary>
   /// We filter out parameters that generate lots of noise in hints.
   /// * parameter has a name
@@ -271,6 +280,7 @@ module private ShouldCreate =
     && (not (isOperator func))
     // && doesNotMatchArgumentText p.DisplayName argumentText
     && (not (areSimilar p.DisplayName argumentText))
+    && (not (isParamNamePostfixOfFuncName func p.DisplayName))
 
 
 let provideHints (text: NamedText, p: ParseAndCheckResults, range: Range) : Async<Hint []> =

--- a/src/FsAutoComplete.Core/InlayHints.fs
+++ b/src/FsAutoComplete.Core/InlayHints.fs
@@ -157,6 +157,21 @@ module private ShouldCreate =
   [<return: Struct>]
   let private (|Namespace|_|) = (|StartsWith|_|)
 
+  let private commonCollectionParams = Set.ofList [
+    "mapping"
+    "projection"
+    "chooser"
+    "value"
+    "predicate"
+    "folder"
+    "state"
+    "initializer"
+    "action"
+
+    "list"
+    "array"
+    "source"
+  ]
   let private isWellKnownParameterOrFunction 
     (func: FSharpMemberOrFunctionOrValue)
     (param: FSharpParameter)
@@ -179,7 +194,8 @@ module private ShouldCreate =
         | _ -> false
     | Namespace "Microsoft.FSharp.Collections" ->
         match param.Name with
-        | Some "mapping" -> true
+        | Some name ->
+            commonCollectionParams |> Set.contains name
         | _ -> false
     | _ -> false
 

--- a/src/FsAutoComplete.Core/InlayHints.fs
+++ b/src/FsAutoComplete.Core/InlayHints.fs
@@ -292,10 +292,7 @@ module private ShouldCreate =
       if isLongIdentifier argTextNoParens then
         removeTrailingTick (extractLastIdentifier argTextNoParens)
       else
-        //todo: expression -> early out? or further processing? special processing?
         argumentText
-
-    //todo: all useful?
 
     // // covered by each isPre/PostfixOf
     // areSame paramName argumentName

--- a/src/FsAutoComplete.Core/InlayHints.fs
+++ b/src/FsAutoComplete.Core/InlayHints.fs
@@ -264,10 +264,12 @@ module private ShouldCreate =
 
   /// </summary>
   /// We filter out parameters that generate lots of noise in hints.
-  /// * parameter has a name
+  /// * parameter has no name
   /// * parameter is one of a set of 'known' names that clutter (like printfn formats)
   /// * parameter has length > 2
-  /// * parameter does not match (or is an extension of) the user-entered text
+  /// * parameter does match or is a pre/postfix of user-entered text
+  /// * user-entered text does match or is a pre/postfix of parameter
+  /// * parameter is postfix of function name
   /// </summary>
   let paramHint
     (func: FSharpMemberOrFunctionOrValue)
@@ -278,7 +280,6 @@ module private ShouldCreate =
     && isNotWellKnownName p
     && isMeaningfulName p
     && (not (isOperator func))
-    // && doesNotMatchArgumentText p.DisplayName argumentText
     && (not (areSimilar p.DisplayName argumentText))
     && (not (isParamNamePostfixOfFuncName func p.DisplayName))
 

--- a/src/FsAutoComplete.Core/InlayHints.fs
+++ b/src/FsAutoComplete.Core/InlayHints.fs
@@ -171,6 +171,9 @@ module private ShouldCreate =
     "list"
     "array"
     "source"
+    "lists"
+    "arrays"
+    "sources"
   ]
   let private isWellKnownParameterOrFunction 
     (func: FSharpMemberOrFunctionOrValue)

--- a/src/FsAutoComplete.Core/InlayHints.fs
+++ b/src/FsAutoComplete.Core/InlayHints.fs
@@ -141,21 +141,26 @@ module private ShouldCreate =
     | None -> true
     | Some n -> not (Set.contains n names)
 
+
+  [<return: Struct>]
+  let private (|StartsWith|_|) (v: string) (fullName: string) =
+    if fullName.StartsWith v then
+      ValueSome ()
+    else
+      ValueNone
+  // doesn't differentiate between modules, types, namespaces 
+  // -> is just for documentation in code
+  [<return: Struct>]
+  let private (|Module|_|) = (|StartsWith|_|)
+  [<return: Struct>]
+  let private (|Type|_|) = (|StartsWith|_|)
+  [<return: Struct>]
+  let private (|Namespace|_|) = (|StartsWith|_|)
+
   let private isWellKnownParameterOrFunction 
     (func: FSharpMemberOrFunctionOrValue)
     (param: FSharpParameter)
     =
-    let startsWith (v: string) (fullName: string) =
-      if fullName.StartsWith v then
-        Some ()
-      else
-        None
-    // doesn't differentiate between modules, types, namespaces 
-    // -> is just for documentation in code
-    let (|Module|_|) = startsWith
-    let (|Type|_|) = startsWith
-    let (|Namespace|_|) = startsWith
-
     match func.FullName with
     | Module "Microsoft.FSharp.Core.Option" ->
         // don't show param named `option`, but other params for Option

--- a/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
@@ -382,6 +382,14 @@ let tests state =
           """
           []
 
-        
+      testCaseAsync "hide: func name ends with param name" <|
+        InlayHints.checkRange server
+          """
+          let validateRange range = ()
+          let data = 42
+
+          $0validateRange data$0
+          """
+          []
     ]
   ])

--- a/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
@@ -471,6 +471,24 @@ let tests state =
               $0Seq.tryLast [1..3]$0
               """
               []
+          testCaseAsync "hide: lists" <|
+            InlayHints.checkRange server
+              """
+              $0List.concat []$0
+              """
+              []
+          testCaseAsync "hide: arrays" <|
+            InlayHints.checkRange server
+              """
+              $0Array.concat [||]$0
+              """
+              []
+          testCaseAsync "hide: sources" <|
+            InlayHints.checkRange server
+              """
+              $0Seq.concat []$0
+              """
+              []
         ]
         testList "option" [
           testCaseAsync "hide: for Option" <|

--- a/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
@@ -391,5 +391,87 @@ let tests state =
           $0validateRange data$0
           """
           []
+
+      testList "special names" [
+        testList "mapping" [
+          testCaseAsync "hide: for List" <|
+            InlayHints.checkRange server
+              """
+              $0[1..3] |> List.map id$0
+              """
+              []
+          testCaseAsync "hide: for Array" <|
+            InlayHints.checkRange server
+              """
+              $0[|1..3|] |> Array.map id$0
+              """
+              []
+          testCaseAsync "show: for custom function" <|
+            InlayHints.checkRange server
+              """
+              let doStuff mapping = ()
+              $0doStuff $042$0
+              """
+              [ param "mapping" ]
+        ]
+        testList "option" [
+          testCaseAsync "hide: for Option" <|
+            InlayHints.checkRange server
+              """
+              $0Option.count (Some 3)$0
+              """
+              []
+          testCaseAsync "show: for custom function" <|
+            InlayHints.checkRange server
+              """
+              let doStuff option = ()
+              $0doStuff $042$0
+              """
+              [ param "option" ]
+        ]
+        testList "voption" [
+          testCaseAsync "hide: for ValueOption" <|
+            InlayHints.checkRange server
+              """
+              $0ValueOption.count (ValueSome 3)$0
+              """
+              []
+          testCaseAsync "show: for custom function" <|
+            InlayHints.checkRange server
+              """
+              let doStuff voption = ()
+              $0doStuff $042$0
+              """
+              [ param "voption" ]
+        ]
+        testList "format" [
+          testCaseAsync "hide: in printfn" <|
+            InlayHints.checkRange server
+              """
+              $0printfn "foo"$0
+              """
+              []
+          testCaseAsync "hide: in sprintf" <|
+            InlayHints.checkRange server
+              """
+              $0sprintf "foo"$0
+              """
+              []
+          testCaseAsync "hide: in Core.Printf" <|
+            // "normal" printf is in `Microsoft.FSharp.Core.ExtraTopLevelOperators`
+            InlayHints.checkRange server
+              """
+              $0Microsoft.FSharp.Core.Printf.printfn "foo"$0
+              """
+              []
+          testCaseAsync "show: for custom function" <|
+            InlayHints.checkRange server
+              """
+              let doStuff format = ()
+              $0doStuff $042$0
+              """
+              [ param "format" ]
+        ]
+      ]
     ]
   ])

--- a/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
@@ -362,6 +362,26 @@ let tests state =
           $0f ($0string alpha, $0beta.ToString(), $0gamma |> string)$0
           """
           [ param "alpha"; param "beta"; param "gamma" ]
+
+      testCaseAsync "hide: unary operator" <|
+        InlayHints.checkRange server
+          """
+          let (~+.) listWithNumbers = List.map ((+) 1) listWithNumbers
+          let data = [1..5]
+
+          $0+. data$0
+          """
+          []
+      testCaseAsync "hide: binary operator" <|
+        InlayHints.checkRange server
+          """
+          let (+.) listWithNumbers numberToAdd = List.map ((+) numberToAdd) listWithNumbers
+          let data = [1..5]
+
+          $0data +. 5$0
+          """
+          []
+
         
     ]
   ])

--- a/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
@@ -414,6 +414,64 @@ let tests state =
               """
               [ param "mapping" ]
         ]
+        testList "in collections" [
+          testCaseAsync "hide: predicate" <|
+            InlayHints.checkRange server
+              """
+              $0[1..3] |> List.filter ((<) 2)$0
+              """
+              []
+          testCaseAsync "hide: chooser" <|
+            InlayHints.checkRange server
+              """
+              $0[1..3] |> List.tryPick Some$0
+              """
+              []
+          testCaseAsync "hide: value" <|
+            InlayHints.checkRange server
+              """
+              $0[1..3] |> List.contains 2$0
+              """
+              []
+          testCaseAsync "hide: projection" <|
+            InlayHints.checkRange server
+              """
+              $0[1..3] |> List.sumBy id$0
+              """
+              []
+          testCaseAsync "hide: action" <|
+            InlayHints.checkRange server
+              """
+              $0[1..3] |> List.iter (printfn "%i")$0
+              """
+              []
+          testCaseAsync "hide: folder & state" <|
+            InlayHints.checkRange server
+              """
+              $0[1..3] |> List.fold (+) 0$0
+              """
+              []
+
+
+          testCaseAsync "hide: list" <|
+            InlayHints.checkRange server
+              """
+              $0List.tryLast [1..3]$0
+              """
+              []
+          testCaseAsync "hide: array" <|
+            InlayHints.checkRange server
+              """
+              $0Array.tryLast [|1..3|]$0
+              """
+              []
+          testCaseAsync "hide: source" <|
+            InlayHints.checkRange server
+              """
+              $0Seq.tryLast [1..3]$0
+              """
+              []
+        ]
         testList "option" [
           testCaseAsync "hide: for Option" <|
             InlayHints.checkRange server

--- a/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
@@ -179,96 +179,96 @@ let tests state =
       testCaseAsync "hide: variable prefix of param" <|
         InlayHints.checkRange server
           """
-          let f specialNumber = ()
-          let special = 2
+          let f rangeCoveringExpr = ()
+          let range = 2
 
-          $0f special$0
+          $0f range$0
           """
           [  ]
       testCaseAsync "hide: variable postfix of param" <|
         InlayHints.checkRange server
           """
-          let f specialNumber = ()
-          let number = 2
+          let f exactRange = ()
+          let range = 2
 
-          $0f number$0
+          $0f range$0
           """
           [  ]
       //todo: or hide?
       testCaseAsync "show: variable infix of param" <|
         InlayHints.checkRange server
           """
-          let f extraSpecialNumber = ()
-          let special = 2
+          let f exactRangeCoveringExpr = ()
+          let range = 2
 
-          $0f $0special$0
+          $0f $0range$0
           """
-          [ param "extraSpecialNumber" ]
+          [ param "exactRangeCoveringExpr" ]
       //todo: or hide?
       testCaseAsync "show: variable prefix of param, but no word boundary" <|
         InlayHints.checkRange server
           """
-          let f specialnumber = ()
-          let special = 2
+          let f rangecover = ()
+          let range = 2
 
-          $0f $0special$0
+          $0f $0range$0
           """
-          [ param "specialnumber" ]
+          [ param "rangecover" ]
       //todo: or hide?
       testCaseAsync "show: variable postfix of param, but no word boundary" <|
         InlayHints.checkRange server
           """
-          let f specialnumber = ()
-          let number = 2
+          let f exactrange = ()
+          let range = 2
 
-          $0f $0number$0
+          $0f $0range$0
           """
-          [ param "specialnumber" ]
+          [ param "exactrange" ]
 
       testCaseAsync "hide: arg is prefix of param with leading _" <|
         InlayHints.checkRange server
           """
-          let f _specialNumber = ()
-          let special = 2
+          let f _rangeCoveringExpr = ()
+          let range = 2
 
-          $0f special$0
+          $0f range$0
           """
           []
       testCaseAsync "hide: arg is postfix of param with trailing '" <|
         InlayHints.checkRange server
           """
-          let f specialNumber' = ()
-          let number = 2
+          let f exactRange' = ()
+          let range = 2
 
-          $0f number$0
+          $0f range$0
           """
           []
       testCaseAsync "hide: arg is prefix of param with trailing ' in arg" <|
         InlayHints.checkRange server
           """
-          let f specialNumber = ()
-          let special' = 2
+          let f rangeCoveringExpr = ()
+          let range' = 2
 
-          $0f special'$0
+          $0f range'$0
           """
           []
 
       testCaseAsync "hide: param prefix of arg" <|
         InlayHints.checkRange server
           """
-          let f special = ()
-          let specialNumber = 2
+          let f range = ()
+          let rangeCoveringExpr = 2
 
-          $0f specialNumber$0
+          $0f rangeCoveringExpr$0
           """
           []
       testCaseAsync "hide: param postfix of arg" <|
         InlayHints.checkRange server
           """
-          let f number = ()
-          let specialNumber = 2
+          let f range = ()
+          let exactRange = 2
 
-          $0f specialNumber$0
+          $0f exactRange$0
           """
           []
 
@@ -276,48 +276,48 @@ let tests state =
         InlayHints.checkRange server
           """
           type Data = {
-            Number: int
+            Range: int
           }
-          let f number = ()
-          let data: Data = { Number = 2 }
+          let f range = ()
+          let data: Data = { Range = 2 }
 
-          $0f data.Number$0
+          $0f data.Range$0
           """
           []
       testCaseAsync "hide: arg is field access with same name as param (lower case start)" <|
         InlayHints.checkRange server
           """
           type Data = {
-            number: int
+            range: int
           }
-          let f number = ()
-          let data: Data = { number = 2 }
+          let f range = ()
+          let data: Data = { range = 2 }
 
-          $0f data.number$0
+          $0f data.range$0
           """
           []
       testCaseAsync "hide: arg is field access prefix of param (upper case start)" <|
         InlayHints.checkRange server
           """
           type Data = {
-            Special: int
+            Range: int
           }
-          let f specialNumber = ()
-          let data: Data = { Special = 2 }
+          let f rangeCoveringExpr = ()
+          let data: Data = { Range = 2 }
 
-          $0f data.Special$0
+          $0f data.Range$0
           """
           []
       testCaseAsync "hide: arg is field access, param is prefix of arg" <|
         InlayHints.checkRange server
           """
           type Data = {
-            SpecialNumber: int
+            RangeCoveringExpr: int
           }
-          let f special = ()
-          let data: Data = { SpecialNumber = 2 }
+          let f range = ()
+          let data: Data = { RangeCoveringExpr = 2 }
 
-          $0f data.SpecialNumber$0
+          $0f data.RangeCoveringExpr$0
           """
           []
 

--- a/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
@@ -194,7 +194,6 @@ let tests state =
           $0f range$0
           """
           [  ]
-      //todo: or hide?
       testCaseAsync "show: variable infix of param" <|
         InlayHints.checkRange server
           """
@@ -204,7 +203,6 @@ let tests state =
           $0f $0range$0
           """
           [ param "exactRangeCoveringExpr" ]
-      //todo: or hide?
       testCaseAsync "show: variable prefix of param, but no word boundary" <|
         InlayHints.checkRange server
           """
@@ -214,7 +212,6 @@ let tests state =
           $0f $0range$0
           """
           [ param "rangecover" ]
-      //todo: or hide?
       testCaseAsync "show: variable postfix of param, but no word boundary" <|
         InlayHints.checkRange server
           """
@@ -339,7 +336,6 @@ let tests state =
           $0f ( alpha )$0
           """
           [  ]
-      //todo: or hide? based on: what is last? but then (`alpha <| 1`, `1 |> alpha 2`, etc?) -> too complex to detect
       testCaseAsync "show: expr including param name in parens" <|
         InlayHints.checkRange server
           """
@@ -350,7 +346,10 @@ let tests state =
           """
           [ param "alpha" ]
           
-      //todo: inspect most left/right identifier? extract function name? look for left of `.`? use ast?
+      //ENHANCEMENT: detect some common expressions like:
+      // * receiving end of pipe: `1 |> alpha`, `alpha <| 1`, `1 |> toAlpha`
+      // * last function: `1.ToAlpha()`
+      // * often used convert functions: `string alpha`, `alpha.ToString()`
       testCaseAsync "show: any expression" <|
         InlayHints.checkRange server
           """


### PR DESCRIPTION
(mostly inspired by rust-analyzer)

Parameter Hints are now additional hidden when:
* Operator
  * In practice: were already not shown -- but because of short names, not because of operator
* Param or Argument Prefix or Postfix of each other
  * prev: only same or arg starts with param
  * now: a bit more elaborated:
    * must be identifier (-> excludes other expressions like `(foo |> bar)` or `foo.ToString()`)
      * Special case: extracts identifier from parens (`(foo)` -> `foo`)
    * only looks at most right identifier when long ident (`foo.bar.baz` -> `baz`)
      ```fsharp
      let f range = ()
      f data.Range
      //     ^^^^^ -> no param hint
      ```
      * to restrictive? arg might be `config.baz.value` -> `baz` in center
    * Removes leading `_` from param for comparison
      ```fsharp
      let f _range = ()
      let range = 42
      f range
      //^^^^^ -> no param hint
      ```
    * Removes trailing `'` from argument for comparison
      ```fsharp
      let f range = ()
      let range' = 42
      f range'
      //^^^^^^ -> no param hint
      ```
    * Pre/Postfix must be at word boundary (-> Upper case letter: `foo` is prefix of `fooBar` but not `foobar`)
      ```fsharp
      let f1 exactRange = ()
      //          ^ word boundary
      let f2 exactrange = ()
      //          ^ no word boundary
      let (range, exact) = (42, 13)
      
      f1 range
      // ^^^^^ -> no param hint
      f2 range
      // ^^^^^ -> param hint
      
      f1 exact
      // ^^^^^ -> no param hint
      f2 exact
      // ^^^^^ -> param hint
      ```
      * Besides at word boundary capitalization isn't considered: `range = Range = RANGE`
      * I'm not sure word boundaries are always good? might be too restrictive? or recognize something like plural `s` too?
      * All Pre/Postfix combinations (param pre/postfix of arg, arg pre/postfix of param) -> to intrusive? might allow to many names
      * Doesn't look what is inside word. But might be the match: arg=`exactRangeOfExpr` param=`range` -> might be nice to not show hint
      * Recognize acronym? `f abstractSyntaxTree` -> param `ast` -> no param hint?

    But: far to many possibilities when looking for something similar -> here now just some and not too hard to detect
* Param postfix of Function Name:
  ```fsharp
  let validateRange range = ()
  //          ^^^^^ ^^^^^ -> never param hint
  ```
  * Like above: Postfix -> word boundary (-> uppercase)
* Some more hiding when well known function. Unlike `wellKnownNames` (which just checks param name), I'll look at the function (and its module) too:
  -> only hide certain parameter names in certain functions:
  * `option` & `voption` in `Option.xxx` and `ValueOption.xxx` functions
  * `format` in printf functions
    * -> removed from general `wellKnownNames`: I think that's quite often a very valuable info -- just not for the commonly used printf-functions
  * `mapping` in Collection functions (`List.xxx`, `Array.xxx`, ...)
    * -> removed from general wellKnownNames


About "excludes expressions": 
Might actually be worth recognizing some expressions (like param name is `foo`, arg: `bar.Foo()`, `bar |> toFoo`, ...) -- but there are so many possibilities -> I just completely ignore anything not-identifier.


Note: There are quite a few `TODO`s in tests for cases I'm not sure the current way is best. Any opinions?


<br/>

------------------------------

<br/>

**Next**:  
I think we should move to Inlay Hints from LSP ([coming in `3.17.0`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlayHint)). Besides being an official LSP feature instead of custom one, this provides some additional things:
* `TextEdit[]` instead of `NewText: string option` (inserted at `Pos`): A single insert at one position might not be enough to insert a type hint (might need parens)
* `Tooltip`: Displaying a parameter's type and/or its XML Doc would be nice


If OK, I would add LSP types and corresponding request to FSAC
* LSP Types here and not in `ionide/LanguageServerProtocol`: Inlay Hints still in preview -> easier to manage everything directly here instead of syncing with other repo   (-> move once it's released)
* Current `fsharp/inlayHints` stays (currently used in Ionide) (-> version of `textDocument/inlayHint` with simpler return data)