### PR TITLE
Update Fantomas.Client to 0.9.0

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -24,7 +24,7 @@ NUGET
       DiffPlex (>= 1.6.3)
       Expecto (>= 9.0.4)
       FSharp.Core (>= 4.6)
-    Fantomas.Client (0.7)
+    Fantomas.Client (0.9)
       FSharp.Core (>= 5.0.1)
       SemanticVersioning (>= 2.0.2)
       StreamJsonRpc (>= 2.8.28)

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -433,7 +433,8 @@ module Commands =
           formatDocumentAsync
             { SourceCode = currentCode
               FilePath = filePath
-              Config = None }
+              Config = None
+              Cursor = None }
 
         match fantomasResponse with
         | { Code = 1; Content = Some code } ->


### PR DESCRIPTION
See https://github.com/fsprojects/fantomas/issues/2727, you can now pass the current cursor position and get the supposed cursor location after formatting.

This version also contains a fix that users of both the `5.x` and `6.x` series can keep connecting to Fantomas.Client.