### PR TITLE
Many tweaks to AdaptiveLSPServer for performance

### DIFF
--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -440,8 +440,8 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
   do
     disposables.Add(
       (notifications.Publish :> IObservable<_>)
-        // .BufferedDebounce(TimeSpan.FromMilliseconds(200.))
-        // .SelectMany(fun l -> l.Distinct())
+        .BufferedDebounce(TimeSpan.FromMilliseconds(200.))
+        .SelectMany(fun l -> l.Distinct())
         .Subscribe(fun e -> handleCommandEvents e)
     )
 

--- a/src/FsAutoComplete/LspServers/Common.fs
+++ b/src/FsAutoComplete/LspServers/Common.fs
@@ -188,7 +188,9 @@ module ObservableExtensions =
 
     /// Fires an event only after the specified interval has passed in which no other pending event has fired. Buffers all events leading up to that emit.
     member x.BufferedDebounce(ts: TimeSpan) =
-      x.Publish(fun shared -> shared.Window(shared.Throttle(ts)))
+      x
+        .Publish(fun shared -> shared.Window(shared.Throttle(ts)))
+        .SelectMany(fun l -> l.ToList())
 
 module Helpers =
   let notImplemented<'t> = async.Return LspResult.notImplemented<'t>


### PR DESCRIPTION
- Updates FileSystem GetLastWriteTimeShim
  - This updates GetLastWriteTimeShim to use actualFs.GetLastWriteTimeShim which should help with how the type checker recognizes doing caching for type checks. Additionally updates DidOpen, DidChange, and DidSave to use the file systems GetLastWriteTimeUtc to further help with this type check caching.
-  Adds cancelAllOpenFileCheckRequests on DidSave
- Moves some built in analyzers to be done at the same time as type checking (this is more of a testing tweak but stops having many threads as well)
- Moves `lspClient.CodeLensRefresh()` to `DidSave` instead of every typecheck
- Fixes the .BufferedDebounce to actualy buffer


Thanks to @angelmunoz and @paigem89 for pairing with me on these.