### PR TITLE
fix off by one in code lens resolve

### DIFF
--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -481,7 +481,7 @@ type ParseAndCheckResults
       Ok(symboluse, symboluses)
 
   member __.TryGetSignatureData (pos: Position) (lineStr: LineStr) =
-    match Lexer.findLongIdents (pos.Column - 1, lineStr) with
+    match Lexer.findLongIdents (pos.Column, lineStr) with
     | None -> ResultOrString.Error "No ident at this location"
     | Some (colu, identIsland) ->
 

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -153,9 +153,8 @@ module Conversions =
         Data = Some(Newtonsoft.Json.Linq.JToken.FromObject [| uri; typ |])
         Range = fcsRangeToLsp decl.Range }
 
-    topLevel.Nested
-    |> Array.filter (fun n ->
-      not (
+    let shouldKeep (n: NavigationItem) =
+      let keep =
         n.Glyph <> FSharpGlyph.Method
         && n.Glyph <> FSharpGlyph.OverridenMethod
         && n.Glyph <> FSharpGlyph.ExtensionMethod
@@ -168,8 +167,11 @@ module Conversions =
         || n.EnclosingEntityKind = NavigationEntityKind.Union
         || n.EnclosingEntityKind = NavigationEntityKind.Enum
         || n.EnclosingEntityKind = NavigationEntityKind.Exception
-      ))
-    |> Array.map map
+
+      not keep
+
+    topLevel.Nested
+    |> Array.choose (fun n -> if shouldKeep n then Some(map n) else None)
 
   let getLine (lines: string[]) (pos: Lsp.Position) = lines.[pos.Line]
 

--- a/test/FsAutoComplete.Tests.Lsp/CodeLensTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeLensTests.fs
@@ -101,7 +101,7 @@ let tests state =
                   (args[1] :?> JObject).ToObject<Ionide.LanguageServerProtocol.Types.Position>(),
                   (args[2] :?> JArray) |> Seq.map (fun t -> (t:?>JObject).ToObject<Ionide.LanguageServerProtocol.Types.Location>()) |> Array.ofSeq
                 Expect.equal filePath doc.Uri "File path should be the doc we're checking"
-                Expect.equal triggerPos { Line = 1; Character = 8 } "Position should be 1:8"
+                Expect.equal triggerPos { Line = 1; Character = 6 } "Position should be 1:6"
                 Expect.hasLength referenceRanges 1 "There should be 1 reference range for the `func` function"
                 Expect.equal referenceRanges[0] { Uri = doc.Uri; Range = { Start = { Line = 3; Character = 19 }; End = { Line = 3; Character = 23 } } } "Reference range should be 0:0"
             )

--- a/test/FsAutoComplete.Tests.Lsp/CodeLensTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeLensTests.fs
@@ -101,10 +101,23 @@ let tests state =
                   (args[1] :?> JObject).ToObject<Ionide.LanguageServerProtocol.Types.Position>(),
                   (args[2] :?> JArray) |> Seq.map (fun t -> (t:?>JObject).ToObject<Ionide.LanguageServerProtocol.Types.Location>()) |> Array.ofSeq
                 Expect.equal filePath doc.Uri "File path should be the doc we're checking"
-                Expect.equal triggerPos { Line = 1; Character = 8 } "Position should be 0:0"
+                Expect.equal triggerPos { Line = 1; Character = 8 } "Position should be 1:8"
                 Expect.hasLength referenceRanges 1 "There should be 1 reference range for the `func` function"
                 Expect.equal referenceRanges[0] { Uri = doc.Uri; Range = { Start = { Line = 3; Character = 19 }; End = { Line = 3; Character = 23 } } } "Reference range should be 0:0"
             )
+      testCaseAsync "can show reference counts for 1-character identifier" <|
+        CodeLens.check server
+          """
+          $0let f () = ""$0
+          """ (fun (doc, lenses) ->
+                Expect.hasLength lenses 2 "should have a type lens and a reference lens"
+                let referenceLens = lenses[1]
+                Expect.isSome referenceLens.Command "There should be a command for multiple references"
+                let referenceCommand = referenceLens.Command.Value
+                Expect.equal referenceCommand.Title "0 References" "There should be a title for multiple references"
+                Expect.equal referenceCommand.Command "" "There should be no command for multiple references"
+                Expect.isNone referenceCommand.Arguments "There should be arguments for multiple references"
+          )
     ]
     )
 


### PR DESCRIPTION
Fixes https://github.com/ionide/ionide-vscode-fsharp/issues/1763

Turns out it _was_ an off by one! We basically should never use Pos.mkPos directly IMO if possible :(