### PR TITLE
Use Uri instead of FileName for several `fsharp/` requests

### DIFF
--- a/src/FsAutoComplete.Core/AbstractClassStubGenerator.fs
+++ b/src/FsAutoComplete.Core/AbstractClassStubGenerator.fs
@@ -45,6 +45,7 @@ let private walkTypeDefn (SynTypeDefn (info, repr, members, implicitCtor, range,
 
 
 
+
       (
        // filter out implicit/explicit constructors and inherit statements, as all members _must_ come after these
        function

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -546,7 +546,7 @@ type ParseAndCheckResults
         | _ -> ResultOrString.Error "Not a member, function or value"
 
   member __.TryGetF1Help (pos: Position) (lineStr: LineStr) =
-    match Lexer.findLongIdents (pos.Column - 1, lineStr) with
+    match Lexer.findLongIdents (pos.Column, lineStr) with
     | None -> ResultOrString.Error "No ident at this location"
     | Some (colu, identIsland) ->
 

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -374,7 +374,7 @@ type ParseAndCheckResults
               Ok(Some(tip, signature, footer, typeDoc))
 
   member __.TryGetFormattedDocumentation (pos: Position) (lineStr: LineStr) =
-    match Lexer.findLongIdents (pos.Column - 1, lineStr) with
+    match Lexer.findLongIdents (pos.Column, lineStr) with
     | None -> Error "Cannot find ident"
     | Some (col, identIsland) ->
       let identIsland = Array.toList identIsland

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -337,7 +337,8 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
     try
       match n with
       | NotificationEvent.FileParsed fn ->
-        ({ Content = UMX.untag fn }: PlainNotification)
+        let uri = Path.LocalPathToUri fn
+        ({ Content = UMX.untag uri }: PlainNotification)
         |> lspClient.NotifyFileParsed
         |> Async.Start
       | NotificationEvent.Workspace ws ->

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -338,6 +338,7 @@ type FSharpLspServer(backgroundServiceEnabled: bool, state: State, lspClient: FS
       match n with
       | NotificationEvent.FileParsed fn ->
         let uri = Path.LocalPathToUri fn
+
         ({ Content = UMX.untag uri }: PlainNotification)
         |> lspClient.NotifyFileParsed
         |> Async.Start

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -594,7 +594,7 @@ type DocumentationForSymbolReuqest = { XmlSig: string; Assembly: string }
 
 // type FakeTargetsRequest = { FileName : string; FakeContext : FakeSupport.FakeContext; }
 
-type HighlightingRequest = { FileName: string }
+type HighlightingRequest = { TextDocument: TextDocumentIdentifier }
 
 type LineLensConfig = { Enabled: string; Prefix: string }
 
@@ -618,9 +618,9 @@ type DotnetFile2Request =
     FileVirtualPath: string
     NewFile: string }
 
-type FSharpLiterateRequest = { FileName: string }
+type FSharpLiterateRequest = { TextDocument: TextDocumentIdentifier }
 
-type FSharpPipelineHintRequest = { FileName: string }
+type FSharpPipelineHintRequest = { TextDocument: TextDocumentIdentifier }
 
 type CodeLensConfigDto =
   { Signature: {| Enabled: bool option |} option

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -594,7 +594,8 @@ type DocumentationForSymbolReuqest = { XmlSig: string; Assembly: string }
 
 // type FakeTargetsRequest = { FileName : string; FakeContext : FakeSupport.FakeContext; }
 
-type HighlightingRequest = { TextDocument: TextDocumentIdentifier }
+type HighlightingRequest =
+  { TextDocument: TextDocumentIdentifier }
 
 type LineLensConfig = { Enabled: string; Prefix: string }
 
@@ -618,9 +619,11 @@ type DotnetFile2Request =
     FileVirtualPath: string
     NewFile: string }
 
-type FSharpLiterateRequest = { TextDocument: TextDocumentIdentifier }
+type FSharpLiterateRequest =
+  { TextDocument: TextDocumentIdentifier }
 
-type FSharpPipelineHintRequest = { TextDocument: TextDocumentIdentifier }
+type FSharpPipelineHintRequest =
+  { TextDocument: TextDocumentIdentifier }
 
 type CodeLensConfigDto =
   { Signature: {| Enabled: bool option |} option


### PR DESCRIPTION
In Ionide quite a lot of commands don't work in untitled documents.  
Reason: FileName instead of Uri is used.

Additional to changes here in FSAC, clients must make some adjustments too.  
For Ionide these are in ionide/ionide-vscode-fsharp#1717

Changes:
* `fsharp/FileParsed`: returns URI instead of FileName. No type change (is `PlainNotification`), but content is now URI
* `FSharpPipelineHintRequest`, `HighlightingRequest`, `FSharpLiterateRequest` use now `TextDocumentIdentifier`:
  * Prev: `{ FileName: string }`
  * Now: `{ TextDocument: TextDocumentIdentifier }`

Note: This results in changed API  
-> as mentioned above: Clients must be adjusted


<br/>

Additional Fix:
* Off-by-One column in `fsharp/f1Help` & `fsharp/documentation` (used in Info Panel)
