### PR TITLE
Fixes ResolveNamespace in nested modules

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -78,7 +78,7 @@
       "args": [
         "--debug",
         "--filter",
-        "FSAC.lsp.${input:loader}.${input:testName}"
+        "FSAC.lsp.${input:loader}.${input:lsp-server}.${input:testName}"
       ]
     }
   ],
@@ -101,6 +101,17 @@
         "MSBuild Project Graph WorkspaceLoader"
       ],
       "default": "WorkspaceLoader",
+      "type": "pickString"
+    },
+
+    {
+      "id": "lsp-server",
+      "description": "The lsp serrver",
+      "options": [
+        "FSharpLspServer",
+        "AdaptiveLspServer"
+      ],
+      "default": "FSharpLspServer",
       "type": "pickString"
     },
     {

--- a/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
+++ b/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
@@ -76,7 +76,23 @@ let fix
         ns
 
     let lineStr =
-      let whitespace = String.replicate ctx.Pos.Column " "
+      let whitespace =
+        let column =
+          // HACK: This is a work around for inheriting the correct column of the current module
+          // It seems the column we get from FCS is incorrect
+          let previousLine = docLine - 1
+          let insertionPointIsNotOutOfBoundsOfTheFile = docLine > 0
+
+          let theThereAreOtherOpensInThisModule =
+            text.GetLineString(previousLine).Contains "open "
+
+          if insertionPointIsNotOutOfBoundsOfTheFile && theThereAreOtherOpensInThisModule then
+            text.GetLineString(previousLine).Split("open") |> Seq.head |> Seq.length // inherit the previous opens whitespace
+          else
+            ctx.Pos.Column
+
+        String.replicate column " "
+
       $"%s{whitespace}open %s{actualOpen}\n"
 
     let edits =

--- a/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
+++ b/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
@@ -29,6 +29,7 @@ let fix
 
   let adjustInsertionPoint (lines: ISourceText) (ctx: InsertionContext) =
     let l = ctx.Pos.Line
+
     let retVal =
       match ctx.ScopeKind with
       | ScopeKind.TopModule when l > 1 ->
@@ -53,8 +54,10 @@ let fix
         | Some line -> line + 2
         | None -> l
       | _ -> l
-    let containsAttribute (x : string) = x.Contains "[<"
-    let currentLine = System.Math.Max(retVal - 2 , 0) |> lines.GetLineString
+
+    let containsAttribute (x: string) = x.Contains "[<"
+    let currentLine = System.Math.Max(retVal - 2, 0) |> lines.GetLineString
+
     if currentLine |> containsAttribute then
       retVal + 1
     else

--- a/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
+++ b/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
@@ -83,10 +83,10 @@ let fix
           let previousLine = docLine - 1
           let insertionPointIsNotOutOfBoundsOfTheFile = docLine > 0
 
-          let theThereAreOtherOpensInThisModule =
+          let theThereAreOtherOpensInThisModule () =
             text.GetLineString(previousLine).Contains "open "
 
-          if insertionPointIsNotOutOfBoundsOfTheFile && theThereAreOtherOpensInThisModule then
+          if insertionPointIsNotOutOfBoundsOfTheFile && theThereAreOtherOpensInThisModule () then
             text.GetLineString(previousLine).Split("open") |> Seq.head |> Seq.length // inherit the previous opens whitespace
           else
             ctx.Pos.Column

--- a/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
+++ b/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
@@ -95,19 +95,7 @@ let fix
 
       $"%s{whitespace}open %s{actualOpen}\n"
 
-    let edits =
-      [| yield insertLine docLine lineStr
-         if
-           text.GetLineCount() < docLine + 1
-           && text.GetLineString(docLine + 1).Trim() <> ""
-         then
-           yield insertLine (docLine + 1) ""
-         if
-           (ctx.Pos.Column = 0 || ctx.ScopeKind = ScopeKind.Namespace)
-           && docLine > 0
-           && not (text.GetLineString(docLine - 1).StartsWith "open")
-         then
-           yield insertLine (docLine - 1) "" |]
+    let edits = [| yield insertLine docLine lineStr |]
 
     { Edits = edits
       File = file

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -1517,7 +1517,7 @@ module Foo =
 
 
 
-    testCaseAsync "With-attribute"
+    testCaseAsync "With attribute"
       <| CodeFix.check
           server
           """

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -1514,6 +1514,27 @@ module Foo =
   open System
   let foo = DateTime.Now
         """
+
+
+
+    testCaseAsync "With-attribute"
+      <| CodeFix.check
+          server
+          """
+[<AutoOpen>]
+module Foo =
+
+  let foo = $0DateTime.Now
+          """
+          (Diagnostics.log >> Diagnostics.acceptAll)
+          selectCodeFix
+          """
+[<AutoOpen>]
+module Foo =
+  open System
+
+  let foo = DateTime.Now
+          """
     //TODO: Implement & unify with `Completion.AutoOpen` (`CompletionTests.fs`)
     // Issues:
     // * Complex because of nesting modules (-> where to open)
@@ -1613,7 +1634,7 @@ let private wrapExpressionInParenthesesTests state =
         selectCodeFix
   ])
 
-let tests state = testList "CodeFix tests" [
+let tests state = testList "CodeFix-tests" [
   HelpersTests.tests
 
   AddExplicitTypeAnnotationTests.tests state

--- a/test/FsAutoComplete.Tests.Lsp/Utils/TextEdit.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/TextEdit.fs
@@ -382,8 +382,8 @@ module TextEdit =
       Some "Expected positive End.Character, but was negative"
     else if edit.Range.Start > edit.Range.End then
       Some "Expected Range.Start <= Range.End, but was Start > End"
-    // else if edit |> doesNothing then
-    //   Some "Expected change, but does nothing (neither delete nor insert)"
+    else if edit |> doesNothing then
+      Some "Expected change, but does nothing (neither delete nor insert)"
     else
       None
 


### PR DESCRIPTION
Correctly inherits the whitespace from previous opens.

![resolve-namespace-fix](https://user-images.githubusercontent.com/1490044/195230993-91870ccb-15a9-44e7-b3a2-c60ae0309a22.gif)

Not entirely sure how to write a test for this yet. 

Thanks to @angelmunoz for the help!