### PR TITLE
Remove fantomas-tool

### DIFF
--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1715,7 +1715,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
 
                 let! result =
                   Cli.Wrap("dotnet").WithArguments(
-                    "tool install fantomas-tool"
+                    "tool install fantomas"
                   )
                     .WithWorkingDirectory(
                     rootPath
@@ -1730,12 +1730,12 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
                   do!
                     lspClient.WindowShowMessage
                       { Type = MessageType.Info
-                        Message = "fantomas-tool was installed locally" }
+                        Message = "fantomas was installed locally" }
 
                   commands.ClearFantomasCache()
                 else
                   fantomasLogger.warn (
-                    Log.setMessage (sprintf "Unable to install a compatible version of fantomas-tool in %s" rootPath)
+                    Log.setMessage (sprintf "Unable to install a compatible version of fantomas in %s" rootPath)
                   )
               }
 
@@ -1744,7 +1744,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
         | Ok (Some { Title = "Install globally" }) ->
           let! result =
             Cli.Wrap("dotnet").WithArguments(
-              "tool install -g fantomas-tool"
+              "tool install -g fantomas"
             )
               .ExecuteBufferedAsync()
               .Task
@@ -1756,11 +1756,11 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
             do!
               lspClient.WindowShowMessage
                 { Type = MessageType.Info
-                  Message = "fantomas-tool was installed globally" }
+                  Message = "fantomas was installed globally" }
 
             commands.ClearFantomasCache()
           else
-            fantomasLogger.warn (Log.setMessage "Unable to install a compatible version of fantomas-tool globally")
+            fantomasLogger.warn (Log.setMessage "Unable to install a compatible version of fantomas globally")
         | _ -> ()
 
         return LspResult.internalError "Fantomas install not found."

--- a/src/FsAutoComplete/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/FsAutoComplete.Lsp.fs
@@ -1714,10 +1714,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
                       )
 
                 let! result =
-                  Cli.Wrap("dotnet").WithArguments(
-                    "tool install fantomas"
-                  )
-                    .WithWorkingDirectory(
+                  Cli.Wrap("dotnet").WithArguments("tool install fantomas").WithWorkingDirectory(
                     rootPath
                   )
                     .ExecuteBufferedAsync()

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Formatting/.config/dotnet-tools.json
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Formatting/.config/dotnet-tools.json
@@ -2,8 +2,8 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "fantomas-tool": {
-      "version": "4.6.0",
+    "fantomas": {
+      "version": "5.0.0",
       "commands": [
         "fantomas"
       ]


### PR DESCRIPTION
Replace most `fantomas-tool` with `fantomas`.
I've kept one, that is when you have installed an older `fantomas-tool` that is not compatible.
This cannot happen in case of `fantomas`.