### PR TITLE
Remove unnecessary `GetBackgroundCheckResultsForFileInProject`

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -20,7 +20,6 @@ nuget Microsoft.Build  copy_local:false
 nuget Microsoft.Build.Framework copy_local:false
 nuget Microsoft.Build.Utilities.Core copy_local:false
 nuget Microsoft.Build.Tasks.Core copy_local: false
-nuget NuGet.Frameworks
 nuget FSharp.Analyzers.SDK
 nuget ICSharpCode.Decompiler
 nuget Mono.Cecil >= 0.10.0-beta7

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -20,6 +20,7 @@ nuget Microsoft.Build  copy_local:false
 nuget Microsoft.Build.Framework copy_local:false
 nuget Microsoft.Build.Utilities.Core copy_local:false
 nuget Microsoft.Build.Tasks.Core copy_local: false
+nuget NuGet.Frameworks copy_local: false
 nuget FSharp.Analyzers.SDK
 nuget ICSharpCode.Decompiler
 nuget Mono.Cecil >= 0.10.0-beta7

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -20,7 +20,7 @@ nuget Microsoft.Build  copy_local:false
 nuget Microsoft.Build.Framework copy_local:false
 nuget Microsoft.Build.Utilities.Core copy_local:false
 nuget Microsoft.Build.Tasks.Core copy_local: false
-nuget NuGet.Frameworks copy_local: false
+nuget NuGet.Frameworks
 nuget FSharp.Analyzers.SDK
 nuget ICSharpCode.Decompiler
 nuget Mono.Cecil >= 0.10.0-beta7

--- a/paket.lock
+++ b/paket.lock
@@ -233,7 +233,7 @@ NUGET
       System.IO.Pipelines (>= 5.0.1)
       System.Runtime.CompilerServices.Unsafe (>= 5.0)
     Newtonsoft.Json (13.0.1)
-    NuGet.Frameworks (6.2.1)
+    NuGet.Frameworks (6.2.1) - copy_local: false
     runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
     runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
     runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)

--- a/paket.lock
+++ b/paket.lock
@@ -148,7 +148,7 @@ NUGET
     Microsoft.Build.Framework (17.2) - copy_local: false
       Microsoft.Win32.Registry (>= 4.3)
       System.Security.Permissions (>= 4.7)
-    Microsoft.Build.Locator (1.4.1) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= net5.0))
+    Microsoft.Build.Locator (1.5.3) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= net5.0))
     Microsoft.Build.Tasks.Core (17.2) - copy_local: false
       Microsoft.Build.Framework (>= 17.2)
       Microsoft.Build.Utilities.Core (>= 17.2)
@@ -171,7 +171,7 @@ NUGET
       System.Configuration.ConfigurationManager (>= 4.7)
       System.Security.Permissions (>= 4.7) - restriction: == netstandard2.0
       System.Text.Encoding.CodePages (>= 4.0.1) - restriction: == netstandard2.0
-    Microsoft.CodeCoverage (17.2) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= net45)) (&& (== netstandard2.0) (>= netcoreapp1.0))
+    Microsoft.CodeCoverage (17.3) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= net45)) (&& (== netstandard2.0) (>= netcoreapp1.0))
     Microsoft.DotNet.PlatformAbstractions (3.1.6) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= net5.0))
     Microsoft.Extensions.DependencyModel (6.0) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= net5.0))
       System.Buffers (>= 4.5.1)
@@ -182,9 +182,9 @@ NUGET
     Microsoft.NET.StringTools (1.0) - copy_local: false
       System.Memory (>= 4.5.4)
       System.Runtime.CompilerServices.Unsafe (>= 5.0)
-    Microsoft.NET.Test.Sdk (17.2)
-      Microsoft.CodeCoverage (>= 17.2) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= net45)) (&& (== netstandard2.0) (>= netcoreapp1.0))
-      Microsoft.TestPlatform.TestHost (>= 17.2) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp1.0))
+    Microsoft.NET.Test.Sdk (17.3)
+      Microsoft.CodeCoverage (>= 17.3) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= net45)) (&& (== netstandard2.0) (>= netcoreapp1.0))
+      Microsoft.TestPlatform.TestHost (>= 17.3) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp1.0))
     Microsoft.NETCore.Platforms (6.0.5)
     Microsoft.NETCore.Targets (5.0)
     Microsoft.NETFramework.ReferenceAssemblies (1.0.2)
@@ -201,20 +201,20 @@ NUGET
     Microsoft.SourceLink.GitLab (1.1.1) - copy_local: true
       Microsoft.Build.Tasks.Git (>= 1.1.1)
       Microsoft.SourceLink.Common (>= 1.1.1)
-    Microsoft.TestPlatform.ObjectModel (17.2)
+    Microsoft.TestPlatform.ObjectModel (17.3)
       NuGet.Frameworks (>= 5.11)
       System.Reflection.Metadata (>= 1.6)
