### PR TITLE
use dotnet that spawned FSAC as an input to SDK discovery

### DIFF
--- a/src/FsAutoComplete/Parser.fs
+++ b/src/FsAutoComplete/Parser.fs
@@ -9,9 +9,10 @@ open System.CommandLine
 open System.CommandLine.Parsing
 open System.CommandLine.Builder
 open Serilog.Filters
+open System.Runtime.InteropServices
+open System.Threading.Tasks
 
 module Parser =
-  open System.Threading.Tasks
 
   [<Struct>]
   type Pos = { Line: int; Column: int }
@@ -117,8 +118,18 @@ module Parser =
           else
             Ionide.ProjInfo.WorkspaceLoader.Create
 
+        let dotnetPath =
+          if
+            Environment.ProcessPath.EndsWith("dotnet")
+            || Environment.ProcessPath.EndsWith("dotnet.exe")
+          then
+            // this is valid when not running as a global tool
+            Some(FileInfo(Environment.ProcessPath))
+          else
+            None
+
         let toolsPath =
-          Ionide.ProjInfo.Init.init (IO.DirectoryInfo Environment.CurrentDirectory) None
+          Ionide.ProjInfo.Init.init (IO.DirectoryInfo Environment.CurrentDirectory) dotnetPath
 
         use _compilerEventListener = new Debug.FSharpCompilerEventLogger.Listener()
 


### PR DESCRIPTION
_may_ fix some cases presented in https://github.com/ionide/ionide-vscode-fsharp/issues/1697.

Instead of delegating to the probing in proj-info, when we've been launched by a `dotnet` command (which IMO is the common case - only scenario when that's not the case is a global .NET tool install) we can use the path to that `dotnet` binary to skip the probing in proj-info that finds the dotnet binary.  We still do SDK probing, but we remove a big case of potential errors.