### PR TITLE
Remove Cache when non-existing file or file outside of workspace gets closed

### DIFF
--- a/src/FsAutoComplete.Core/State.fs
+++ b/src/FsAutoComplete.Core/State.fs
@@ -292,3 +292,10 @@ type State =
 
       return (opts, text, line)
     }
+
+  /// Removes `file` from all caches
+  member x.Forget(file: string<LocalPath>) =
+    x.LastCheckedVersion.TryRemove(file) |> ignore
+    x.Files.TryRemove(file) |> ignore
+    x.ProjectController.RemoveProjectOptions(UMX.untag file) |> ignore
+    x.ScriptProjectOptions.TryRemove(file) |> ignore

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -612,6 +612,66 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
 
   do commandDisposables.Add <| commands.Notify.Subscribe handleCommandEvents
 
+  /// Removes all caches (state & diagnostics) if:
+  /// * file doesn't exist on disk (untitled or deleted)
+  /// * file is outside of current workspace (and not part of any project)
+  let forgetDocument (uri: DocumentUri) =
+    let filePath = 
+      uri 
+      |> Path.FileUriToLocalPath
+      |> Utils.normalizePath
+
+    // remove cached data for
+    // * non-existing files (untitled & deleted)
+    // * files outside of workspace (and not used by any project)
+    let doesNotExist (file: string<LocalPath>) =
+      not (File.Exists (UMX.untag file))
+    let isOutsideWorkspace (file: string<LocalPath>) =
+      match rootPath with
+      | None -> 
+          // no workspace specified
+          true
+      | Some rootPath ->
+          let rec isInside (rootDir: DirectoryInfo, dirToCheck: DirectoryInfo) =
+            if String.Equals(rootDir.FullName, dirToCheck.FullName, StringComparison.InvariantCultureIgnoreCase) then
+              true
+            else
+              match dirToCheck.Parent with
+              | null -> false
+              | parent ->
+                  isInside (rootDir, parent)
+
+          let rootDir = DirectoryInfo(rootPath)
+          let fileDir = FileInfo(UMX.untag file).Directory
+          
+          if isInside (rootDir, fileDir) then
+            false
+          else
+            // file might be outside of workspace but part of a project
+            match state.GetProjectOptions file with
+            | None -> true
+            | Some projOptions ->
+                if doesNotExist (UMX.tag projOptions.ProjectFileName) then
+                  // case for script file
+                  true
+                else
+                  // issue: fs-file does never get removed from project options (-> requires reload of FSAC to register)
+                  // -> don't know if file still part of project (file might have been removed from project)
+                  // -> keep cache for file
+                  false
+
+    if
+      doesNotExist filePath
+      ||
+      isOutsideWorkspace filePath
+    then
+      logger.info (
+        Log.setMessage "Removing cached data for {file}"
+        >> Log.addContext "file" filePath
+      )
+      state.Forget filePath
+      diagnosticCollections.ClearFor uri
+
   ///Helper function for handling Position requests using **recent** type check results
   member x.positionHandler<'a, 'b when 'b :> ITextDocumentPositionParams>
     (f: 'b -> FcsPos -> ParseAndCheckResults -> string -> NamedText -> AsyncLspResult<'a>)
@@ -1042,6 +1102,15 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
 
       ()
     }
+
+  override _.TextDocumentDidClose(p) = async {
+    logger.info (
+      Log.setMessage "TextDocumentDidOpen Request: {parms}"
+      >> Log.addContextDestructured "parms" p
+    )
+
+    forgetDocument p.TextDocument.Uri
+  }
 
   override __.TextDocumentCompletion(p: CompletionParams) =
     asyncResult {
@@ -1941,9 +2010,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
       p.Changes
       |> Array.iter (fun c ->
         if c.Type = FileChangeType.Deleted then
-          let uri = c.Uri
-          diagnosticCollections.ClearFor uri
-
+          forgetDocument c.Uri
         ())
 
       return ()

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -51,6 +51,7 @@ let lspTests =
               FsAutoComplete.State.Initial toolsPath testRunDir workspaceLoaderFactory
 
             initTests state
+            closeTests state
 
             Utils.Tests.Server.tests state
             Utils.Tests.CursorbasedTests.tests state

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/CloseTests/InsideProjectOutsideWorkspace.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/CloseTests/InsideProjectOutsideWorkspace.fs
@@ -1,0 +1,3 @@
+﻿namespace MyProject
+
+let someValue = inProjectOutsideWorkspace

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/CloseTests/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/CloseTests/Script.fsx
@@ -1,0 +1,1 @@
+let foo = outsideWorkspace

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/CloseTests/Workspace/InsideProjectInsideWorkspace.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/CloseTests/Workspace/InsideProjectInsideWorkspace.fs
@@ -1,0 +1,3 @@
+﻿namespace MyProject
+
+let someValue = inProjectInsideWorkspace

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/CloseTests/Workspace/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/CloseTests/Workspace/Script.fsx
@@ -1,0 +1,1 @@
+let foo = insideWorkspace

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/CloseTests/Workspace/Workspace.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/CloseTests/Workspace/Workspace.fsproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="InsideProjectInsideWorkspace.fs" />
+    <Compile Include="../InsideProjectOutsideWorkspace.fs" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Currently caches for all files are kept forever (inside [`State`](https://github.com/fsharp/FsAutoComplete/blob/6f3090359367da1b829fb0bd0bd093faebdef0ac/src/FsAutoComplete.Core/State.fs#L149)).  

That's ok, but in certain situations unnecessary and we can safely remove caches:
* When a non-existing file gets closed (-> deleted file or untitled file (never existed in filesystem))
* When a file outside the current workspace gets closed


It's nice to slightly reduce memory footprint for long sessions, but also fixes following cases:

* VSCode shows old diags for a new untitled file with same name (even when language not set to F# in new untitled file...) -> clearing cache (or more precise: clearing diags) removes old diags
  * To reproduce:
      * In VSCode create new untitled document (`Ctrl+N`) (-> `Untitled-1` if it's the only untitled doc)
      * set language to `F#` (-> F# script file)
      * write `let foo = bar` -> error "The value or constructor 'bar' is not defined."
      * close untitled document
      * create new untitled document (-> should have same name (`Untitled-1`))
      * Still shows error from old document

* Iterating over all projects and their source files in `State` contains closed non-existing files (like untitled files) and external files -> not something to consider when doing something in FSAC, but are currently inside `State`.
  * Also an issue for tests: Same server, every testCase creates and untitled files (and closes it afterwards) -> State of 2nd testCase contains file & project for 1st testCase
  * I don't think that's currently an actual issue because nothing iterates over all files in all projects.  
  But I'm looking into "Find all references" -> Sometimes want to find in all files -> iterate over all projects & their files. But this contains obsolete files too

<br/>
<br/>


This PR removes non-existing files and files outside workspace when they get closed (`textDocument/didClose` Notification) -> removed from State & diags get cleared for that file.

<br/>

Some issues:
* I think file might get reintroduced into `State` when a `textDocument/didChange` notification is still processed when `textDocument/DidClose` comes in
* *I think*: A file outside of current workspace & outside of project might still be kept if file was previously part of project but removed from it during the current session.
  * Reason: Changes (at least file removals) inside fsproj aren't adopted by FSAC -> inside `State` the file is still part of a project and requires a restart to revaluate.
