### PR TITLE
Inspect/Test File Checking Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,17 @@ Options that should be send as `initializationOptions` as part of `initialize` r
         "FSharp.fsiExtraParameters": ["--langversion:preview"]
     ```
 
+#### Debug Settings
+Settings to change internal behavior. Intended for debugging purposes and not for normal use.
+* `FSharp.Debug.DontCheckRelatedFiles` - usually checking a file involves checking related files too. This prevents this and limits file checking to just the current file.  
+  Default: `false`
+* `FSharp.Debug.CheckFileDebouncerTimeout` - Duration (in ms) of no user write activity (in practice: no LSP `textDocument/didChange` notification) before file checking gets triggered.  
+  Default: `250`
+* `FSharp.Debug.LogDurationBetweenCheckFiles`: Logs duration between the start of to consecutive file checks.  
+  Default: `false`  
+* `FSharp.Debug.LogCheckFileDuration`: Logs duration of file checking operation.  
+  Default: `false`
+
 ## Troubleshooting
 
 ### FileWatcher exceptions

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -767,21 +767,20 @@ type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers:
   /// * check the file
   /// * check the other files in the project that depend on this file
   /// * check projects that are downstream of the project containing this file
-  member x.CheckFileAndAllDependentFilesInAllProjects
-    (
-      file: string<LocalPath>,
-      version,
-      content,
-      tfmConfig,
-      isFirstOpen
-    ) : Async<unit> =
-    async {
-      match! x.EnsureProjectOptionsForFile(file, content, version, tfmConfig) with
-      | None -> ()
-      | Some opts ->
-
-        // parse dependent files, if necessary
-        if isFirstOpen then
+  member x.CheckFile(
+    file: string<LocalPath>,
+    version,
+    content,
+    tfmConfig,
+    checkFilesThatThisFileDependsOn,
+    checkFilesThatDependsOnFile,
+    checkDependentProjects
+  ) : Async<unit> = async {
+    match! x.EnsureProjectOptionsForFile(file, content, version, tfmConfig) with
+    | None -> ()
+    | Some opts ->
+        // parse dependent  files, if necessary
+        if checkFilesThatThisFileDependsOn then
           do!
             opts.SourceFilesThatThisFileDependsOn(file)
             |> Array.map (UMX.tag >> (fun f -> x.SimpleCheckFile(f, tfmConfig)))
@@ -792,22 +791,44 @@ type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers:
         do! x.CheckFile(file, content, version, opts)
 
         // then parse all files that depend on it in this project,
+        if checkFilesThatDependsOnFile then
+          do!
+            opts.SourceFilesThatDependOnFile(file)
+            |> Array.map (UMX.tag >> (fun f -> x.SimpleCheckFile(f, tfmConfig)))
+            |> Async.Sequential
+            |> Async.map ignore<unit[]>
 
-        do!
-          opts.SourceFilesThatDependOnFile(file)
-          |> Array.map (UMX.tag >> (fun f -> x.SimpleCheckFile(f, tfmConfig)))
-          |> Async.Sequential
-          |> Async.map ignore<unit[]>
+        // then parse all files in dependent projects
+        if checkDependentProjects then
+          do!
+            state.ProjectController.GetDependentProjectsOfProjects([ opts ])
+            |> List.map x.CheckProject
+            |> Async.Sequential
+            |> Async.map ignore<unit[]>
+  }
 
-    // then parse all files in dependent projects
-    // TODO: Disabled due to performance issues - investigate.
-    // do!
-    //   state.ProjectController.GetDependentProjectsOfProjects([ opts ])
-    //   |> List.map x.CheckProject
-    //   |> Async.Sequential
-    //   |> Async.map ignore<unit[]>
-
-    }
+  /// Does everything required to check a file:
+  /// * ensure we have project options for the file available
+  /// * check any unchecked files in the project that this file depends on
+  /// * check the file
+  /// * check the other files in the project that depend on this file
+  /// * check projects that are downstream of the project containing this file
+  member x.CheckFileAndAllDependentFilesInAllProjects
+    (
+      file: string<LocalPath>,
+      version: int,
+      content: NamedText,
+      tfmConfig: FSIRefs.TFM,
+      isFirstOpen: bool
+    ) : Async<unit> =
+      x.CheckFile(
+        file, version, content,
+        tfmConfig,
+        checkFilesThatThisFileDependsOn = isFirstOpen,
+        checkFilesThatDependsOnFile = true,
+        // TODO: Disabled due to performance issues - investigate.
+        checkDependentProjects = false
+      )
 
   /// easy helper that looks up a file and all required checking information then checks it.
   /// intended use is from the other, more complex Parse members, because the filePath is untagged

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -767,18 +767,20 @@ type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers:
   /// * check the file
   /// * check the other files in the project that depend on this file
   /// * check projects that are downstream of the project containing this file
-  member x.CheckFile(
-    file: string<LocalPath>,
-    version,
-    content,
-    tfmConfig,
-    checkFilesThatThisFileDependsOn,
-    checkFilesThatDependsOnFile,
-    checkDependentProjects
-  ) : Async<unit> = async {
-    match! x.EnsureProjectOptionsForFile(file, content, version, tfmConfig) with
-    | None -> ()
-    | Some opts ->
+  member x.CheckFile
+    (
+      file: string<LocalPath>,
+      version,
+      content,
+      tfmConfig,
+      checkFilesThatThisFileDependsOn,
+      checkFilesThatDependsOnFile,
+      checkDependentProjects
+    ) : Async<unit> =
+    async {
+      match! x.EnsureProjectOptionsForFile(file, content, version, tfmConfig) with
+      | None -> ()
+      | Some opts ->
         // parse dependent  files, if necessary
         if checkFilesThatThisFileDependsOn then
           do!
@@ -805,7 +807,7 @@ type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers:
             |> List.map x.CheckProject
             |> Async.Sequential
             |> Async.map ignore<unit[]>
-  }
+    }
 
   /// Does everything required to check a file:
   /// * ensure we have project options for the file available
@@ -821,14 +823,16 @@ type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers:
       tfmConfig: FSIRefs.TFM,
       isFirstOpen: bool
     ) : Async<unit> =
-      x.CheckFile(
-        file, version, content,
-        tfmConfig,
-        checkFilesThatThisFileDependsOn = isFirstOpen,
-        checkFilesThatDependsOnFile = true,
-        // TODO: Disabled due to performance issues - investigate.
-        checkDependentProjects = false
-      )
+    x.CheckFile(
+      file,
+      version,
+      content,
+      tfmConfig,
+      checkFilesThatThisFileDependsOn = isFirstOpen,
+      checkFilesThatDependsOnFile = true,
+      // TODO: Disabled due to performance issues - investigate.
+      checkDependentProjects = false
+    )
 
   /// easy helper that looks up a file and all required checking information then checks it.
   /// intended use is from the other, more complex Parse members, because the filePath is untagged

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -740,11 +740,7 @@ type Debounce<'a>(timeout, fn) as x =
             match r with
             | Some arg -> return! loop ida (idb + 1) (Some arg)
             | None when ida <> idb ->
-              if x.WaitForFnToFinish then
-                do! fn arg.Value
-              else
-                fn arg.Value |> Async.Start
-
+              do! fn arg.Value
               return! loop 0 0 None
             | None -> return! loop 0 0 arg
           }
@@ -756,21 +752,6 @@ type Debounce<'a>(timeout, fn) as x =
 
   /// Timeout in ms
   member val Timeout = timeout with get, set
-  /// * `true`: waits for `fn` to finish before getting new messages
-  /// * `false`: starts and forgets `fn` (`Async.Start`). Immediately waits for new message.
-  ///
-  /// Practical differences:
-  /// * parallel:
-  ///   * `true`: only one `fn` can run at the same time
-  ///   * `false`: multiple `fn` can run at same time
-  /// * timeout:
-  ///   * `true`: timeout only starts after `fn` is finished
-  ///     -> practical debounce timeout: execution time of `fn` + timeout
-  ///   * `false`: execution of `fn` has no impact on timeout
-  ///     -> practical debounce timeout: timeout
-  ///
-  /// Default is `false`
-  member val WaitForFnToFinish = false with get, set
 
 module Indentation =
   let inline get (line: string) =

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -3,11 +3,9 @@ module FsAutoComplete.Lsp
 open System
 open System.IO
 open System.Threading
-open System.Diagnostics
 open FsAutoComplete
 open FsAutoComplete.Core
 open FsAutoComplete.LspHelpers
-open FsAutoComplete.Utils
 open FsAutoComplete.CodeFix
 open FsAutoComplete.CodeFix.Types
 open FsAutoComplete.Logging
@@ -15,7 +13,6 @@ open Ionide.LanguageServerProtocol
 open Ionide.LanguageServerProtocol.Types.LspResult
 open Ionide.LanguageServerProtocol.Server
 open Ionide.LanguageServerProtocol.Types
-open LspHelpers
 open Newtonsoft.Json.Linq
 open Ionide.ProjInfo.ProjectSystem
 open FsToolkit.ErrorHandling
@@ -27,14 +24,8 @@ open CliWrap.Buffered
 open FSharp.Compiler.Tokenization
 open FSharp.Compiler.EditorServices
 open FSharp.Compiler.Symbols
-open FSharp.UMX
-open StreamJsonRpc
 open Fantomas.Client.Contracts
-open System.Reactive.Linq
 open FSharp.Control.Reactive.Observable
-open FSharp.Control.Reactive
-open System.Threading.Tasks
-open System.Reactive.Subjects
 
 module FcsRange = FSharp.Compiler.Text.Range
 type FcsRange = FSharp.Compiler.Text.Range

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -250,14 +250,15 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
                 Version = Some version } }
     }
 
-  /// UTC Time of start of last `checkFile` call 
-  /// -> `lastCheckFile - DateTime.UtcNow` is duration between two `checkFile` calls, 
+  /// UTC Time of start of last `checkFile` call
+  /// -> `lastCheckFile - DateTime.UtcNow` is duration between two `checkFile` calls,
   ///    but doesn't include execution time of previous `checkFile`!
-  /// 
+  ///
   /// `UtcNow` instead if `Utc`: faster, and we're only interested in elapsed duration
-  /// 
+  ///
   /// `DateTime` instead of `Stopwatch`: stopwatch doesn't work with multiple simultaneous consumers
   let mutable lastCheckFile = DateTime.UtcNow
+
   let checkFile (filePath: string<LocalPath>, version: int, content: NamedText, isFirstOpen: bool) =
     asyncResult {
 
@@ -266,12 +267,14 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
           let now = DateTime.UtcNow
           let d = now - lastCheckFile
           lastCheckFile <- now
+
           logger.warn (
             Log.setMessage "Start: checkFile({file}, version={version}), {duration} after last checkFile start"
             >> Log.addContext "file" filePath
             >> Log.addContext "version" version
             >> Log.addContext "duration" d
           )
+
           now
         elif config.Debug.LogCheckFileDuration then
           DateTime.UtcNow
@@ -302,6 +305,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
 
       if config.Debug.LogCheckFileDuration then
         let d = DateTime.UtcNow - start
+
         logger.warn (
           Log.setMessage "Finished: checkFile({file}, version={version}) in {duration}"
           >> Log.addContext "file" filePath
@@ -340,7 +344,8 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
         )
     }
 
-  let checkFileDebouncer = Debounce(DebugConfig.Default.CheckFileDebouncerTimeout, checkChangedFile)
+  let checkFileDebouncer =
+    Debounce(DebugConfig.Default.CheckFileDebouncerTimeout, checkChangedFile)
 
   let sendDiagnostics (uri: DocumentUri) (diags: Diagnostic[]) =
     logger.info (
@@ -556,7 +561,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
       else
         logger.warn (Log.setMessage "Checking of related files enabled (default)")
 
-    
+
     if newConfig.CheckFileDebouncerTimeout < 0 then
       logger.error (
         Log.setMessage "CheckFileDebouncerTimeout cannot be negative, but is {timeout}"

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -594,6 +594,13 @@ type InlayHintDto =
   { typeAnnotations: bool option
     parameterNames: bool option
     disableLongTooltip: bool option }
+type DebugDto =
+  { DontCheckRelatedFiles: bool option
+    CheckFileDebouncerTimeout: int option
+    WaitTillFileChecked: bool option
+    LogDurationBetweenCheckFiles: bool option
+    LogCheckFileFinished: bool option
+  }
 
 type FSharpConfigDto =
   { AutomaticWorkspaceInit: bool option
@@ -630,7 +637,8 @@ type FSharpConfigDto =
     AbstractClassStubGenerationObjectIdentifier: string option
     AbstractClassStubGenerationMethodBody: string option
     CodeLenses: CodeLensConfigDto option
-    InlayHints: InlayHintDto option }
+    InlayHints: InlayHintDto option
+    Debug: DebugDto option }
 
 type FSharpConfigRequest = { FSharp: FSharpConfigDto }
 
@@ -651,6 +659,24 @@ type InlayHintsConfig =
     { typeAnnotations = true
       parameterNames = true
       disableLongTooltip = true }
+
+type DebugConfig = 
+  {
+    DontCheckRelatedFiles: bool
+    CheckFileDebouncerTimeout: int
+    WaitTillFileChecked: bool
+    LogDurationBetweenCheckFiles: bool
+    LogCheckFileFinished: bool
+  }
+
+  static member Default =
+    {
+      DontCheckRelatedFiles = false
+      CheckFileDebouncerTimeout = 250
+      WaitTillFileChecked = false
+      LogDurationBetweenCheckFiles = false
+      LogCheckFileFinished = false
+    }
 
 type FSharpConfig =
   { AutomaticWorkspaceInit: bool
@@ -687,7 +713,8 @@ type FSharpConfig =
     TooltipMode: string
     GenerateBinlog: bool
     CodeLenses: CodeLensConfig
-    InlayHints: InlayHintsConfig }
+    InlayHints: InlayHintsConfig
+    Debug: DebugConfig }
 
   static member Default: FSharpConfig =
     { AutomaticWorkspaceInit = false
@@ -724,7 +751,8 @@ type FSharpConfig =
       TooltipMode = "full"
       GenerateBinlog = false
       CodeLenses = CodeLensConfig.Default
-      InlayHints = InlayHintsConfig.Default }
+      InlayHints = InlayHintsConfig.Default
+      Debug = DebugConfig.Default }
 
   static member FromDto(dto: FSharpConfigDto) : FSharpConfig =
     { AutomaticWorkspaceInit = defaultArg dto.AutomaticWorkspaceInit false
@@ -780,7 +808,19 @@ type FSharpConfig =
         | Some ihDto ->
           { typeAnnotations = defaultArg ihDto.typeAnnotations true
             parameterNames = defaultArg ihDto.parameterNames true
-            disableLongTooltip = defaultArg ihDto.disableLongTooltip true } }
+            disableLongTooltip = defaultArg ihDto.disableLongTooltip true }
+      Debug =
+        match dto.Debug with
+        | None -> DebugConfig.Default
+        | Some dDto ->
+            {
+              DontCheckRelatedFiles = defaultArg dDto.DontCheckRelatedFiles DebugConfig.Default.DontCheckRelatedFiles
+              CheckFileDebouncerTimeout = defaultArg dDto.CheckFileDebouncerTimeout DebugConfig.Default.CheckFileDebouncerTimeout
+              WaitTillFileChecked = defaultArg dDto.WaitTillFileChecked DebugConfig.Default.WaitTillFileChecked
+              LogDurationBetweenCheckFiles = defaultArg dDto.LogDurationBetweenCheckFiles DebugConfig.Default.LogDurationBetweenCheckFiles
+              LogCheckFileFinished = defaultArg dDto.LogDurationBetweenCheckFiles DebugConfig.Default.LogCheckFileFinished
+            }
+    }
 
 
   /// called when a configuration change takes effect, so None-valued members here should revert options
@@ -849,7 +889,19 @@ type FSharpConfig =
         | Some ihDto ->
           { typeAnnotations = defaultArg ihDto.typeAnnotations x.InlayHints.typeAnnotations
             parameterNames = defaultArg ihDto.parameterNames x.InlayHints.parameterNames
-            disableLongTooltip = defaultArg ihDto.disableLongTooltip x.InlayHints.disableLongTooltip } }
+            disableLongTooltip = defaultArg ihDto.disableLongTooltip x.InlayHints.disableLongTooltip }
+      Debug =
+        match dto.Debug with
+        | None -> DebugConfig.Default
+        | Some dDto ->
+            {
+              DontCheckRelatedFiles = defaultArg dDto.DontCheckRelatedFiles x.Debug.DontCheckRelatedFiles
+              CheckFileDebouncerTimeout = defaultArg dDto.CheckFileDebouncerTimeout x.Debug.CheckFileDebouncerTimeout
+              WaitTillFileChecked = defaultArg dDto.WaitTillFileChecked x.Debug.WaitTillFileChecked
+              LogDurationBetweenCheckFiles = defaultArg dDto.LogDurationBetweenCheckFiles x.Debug.LogDurationBetweenCheckFiles
+              LogCheckFileFinished = defaultArg dDto.LogCheckFileFinished x.Debug.LogCheckFileFinished
+            }
+    }
 
   member x.ScriptTFM =
     match x.UseSdkScripts with

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -599,7 +599,7 @@ type DebugDto =
   { DontCheckRelatedFiles: bool option
     CheckFileDebouncerTimeout: int option
     LogDurationBetweenCheckFiles: bool option
-    LogCheckFileFinished: bool option }
+    LogCheckFileDuration: bool option }
 
 type FSharpConfigDto =
   { AutomaticWorkspaceInit: bool option
@@ -663,13 +663,13 @@ type DebugConfig =
   { DontCheckRelatedFiles: bool
     CheckFileDebouncerTimeout: int
     LogDurationBetweenCheckFiles: bool
-    LogCheckFileFinished: bool }
+    LogCheckFileDuration: bool }
 
   static member Default =
     { DontCheckRelatedFiles = false
       CheckFileDebouncerTimeout = 250
       LogDurationBetweenCheckFiles = false
-      LogCheckFileFinished = false }
+      LogCheckFileDuration = false }
 
 type FSharpConfig =
   { AutomaticWorkspaceInit: bool
@@ -811,7 +811,7 @@ type FSharpConfig =
               defaultArg dDto.CheckFileDebouncerTimeout DebugConfig.Default.CheckFileDebouncerTimeout
             LogDurationBetweenCheckFiles =
               defaultArg dDto.LogDurationBetweenCheckFiles DebugConfig.Default.LogDurationBetweenCheckFiles
-            LogCheckFileFinished = defaultArg dDto.LogDurationBetweenCheckFiles DebugConfig.Default.LogCheckFileFinished } }
+            LogCheckFileDuration = defaultArg dDto.LogCheckFileDuration DebugConfig.Default.LogCheckFileDuration } }
 
 
   /// called when a configuration change takes effect, so None-valued members here should revert options
@@ -889,7 +889,7 @@ type FSharpConfig =
             CheckFileDebouncerTimeout = defaultArg dDto.CheckFileDebouncerTimeout x.Debug.CheckFileDebouncerTimeout
             LogDurationBetweenCheckFiles =
               defaultArg dDto.LogDurationBetweenCheckFiles x.Debug.LogDurationBetweenCheckFiles
-            LogCheckFileFinished = defaultArg dDto.LogCheckFileFinished x.Debug.LogCheckFileFinished } }
+            LogCheckFileDuration = defaultArg dDto.LogCheckFileDuration x.Debug.LogCheckFileDuration } }
 
   member x.ScriptTFM =
     match x.UseSdkScripts with

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -598,7 +598,6 @@ type InlayHintDto =
 type DebugDto =
   { DontCheckRelatedFiles: bool option
     CheckFileDebouncerTimeout: int option
-    WaitTillFileChecked: bool option
     LogDurationBetweenCheckFiles: bool option
     LogCheckFileFinished: bool option }
 
@@ -663,14 +662,12 @@ type InlayHintsConfig =
 type DebugConfig =
   { DontCheckRelatedFiles: bool
     CheckFileDebouncerTimeout: int
-    WaitTillFileChecked: bool
     LogDurationBetweenCheckFiles: bool
     LogCheckFileFinished: bool }
 
   static member Default =
     { DontCheckRelatedFiles = false
       CheckFileDebouncerTimeout = 250
-      WaitTillFileChecked = false
       LogDurationBetweenCheckFiles = false
       LogCheckFileFinished = false }
 
@@ -812,7 +809,6 @@ type FSharpConfig =
           { DontCheckRelatedFiles = defaultArg dDto.DontCheckRelatedFiles DebugConfig.Default.DontCheckRelatedFiles
             CheckFileDebouncerTimeout =
               defaultArg dDto.CheckFileDebouncerTimeout DebugConfig.Default.CheckFileDebouncerTimeout
-            WaitTillFileChecked = defaultArg dDto.WaitTillFileChecked DebugConfig.Default.WaitTillFileChecked
             LogDurationBetweenCheckFiles =
               defaultArg dDto.LogDurationBetweenCheckFiles DebugConfig.Default.LogDurationBetweenCheckFiles
             LogCheckFileFinished = defaultArg dDto.LogDurationBetweenCheckFiles DebugConfig.Default.LogCheckFileFinished } }
@@ -891,7 +887,6 @@ type FSharpConfig =
         | Some dDto ->
           { DontCheckRelatedFiles = defaultArg dDto.DontCheckRelatedFiles x.Debug.DontCheckRelatedFiles
             CheckFileDebouncerTimeout = defaultArg dDto.CheckFileDebouncerTimeout x.Debug.CheckFileDebouncerTimeout
-            WaitTillFileChecked = defaultArg dDto.WaitTillFileChecked x.Debug.WaitTillFileChecked
             LogDurationBetweenCheckFiles =
               defaultArg dDto.LogDurationBetweenCheckFiles x.Debug.LogDurationBetweenCheckFiles
             LogCheckFileFinished = defaultArg dDto.LogCheckFileFinished x.Debug.LogCheckFileFinished } }

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -594,13 +594,13 @@ type InlayHintDto =
   { typeAnnotations: bool option
     parameterNames: bool option
     disableLongTooltip: bool option }
+
 type DebugDto =
   { DontCheckRelatedFiles: bool option
     CheckFileDebouncerTimeout: int option
     WaitTillFileChecked: bool option
     LogDurationBetweenCheckFiles: bool option
-    LogCheckFileFinished: bool option
-  }
+    LogCheckFileFinished: bool option }
 
 type FSharpConfigDto =
   { AutomaticWorkspaceInit: bool option
@@ -660,23 +660,19 @@ type InlayHintsConfig =
       parameterNames = true
       disableLongTooltip = true }
 
-type DebugConfig = 
-  {
-    DontCheckRelatedFiles: bool
+type DebugConfig =
+  { DontCheckRelatedFiles: bool
     CheckFileDebouncerTimeout: int
     WaitTillFileChecked: bool
     LogDurationBetweenCheckFiles: bool
-    LogCheckFileFinished: bool
-  }
+    LogCheckFileFinished: bool }
 
   static member Default =
-    {
-      DontCheckRelatedFiles = false
+    { DontCheckRelatedFiles = false
       CheckFileDebouncerTimeout = 250
       WaitTillFileChecked = false
       LogDurationBetweenCheckFiles = false
-      LogCheckFileFinished = false
-    }
+      LogCheckFileFinished = false }
 
 type FSharpConfig =
   { AutomaticWorkspaceInit: bool
@@ -813,14 +809,13 @@ type FSharpConfig =
         match dto.Debug with
         | None -> DebugConfig.Default
         | Some dDto ->
-            {
-              DontCheckRelatedFiles = defaultArg dDto.DontCheckRelatedFiles DebugConfig.Default.DontCheckRelatedFiles
-              CheckFileDebouncerTimeout = defaultArg dDto.CheckFileDebouncerTimeout DebugConfig.Default.CheckFileDebouncerTimeout
-              WaitTillFileChecked = defaultArg dDto.WaitTillFileChecked DebugConfig.Default.WaitTillFileChecked
-              LogDurationBetweenCheckFiles = defaultArg dDto.LogDurationBetweenCheckFiles DebugConfig.Default.LogDurationBetweenCheckFiles
-              LogCheckFileFinished = defaultArg dDto.LogDurationBetweenCheckFiles DebugConfig.Default.LogCheckFileFinished
-            }
-    }
+          { DontCheckRelatedFiles = defaultArg dDto.DontCheckRelatedFiles DebugConfig.Default.DontCheckRelatedFiles
+            CheckFileDebouncerTimeout =
+              defaultArg dDto.CheckFileDebouncerTimeout DebugConfig.Default.CheckFileDebouncerTimeout
+            WaitTillFileChecked = defaultArg dDto.WaitTillFileChecked DebugConfig.Default.WaitTillFileChecked
+            LogDurationBetweenCheckFiles =
+              defaultArg dDto.LogDurationBetweenCheckFiles DebugConfig.Default.LogDurationBetweenCheckFiles
+            LogCheckFileFinished = defaultArg dDto.LogDurationBetweenCheckFiles DebugConfig.Default.LogCheckFileFinished } }
 
 
   /// called when a configuration change takes effect, so None-valued members here should revert options
@@ -894,14 +889,12 @@ type FSharpConfig =
         match dto.Debug with
         | None -> DebugConfig.Default
         | Some dDto ->
-            {
-              DontCheckRelatedFiles = defaultArg dDto.DontCheckRelatedFiles x.Debug.DontCheckRelatedFiles
-              CheckFileDebouncerTimeout = defaultArg dDto.CheckFileDebouncerTimeout x.Debug.CheckFileDebouncerTimeout
-              WaitTillFileChecked = defaultArg dDto.WaitTillFileChecked x.Debug.WaitTillFileChecked
-              LogDurationBetweenCheckFiles = defaultArg dDto.LogDurationBetweenCheckFiles x.Debug.LogDurationBetweenCheckFiles
-              LogCheckFileFinished = defaultArg dDto.LogCheckFileFinished x.Debug.LogCheckFileFinished
-            }
-    }
+          { DontCheckRelatedFiles = defaultArg dDto.DontCheckRelatedFiles x.Debug.DontCheckRelatedFiles
+            CheckFileDebouncerTimeout = defaultArg dDto.CheckFileDebouncerTimeout x.Debug.CheckFileDebouncerTimeout
+            WaitTillFileChecked = defaultArg dDto.WaitTillFileChecked x.Debug.WaitTillFileChecked
+            LogDurationBetweenCheckFiles =
+              defaultArg dDto.LogDurationBetweenCheckFiles x.Debug.LogDurationBetweenCheckFiles
+            LogCheckFileFinished = defaultArg dDto.LogCheckFileFinished x.Debug.LogCheckFileFinished } }
 
   member x.ScriptTFM =
     match x.UseSdkScripts with

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -211,7 +211,8 @@ let defaultConfigDto: FSharpConfigDto =
       Some
         { typeAnnotations = Some true
           parameterNames = Some true
-          disableLongTooltip = Some true } }
+          disableLongTooltip = Some true }
+    Debug = None }
 
 let clientCaps: ClientCapabilities =
   let dynCaps: DynamicCapabilities = { DynamicRegistration = Some true }


### PR DESCRIPTION
Even with newest changes performance while writing code in bigger projects (like in FSAC) is still unpleasant: Still lots of small stutter.


So: time to test some things:

Issue is while writing -> issue is most likely in [`checkFile`](https://github.com/fsharp/FsAutoComplete/blob/680a95b9d02c330d5b8a3a459271cc532efb368c/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L251-L262)

<br/>

First test: disable checking of related files in [`Commands.CheckFileAndAllDependentFilesInAllProjects`](https://github.com/fsharp/FsAutoComplete/blob/680a95b9d02c330d5b8a3a459271cc532efb368c/src/FsAutoComplete.Core/Commands.fs#L764). Less checking should result in better performance.  
But: doesn't have huge impact. I think slightly better, but just barely.

<br/>

Next: change [debounce timeout](https://github.com/fsharp/FsAutoComplete/blob/680a95b9d02c330d5b8a3a459271cc532efb368c/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L295) for `checkChangeFiles` (from `250ms` to `350ms`).  
Now writing does work without any mayor lags (but with errors displayed slightly later)


`checkChangedFile` in [debouncer](https://github.com/fsharp/FsAutoComplete/blob/680a95b9d02c330d5b8a3a459271cc532efb368c/src/FsAutoComplete.Core/Utils.fs#L731) gets [started and immediately forgotten](https://github.com/fsharp/FsAutoComplete/blob/680a95b9d02c330d5b8a3a459271cc532efb368c/src/FsAutoComplete.Core/Utils.fs#L742) (-> `checkChangedFile` get [started](https://github.com/fsharp/FsAutoComplete/blob/680a95b9d02c330d5b8a3a459271cc532efb368c/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L293) with `Async.Start`).  
So it seems: multiple `checkFile` can run at the same time.  
Logging proofs that (with default timeout) (number after path is file version):
```
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 38, dontCheckRelatedFiles=False, since last check=00:00:00.7844834)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 42, dontCheckRelatedFiles=False, since last check=00:00:00.5009282)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 44, dontCheckRelatedFiles=False, since last check=00:00:00.5212574)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 24) finished
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 32) finished
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 49, dontCheckRelatedFiles=False, since last check=00:00:00.7109144)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 50, dontCheckRelatedFiles=False, since last check=00:00:00.4989457)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 44) finished
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 50) finished
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 38) finished
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 49) finished
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 42) finished
```
-> multiple `checkFile`s running at same time. (also: finish out of order)

<br/>

So next test: wait in debouncer till `checkFile` finished (-> `do! fn arg.Value` instead of [just calling](https://github.com/fsharp/FsAutoComplete/blob/680a95b9d02c330d5b8a3a459271cc532efb368c/src/FsAutoComplete.Core/Utils.fs#L742) `fn`).  
This too made writing without mayor stutter possible. But again with errors display a bit later.  
It behaves quite similar to changing debounce timeout. Which is expected: larger debounce timeout -> less likely for multiple `checkFile`s to run at the same time


</br>
</br>

How much later (and less often) does `checkFile` get called when we ensure just one `checkFile` is running at the same time?


Fire & forget (`Async |> Start`):
```
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 58, dontCheckRelatedFiles=False, since last check=00:00:00.4630319)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 63, dontCheckRelatedFiles=False, since last check=00:00:00.7380374)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 64, dontCheckRelatedFiles=False, since last check=00:00:00.6643221)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 66, dontCheckRelatedFiles=False, since last check=00:00:00.6950823)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 70, dontCheckRelatedFiles=False, since last check=00:00:00.5220683)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 71, dontCheckRelatedFiles=False, since last check=00:00:00.6024039)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 73, dontCheckRelatedFiles=False, since last check=00:00:00.3460527)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 78, dontCheckRelatedFiles=False, since last check=00:00:00.8328280)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 84, dontCheckRelatedFiles=False, since last check=00:00:00.6693897)
```

wait (`do!`)
```
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 101, dontCheckRelatedFiles=False, since last check=00:00:03.0156481)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 114, dontCheckRelatedFiles=False, since last check=00:00:02.4365100)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 125, dontCheckRelatedFiles=False, since last check=00:00:02.0815498)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 129, dontCheckRelatedFiles=False, since last check=00:00:01.8309675)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 137, dontCheckRelatedFiles=False, since last check=00:00:01.4969826)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 147, dontCheckRelatedFiles=False, since last check=00:00:02.1179966)
[LSP] checkFile([...]\src\FsAutoComplete\FsAutoComplete.Lsp.fs, 158, dontCheckRelatedFiles=False, since last check=00:00:02.2869400)
```

-> now checks are seconds apart instead of under a second.
(Similar behavior for increased debounce timeout)


Though later & less diagnostic updates are unfortunate, for me that's worth the change as it removes the greater annoyance of stutter.


------------------

This PR introduces some debug settings to change the different behaviours mentioned above. Without any of the settings specified, no behaviour is changed and FSAC behaves just like current `main`.  
(-> for testing, not to be merged)

* [`FSharp.debug.dontCheckRelatedFiles`](https://github.com/Booksbaum/FsAutoComplete/blob/07629d1025541490ed3dd7f037eb4ec5f02cdb6b/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L277-L289): when enabled just checks current file and no related source files
* [`FSharp.debug.checkFileDebouncerTimeout`](https://github.com/Booksbaum/FsAutoComplete/blob/07629d1025541490ed3dd7f037eb4ec5f02cdb6b/src/FsAutoComplete.Core/Utils.fs#L758): debouncer timeout in ms: how long should there no be source change before `checkFile` gets called
  * Note: no validation of correct number. Probably throws exception with negative number.
* [`FSharp.debug.waitTillFileChecked`](https://github.com/Booksbaum/FsAutoComplete/blob/07629d1025541490ed3dd7f037eb4ec5f02cdb6b/src/FsAutoComplete.Core/Utils.fs#L743-L746): only one `checkFile` can run at same time
* [`FSharp.debug.logDurationBetweenCheckFiles`](https://github.com/Booksbaum/FsAutoComplete/blob/07629d1025541490ed3dd7f037eb4ec5f02cdb6b/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L261-L275): Logs durations between two consecutive `checkFile` calls (-> output above)
  * With log level `Warn` -> visible in VSCode console even without any additional log setting.
* [`FSharp.debug.logCheckFileFinished`](https://github.com/Booksbaum/FsAutoComplete/blob/07629d1025541490ed3dd7f037eb4ec5f02cdb6b/src/FsAutoComplete/FsAutoComplete.Lsp.fs#L293-L298): Logs `checkFile` finished.  
  In combination with `logDurationBetweenCheckFiles`: can trace start and end of `checkFile` (see output above)


To set settings in VsCode & Ionide: specify in `settings.json`. Settings are then immediately adopted and reflected by FSAC (-> can be changed while running. No restart necessary)


<br/>
<br/>

--------------------

<br/>

I don't know if any default behaviour should be changed based on these findings. But i would very much like to have the option to prevent simultaneous file checking (`waitTillFileChecked`) as it greatly increased performance for me.

Additional: as logs above show, multiple simultaneous running checkFiles indicate a bug in FSAC: different checks on different file states finishing at different times in different orders.
So limit to just one checkFile at a time might actually increase correctness
-> maybe make that the default?

(maybe even with further adjustments like cancelling a running file check when a new change comes in? (-> less diag updates for client, but faster diags when user done writing))
