### PR TITLE
include keywords in tooltip lookups

### DIFF
--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -327,6 +327,12 @@ type ParseAndCheckResults
       | _ -> Ok(tip)
 
   member x.TryGetToolTipEnhanced (pos: Position) (lineStr: LineStr) =
+    let (|EmptyTooltip|_|) (ToolTipText elems) =
+      match elems with
+      | [] -> Some()
+      | elems when elems |> List.forall ((=) ToolTipElement.None) -> Some()
+      | _ -> None
+
     match Completion.atPos (pos, x.GetParseResults.ParseTree) with
     | Completion.Context.StringLiteral -> Ok None
     | Completion.Context.SynType
@@ -343,7 +349,7 @@ type ParseAndCheckResults
           checkResults.GetSymbolUseAtLocation(pos.Line, col, lineStr, identIsland)
 
         match tip with
-        | ToolTipText (elems) when elems |> List.forall ((=) ToolTipElement.None) && symbol.IsNone ->
+        | EmptyTooltip when symbol.IsNone ->
           match identIsland with
           | [ ident ] ->
             match KeywordList.keywordTooltips.TryGetValue ident with


### PR DESCRIPTION
Part of https://github.com/fsharp/FsAutoComplete/issues/940, this needs a test to ensure we don't regress. All baked-in keywords should be covered by this.