### PR TITLE
When removing a file clear its diagnostics

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1346,7 +1346,7 @@ type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers:
   member _.FsProjRemoveFile (fsprojPath: string) (fileVirtPath: string) (fullPath: string) =
     async {
       FsProjEditor.removeFile fsprojPath fileVirtPath
-      state.RemoveProjectOptions(normalizePath fullPath)
+      state.RemoveProjectOptions (normalizePath fullPath)
       return CoreResponse.Res()
     }
 

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1346,7 +1346,7 @@ type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers:
   member _.FsProjRemoveFile (fsprojPath: string) (fileVirtPath: string) (fullPath: string) =
     async {
       FsProjEditor.removeFile fsprojPath fileVirtPath
-      state.RemoveProjectOptions (normalizePath fullPath)
+      state.RemoveProjectOptions(normalizePath fullPath)
       return CoreResponse.Res()
     }
 

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1343,9 +1343,10 @@ type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers:
       return CoreResponse.Res()
     }
 
-  member _.FsProjRemoveFile (fsprojPath: string) (fileVirtPath: string) =
+  member _.FsProjRemoveFile (fsprojPath: string) (fileVirtPath: string) (fullPath: string) =
     async {
       FsProjEditor.removeFile fsprojPath fileVirtPath
+      state.RemoveProjectOptions(normalizePath fullPath)
       return CoreResponse.Res()
     }
 

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -3709,8 +3709,12 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
             >> Log.addContextDestructured "parms" p
           )
 
+          let fullPath = Path.Combine(Path.GetDirectoryName p.FsProj, p.FileVirtualPath)
           do! Commands.removeFile p.FsProj p.FileVirtualPath |> AsyncResult.ofCoreResponse
           loadedProjectOptions |> AVal.force |> ignore
+          let fileUri = Path.FilePathToUri fullPath
+          diagnosticCollections.ClearFor fileUri
+
           return { Content = "" }
         with e ->
           logger.error (

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -2636,7 +2636,12 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
           >> Log.addContextDestructured "parms" p
         )
 
-        let! res = commands.FsProjRemoveFile p.FsProj p.FileVirtualPath
+        let fullPath = Path.Combine(Path.GetDirectoryName p.FsProj, p.FileVirtualPath)
+        let! res = commands.FsProjRemoveFile p.FsProj p.FileVirtualPath fullPath
+        // Compute the fileUri, as this is the key used by the diagnostics collection.
+        let fileUri = Path.FilePathToUri fullPath
+
+        diagnosticCollections.ClearFor fileUri
 
         let res =
           match res with


### PR DESCRIPTION
Related to https://github.com/ionide/ionide-vscode-fsharp/issues/1768

This PR apply the fix suggested by @Krzysztof-Cieslak on https://github.com/ionide/ionide-vscode-fsharp/issues/1768#issuecomment-1229223598

https://user-images.githubusercontent.com/4760796/187470228-26fbb700-7055-405a-821a-bd55e8c4c2ca.mp4

It works however, if user start to edit the file again. New diagnostics are computed for this file. I believe that we need to remove/clear/unregister something else too.

Example:

https://user-images.githubusercontent.com/4760796/187470835-730550b5-2ea7-4ab8-8fcc-598dfdae6e2b.mp4

Editing the file should not generate diagnostics for `Log.fs` file.


