### PR TITLE
Add textDocument/inlineValue from LSP 3.17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ test/FsAutoComplete.Tests.Lsp/TestCases/FakeInterop/build.fsx.lock
 coverage.xml
 coverage
 test/FsAutoComplete.Tests.Lsp/TestResults/
+
+.tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.58.5] - 2023-02-04
+
+* Add textDocument/inlineValue from LSP 3.17
+* InlineValue config option to shadow PipelineHint config option
+* Fix inlayHints for typed params #1046
+
 ## [0.58.4] - 2023-02-04
 
 * Fix crash due to missing dependency on Microsoft.Extensions.Caching.Memory

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ FsAutoComplete supports [LSP](https://microsoft.github.io/language-server-protoc
 * `textDocument/documentHighlight`
 * `textDocument/signatureHelp`
 * `textDocument/documentSymbol`
+* `textDocument/inlayHint`
+* `textDocument/inlineValue`
 * `workspace/didChangeWatchedFiles`
 * `workspace/didChangeConfiguration`
 * `workspace/symbol`

--- a/paket.lock
+++ b/paket.lock
@@ -100,7 +100,7 @@ NUGET
       System.Collections.Immutable (>= 5.0)
       System.Reflection.Metadata (>= 5.0)
     Ionide.KeepAChangelog.Tasks (0.1.8) - copy_local: true
-    Ionide.LanguageServerProtocol (0.4.11)
+    Ionide.LanguageServerProtocol (0.4.12)
       FSharp.Core (>= 6.0)
       Newtonsoft.Json (>= 13.0.1)
       StreamJsonRpc (>= 2.10.44)

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -596,6 +596,10 @@ type InlayHintDto =
     parameterNames: bool option
     disableLongTooltip: bool option }
 
+type InlineValueDto =
+  { Enabled: bool option
+    Prefix: string option }
+
 type DebugDto =
   { DontCheckRelatedFiles: bool option
     CheckFileDebouncerTimeout: int option
@@ -637,6 +641,7 @@ type FSharpConfigDto =
     AbstractClassStubGenerationObjectIdentifier: string option
     AbstractClassStubGenerationMethodBody: string option
     CodeLenses: CodeLensConfigDto option
+    PipelineHints: InlineValueDto option
     InlayHints: InlayHintDto option
     Debug: DebugDto option }
 
@@ -659,6 +664,14 @@ type InlayHintsConfig =
     { typeAnnotations = true
       parameterNames = true
       disableLongTooltip = true }
+
+type InlineValuesConfig =
+  { Enabled: bool option
+    Prefix: string option }
+
+  static member Default =
+    { Enabled = Some true
+      Prefix = Some "//" }
 
 type DebugConfig =
   { DontCheckRelatedFiles: bool
@@ -708,6 +721,7 @@ type FSharpConfig =
     GenerateBinlog: bool
     CodeLenses: CodeLensConfig
     InlayHints: InlayHintsConfig
+    InlineValues: InlineValuesConfig
     Debug: DebugConfig }
 
   static member Default: FSharpConfig =
@@ -746,6 +760,7 @@ type FSharpConfig =
       GenerateBinlog = false
       CodeLenses = CodeLensConfig.Default
       InlayHints = InlayHintsConfig.Default
+      InlineValues = InlineValuesConfig.Default
       Debug = DebugConfig.Default }
 
   static member FromDto(dto: FSharpConfigDto) : FSharpConfig =
@@ -803,6 +818,14 @@ type FSharpConfig =
           { typeAnnotations = defaultArg ihDto.typeAnnotations true
             parameterNames = defaultArg ihDto.parameterNames true
             disableLongTooltip = defaultArg ihDto.disableLongTooltip true }
+
+      InlineValues =
+        match dto.PipelineHints with
+        | None -> InlineValuesConfig.Default
+        | Some ivDto ->
+          { Enabled = ivDto.Enabled |> Option.defaultValue true |> Some
+            Prefix = ivDto.Prefix |> Option.defaultValue "//" |> Some }
+
       Debug =
         match dto.Debug with
         | None -> DebugConfig.Default
@@ -882,6 +905,9 @@ type FSharpConfig =
           { typeAnnotations = defaultArg ihDto.typeAnnotations x.InlayHints.typeAnnotations
             parameterNames = defaultArg ihDto.parameterNames x.InlayHints.parameterNames
             disableLongTooltip = defaultArg ihDto.disableLongTooltip x.InlayHints.disableLongTooltip }
+      InlineValues =
+        { Enabled = defaultArg (dto.PipelineHints |> Option.map (fun n -> n.Enabled)) x.InlineValues.Enabled
+          Prefix = defaultArg (dto.PipelineHints |> Option.map (fun n -> n.Prefix)) x.InlineValues.Prefix }
       Debug =
         match dto.Debug with
         | None -> DebugConfig.Default

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -220,6 +220,10 @@ let defaultConfigDto: FSharpConfigDto =
         { typeAnnotations = Some true
           parameterNames = Some true
           disableLongTooltip = Some true }
+    PipelineHints =
+      Some
+        { Enabled = Some true
+          Prefix = Some "//" }
     Debug = None }
 
 let clientCaps: ClientCapabilities =
@@ -243,6 +247,9 @@ let clientCaps: ClientCapabilities =
     let inlayHintCaps: InlayHintWorkspaceClientCapabilities =
       { RefreshSupport = Some false }
 
+    let inlineValueCaps: InlineValueWorkspaceClientCapabilities =
+      { RefreshSupport = Some false }
+
     let codeLensCaps: CodeLensWorkspaceClientCapabilities =
       { RefreshSupport = Some true }
 
@@ -253,6 +260,7 @@ let clientCaps: ClientCapabilities =
       Symbol = Some symbolCaps
       SemanticTokens = Some semanticTokenCaps
       InlayHint = Some inlayHintCaps
+      InlineValue = Some inlineValueCaps
       CodeLens = Some codeLensCaps }
 
   let textCaps: TextDocumentClientCapabilities =
@@ -328,6 +336,10 @@ let clientCaps: ClientCapabilities =
       { DynamicRegistration = Some true
         ResolveSupport = None }
 
+    let inlineValueCaps: InlineValueClientCapabilities =
+      { DynamicRegistration = Some true
+        ResolveSupport = None }
+
     let renameCaps: RenameClientCapabilities =
       { DynamicRegistration = Some true
         HonorsChangeAnnotations = Some false
@@ -353,6 +365,7 @@ let clientCaps: ClientCapabilities =
       SelectionRange = Some dynCaps
       SemanticTokens = Some semanticTokensCaps
       InlayHint = Some inlayHintCaps }
+      // InlineValue = Some inlineValueCaps }
 
 
   { Workspace = Some workspaceCaps

--- a/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
@@ -1058,6 +1058,15 @@ let private paramHintTests state =
         """
            []
 
+      testCaseAsync "Show param hint for type arg"
+      <| checkAllInMarkedRange
+           server
+           """
+        type Parser(jsonText: string) = member _.Parse(decoder: string -> string) = decoder jsonText
+        $|let parse (decoder: string -> string) (str: string) =  Parser$0(str).Parse(decoder)$|
+        """
+           [ paramHint "jsonText"]
+
       testList
         "operator"
         [ testList


### PR DESCRIPTION
Serve information from fSharp/pipelineHints via the new LSP endpoint textDocument/inlineValue (LSP spec 3.17)