### PR TITLE
Fixes tooltips on tokens that had a trailing left paren

### DIFF
--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -343,7 +343,19 @@ let tooltipTests state =
               ""
               "* `'a` is `int`"
               "* `'b` is `int`"
-              "* `'c` is `int`" ] ] ]
+              "* `'c` is `int`" ]
+          verifySignature
+            48
+            28
+            (concatLines
+              [
+                  "static member Start:"
+                  "   body             : (MailboxProcessor<string> -> Async<unit>) *"
+                  "   cancellationToken: option<System.Threading.CancellationToken>"
+                  "                   -> MailboxProcessor<string>"
+              ]
+            )
+        ] ]
 
 let closeTests state =
   // Note: clear diagnostics also implies clear caches (-> remove file & project options from State).

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -44,3 +44,8 @@ let (^) x y = x + y
 let inline add x y = x + y
 
 let result = add 5 5
+
+let mailbox =
+  MailboxProcessor<string>.Start(
+    fun _ -> async.Return()
+  )


### PR DESCRIPTION
Previous tooltips weren't showing when hovering over the `MailboxProcessor<string>.Start(` of code like:

```
let mailbox =
  MailboxProcessor<string>.Start(
    fun _ -> async.Return()
  )
  ```
  
  
<img width="684" alt="image" src="https://user-images.githubusercontent.com/1490044/194790769-59a48793-6345-42d8-aadb-075c5c355854.png">

  
 This fixes that.
 
 Thanks to @angelmunoz to pairing on this with me!