### PR TITLE
Remove `--background-service-enabled` CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ Custom endpoints are using (for messages body) `PlainNotification` type and stri
 ### Additional startup options
 
 * `--state-directory dir` - a workspace-specific directory for keeping language server states.
-* `--background-service-enabled` - passing this flag enables background service feature, increasing FSAC responsiveness by moving some of the operations (especially background type checking) to other process. It results in increased memory usage. Used by default in Ionide.
 * `--verbose` - passing this flag enables additional logging being printed out in `stderr`
 * `DOTNET_ROOT` - setting this environment variable will set the dotnet SDK root, which is used when finding references for FSX scripts.
 
@@ -177,8 +176,6 @@ The maintainers of this repository are:
 
 * [Krzysztof Cieślak](http://github.com/Krzysztof-Cieslak)
 * [Chester Husk](http://github.com/baronfel)
-
-The primary maintainer for this repository is [Krzysztof Cieślak](http://github.com/Krzysztof-Cieslak))
 
 Previous maintainers:
 

--- a/src/FsAutoComplete/Parser.fs
+++ b/src/FsAutoComplete/Parser.fs
@@ -74,13 +74,6 @@ module Parser =
     )
     |> zero
 
-  let backgroundServiceOption =
-    Option<bool>(
-      "--background-service-enabled",
-      "Enable running typechecking services in a background process. Enables various performance optimizations."
-    )
-    |> zero
-
   let projectGraphOption =
     Option<bool>(
       "--project-graph-enabled",
@@ -104,7 +97,6 @@ module Parser =
     rootCommand.AddOption logFileOption
     rootCommand.AddOption logFilterOption
     rootCommand.AddOption waitForDebuggerOption
-    rootCommand.AddOption backgroundServiceOption
     rootCommand.AddOption projectGraphOption
     rootCommand.AddOption logLevelOption
     rootCommand.AddOption stateLocationOption


### PR DESCRIPTION
This is a breaking change - if the editor will try to start FSAC with this parameter it will crash. 