-    Microsoft.TestPlatform.TestHost (17.2) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp1.0))
-      Microsoft.TestPlatform.ObjectModel (>= 17.2) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp1.0)) (&& (== netstandard2.0) (>= uap10.0))
+    Microsoft.TestPlatform.TestHost (17.3) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp1.0))
+      Microsoft.TestPlatform.ObjectModel (>= 17.3) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp1.0)) (&& (== netstandard2.0) (>= uap10.0))
       Newtonsoft.Json (>= 9.0.1) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp1.0)) (&& (== netstandard2.0) (>= uap10.0))
-    Microsoft.VisualStudio.Threading (17.2.32)
+    Microsoft.VisualStudio.Threading (17.3.44)
       Microsoft.Bcl.AsyncInterfaces (>= 6.0)
-      Microsoft.VisualStudio.Threading.Analyzers (>= 17.2.32)
-      Microsoft.VisualStudio.Validation (>= 17.0.53)
+      Microsoft.VisualStudio.Threading.Analyzers (>= 17.3.44)
+      Microsoft.VisualStudio.Validation (>= 17.0.58)
       Microsoft.Win32.Registry (>= 5.0)
       System.Threading.Tasks.Extensions (>= 4.5.4)
-    Microsoft.VisualStudio.Threading.Analyzers (17.2.32)
-    Microsoft.VisualStudio.Validation (17.0.53)
+    Microsoft.VisualStudio.Threading.Analyzers (17.3.44)
+    Microsoft.VisualStudio.Validation (17.0.64)
     Microsoft.Win32.Primitives (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
@@ -233,7 +233,7 @@ NUGET
       System.IO.Pipelines (>= 5.0.1)
       System.Runtime.CompilerServices.Unsafe (>= 5.0)
     Newtonsoft.Json (13.0.1)
-    NuGet.Frameworks (6.2.1) - copy_local: false
+    NuGet.Frameworks (6.3)
     runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
     runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
     runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
@@ -285,15 +285,15 @@ NUGET
       Serilog (>= 2.10)
     Serilog.Sinks.File (5.0)
       Serilog (>= 2.10)
-    StreamJsonRpc (2.11.35)
+    StreamJsonRpc (2.12.27)
       MessagePack (>= 2.3.85)
       Microsoft.Bcl.AsyncInterfaces (>= 6.0)
       Microsoft.VisualStudio.Threading (>= 17.1.46)
       Nerdbank.Streams (>= 2.8.57)
       Newtonsoft.Json (>= 13.0.1)
-      System.Collections.Immutable (>= 5.0)
+      System.Collections.Immutable (>= 6.0)
       System.Diagnostics.DiagnosticSource (>= 6.0)
-      System.IO.Pipelines (>= 6.0.1)
+      System.IO.Pipelines (>= 6.0.3)
       System.Threading.Tasks.Dataflow (>= 6.0)
     System.Buffers (4.5.1)
     System.CodeDom (6.0) - copy_local: false
@@ -684,10 +684,10 @@ NUGET
       System.Security.Cryptography.Primitives (>= 4.3)
       System.Text.Encoding (>= 4.3)
       System.Threading (>= 4.3)
-    System.Security.Cryptography.Xml (6.0) - copy_local: false
+    System.Security.Cryptography.Xml (6.0.1) - copy_local: false
       System.Memory (>= 4.5.4) - restriction: == netstandard2.0
       System.Security.AccessControl (>= 6.0)
-      System.Security.Cryptography.Pkcs (>= 6.0)
+      System.Security.Cryptography.Pkcs (>= 6.0.1)
     System.Security.Permissions (6.0)
       System.Security.AccessControl (>= 6.0)
       System.Windows.Extensions (>= 6.0) - restriction: || (== net6.0) (&& (== netstandard2.0) (>= netcoreapp3.1))
@@ -935,21 +935,21 @@ NUGET
       Microsoft.Build.Tasks.Core (>= 16.10) - restriction: >= netstandard2.0
       Microsoft.Build.Utilities.Core (>= 16.10) - restriction: >= netstandard2.0
     Newtonsoft.Json (13.0.1) - restriction: >= netstandard2.0
-    NuGet.Common (6.2.1) - restriction: >= netstandard2.0
-      NuGet.Frameworks (>= 6.2.1) - restriction: || (>= net45) (>= netstandard2.0)
-    NuGet.Configuration (6.2.1) - restriction: >= netstandard2.0
-      NuGet.Common (>= 6.2.1) - restriction: || (>= net45) (>= netstandard2.0)
-      System.Security.Cryptography.ProtectedData (>= 4.4) - restriction: && (< net45) (>= netstandard2.0)
-    NuGet.Frameworks (6.2.1) - restriction: >= netstandard2.0
-    NuGet.Packaging (6.2.1) - restriction: >= netstandard2.0
+    NuGet.Common (6.3) - restriction: >= netstandard2.0
+      NuGet.Frameworks (>= 6.3) - restriction: >= netstandard2.0
+    NuGet.Configuration (6.3) - restriction: >= netstandard2.0
+      NuGet.Common (>= 6.3) - restriction: >= netstandard2.0
+      System.Security.Cryptography.ProtectedData (>= 4.4) - restriction: && (< net472) (>= netstandard2.0)
+    NuGet.Frameworks (6.3) - restriction: >= netstandard2.0
+    NuGet.Packaging (6.3) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 13.0.1) - restriction: >= netstandard2.0
-      NuGet.Configuration (>= 6.2.1) - restriction: >= netstandard2.0
-      NuGet.Versioning (>= 6.2.1) - restriction: >= netstandard2.0
+      NuGet.Configuration (>= 6.3) - restriction: >= netstandard2.0
+      NuGet.Versioning (>= 6.3) - restriction: >= netstandard2.0
       System.Security.Cryptography.Cng (>= 5.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net5.0)
       System.Security.Cryptography.Pkcs (>= 5.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net5.0)
