### PR TITLE
Workaround for ref assemblies interfering with typechecks

### DIFF
--- a/src/FsAutoComplete/Parser.fs
+++ b/src/FsAutoComplete/Parser.fs
@@ -109,14 +109,16 @@ module Parser =
     rootCommand.AddOption logLevelOption
     rootCommand.AddOption stateLocationOption
 
+    let globalProps = [ "ProduceReferenceAssembly", "false" ]
 
     rootCommand.SetHandler(
       Func<_, _, _, Task>(fun projectGraphEnabled stateDirectory adaptiveLspEnabled ->
         let workspaceLoaderFactory =
-          if projectGraphEnabled then
-            Ionide.ProjInfo.WorkspaceLoaderViaProjectGraph.Create
-          else
-            Ionide.ProjInfo.WorkspaceLoader.Create
+          fun toolsPath ->
+            if projectGraphEnabled then
+              Ionide.ProjInfo.WorkspaceLoaderViaProjectGraph.Create(toolsPath, globalProps)
+            else
+              Ionide.ProjInfo.WorkspaceLoader.Create(toolsPath, globalProps)
 
         let dotnetPath =
           if


### PR DESCRIPTION
An issue was report on discord that Ionide wasn't type checking across projects.  I narrowed it down to net6 vs net7 issue, turns out `ProduceReferenceAssembly` is turned on by default for net7 projects. I verified it locally but we should probably update our tests to make sure we can deal with this net7 issue. 