### PR TITLE
Fix Tests for AdaptiveLspServer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     env:
       TEST_TIMEOUT_MINUTES: 30
+      FSAC_TEST_DEFAULT_TIMEOUT : 120000 #ms, individual test timeouts
     timeout-minutes: 30 # we have a locking issue, so cap the runs at ~20m to account for varying build times, etc
     strategy:
       matrix:

--- a/paket.lock
+++ b/paket.lock
@@ -917,20 +917,6 @@ NUGET
       Microsoft.Win32.Registry (>= 4.3) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
       System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: >= net472
       System.Security.Permissions (>= 4.7) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
-    Microsoft.Build.Tasks.Core (17.2) - restriction: >= netstandard2.0
-      Microsoft.Build.Framework (>= 17.2) - restriction: >= netstandard2.0
-      Microsoft.Build.Utilities.Core (>= 17.2) - restriction: >= netstandard2.0
-      Microsoft.IO.Redist (>= 6.0) - restriction: >= net472
-      Microsoft.NET.StringTools (>= 1.0) - restriction: >= netstandard2.0
-      Microsoft.Win32.Registry (>= 4.3) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
-      System.CodeDom (>= 4.4) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
-      System.Collections.Immutable (>= 5.0) - restriction: >= netstandard2.0
-      System.Reflection.Metadata (>= 1.6) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
-      System.Resources.Extensions (>= 4.6) - restriction: >= netstandard2.0
-      System.Security.Cryptography.Pkcs (>= 4.7) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
-      System.Security.Cryptography.Xml (>= 4.7) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
-      System.Security.Permissions (>= 4.7) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
-      System.Threading.Tasks.Dataflow (>= 6.0) - restriction: >= netstandard2.0
     Microsoft.Build.Utilities.Core (17.2) - restriction: >= netstandard2.0
       Microsoft.Build.Framework (>= 17.2) - restriction: >= netstandard2.0
       Microsoft.IO.Redist (>= 6.0) - restriction: >= net472
@@ -946,7 +932,7 @@ NUGET
     Microsoft.NET.StringTools (1.0) - restriction: >= netstandard2.0
       System.Memory (>= 4.5.4) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 5.0) - restriction: >= netstandard2.0
-    Microsoft.NETCore.Platforms (6.0.5) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp3.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (>= net6.0) (< netcoreapp2.1) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netcoreapp2.1) (>= netcoreapp3.1) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
+    Microsoft.NETCore.Platforms (6.0.5) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp3.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (>= net5.0) (< netcoreapp2.1) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos))
     Microsoft.NETCore.Targets (5.0) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp3.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81))
     Microsoft.Win32.Registry (5.0) - restriction: || (&& (< net45) (>= netstandard2.0)) (&& (< net472) (>= netstandard2.0)) (>= net6.0)
       System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard1.3)) (>= monotouch) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
@@ -954,10 +940,8 @@ NUGET
       System.Security.Principal.Windows (>= 5.0) - restriction: || (&& (>= monoandroid) (< netstandard1.3)) (&& (< monoandroid) (>= netcoreapp2.0)) (>= monotouch) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.1) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
     Microsoft.Win32.SystemEvents (6.0.1) - restriction: || (&& (>= net472) (>= netcoreapp3.1)) (>= net6.0)
     Mono.Posix.NETStandard (1.0) - restriction: >= netstandard2.0
-    MSBuild.StructuredLogger (2.1.669)
-      Microsoft.Build (>= 16.10) - restriction: >= netstandard2.0
+    MSBuild.StructuredLogger (2.1.768)
       Microsoft.Build.Framework (>= 16.10) - restriction: >= netstandard2.0
-      Microsoft.Build.Tasks.Core (>= 16.10) - restriction: >= netstandard2.0
       Microsoft.Build.Utilities.Core (>= 16.10) - restriction: >= netstandard2.0
     Newtonsoft.Json (13.0.1) - restriction: >= netstandard2.0
     NuGet.Common (6.3) - restriction: >= netstandard2.0
@@ -976,8 +960,7 @@ NUGET
       NuGet.Packaging (>= 6.3) - restriction: >= netstandard2.0
     NuGet.Versioning (6.3) - restriction: >= netstandard2.0
     Octokit (0.48)
-    System.Buffers (4.5.1) - restriction: || (&& (>= monoandroid) (>= net6.0) (< netstandard1.3)) (&& (>= monotouch) (>= net6.0)) (&& (>= net461) (>= netstandard2.1)) (&& (< net461) (< net6.0) (>= netstandard2.0)) (&& (< net461) (>= netstandard2.0) (< netstandard2.1)) (>= net472) (&& (>= net6.0) (< netcoreapp2.0)) (&& (>= net6.0) (< netstandard2.1)) (&& (>= net6.0) (>= xamarinios)) (&& (>= net6.0) (>= xamarinmac)) (&& (>= net6.0) (>= xamarintvos)) (&& (>= net6.0) (>= xamarinwatchos)) (&& (< net6.0) (>= netstandard2.1))
-    System.CodeDom (6.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
+    System.Buffers (4.5.1) - restriction: || (&& (>= monoandroid) (>= net6.0) (< netstandard1.3)) (&& (>= monotouch) (>= net6.0)) (&& (>= net461) (>= netstandard2.1)) (&& (< net461) (< net6.0) (>= netstandard2.0)) (&& (< net461) (>= netstandard2.0) (< netstandard2.1)) (>= net472) (&& (>= net5.0) (< netstandard2.1)) (&& (>= net6.0) (< netcoreapp2.0)) (&& (>= net6.0) (>= xamarinios)) (&& (>= net6.0) (>= xamarinmac)) (&& (>= net6.0) (>= xamarintvos)) (&& (>= net6.0) (>= xamarinwatchos)) (&& (< net6.0) (>= netstandard2.1))
     System.Collections.Immutable (6.0) - restriction: >= netstandard2.0
       System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (< net6.0) (>= netstandard2.0))
       System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
@@ -986,10 +969,11 @@ NUGET
       System.Security.Permissions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
     System.Drawing.Common (6.0) - restriction: || (&& (>= net472) (>= netcoreapp3.1)) (>= net6.0)
       Microsoft.Win32.SystemEvents (>= 6.0) - restriction: >= netcoreapp3.1
-    System.Formats.Asn1 (6.0) - restriction: || (&& (< net461) (>= netstandard2.0)) (&& (>= net6.0) (< xamarintvos) (< xamarinwatchos)) (&& (< net6.0) (>= netcoreapp3.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp3.0) (< xamarintvos) (< xamarinwatchos)) (>= netstandard2.1)
+    System.Formats.Asn1 (6.0) - restriction: || (&& (< net461) (>= netstandard2.0)) (&& (>= net5.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netstandard2.1)
       System.Buffers (>= 4.5.1) - restriction: || (>= net461) (&& (< net6.0) (>= netstandard2.0))
       System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (< net6.0) (>= netstandard2.0))
-    System.Memory (4.5.5) - restriction: || (&& (>= net6.0) (< netstandard2.1)) (>= netstandard2.0)
+    System.IO (4.3) - restriction: || (&& (< monoandroid) (< net46) (< netstandard1.4) (>= netstandard2.0)) (&& (< monoandroid) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< monoandroid) (>= net5.0) (< netstandard1.4)) (&& (< monoandroid) (>= net5.0) (< netstandard1.6)) (&& (< monoandroid) (>= net5.0) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (>= net5.0) (< netstandard1.4)) (&& (< net46) (>= net461) (< netstandard1.4) (>= netstandard2.0)) (&& (< net46) (>= net461) (< netstandard1.6) (>= netstandard2.0)) (&& (< net46) (>= net462) (< netstandard1.4) (>= netstandard2.0)) (&& (< net46) (>= net462) (< netstandard1.6) (>= netstandard2.0)) (&& (< net46) (>= net47) (>= netstandard2.0)) (&& (>= net461) (>= net5.0) (< netstandard1.4)) (&& (>= net461) (>= net5.0) (< netstandard1.6)) (&& (>= net462) (>= net5.0) (< netstandard1.4)) (&& (>= net462) (>= net5.0) (< netstandard1.6)) (&& (>= net463) (>= net5.0) (< netstandard1.4)) (&& (>= net463) (>= net5.0) (< netstandard1.6)) (&& (>= net463) (>= net5.0) (< netstandard2.0)) (&& (>= net463) (< netstandard1.4) (>= netstandard2.0)) (&& (>= net463) (< netstandard1.6) (>= netstandard2.0)) (&& (>= net47) (< net472) (>= netstandard2.0)) (&& (>= net47) (>= net5.0))
+    System.Memory (4.5.5) - restriction: || (&& (>= net461) (>= netstandard2.1)) (&& (>= net5.0) (< netstandard2.1)) (&& (< net6.0) (>= netstandard2.1)) (>= netstandard2.0)
       System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard1.1)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
       System.Numerics.Vectors (>= 4.5) - restriction: >= net461
       System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (>= monoandroid) (< netstandard1.1)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
