### PR TITLE
remove markdown highlighting from completion item details

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fake-cli": {
-      "version": "5.22.0",
+      "version": "5.23.0-alpha002",
       "commands": [
         "fake"
       ]

--- a/src/FsAutoComplete/Parser.fs
+++ b/src/FsAutoComplete/Parser.fs
@@ -109,6 +109,7 @@ module Parser =
     rootCommand.AddOption logLevelOption
     rootCommand.AddOption stateLocationOption
 
+
     rootCommand.SetHandler(
       Func<_, _, Task>(fun projectGraphEnabled stateDirectory ->
         let workspaceLoaderFactory =


### PR DESCRIPTION
Closes #978 by removing backticks from signature formatting for completion items, since that field isn't markdown.  One nice side effect of this is that all entry points into TipFormatter are now named, so it's more clear what context each function is used for.