### PR TITLE
Add back option to disable in-memory project references

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -86,7 +86,11 @@ type FSharpCompilerServiceChecker(hasAnalyzers) =
       | StartsWith "--load:" file -> args, Array.append files [| file |]
       | arg -> Array.append args [| arg |], files)
 
-  let clearProjectReferences (opts: FSharpProjectOptions) = opts
+  let clearProjectReferences (opts: FSharpProjectOptions) =
+    if disableInMemoryProjectReferences then
+      { opts with ReferencedProjects = [||] }
+    else
+      opts
 
   let filterBadRuntimeRefs =
     let badRefs =


### PR DESCRIPTION
Turning on this setting (i.e. disabling in-memory project refs) means less accurate tooling (you need to build code to pick up changes from projects on which the current project depends) but highly reduces the performance overhead - it may be useful in some specific cases like working on the compiler code base. 