@@ -997,30 +981,32 @@ NUGET
     System.Reactive (5.0) - restriction: >= netstandard2.0
       System.Runtime.InteropServices.WindowsRuntime (>= 4.3) - restriction: && (< net472) (< netcoreapp3.1) (>= netstandard2.0)
       System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net472) (&& (< netcoreapp3.1) (>= netstandard2.0)) (>= uap10.1)
-    System.Reflection.Metadata (6.0.1) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
+    System.Reflection.Metadata (6.0.1) - restriction: >= net6.0
       System.Collections.Immutable (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Resources.Extensions (6.0) - restriction: >= netstandard2.0
-      System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (< net6.0) (>= netstandard2.0))
-    System.Runtime (4.3.1) - restriction: && (< monoandroid) (< net45) (< netcoreapp3.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+    System.Runtime (4.3.1) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp3.1) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (< netstandard1.4) (>= netstandard2.0)) (&& (< monoandroid) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< monoandroid) (>= net5.0) (< netstandard1.4)) (&& (< monoandroid) (>= net5.0) (< netstandard1.6)) (&& (< monoandroid) (>= net5.0) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (>= net5.0) (< netstandard1.4)) (&& (< net46) (>= net461) (< netstandard1.4) (>= netstandard2.0)) (&& (< net46) (>= net461) (< netstandard1.6) (>= netstandard2.0)) (&& (< net46) (>= net462) (< netstandard1.4) (>= netstandard2.0)) (&& (< net46) (>= net462) (< netstandard1.6) (>= netstandard2.0)) (&& (< net46) (>= net47) (>= netstandard2.0)) (&& (>= net461) (>= net5.0) (< netstandard1.4)) (&& (>= net461) (>= net5.0) (< netstandard1.6)) (&& (>= net462) (>= net5.0) (< netstandard1.4)) (&& (>= net462) (>= net5.0) (< netstandard1.6)) (&& (>= net463) (>= net5.0) (< netstandard1.4)) (&& (>= net463) (>= net5.0) (< netstandard1.6)) (&& (>= net463) (>= net5.0) (< netstandard2.0)) (&& (>= net463) (< netstandard1.4) (>= netstandard2.0)) (&& (>= net463) (< netstandard1.6) (>= netstandard2.0)) (&& (>= net47) (< net472) (>= netstandard2.0)) (&& (>= net47) (>= net5.0))
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Targets (>= 1.1.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
     System.Runtime.CompilerServices.Unsafe (6.0) - restriction: >= netstandard2.0
     System.Runtime.InteropServices.WindowsRuntime (4.3) - restriction: && (< net472) (< netcoreapp3.1) (>= netstandard2.0)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.AccessControl (6.0) - restriction: >= netstandard2.0
-    System.Security.Cryptography.Cng (5.0) - restriction: || (&& (< net461) (>= netstandard2.0) (< netstandard2.1)) (&& (< net472) (>= netstandard2.0)) (>= net5.0) (&& (>= net6.0) (< netcoreapp3.1)) (&& (>= net6.0) (< netstandard2.1)) (&& (< net6.0) (>= netcoreapp3.1)) (&& (< netcoreapp3.1) (>= netstandard2.1))
+    System.Security.AccessControl (6.0) - restriction: || (>= net472) (>= net6.0)
+    System.Security.Cryptography.Algorithms (4.3.1) - restriction: || (&& (< monoandroid) (< net46) (< netstandard1.4) (>= netstandard2.0)) (&& (< monoandroid) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< monoandroid) (>= net5.0) (< netstandard1.4)) (&& (< monoandroid) (>= net5.0) (< netstandard1.6)) (&& (< monoandroid) (>= net5.0) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (>= net5.0) (< netstandard1.4)) (&& (>= net46) (< netstandard1.4) (>= netstandard2.0)) (&& (>= net461) (< net462) (< netstandard1.6) (>= netstandard2.0)) (&& (>= net461) (>= net5.0) (< netstandard1.6)) (&& (>= net462) (>= net5.0) (< netstandard1.6)) (&& (>= net462) (< netstandard1.6) (>= netstandard2.0)) (&& (>= net47) (< net472) (>= netstandard2.0)) (&& (>= net47) (>= net5.0))
+      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net463)
+      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net463)
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net463)
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (< netstandard1.4)) (&& (>= net461) (< netstandard1.6)) (>= net463)
+    System.Security.Cryptography.Cng (5.0) - restriction: || (&& (< net461) (>= netstandard2.0) (< netstandard2.1)) (&& (< net472) (>= netstandard2.0)) (>= net5.0) (&& (< net6.0) (>= netcoreapp3.1)) (&& (< netcoreapp3.1) (>= netstandard2.1))
       Microsoft.NETCore.Platforms (>= 5.0) - restriction: && (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)
       System.Formats.Asn1 (>= 5.0) - restriction: && (>= netcoreapp3.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Pkcs (6.0.1) - restriction: || (&& (< net461) (>= netstandard2.0)) (&& (< net472) (>= netstandard2.0)) (>= net5.0)
+      System.Security.Cryptography.Algorithms (>= 4.3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6) (< uap10.1)) (&& (>= net46) (< netstandard1.4)) (&& (>= net461) (< net462) (< netstandard1.6)) (&& (>= net462) (< netstandard1.6)) (>= net47)
+    System.Security.Cryptography.Encoding (4.3) - restriction: || (&& (< monoandroid) (< net46) (< netstandard1.4) (>= netstandard2.0)) (&& (< monoandroid) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< monoandroid) (>= net5.0) (< netstandard1.4)) (&& (< monoandroid) (>= net5.0) (< netstandard1.6)) (&& (< monoandroid) (>= net5.0) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (>= net5.0) (< netstandard1.4)) (&& (< net46) (>= net461) (< netstandard1.6) (>= netstandard2.0)) (&& (< net46) (>= net462) (< netstandard1.6) (>= netstandard2.0)) (&& (< net46) (>= net47) (>= netstandard2.0)) (&& (>= net461) (>= net5.0) (< netstandard1.6)) (&& (>= net462) (>= net5.0) (< netstandard1.6)) (&& (>= net463) (>= net5.0) (< netstandard1.4)) (&& (>= net463) (>= net5.0) (< netstandard1.6)) (&& (>= net463) (>= net5.0) (< netstandard2.0)) (&& (>= net463) (< netstandard1.4) (>= netstandard2.0)) (&& (>= net463) (< netstandard1.6) (>= netstandard2.0)) (&& (>= net47) (< net472) (>= netstandard2.0)) (&& (>= net47) (>= net5.0))
+    System.Security.Cryptography.Pkcs (6.0.1) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net5.0)
       System.Buffers (>= 4.5.1) - restriction: && (< net461) (>= netstandard2.0) (< netstandard2.1)
       System.Formats.Asn1 (>= 6.0) - restriction: || (&& (< net461) (>= netstandard2.0)) (>= netstandard2.1)
       System.Memory (>= 4.5.4) - restriction: && (< net461) (>= netstandard2.0) (< netstandard2.1)
       System.Security.Cryptography.Cng (>= 5.0) - restriction: || (&& (< net461) (>= netstandard2.0) (< netstandard2.1)) (&& (< net6.0) (>= netcoreapp3.1)) (&& (< netcoreapp3.1) (>= netstandard2.1))
