### PR TITLE
Fix reference count when function/variable consist of a single letter

### DIFF
--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -465,7 +465,7 @@ type ParseAndCheckResults
         Ok(symbol.XmlDocSig, symbol.Assembly.FileName |> Option.defaultValue "", symbol.XmlDoc, signature, footer, cn)
 
   member __.TryGetSymbolUse (pos: Position) (lineStr: LineStr) : FSharpSymbolUse option =
-    match Lexer.findLongIdents (pos.Column, lineStr) with
+    match Lexer.findLongIdents (pos.Column - 1, lineStr) with
     | None -> None
     | Some (colu, identIsland) ->
       let identIsland = Array.toList identIsland


### PR DESCRIPTION
Related to https://github.com/ionide/ionide-vscode-fsharp/issues/1763

**Before**

![image](https://user-images.githubusercontent.com/4760796/185073220-374e964b-a313-41ae-829d-8813e13dadb9.png)


**After**

![image](https://user-images.githubusercontent.com/4760796/185073150-010eb962-d853-4119-be31-37e5844d2c8f.png)
