### PR TITLE
Update `Ionide.LanguageServerProtocol` dependency

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -99,9 +99,8 @@ NUGET
       System.Collections.Immutable (>= 5.0)
       System.Reflection.Metadata (>= 5.0)
     Ionide.KeepAChangelog.Tasks (0.1.8) - copy_local: true
-    Ionide.LanguageServerProtocol (0.4)
-      FSharp.Core (>= 6.0.1)
-      Microsoft.NETFramework.ReferenceAssemblies (>= 1.0.2)
+    Ionide.LanguageServerProtocol (0.4.1)
+      FSharp.Core (>= 6.0)
       Newtonsoft.Json (>= 13.0.1)
       StreamJsonRpc (>= 2.10.44)
     Ionide.ProjInfo (0.59.1)

--- a/paket.lock
+++ b/paket.lock
@@ -99,7 +99,7 @@ NUGET
       System.Collections.Immutable (>= 5.0)
       System.Reflection.Metadata (>= 5.0)
     Ionide.KeepAChangelog.Tasks (0.1.8) - copy_local: true
-    Ionide.LanguageServerProtocol (0.4.1)
+    Ionide.LanguageServerProtocol (0.4.2)
       FSharp.Core (>= 6.0)
       Newtonsoft.Json (>= 13.0.1)
       StreamJsonRpc (>= 2.10.44)

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -11,7 +11,7 @@ open FsAutoComplete.CodeFix
 open FsAutoComplete.CodeFix.Types
 open FsAutoComplete.Logging
 open Ionide.LanguageServerProtocol
-open Ionide.LanguageServerProtocol.LspResult
+open Ionide.LanguageServerProtocol.Types.LspResult
 open Ionide.LanguageServerProtocol.Server
 open Ionide.LanguageServerProtocol.Types
 open LspHelpers
@@ -1534,6 +1534,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
             fst
             >> fun top -> getSymbolInformations p.TextDocument.Uri glyphToSymbolKind top (fun s -> true)
           )
+          |> U2.First
           |> Some
           |> success
 

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -121,14 +121,15 @@ let documentSymbolTest state =
           match res with
           | Result.Error e -> failtestf "Request failed: %A" e
           | Result.Ok None -> failtest "Request none"
-          | Result.Ok (Some res) ->
-
+          | Result.Ok (Some (U2.First res)) ->
             Expect.equal res.Length 15 "Document Symbol has all symbols"
 
             Expect.exists
               res
               (fun n -> n.Name = "MyDateTime" && n.Kind = SymbolKind.Class)
               "Document symbol contains given symbol"
+          | Result.Ok (Some (U2.Second res)) ->
+              raise (NotImplementedException("DocumentSymbol isn't used in FSAC yet"))
         }) ]
 
 let foldingTests state =

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -226,12 +226,16 @@ let clientCaps: ClientCapabilities =
     let semanticTokenCaps: SemanticTokensWorkspaceClientCapabilities =
       { RefreshSupport = Some true }
 
+    let inlayHintCaps: InlayHintWorkspaceClientCapabilities =
+      { RefreshSupport = Some false }
+
     { ApplyEdit = Some true
       WorkspaceEdit = Some weCaps
       DidChangeConfiguration = Some dynCaps
       DidChangeWatchedFiles = Some dynCaps
       Symbol = Some symbolCaps
-      SemanticTokens = Some semanticTokenCaps }
+      SemanticTokens = Some semanticTokenCaps
+      InlayHint = Some inlayHintCaps }
 
   let textCaps: TextDocumentClientCapabilities =
     let syncCaps: SynchronizationCapabilities =
@@ -330,8 +334,6 @@ let clientCaps: ClientCapabilities =
 
   { Workspace = Some workspaceCaps
     TextDocument = Some textCaps
-    //TODO: wrong place (-> should be inside Workspace) and is option
-    InlayHint = { RefreshSupport = Some false }
     Experimental = None }
 
 open Expecto.Logging

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -274,7 +274,8 @@ let clientCaps: ClientCapabilities =
       let skCaps: SymbolKindCapabilities = { ValueSet = None }
 
       { DynamicRegistration = Some true
-        SymbolKind = Some skCaps }
+        SymbolKind = Some skCaps
+        HierarchicalDocumentSymbolSupport = Some false }
 
     let foldingRangeCaps: FoldingRangeCapabilities =
       { DynamicRegistration = Some true
@@ -301,6 +302,10 @@ let clientCaps: ClientCapabilities =
         ResolveSupport = None
         HonorsChangeAnnotations = None }
 
+    let inlayHintCaps: InlayHintClientCapabilities =
+      { DynamicRegistration = Some true
+        ResolveSupport = None }
+
     { Synchronization = Some syncCaps
       PublishDiagnostics = diagCaps
       Completion = Some compCaps
@@ -319,11 +324,14 @@ let clientCaps: ClientCapabilities =
       Rename = Some dynCaps
       FoldingRange = Some foldingRangeCaps
       SelectionRange = Some dynCaps
-      SemanticTokens = Some semanticTokensCaps }
+      SemanticTokens = Some semanticTokensCaps
+      InlayHint = Some inlayHintCaps }
 
 
   { Workspace = Some workspaceCaps
     TextDocument = Some textCaps
+    //TODO: wrong place (-> should be inside Workspace) and is option
+    InlayHint = { RefreshSupport = Some false }
     Experimental = None }
 
 open Expecto.Logging


### PR DESCRIPTION
Updates `Ionide.LanguageServerProtocol` to newest version (`0.4.1`)

(just adjustments to make it compile -- nothing further (for example: `textDocument/documentSymbol` still uses `SymbolInformation` instead of [newer](https://github.com/ionide/LanguageServerProtocol/pull/18) and [recommended](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol) `DocumentSymbol`))


But there are two issues regarding InlayHints that are now fixed in `ionide/LSP` ([1](https://github.com/ionide/LanguageServerProtocol/pull/23), [2](https://github.com/ionide/LanguageServerProtocol/pull/26)), but came after `0.4.1` -> PR here marked as WIP  
@baronfel: can you release a new `Ionide.LanguageServerProtocol` Version? (hopefully this time everything is in correct place 😅) Thanks  