+    System.Security.Cryptography.Primitives (4.3) - restriction: || (&& (< monoandroid) (< net46) (< netstandard1.4) (>= netstandard2.0)) (&& (< monoandroid) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< monoandroid) (>= net5.0) (< netstandard1.4)) (&& (< monoandroid) (>= net5.0) (< netstandard1.6)) (&& (< monoandroid) (>= net5.0) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (>= net5.0) (< netstandard1.4)) (&& (>= net46) (< netstandard1.4) (>= netstandard2.0)) (&& (< net46) (>= net461) (< netstandard1.6) (>= netstandard2.0)) (&& (< net46) (>= net47) (>= netstandard2.0)) (&& (>= net461) (< net462) (< netstandard1.6) (>= netstandard2.0)) (&& (>= net461) (>= net5.0) (< netstandard1.4)) (&& (>= net461) (>= net5.0) (< netstandard1.6)) (&& (>= net461) (< netstandard1.4) (>= netstandard2.0)) (&& (>= net462) (>= net5.0) (< netstandard1.4)) (&& (>= net462) (>= net5.0) (< netstandard1.6)) (&& (>= net462) (< netstandard1.4) (>= netstandard2.0)) (&& (>= net462) (< netstandard1.6) (>= netstandard2.0)) (&& (>= net463) (>= net5.0) (< netstandard1.4)) (&& (>= net463) (>= net5.0) (< netstandard1.6)) (&& (>= net463) (>= net5.0) (< netstandard2.0)) (&& (>= net463) (< netstandard1.4) (>= netstandard2.0)) (&& (>= net463) (< netstandard1.6) (>= netstandard2.0)) (&& (>= net47) (< net472) (>= netstandard2.0)) (&& (>= net47) (>= net5.0)) (&& (>= net47) (< netstandard1.4) (>= netstandard2.0)) (&& (>= net47) (< netstandard1.6) (>= netstandard2.0))
     System.Security.Cryptography.ProtectedData (6.0) - restriction: || (&& (< net461) (>= net472)) (&& (< net472) (>= netstandard2.0)) (>= net6.0)
-    System.Security.Cryptography.Xml (6.0.1) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
-      System.Memory (>= 4.5.4) - restriction: && (< net461) (< net6.0) (>= netstandard2.0)
-      System.Security.AccessControl (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Security.Cryptography.Pkcs (>= 6.0.1) - restriction: || (&& (< net461) (>= netstandard2.0)) (>= net6.0)
     System.Security.Permissions (6.0) - restriction: >= netstandard2.0
       System.Security.AccessControl (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
       System.Windows.Extensions (>= 6.0) - restriction: >= netcoreapp3.1
@@ -1040,7 +1026,7 @@ NUGET
       System.Text.Encodings.Web (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
       System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
       System.ValueTuple (>= 4.5) - restriction: >= net461
-    System.Threading.Tasks.Dataflow (6.0) - restriction: >= netstandard2.0
+    System.Threading.Tasks.Dataflow (6.0) - restriction: || (>= net472) (>= net6.0)
     System.Threading.Tasks.Extensions (4.5.4) - restriction: || (&& (>= net461) (>= net6.0)) (>= net472) (&& (>= net6.0) (< netcoreapp3.1)) (&& (< netcoreapp3.1) (>= netstandard2.0)) (&& (>= netstandard2.0) (>= uap10.1))
       System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net461) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= wp8)
     System.ValueTuple (4.5) - restriction: || (&& (>= net45) (>= netstandard2.0)) (&& (>= net461) (>= net6.0)) (>= net472)

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -88,6 +88,7 @@ type NotificationEvent =
   | TestDetected of file: string<LocalPath> * tests: TestAdapter.TestAdapterEntry<range>[]
 
 module Commands =
+  open System.Collections.Concurrent
   let fantomasLogger = LogProvider.getLoggerByName "Fantomas"
   let commandsLogger = LogProvider.getLoggerByName "Commands"
 
@@ -836,7 +837,7 @@ module Commands =
         return Choice1Of2(declarationRanges, usageRanges)
 
       | SymbolDeclarationLocation.Projects (projects, isInternalToProject) ->
-        let symbolUseRanges = ImmutableArray.CreateBuilder()
+        let symbolUseRanges = ConcurrentBag<_>()
         let symbolRange = symbol.DefinitionRange.NormalizeDriveLetterCasing()
         let symbolFile = symbolRange.TaggedFileName
 

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -968,30 +968,6 @@ module Commands =
       highlights |> Array.collect expandParents)
     |> Array.sortBy startToken
 
-type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers: bool, rootPath: string option) =
-  let fileParsed = Event<FSharpParseFileResults>()
-
-  let fileChecked = Event<ParseAndCheckResults * string<LocalPath> * int>()
-
-  let scriptFileProjectOptions = Event<FSharpProjectOptions>()
-
-  let disposables = ResizeArray()
-
-  let mutable workspaceRoot: string option = rootPath
-  let mutable linterConfigFileRelativePath: string option = None
-  // let mutable linterConfiguration: FSharpLint.Application.Lint.ConfigurationParam = FSharpLint.Application.Lint.ConfigurationParam.Default
-  let mutable lastCheckResult: ParseAndCheckResults option = None
-
-  let notify = Event<NotificationEvent>()
-
-  let fileStateSet = Event<unit>()
-  let commandsLogger = LogProvider.getLoggerByName "Commands"
-
-  let checkerLogger = LogProvider.getLoggerByName "CheckerEvents"
-
-  let fantomasLogger = LogProvider.getLoggerByName "Fantomas"
-
-
 
 
   let analyzerHandler (file: string<LocalPath>, content, pt, tast, symbols, getAllEnts) =
@@ -1038,6 +1014,32 @@ type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers:
       )
 
       [||]
+
+
+type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers: bool, rootPath: string option) =
+  let fileParsed = Event<FSharpParseFileResults>()
+
+  let fileChecked = Event<ParseAndCheckResults * string<LocalPath> * int>()
+
+  let scriptFileProjectOptions = Event<FSharpProjectOptions>()
+
+  let disposables = ResizeArray()
+
+  let mutable workspaceRoot: string option = rootPath
+  let mutable linterConfigFileRelativePath: string option = None
+  // let mutable linterConfiguration: FSharpLint.Application.Lint.ConfigurationParam = FSharpLint.Application.Lint.ConfigurationParam.Default
+  let mutable lastCheckResult: ParseAndCheckResults option = None
+
+  let notify = Event<NotificationEvent>()
+
+  let fileStateSet = Event<unit>()
+  let commandsLogger = LogProvider.getLoggerByName "Commands"
+
+  let checkerLogger = LogProvider.getLoggerByName "CheckerEvents"
+
+  let fantomasLogger = LogProvider.getLoggerByName "Fantomas"
+
+
 
   do
     disposables.Add
@@ -1106,7 +1108,7 @@ type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers:
               | true, fileData ->
 
                 let res =
-                  analyzerHandler (
+                  Commands.analyzerHandler (
                     file,
                     fileData.Lines.ToString().Split("\n"),
                     parseAndCheck.GetParseResults.ParseTree,

--- a/src/FsAutoComplete.Core/Consts.fs
+++ b/src/FsAutoComplete.Core/Consts.fs
@@ -1,0 +1,10 @@
+namespace FsAutoComplete.Core
+
+module ProjectLoader =
+  [<Literal>]
+  let ProduceReferenceAssembly = "ProduceReferenceAssembly"
+
+  let globalProperties =
+    [
+      // For tooling we don't want to use Reference Assemblies as this doesn't play well with type checking across projects
+      ProduceReferenceAssembly, "false" ]

--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -9,6 +9,7 @@
     <TrimmerRootAssembly Include="FsAutoComplete.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Consts.fs" />
     <Compile Include="Workaround/ServiceParseTreeWalk.fs" />
     <Compile Include="Debug.fs" />
     <Compile Include="Utils.fs" />

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -796,6 +796,9 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
         return options |> List.map fst
     }
 
+  let forceLoadProjects () =
+    loadedProjectOptions
+    |> AVal.force
 
 
   let sourceFileToProjectOptions =
@@ -1604,7 +1607,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
     |> Array.distinct
 
   let getDependentProjectsOfProjects ps =
-    let projectSnapshot = loadedProjectOptions |> AVal.force
+    let projectSnapshot = forceLoadProjects ()
 
     let allDependents = System.Collections.Generic.HashSet<FSharpProjectOptions>()
 
@@ -1986,7 +1989,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
         try
           logger.info (Log.setMessage "Initialized request {p}" >> Log.addContextDestructured "p" p)
           // Starts getting project options to cache
-          let _ = loadedProjectOptions |> AVal.force
+          forceLoadProjects () |> ignore
 
           return ()
         with e ->
@@ -3760,7 +3763,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
             |> HashSet.ofArray
 
           transact (fun () -> workspacePaths.Value <- (WorkspaceChosen.Projs projs))
-          let options = loadedProjectOptions |> AVal.force
+          forceLoadProjects () |> ignore
 
           return { Content = CommandResponse.workspaceLoad FsAutoComplete.JsonSerializer.writeJson true }
 
@@ -3833,7 +3836,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
                 |> HashSet.single
                 |> WorkspaceChosen.Projs)
 