-    NuGet.Protocol (6.2.1) - restriction: >= netstandard2.0
-      NuGet.Packaging (>= 6.2.1) - restriction: >= netstandard2.0
-    NuGet.Versioning (6.2.1) - restriction: >= netstandard2.0
+    NuGet.Protocol (6.3) - restriction: >= netstandard2.0
+      NuGet.Packaging (>= 6.3) - restriction: >= netstandard2.0
+    NuGet.Versioning (6.3) - restriction: >= netstandard2.0
     Octokit (0.48)
     System.Buffers (4.5.1) - restriction: || (&& (>= monoandroid) (>= net6.0) (< netstandard1.3)) (&& (>= monotouch) (>= net6.0)) (&& (>= net461) (>= netstandard2.1)) (&& (< net461) (< net6.0) (>= netstandard2.0)) (&& (< net461) (>= netstandard2.0) (< netstandard2.1)) (>= net472) (&& (>= net6.0) (< netcoreapp2.0)) (&& (>= net6.0) (< netstandard2.1)) (&& (>= net6.0) (>= xamarinios)) (&& (>= net6.0) (>= xamarinmac)) (&& (>= net6.0) (>= xamarintvos)) (&& (>= net6.0) (>= xamarinwatchos)) (&& (< net6.0) (>= netstandard2.1))
     System.CodeDom (6.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
@@ -991,11 +991,11 @@ NUGET
       System.Formats.Asn1 (>= 6.0) - restriction: || (&& (< net461) (>= netstandard2.0)) (>= netstandard2.1)
       System.Memory (>= 4.5.4) - restriction: && (< net461) (>= netstandard2.0) (< netstandard2.1)
       System.Security.Cryptography.Cng (>= 5.0) - restriction: || (&& (< net461) (>= netstandard2.0) (< netstandard2.1)) (&& (< net6.0) (>= netcoreapp3.1)) (&& (< netcoreapp3.1) (>= netstandard2.1))
-    System.Security.Cryptography.ProtectedData (6.0) - restriction: || (&& (< net45) (>= netstandard2.0)) (&& (< net461) (>= net472)) (>= net6.0)
-    System.Security.Cryptography.Xml (6.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
+    System.Security.Cryptography.ProtectedData (6.0) - restriction: || (&& (< net461) (>= net472)) (&& (< net472) (>= netstandard2.0)) (>= net6.0)
+    System.Security.Cryptography.Xml (6.0.1) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
       System.Memory (>= 4.5.4) - restriction: && (< net461) (< net6.0) (>= netstandard2.0)
       System.Security.AccessControl (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Security.Cryptography.Pkcs (>= 6.0) - restriction: || (&& (< net461) (>= netstandard2.0)) (>= net6.0)
+      System.Security.Cryptography.Pkcs (>= 6.0.1) - restriction: || (&& (< net461) (>= netstandard2.0)) (>= net6.0)
     System.Security.Permissions (6.0) - restriction: >= netstandard2.0
       System.Security.AccessControl (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
       System.Windows.Extensions (>= 6.0) - restriction: >= netcoreapp3.1

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -363,8 +363,6 @@ type FSharpCompilerServiceChecker(hasAnalyzers) =
 
   member __.Compile = checker.Compile
 
-  member internal __.GetFSharpChecker() = checker
-
   member __.SetDotnetRoot(dotnetBinary: FileInfo, cwd: DirectoryInfo) =
     match Ionide.ProjInfo.SdkDiscovery.versionAt cwd dotnetBinary with
     | Ok sdkVersion ->

--- a/test/FsAutoComplete.Tests.Lsp/GoToTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/GoToTests.fs
@@ -152,7 +152,7 @@ let private gotoTest state =
                    "Result should have correct range"
            })
 
-         testCaseAsync
+         ptestCaseAsync
            "Go-to-implementation-on-interface-definition"
            (async {
              let! server, path, externalPath, definitionPath = server


### PR DESCRIPTION
This is some residue of when Checker was implicitly queuing type checking in the background. Since we're handling all checking explicitly now, we don't need it. I suspect it may have been causing some performance issues in the last few FSAC releases. 