### PR TITLE
Incremental text sync

### DIFF
--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -140,18 +140,19 @@ type NamedText(fileName: string<LocalPath>, str: string) =
     else
       // multiline, use a builder
       let builder = new System.Text.StringBuilder()
-      // slice of the first line
+      // potential slice of the first line, including newline
+      // because we know there are lines after the first line
       let firstLine = (x :> ISourceText).GetLineString(m.StartLine - 1)
-
-      builder.Append(firstLine.Substring(m.StartColumn))
+      builder.AppendLine(firstLine.Substring(m.StartColumn))
       |> ignore<System.Text.StringBuilder>
-      // whole intermediate lines
+
+      // whole intermediate lines, including newlines
       for line in (m.StartLine + 1) .. (m.EndLine - 1) do
         builder.AppendLine((x :> ISourceText).GetLineString(line - 1))
         |> ignore<System.Text.StringBuilder>
-      // final part, potential slice
-      let lastLine = (x :> ISourceText).GetLineString(m.EndLine - 1)
 
+      // final part, potential slice, so we do not include the trailing newline
+      let lastLine = (x :> ISourceText).GetLineString(m.EndLine - 1)
       builder.Append(lastLine.Substring(0, m.EndColumn))
       |> ignore<System.Text.StringBuilder>
 

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -86,7 +86,7 @@ let initTests state =
         let td =
           { TextDocumentSyncOptions.Default with
               OpenClose = Some true
-              Change = Some TextDocumentSyncKind.Full
+              Change = Some TextDocumentSyncKind.Incremental
               Save = Some { IncludeText = Some true } }
 
         Expect.equal res.Capabilities.TextDocumentSync (Some td) "Text Document Provider"


### PR DESCRIPTION
Changes FSAC from using a full-text sync model to an incremental sync model for document changes. This should result in less overall data being transmitted.  This also brought to light a bug in the `NamedText.GetText(Range)` method around a missing newline on the end of the first line of a multiline range.