-          loadedProjectOptions |> AVal.force |> ignore
+          forceLoadProjects () |> ignore
 
           return! Helpers.notImplemented
         with e ->
@@ -3907,7 +3910,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
           )
 
           do! Commands.DotnetAddProject p.Target p.Reference |> AsyncResult.ofCoreResponse
-          loadedProjectOptions |> AVal.force |> ignore
+          forceLoadProjects () |> ignore
           return { Content = "" }
         with e ->
           logger.error (
@@ -3928,7 +3931,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
           )
 
           do! Commands.DotnetRemoveProject p.Target p.Reference |> AsyncResult.ofCoreResponse
-          loadedProjectOptions |> AVal.force |> ignore
+          forceLoadProjects () |> ignore
           return { Content = "" }
         with e ->
           logger.error (
@@ -3949,7 +3952,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
           )
 
           do! Commands.DotnetSlnAdd p.Target p.Reference |> AsyncResult.ofCoreResponse
-          loadedProjectOptions |> AVal.force |> ignore
+          forceLoadProjects () |> ignore
           return { Content = "" }
         with e ->
           logger.error (
@@ -4094,7 +4097,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
             Commands.FsProjMoveFileUp p.FsProj p.FileVirtualPath
             |> AsyncResult.ofCoreResponse
 
-          loadedProjectOptions |> AVal.force |> ignore
+          forceLoadProjects () |> ignore
           return { Content = "" }
         with e ->
           logger.error (
@@ -4119,7 +4122,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
             Commands.FsProjMoveFileDown p.FsProj p.FileVirtualPath
             |> AsyncResult.ofCoreResponse
 
-          loadedProjectOptions |> AVal.force |> ignore
+          forceLoadProjects () |> ignore
           return { Content = "" }
         with e ->
           logger.error (
@@ -4144,7 +4147,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
             Commands.addFileAbove p.FsProj p.FileVirtualPath p.NewFile
             |> AsyncResult.ofCoreResponse
 
-          loadedProjectOptions |> AVal.force |> ignore
+          forceLoadProjects () |> ignore
           return { Content = "" }
         with e ->
           logger.error (
@@ -4168,7 +4171,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
             Commands.addFileBelow p.FsProj p.FileVirtualPath p.NewFile
             |> AsyncResult.ofCoreResponse
 
-          loadedProjectOptions |> AVal.force |> ignore
+          forceLoadProjects () |> ignore
           return { Content = "" }
         with e ->
           logger.error (
@@ -4190,7 +4193,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
           )
 
           do! Commands.addFile p.FsProj p.FileVirtualPath |> AsyncResult.ofCoreResponse
-          loadedProjectOptions |> AVal.force |> ignore
+          forceLoadProjects () |> ignore
           return { Content = "" }
         with e ->
           logger.error (
@@ -4212,7 +4215,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
 
           let fullPath = Path.Combine(Path.GetDirectoryName p.FsProj, p.FileVirtualPath)
           do! Commands.removeFile p.FsProj p.FileVirtualPath |> AsyncResult.ofCoreResponse
-          loadedProjectOptions |> AVal.force |> ignore
+          forceLoadProjects () |> ignore
           let fileUri = Path.FilePathToUri fullPath
           diagnosticCollections.ClearFor fileUri
 
@@ -4239,7 +4242,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
             Commands.addExistingFile p.FsProj p.FileVirtualPath
             |> AsyncResult.ofCoreResponse
 
-          loadedProjectOptions |> AVal.force |> ignore
+          forceLoadProjects () |> ignore
           return { Content = "" }
         with e ->
           logger.error (

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -188,16 +188,12 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
 
   let analyzersEnabled = config |> AVal.map (fun c -> c.EnableAnalyzers)
 
-  let checker =
-    analyzersEnabled
-    |> AVal.map (FSharpCompilerServiceChecker)
+  let checker = analyzersEnabled |> AVal.map (FSharpCompilerServiceChecker)
 
   /// The reality is a file can be in multiple projects
   /// This is extracted to make it easier to do some type of customized select
   /// in the future
-  let selectProject projs =
-    projs
-    |> List.tryHead
+  let selectProject projs = projs |> List.tryHead
 
   let mutableConfigChanges =
     let toCompilerToolArgument (path: string) = sprintf "--compilertool:%s" path
@@ -250,6 +246,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
         Loggers.analyzers.info (Log.setMessage "Analyzers disabled")
 
       let di = DirectoryInfo config.DotNetRoot
+
       if di.Exists then
         let dotnetBinary =
           if
@@ -602,10 +599,10 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
     )
 
   let getLastUTCChangeForFile (filePath: string<LocalPath>) =
-      AdaptiveFile.GetLastWriteTimeUtc(UMX.untag filePath)
-      |> AVal.map (fun writeTime -> filePath, writeTime)
+    AdaptiveFile.GetLastWriteTimeUtc(UMX.untag filePath)
+    |> AVal.map (fun writeTime -> filePath, writeTime)
 
-  let addAValLogging cb (aval : aval<_>) =
+  let addAValLogging cb (aval: aval<_>) =
     let cb = aval.AddMarkingCallback(cb)
     aval |> AVal.mapDisposableTuple (fun x -> x, cb)
 
@@ -613,13 +610,12 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
     let file = getLastUTCChangeForFile filePath
 
     let logMsg () =
-        logger.info (
-          Log.setMessage "Loading projects because of {delta}"
-          >> Log.addContextDestructured "delta" filePath
-        )
+      logger.info (
+        Log.setMessage "Loading projects because of {delta}"
+        >> Log.addContextDestructured "delta" filePath
+      )
 
-    file
-    |> addAValLogging logMsg
+    file |> addAValLogging logMsg
 
   let loader = cval<Ionide.ProjInfo.IWorkspaceLoader> workspaceLoader
 
@@ -702,7 +698,9 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
 
 
             use progressReport = new ServerProgressReport(lspClient)
-            progressReport.Begin($"Loading {projects.Count} Projects") |> Async.RunSynchronously
+
+            progressReport.Begin($"Loading {projects.Count} Projects")
+            |> Async.RunSynchronously
 
             let projectOptions =
               loader.LoadProjects(projects |> Seq.map (fst >> UMX.untag) |> Seq.toList, [], binlogConfig)
@@ -796,9 +794,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
         return options |> List.map fst
     }
 
-  let forceLoadProjects () =
-    loadedProjectOptions
-    |> AVal.force
+  let forceLoadProjects () = loadedProjectOptions |> AVal.force
 
 
   let sourceFileToProjectOptions =
@@ -1044,11 +1040,9 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
 
   let allProjectOptions =
     let wins =
-      openFilesToChangesAndProjectOptions
-      |> AMap.map (fun k v -> v |> AVal.map snd)
-    let loses =
-      sourceFileToProjectOptions
-      |> AMap.map(fun k v -> AVal.constant v)
+      openFilesToChangesAndProjectOptions |> AMap.map (fun k v -> v |> AVal.map snd)
+
+    let loses = sourceFileToProjectOptions |> AMap.map (fun k v -> AVal.constant v)
     AMap.union loses wins
 
   let getProjectOptionsForFile (filePath: string<LocalPath>) =

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -871,9 +871,9 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
       })
 
   let getProjectOptionsForFile (filePath: string<LocalPath>) =
-    openFilesToChangesAndProjectOptions
-    |> AMap.tryFindA filePath
-    |> AVal.map (Option.map snd >> Option.defaultValue [])
+    sourceFileToProjectOptions
+    |> AMap.tryFind filePath
+    |> AVal.map (Option.defaultValue [])
 
   let autoCompleteItems: cmap<DeclName, DeclarationListItem * Position * string<LocalPath> * (Position -> option<string>) * FSharp.Compiler.Syntax.ParsedInput> =
     cmap ()

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -583,6 +583,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
             // Set some default values as FCS uses these for identification/caching purposes
             let fso =
               { fso with
+                  SourceFiles = fso.SourceFiles |> Array.map(Utils.normalizePath >> UMX.untag)
                   Stamp = fso.Stamp |> Option.orElse (Some DateTime.UtcNow.Ticks)
                   ProjectId = fso.ProjectId |> Option.orElse (Some(Guid.NewGuid().ToString())) }
 

--- a/src/FsAutoComplete/Parser.fs
+++ b/src/FsAutoComplete/Parser.fs
@@ -109,14 +109,16 @@ module Parser =
     rootCommand.AddOption logLevelOption
     rootCommand.AddOption stateLocationOption
 
+    let globalProps = [ "ProduceReferenceAssembly", "false" ]
 
     rootCommand.SetHandler(
       Func<_, _, _, Task>(fun projectGraphEnabled stateDirectory adaptiveLspEnabled ->
         let workspaceLoaderFactory =
-          if projectGraphEnabled then
-            Ionide.ProjInfo.WorkspaceLoaderViaProjectGraph.Create
-          else
-            Ionide.ProjInfo.WorkspaceLoader.Create
+          fun toolsPath ->
+            if projectGraphEnabled then
+              Ionide.ProjInfo.WorkspaceLoaderViaProjectGraph.Create(toolsPath, globalProps)
+            else
+              Ionide.ProjInfo.WorkspaceLoader.Create(toolsPath, globalProps)
 
         let dotnetPath =
           if

--- a/src/FsAutoComplete/Parser.fs
+++ b/src/FsAutoComplete/Parser.fs
@@ -14,6 +14,7 @@ open System.Threading.Tasks
 open FsAutoComplete.Lsp
 
 module Parser =
+  open FsAutoComplete.Core
 
   [<Struct>]
   type Pos = { Line: int; Column: int }
@@ -109,16 +110,16 @@ module Parser =
     rootCommand.AddOption logLevelOption
     rootCommand.AddOption stateLocationOption
 
-    let globalProps = [ "ProduceReferenceAssembly", "false" ]
+
 
     rootCommand.SetHandler(
       Func<_, _, _, Task>(fun projectGraphEnabled stateDirectory adaptiveLspEnabled ->
         let workspaceLoaderFactory =
           fun toolsPath ->
             if projectGraphEnabled then
-              Ionide.ProjInfo.WorkspaceLoaderViaProjectGraph.Create(toolsPath, globalProps)
+              Ionide.ProjInfo.WorkspaceLoaderViaProjectGraph.Create(toolsPath, ProjectLoader.globalProperties)
             else
-              Ionide.ProjInfo.WorkspaceLoader.Create(toolsPath, globalProps)
+              Ionide.ProjInfo.WorkspaceLoader.Create(toolsPath, ProjectLoader.globalProperties)
 
         let dotnetPath =
           if

--- a/test/FsAutoComplete.Tests.Lsp/CodeLensTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeLensTests.fs
@@ -11,6 +11,7 @@ open Utils.Utils
 open Utils.CursorbasedTests
 open Utils.Tests.TextEdit
 open Newtonsoft.Json.Linq
+open Helpers.Expecto.ShadowedTimeouts
 
 module private CodeLens =
   let assertNoDiagnostics (ds: Diagnostic []) =

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -8,6 +8,7 @@ open FsAutoComplete.Utils
 open FsAutoComplete.Lsp
 open FsToolkit.ErrorHandling
 open Utils.Server
+open Helpers.Expecto.ShadowedTimeouts
 
 let tests state =
   let server =

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -27,7 +27,8 @@ let tests state =
     }
     |> Async.Cache
 
-  testList
+  testSequenced
+  <| testList
     "Completion Tests"
     [ testCaseAsync
         "simple module member completion on dot"

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -264,7 +264,7 @@ let tooltipTests state =
           verifySignature 1 5 "val listOfTuples : list<int * int>" // verify we default to prefix-generics style
           verifySignature 2 5 "val listOfStructTuples : list<struct (int * int)>" // verify we render struct tuples in a round-tripabble format
           verifySignature 3 5 "val floatThatShouldHaveGenericReportedInTooltip : float" // verify we strip <MeasureOne> measure annotations
-          pverifyDescription "This test depends on FSharp.Core.xml being in the bin directory of these tests"
+          verifyDescription
             4
             4
             [ "**Description**"

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -22,6 +22,7 @@ open Utils.Utils
 open FsToolkit.ErrorHandling.Operator.AsyncResult
 open FSharpx.Control
 open Utils.Tests
+open Helpers.Expecto.ShadowedTimeouts
 
 ///Test for initialization of the server
 let initTests createServer =

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -223,11 +223,11 @@ let tooltipTests state =
 
   let concatLines = String.concat Environment.NewLine
 
-  let verifyDescription line character expectedDescription =
+  let verifyDescriptionImpl testCaseAsync line character expectedDescription =
     let expectedDescription = concatLines expectedDescription
 
     testCaseAsync
-      (sprintf "description for line %d character %d should be '%s" line character expectedDescription)
+      (sprintf "description for line %d character %d" line character)
       (async {
         let! server, scriptPath = server
 
@@ -241,9 +241,12 @@ let tooltipTests state =
         | Ok response -> failtestf "Should have gotten description but got %A" response
         | Result.Error errors -> failtestf "Error while getting description: %A" errors
       })
+  let verifyDescription line character expectedDescription = verifyDescriptionImpl testCaseAsync line character expectedDescription
+  let pverifyDescription reason line character expectedDescription = verifyDescriptionImpl ptestCaseAsync line character expectedDescription
+  let fverifyDescription  line character expectedDescription = verifyDescriptionImpl ftestCaseAsync line character expectedDescription
 
-
-  testList
+  testSequenced
+  <| testList
     "tooltip evaluation"
     [ testList
         "tests"
@@ -260,7 +263,7 @@ let tooltipTests state =
           verifySignature 1 5 "val listOfTuples : list<int * int>" // verify we default to prefix-generics style
           verifySignature 2 5 "val listOfStructTuples : list<struct (int * int)>" // verify we render struct tuples in a round-tripabble format
           verifySignature 3 5 "val floatThatShouldHaveGenericReportedInTooltip : float" // verify we strip <MeasureOne> measure annotations
-          verifyDescription
+          pverifyDescription "This test depends on FSharp.Core.xml being in the bin directory of these tests"
             4
             4
             [ "**Description**"

--- a/test/FsAutoComplete.Tests.Lsp/DependentFileCheckingTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/DependentFileCheckingTests.fs
@@ -86,7 +86,7 @@ let tests state =
       let crossProject = crossProjectRoot tfm
       let aFile, bFile = Path.Join("Library1" </> "A.fs"), ("App" </> "B.fs")
       testList $"CrossProject-{tfm}" [
-        fserverTestList "single" state defaultConfigDto (Some crossProject) (fun server -> [
+        serverTestList "single" state defaultConfigDto (Some crossProject) (fun server -> [
           testCaseAsync "When A is modified B is re-checked" (async {
             // open the files as they are on-disk and verify things are good
             let! (aDoc, aDiags) = Server.openDocument aFile server

--- a/test/FsAutoComplete.Tests.Lsp/DependentFileCheckingTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/DependentFileCheckingTests.fs
@@ -11,62 +11,105 @@ open FSharp.Control.Reactive
 open FSharpx.Control
 open Helpers.Expecto.ShadowedTimeouts
 
+let (</>) (path1 : string) path2 = Path.Join(path1, path2)
+
 let tests state =
-  let root = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "DependentFileChecking", "SameProject")
+  let sameProjectRoot = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "DependentFileChecking", "SameProject")
+  let crossProjectRoot tfm = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "DependentFileChecking", $"CrossProject-{tfm}")
+  let tfms = [
+#if NET6_0_OR_GREATER
+    "net6.0"
+#endif
+#if NET7_0_OR_GREATER
+    "net7.0"
+#endif
+  ]
   let aFile, bFile = "A.fs", "B.fs"
   testList (nameof DependentFileChecking) [
-    // Separate server for each test
-    // Otherwise share diag stream -> second test must skip diags of first tests. But only when first test runs (-> running all tests vs. running test alone)
-    serverTestList "single" state defaultConfigDto (Some root) (fun server -> [
-      testCaseAsync "When A is modified B is re-checked" (async {
-        // open the files as they are on-disk and verify things are good
-        let! (aDoc, aDiags) = Server.openDocument aFile server
-        let! (bDoc, bDiags) = Server.openDocument bFile server
-        use aDoc = aDoc
-        use bDoc = bDoc
-        Expect.isEmpty aDiags $"There should be no diagnostics in {aFile}"
-        Expect.isEmpty bDiags $"There should be no diagnostics in {bFile}"
-        let bDiagsStream = bDoc.CompilerDiagnostics
-        // make a change to A (that is clearly incorrect)
-        let! startAChange = Document.saveText "farts" aDoc |> Async.StartChild
-        // start listening for new diagnostics for B
-        let! diagnosticsForBWaiter =
-          bDiagsStream
-          |> Observable.timeoutSpan (TimeSpan.FromSeconds 15.)
-          |> Async.AwaitObservable
-          |> Async.StartChild
-        let! aDiags = startAChange
-        Expect.isNonEmpty aDiags $"Should have had some compilation errors for {aFile} after erroneous changes"
-        // observe that compilation errors are reported for B
-        let! bDiags = diagnosticsForBWaiter
-        Expect.isNonEmpty bDiags $"Should have some compilation errors for {bFile} after erroneous change to {aFile}"
-      })
-    ])
-    serverTestList "multi" state defaultConfigDto (Some root) (fun server -> [
-      testCaseAsync "When A is modified repeatedly, B is re-checked after each modification" (async {
-        // open the files as they are on-disk and verify things are good
-        let! (aDoc, aDiags) = Server.openDocument aFile server
-        let! (bDoc, bDiags) = Server.openDocument bFile server
-        use aDoc = aDoc
-        use bDoc = bDoc
-        Expect.isEmpty aDiags $"There should be no diagnostics in {aFile}"
-        Expect.isEmpty bDiags $"There should be no diagnostics in {bFile}"
-        let bDiagsStream = bDoc.CompilerDiagnostics
-        for i in 0..10 do
+    testList "SameProject" [
+      // Separate server for each test
+      // Otherwise share diag stream -> second test must skip diags of first tests. But only when first test runs (-> running all tests vs. running test alone)
+      serverTestList "single" state defaultConfigDto (Some sameProjectRoot) (fun server -> [
+        testCaseAsync "When A is modified B is re-checked" (async {
+          // open the files as they are on-disk and verify things are good
+          let! (aDoc, aDiags) = Server.openDocument aFile server
+          let! (bDoc, bDiags) = Server.openDocument bFile server
+          use aDoc = aDoc
+          use bDoc = bDoc
+          Expect.isEmpty aDiags $"There should be no diagnostics in {aFile}"
+          Expect.isEmpty bDiags $"There should be no diagnostics in {bFile}"
+          let bDiagsStream = bDoc.CompilerDiagnostics
           // make a change to A (that is clearly incorrect)
           let! startAChange = Document.saveText "farts" aDoc |> Async.StartChild
           // start listening for new diagnostics for B
           let! diagnosticsForBWaiter =
             bDiagsStream
-            |> Observable.skip i
             |> Observable.timeoutSpan (TimeSpan.FromSeconds 15.)
             |> Async.AwaitObservable
             |> Async.StartChild
           let! aDiags = startAChange
-          Expect.isNonEmpty aDiags $"Should have had some compilation errors for {aFile} after erroneous change #%d{i}"
+          Expect.isNonEmpty aDiags $"Should have had some compilation errors for {aFile} after erroneous changes"
           // observe that compilation errors are reported for B
           let! bDiags = diagnosticsForBWaiter
-          Expect.isNonEmpty bDiags $"Should have some compilation errors for {bFile} after erroneous change #%d{i} to {aFile}"
-      })
-    ])
+          Expect.isNonEmpty bDiags $"Should have some compilation errors for {bFile} after erroneous change to {aFile}"
+        })
+      ])
+      serverTestList "multi" state defaultConfigDto (Some sameProjectRoot) (fun server -> [
+        testCaseAsync "When A is modified repeatedly, B is re-checked after each modification" (async {
+          // open the files as they are on-disk and verify things are good
+          let! (aDoc, aDiags) = Server.openDocument aFile server
+          let! (bDoc, bDiags) = Server.openDocument bFile server
+          use aDoc = aDoc
+          use bDoc = bDoc
+          Expect.isEmpty aDiags $"There should be no diagnostics in {aFile}"
+          Expect.isEmpty bDiags $"There should be no diagnostics in {bFile}"
+          let bDiagsStream = bDoc.CompilerDiagnostics
+          for i in 0..10 do
+            // make a change to A (that is clearly incorrect)
+            let! startAChange = Document.saveText "farts" aDoc |> Async.StartChild
+            // start listening for new diagnostics for B
+            let! diagnosticsForBWaiter =
+              bDiagsStream
+              |> Observable.skip i
+              |> Observable.timeoutSpan (TimeSpan.FromSeconds 15.)
+              |> Async.AwaitObservable
+              |> Async.StartChild
+            let! aDiags = startAChange
+            Expect.isNonEmpty aDiags $"Should have had some compilation errors for {aFile} after erroneous change #%d{i}"
+            // observe that compilation errors are reported for B
+            let! bDiags = diagnosticsForBWaiter
+            Expect.isNonEmpty bDiags $"Should have some compilation errors for {bFile} after erroneous change #%d{i} to {aFile}"
+        })
+      ])
+    ]
+    for tfm in tfms do
+      let crossProject = crossProjectRoot tfm
+      let aFile, bFile = Path.Join("Library1" </> "A.fs"), ("App" </> "B.fs")
+      testList $"CrossProject-{tfm}" [
+        fserverTestList "single" state defaultConfigDto (Some crossProject) (fun server -> [
+          testCaseAsync "When A is modified B is re-checked" (async {
+            // open the files as they are on-disk and verify things are good
+            let! (aDoc, aDiags) = Server.openDocument aFile server
+            let! (bDoc, bDiags) = Server.openDocument bFile server
+            use aDoc = aDoc
+            use bDoc = bDoc
+            Expect.isEmpty aDiags $"There should be no diagnostics in {aFile}"
+            Expect.isEmpty bDiags $"There should be no diagnostics in {bFile}"
+            let bDiagsStream = bDoc.CompilerDiagnostics
+            // make a change to A (that is clearly incorrect)
+            let! startAChange = Document.saveText "farts" aDoc |> Async.StartChild
+            // start listening for new diagnostics for B
+            let! diagnosticsForBWaiter =
+              bDiagsStream
+              |> Observable.timeoutSpan (TimeSpan.FromSeconds 15.)
+              |> Async.AwaitObservable
+              |> Async.StartChild
+            let! aDiags = startAChange
+            Expect.isNonEmpty aDiags $"Should have had some compilation errors for {aFile} after erroneous changes"
+            // observe that compilation errors are reported for B
+            let! bDiags = diagnosticsForBWaiter
+            Expect.isNonEmpty bDiags $"Should have some compilation errors for {bFile} after erroneous change to {aFile}"
+          })
+        ])
+      ]
   ]

--- a/test/FsAutoComplete.Tests.Lsp/DependentFileCheckingTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/DependentFileCheckingTests.fs
@@ -27,12 +27,12 @@ let tests state =
         Expect.isEmpty bDiags $"There should be no diagnostics in {bFile}"
         let bDiagsStream = bDoc.CompilerDiagnostics
         // make a change to A (that is clearly incorrect)
-        let! startAChange = Document.changeTextTo "farts" aDoc |> Async.StartChild
+        let! startAChange = Document.saveText "farts" aDoc |> Async.StartChild
         // start listening for new diagnostics for B
-        let! diagnosticsForBWaiter = 
-          bDiagsStream 
-          |> Observable.timeoutSpan (TimeSpan.FromSeconds 15.) 
-          |> Async.AwaitObservable 
+        let! diagnosticsForBWaiter =
+          bDiagsStream
+          |> Observable.timeoutSpan (TimeSpan.FromSeconds 15.)
+          |> Async.AwaitObservable
           |> Async.StartChild
         let! aDiags = startAChange
         Expect.isNonEmpty aDiags $"Should have had some compilation errors for {aFile} after erroneous changes"
@@ -53,13 +53,13 @@ let tests state =
         let bDiagsStream = bDoc.CompilerDiagnostics
         for i in 0..10 do
           // make a change to A (that is clearly incorrect)
-          let! startAChange = Document.changeTextTo "farts" aDoc |> Async.StartChild
+          let! startAChange = Document.saveText "farts" aDoc |> Async.StartChild
           // start listening for new diagnostics for B
-          let! diagnosticsForBWaiter = 
-            bDiagsStream 
+          let! diagnosticsForBWaiter =
+            bDiagsStream
             |> Observable.skip i
-            |> Observable.timeoutSpan (TimeSpan.FromSeconds 15.) 
-            |> Async.AwaitObservable 
+            |> Observable.timeoutSpan (TimeSpan.FromSeconds 15.)
+            |> Async.AwaitObservable
             |> Async.StartChild
           let! aDiags = startAChange
           Expect.isNonEmpty aDiags $"Should have had some compilation errors for {aFile} after erroneous change #%d{i}"

--- a/test/FsAutoComplete.Tests.Lsp/DependentFileCheckingTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/DependentFileCheckingTests.fs
@@ -9,6 +9,7 @@ open Utils.Server
 open System
 open FSharp.Control.Reactive
 open FSharpx.Control
+open Helpers.Expecto.ShadowedTimeouts
 
 let tests state =
   let root = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "DependentFileChecking", "SameProject")

--- a/test/FsAutoComplete.Tests.Lsp/DetectUnitTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/DetectUnitTests.fs
@@ -7,6 +7,7 @@ open FsAutoComplete
 open FsAutoComplete.LspHelpers
 open Helpers
 open FsToolkit.ErrorHandling
+open Helpers.Expecto.ShadowedTimeouts
 
 let tests state =
   let geTestNotification projectFolder fileName =

--- a/test/FsAutoComplete.Tests.Lsp/DetectUnitTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/DetectUnitTests.fs
@@ -17,8 +17,9 @@ let tests state =
       do! waitForWorkspaceFinishedParsing events
       let path = Path.Combine(path, fileName)
       let tdop: DidOpenTextDocumentParams = { TextDocument = loadDocument path }
-      do! server.TextDocumentDidOpen tdop
+      let! child = Async.StartChild(server.TextDocumentDidOpen tdop)
       let! _diagnostics = waitForParseResultsForFile fileName events
+      do! child
       return! waitForTestDetected fileName events
     }
     |> Async.Cache

--- a/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
@@ -8,7 +8,7 @@ open FsAutoComplete
 open FsAutoComplete.LspHelpers
 open Helpers
 open FsAutoComplete.Lsp
-
+open Helpers.Expecto.ShadowedTimeouts
 
 let fsdnTest state =
 

--- a/test/FsAutoComplete.Tests.Lsp/FindReferencesTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/FindReferencesTests.fs
@@ -5,6 +5,7 @@ open System.IO
 open FsAutoComplete
 open Helpers
 open Ionide.LanguageServerProtocol.Types
+open Helpers.Expecto.ShadowedTimeouts
 
 let tests state =
   testList

--- a/test/FsAutoComplete.Tests.Lsp/GoToTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/GoToTests.fs
@@ -11,6 +11,7 @@ open Utils.ServerTests
 open Utils.Server
 open Utils.Utils
 open Utils.TextEdit
+open Helpers.Expecto.ShadowedTimeouts
 
 ///GoTo tests
 let private gotoTest state =

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -434,7 +434,6 @@ let serverInitialize path (config: FSharpConfigDto) createServer =
       do! dotnetRestore path
 
     let (server: IFSharpLspServer), clientNotifications = createServer ()
-    logger.Value.Error("LOLOLOLOL")
     clientNotifications |> Observable.add logEvent
 
     let p: InitializeParams =

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -473,10 +473,9 @@ let dotnetToolRestore dir =
 let serverInitialize path (config: FSharpConfigDto) createServer =
   async {
     dotnetCleanup path
-    let files = Directory.GetFiles(path)
 
-    if files |> Seq.exists (fun p -> p.EndsWith ".fsproj") then
-      do! dotnetRestore path
+    for file in System.IO.Directory.EnumerateFiles(path, "*.fsproj", SearchOption.AllDirectories) do
+      do! file |> Path.GetDirectoryName |> dotnetRestore
 
     let (server: IFSharpLspServer), clientNotifications = createServer ()
     clientNotifications |> Observable.add logEvent

--- a/test/FsAutoComplete.Tests.Lsp/HighlightingTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/HighlightingTests.fs
@@ -6,6 +6,7 @@ open Helpers
 open FsAutoComplete.LspHelpers
 open Ionide.LanguageServerProtocol.Types
 open FsAutoComplete.Utils
+open Helpers.Expecto.ShadowedTimeouts
 
 let tests state =
   let testPath = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "HighlightingTest")

--- a/test/FsAutoComplete.Tests.Lsp/InfoPanelTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InfoPanelTests.fs
@@ -6,6 +6,7 @@ open Ionide.LanguageServerProtocol.Types
 open FsAutoComplete
 open Helpers
 open FsToolkit.ErrorHandling
+open Helpers.Expecto.ShadowedTimeouts
 
 let docFormattingTest state =
   let server =

--- a/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
@@ -9,6 +9,7 @@ open FsToolkit.ErrorHandling
 open Utils.ServerTests
 open FsAutoComplete.Core
 open FsAutoComplete.Lsp
+open Helpers.Expecto.ShadowedTimeouts
 
 module private FSharpInlayHints =
   open Utils.Server

--- a/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
@@ -1769,7 +1769,8 @@ let explicitTypeInfoTests =
   let testExplicitType textWithCursor expected =
     testExplicitType' textWithCursor (Some expected)
 
-  testList
+  testSequenced
+  <| testList
     "detect type and parens"
     [ testList
         "Expr"

--- a/test/FsAutoComplete.Tests.Lsp/InteractiveDirectivesTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InteractiveDirectivesTests.fs
@@ -2,6 +2,7 @@ module FsAutoComplete.Tests.InteractiveDirectivesTests
 
 open Expecto
 open FsAutoComplete.InteractiveDirectives
+open Helpers.Expecto.ShadowedTimeouts
 
 let interactiveDirectivesUnitTests =
   testList

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -50,8 +50,8 @@ let adaptiveLspServerFactory toolsPath workspaceLoaderFactory =
 
 let lspServers =
   [
-    "FSharpLspServer", fsharpLspServerFactory
-    // "AdaptiveLspServer", adaptiveLspServerFactory
+    // "FSharpLspServer", fsharpLspServerFactory
+    "AdaptiveLspServer", adaptiveLspServerFactory
     ]
 
 let mutable toolsPath =
@@ -88,13 +88,13 @@ let lspTests =
               dependencyManagerTests createServer
               interactiveDirectivesUnitTests
 
-              // // commented out because FSDN is down
-              // //fsdnTest createServer
-              uriTests
+              // commented out because FSDN is down
+              //fsdnTest createServer
+
               //linterTests createServer
+              uriTests
               formattingTests createServer
-              if lspName <> "AdaptiveLspServer" then
-                analyzerTests createServer // stalling on adaptive
+              analyzerTests createServer
               signatureTests createServer
               SignatureHelp.tests createServer
               CodeFixTests.Tests.tests createServer
@@ -102,8 +102,7 @@ let lspTests =
               GoTo.tests createServer
               FindReferences.tests createServer
               InfoPanelTests.docFormattingTest createServer
-              if lspName <> "AdaptiveLspServer" then
-                DetectUnitTests.tests createServer //stalling on adaptive
+              DetectUnitTests.tests createServer
               XmlDocumentationGeneration.tests createServer
               InlayHintTests.tests createServer
               DependentFileChecking.tests createServer

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -31,9 +31,10 @@ let testTimeout =
 Environment.SetEnvironmentVariable("FSAC_WORKSPACELOAD_DELAY", "250")
 
 let loaders =
-  [ "Ionide WorkspaceLoader", WorkspaceLoader.Create
-    // "MSBuild Project Graph WorkspaceLoader", WorkspaceLoaderViaProjectGraph.Create
-    ]
+  [
+    "Ionide WorkspaceLoader", (fun toolpath -> WorkspaceLoader.Create(toolpath, FsAutoComplete.Core.ProjectLoader.globalProperties))
+    "MSBuild Project Graph WorkspaceLoader", (fun toolpath -> WorkspaceLoaderViaProjectGraph.Create(toolpath, FsAutoComplete.Core.ProjectLoader.globalProperties))
+  ]
 
 let fsharpLspServerFactory toolsPath workspaceLoaderFactory =
   let testRunDir =

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -118,7 +118,9 @@ let tests =
       testList (nameof (Utils)) [ Utils.Tests.Utils.tests; Utils.Tests.TextEdit.tests ]
       InlayHintTests.explicitTypeInfoTests
 
-      lspTests ]
+      testSequenced lspTests
+
+      ]
 
 
 [<EntryPoint>]

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -33,7 +33,7 @@ Environment.SetEnvironmentVariable("FSAC_WORKSPACELOAD_DELAY", "250")
 let loaders =
   [
     "Ionide WorkspaceLoader", (fun toolpath -> WorkspaceLoader.Create(toolpath, FsAutoComplete.Core.ProjectLoader.globalProperties))
-    "MSBuild Project Graph WorkspaceLoader", (fun toolpath -> WorkspaceLoaderViaProjectGraph.Create(toolpath, FsAutoComplete.Core.ProjectLoader.globalProperties))
+    // "MSBuild Project Graph WorkspaceLoader", (fun toolpath -> WorkspaceLoaderViaProjectGraph.Create(toolpath, FsAutoComplete.Core.ProjectLoader.globalProperties))
   ]
 
 let fsharpLspServerFactory toolsPath workspaceLoaderFactory =
@@ -119,9 +119,8 @@ let tests =
       testList (nameof (Utils)) [ Utils.Tests.Utils.tests; Utils.Tests.TextEdit.tests ]
       InlayHintTests.explicitTypeInfoTests
 
-      testSequenced lspTests
-
-      ]
+      lspTests
+    ]
 
 
 [<EntryPoint>]

--- a/test/FsAutoComplete.Tests.Lsp/RenameTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/RenameTests.fs
@@ -11,6 +11,7 @@ open Utils.ServerTests
 open Utils.Server
 open Utils.Utils
 open Utils.TextEdit
+open Helpers.Expecto.ShadowedTimeouts
 
 let private normalizePathCasing =
   Path.FilePathToUri
@@ -141,7 +142,7 @@ let tests state =
             NewName = newName
           }
         let! res = doc.Server.Server.TextDocumentRename p
-        let edits = 
+        let edits =
           match res with
           | Result.Error e -> failtestf "Request failed: %A" e
           | Result.Ok None -> failtest "Request none"

--- a/test/FsAutoComplete.Tests.Lsp/ScriptTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/ScriptTests.fs
@@ -11,6 +11,7 @@ open FsToolkit.ErrorHandling
 open FSharpx.Control.Observable
 open FSharp.Control.Reactive
 open System
+open Helpers.Expecto.ShadowedTimeouts
 
 let scriptPreviewTests state =
   let server =

--- a/test/FsAutoComplete.Tests.Lsp/SignatureHelpTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/SignatureHelpTests.fs
@@ -8,6 +8,7 @@ open Utils.Server
 open Utils.Utils
 open Utils.TextEdit
 open Utils.ServerTests
+open Helpers.Expecto.ShadowedTimeouts
 
 type private TriggerType =
   | Manual

--- a/test/FsAutoComplete.Tests.Lsp/TemplatesTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TemplatesTests.fs
@@ -1,6 +1,7 @@
 module FsAutoComplete.Tests.Templates
 
 open Expecto
+open Helpers.Expecto.ShadowedTimeouts
 
 let withEnvironmentVariable (variable: string) (value: string) (f: unit -> unit) =
   let priorValue = System.Environment.GetEnvironmentVariable variable

--- a/test/FsAutoComplete.Tests.Lsp/TemplatesTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TemplatesTests.fs
@@ -13,7 +13,8 @@ let withEnvironmentVariable (variable: string) (value: string) (f: unit -> unit)
     System.Environment.SetEnvironmentVariable(variable, priorValue)
 
 let tests () =
-  testList
+  testSequenced
+  <| testList
     "Templates Tests"
     [ testCase "Templates are not empty"
       <| fun () ->

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net6.0/App/App.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net6.0/App/App.fsproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="B.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Library1\Library1.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net6.0/App/B.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net6.0/App/B.fs
@@ -1,0 +1,5 @@
+﻿[<EntryPoint>]
+let main _ =
+  let greet name = Library1.Say.hello name
+  greet "lol"
+  0

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net6.0/Library1/A.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net6.0/Library1/A.fs
@@ -1,0 +1,5 @@
+﻿namespace Library1
+
+module Say =
+    let hello name =
+        printfn "Hello %s" name

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net6.0/Library1/Library1.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net6.0/Library1/Library1.fsproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="A.fs" />
+  </ItemGroup>
+
+</Project>

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net7.0/App/App.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net7.0/App/App.fsproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="B.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Library1\Library1.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net7.0/App/B.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net7.0/App/B.fs
@@ -1,0 +1,5 @@
+﻿[<EntryPoint>]
+let main _ =
+  let greet name = Library1.Say.hello name
+  greet "lol"
+  0

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net7.0/Library1/A.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net7.0/Library1/A.fs
@@ -1,0 +1,5 @@
+﻿namespace Library1
+
+module Say =
+    let hello name =
+        printfn "Hello %s" name

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net7.0/Library1/Library1.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net7.0/Library1/Library1.fsproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="A.fs" />
+  </ItemGroup>
+
+</Project>

--- a/test/FsAutoComplete.Tests.Lsp/UnsedDeclarationsTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/UnsedDeclarationsTests.fs
@@ -8,6 +8,7 @@ open Utils.TextEdit
 open Utils.Utils
 open Ionide.LanguageServerProtocol.Types
 open System.IO
+open Helpers.Expecto.ShadowedTimeouts
 
 type private Expected =
   | Used

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
@@ -62,10 +62,9 @@ module Server =
       | Some path ->
         dotnetCleanup path
 
-        if System.IO.Directory.EnumerateFiles(path, "*.fsproj")
-           |> Seq.isEmpty
-           |> not then
-          do! dotnetRestore path
+        for file in System.IO.Directory.EnumerateFiles(path, "*.fsproj", SearchOption.AllDirectories) do
+          do! file |> Path.GetDirectoryName |> dotnetRestore
+
       let (server : IFSharpLspServer, events : IObservable<_>) = createServer ()
       events |> Observable.add logEvent
 

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
@@ -194,6 +194,9 @@ module Server =
         |> Utils.normalizePath
         |> FSharp.UMX.UMX.untag
 
+      // To avoid hitting the typechecker cache, we need to update the file's timestamp
+      IO.File.SetLastWriteTimeUtc(fullPath, DateTime.UtcNow)
+
       let doc =
         server
         |> createDocument fullPath (Path.FilePathToUri fullPath)
@@ -375,6 +378,7 @@ module Document =
         Text = Some text
         TextDocument = doc.TextDocumentIdentifier
       }
+      // Simulate the file being written to disk so we don't hit the typechecker cache
       IO.File.SetLastWriteTimeUtc(doc.FilePath, DateTime.Now)
       do! doc.Server.Server.TextDocumentDidSave p
       do! Async.Sleep(TimeSpan.FromMilliseconds 250.)

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
@@ -379,7 +379,7 @@ module Document =
         TextDocument = doc.TextDocumentIdentifier
       }
       // Simulate the file being written to disk so we don't hit the typechecker cache
-      IO.File.SetLastWriteTimeUtc(doc.FilePath, DateTime.Now)
+      IO.File.SetLastWriteTimeUtc(doc.FilePath, DateTime.UtcNow)
       do! doc.Server.Server.TextDocumentDidSave p
       do! Async.Sleep(TimeSpan.FromMilliseconds 250.)
       return! doc |> waitForLatestDiagnostics Helpers.defaultTimeout

--- a/test/FsAutoComplete.Tests.Lsp/XmlGenerationTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/XmlGenerationTests.fs
@@ -7,6 +7,7 @@ open FsToolkit.ErrorHandling
 open Helpers
 open Ionide.LanguageServerProtocol.Types
 open System.IO
+open Helpers.Expecto.ShadowedTimeouts
 
 open type System.Environment
 

--- a/test/FsAutoComplete.Tests.Lsp/paket.references
+++ b/test/FsAutoComplete.Tests.Lsp/paket.references
@@ -1,4 +1,4 @@
-FSharp.Core
+FSharp.Core content: once
 FSharp.Compiler.Service
 FSharp.Control.Reactive
 FSharpx.Async


### PR DESCRIPTION
Notable changes:

- Fixes remaining tests for Adaptive LSP Server. 
- Fixes ReferenceAssemblies interfering with type checks across projects on net7.0 project
- Adds ability to timeout individual tests to prevent whole test suite from stalling