### PR TITLE
Enhancement for Rename: Add backticks to name if necessary

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1121,7 +1121,7 @@ type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers:
 
         let symbolFileText =
           state.TryGetFileSource(symbolFile)
-          |> Result.fold id (fun e -> failwith "blah blah")
+          |> Result.fold id (fun e -> failwith $"Unable to get file source for file '{symbolFile}'")
 
         let symbolText =
           symbolFileText[symbolRange]

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/RenameTest/SameScript/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/RenameTest/SameScript/Script.fsx
@@ -1,3 +1,0 @@
-let initial () = printfn "hi"
-
-initial ()


### PR DESCRIPTION
```fsharp
let foo = 42
```
=> rename `foo` to `hello world`

prev:
```fsharp
let hello world = 42
```
now:
```fsharp
let ``hello world`` = 42
```
-> backticks get automatically added if necessary