### PR TITLE
Fix #941: IndexOutOfRangeException which crashes whole process

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -510,7 +510,7 @@ type Commands
         // adjust column
         let pos =
           match pos with
-          | Pos (0, c) -> pos
+          | Pos (1, c) -> pos
           | Pos (l, 0) ->
             let prev = getLine (pos.DecLine())
             let indentation = detectIndentation prev

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -130,7 +130,7 @@ type NamedText(fileName: string<LocalPath>, str: string) =
 
   /// Provides safe access to a line of the file via FCS-provided Position
   member x.GetLine(pos: FSharp.Compiler.Text.Position) : string option =
-    if pos.Line > getLines.Value.Length then
+    if pos.Line < 1 || pos.Line > getLines.Value.Length then
       None
     else
       Some(x.GetLineUnsafe pos)

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -14,12 +14,13 @@ open FSharp.Compiler.IO
 [<AutoOpen>]
 module PositionExtensions =
   type FSharp.Compiler.Text.Position with
+    /// Excluding current line
     member x.LinesToBeginning() =
-      if x.Line <= 0 then
+      if x.Line <= 1 then
         Seq.empty
       else
         seq {
-          for i = x.Line - 1 downto 0 do
+          for i = x.Line - 1 downto 1 do
             yield Position.mkPos i 0
         }
 


### PR DESCRIPTION
`NamedText.GetLine` throws exception because it tries to get line `0`. But FCS is `1`-based.

Source of `0` line:  
[`calculateNamespaceInsert`](https://github.com/fsharp/FsAutoComplete/blob/88c747d316a5868e1b9be08ab72bfe10526ec055/src/FsAutoComplete.Core/Commands.fs#L472-L527) contains two locations that might decrease line to `0`:
* https://github.com/fsharp/FsAutoComplete/blob/88c747d316a5868e1b9be08ab72bfe10526ec055/src/FsAutoComplete.Core/Commands.fs#L512-L515
  Incorrect pos match with line `0` (-> case never gets matched) -> line `1` gets matched in next case and decreased by one -- resulting in line `0`
* https://github.com/fsharp/FsAutoComplete/blob/88c747d316a5868e1b9be08ab72bfe10526ec055/src/FsAutoComplete.Core/FileSystem.fs#L17-L24  
  ([`Position.LinesToBeginning()`](https://github.com/fsharp/FsAutoComplete/blob/88c747d316a5868e1b9be08ab72bfe10526ec055/src/FsAutoComplete.Core/FileSystem.fs#L17-L24) via [calculateNamespaceInsert](https://github.com/fsharp/FsAutoComplete/blob/88c747d316a5868e1b9be08ab72bfe10526ec055/src/FsAutoComplete.Core/Commands.fs#L499))  
  counts town to line `0` instead of `1`


<br/>
<br/>

I didn't manage to produce a test for these errors.  
Instead I reenacted the issue by manually setting the pos inside `calculateNamespaceInsert` to line `1`.  
The resulting exception was the same as in #941:
<details>
  <summary markdown="span">exception</summary>

```
Unhandled exception. System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at FsAutoComplete.NamedText.FSharp.Compiler.Text.ISourceText.GetLineString(Int32 lineIndex) in /.../FsAutoComplete/src/FsAutoComplete.Core/FileSystem.fs:line 276
   at FsAutoComplete.NamedText.GetLineUnsafe(Position pos) in /.../FsAutoComplete/src/FsAutoComplete.Core/FileSystem.fs:line 135
   at FsAutoComplete.NamedText.GetLine(Position pos) in /.../FsAutoComplete/src/FsAutoComplete.Core/FileSystem.fs:line 142
   at <StartupCode$FsAutoComplete-Core>.$Commands.Completion@991-7.Invoke(Position arg00) in /.../FsAutoComplete/src/FsAutoComplete.Core/Commands.fs:line 991
   at <StartupCode$FsAutoComplete-Core>.$Commands.getLine@473.Invoke(Position p) in /.../FsAutoComplete/src/FsAutoComplete.Core/Commands.fs:line 473
   at <StartupCode$FsAutoComplete-Core>.$Commands.clo@482-40.Invoke(InsertionContext ic) in /.../FsAutoComplete/src/FsAutoComplete.Core/Commands.fs:line 516
   at Microsoft.FSharp.Core.OptionModule.Map[T,TResult](FSharpFunc`2 mapping, FSharpOption`1 option) in D:\a\_work\1\s\src\fsharp\FSharp.Core\option.fs:line 53
   at <StartupCode$FsAutoComplete-Core>.$Commands.clo@478-39.Invoke(String n) in /.../FsAutoComplete/src/FsAutoComplete.Core/Commands.fs:line 482
   at FsAutoComplete.Commands.calculateNamespaceInsert(DeclarationListItem decl, Position pos, FSharpFunc`2 getLine) in /.../FsAutoComplete/src/FsAutoComplete.Core/Commands.fs:line 478
   at <StartupCode$FsAutoComplete-Core>.$Commands.Pipe #1 input at line 538@539-1.Invoke(DeclarationListItem _arg11) in /.../FsAutoComplete/src/FsAutoComplete.Core/Commands.fs:line 542
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke[T,TResult](AsyncActivation`1 ctxt, TResult result1, FSharpFunc`2 part2) in D:\a\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 447
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in D:\a\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 104
--- End of stack trace from previous location ---
   at Microsoft.FSharp.Control.AsyncPrimitives.Start@1078-1.Invoke(ExceptionDispatchInfo edi)
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in D:\a\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 104
   at <StartupCode$FSharp-Core>.$Async.clo@181-16.Invoke(Object o) in D:\a\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 183
   at System.Threading.QueueUserWorkItemCallback.<>c.<.cctor>b__6_0(QueueUserWorkItemCallback quwi)
   at System.Threading.ExecutionContext.RunForThreadPoolUnsafe[TState](ExecutionContext executionContext, Action`1 callback, TState& state)
   at System.Threading.QueueUserWorkItemCallback.Execute()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
   at System.Threading.Thread.StartCallback()
```

(different line numbers and more steps: Current `main` (vs. commit that is used in FSAC in ionide) & debug build)
</details>

But this also means: I just *think* this fixes #941.


<br/>
<br/>
<br/>

As "backup": `NamedText.GetLine` now checks lower bound too.  
(Advantage: doesn't crash any more when line 0. But disadvantage: it doesn't expose a incorrect line any more...)
