### PR TITLE
Don't put a space before the colons in union field signatures.

### DIFF
--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -173,7 +173,7 @@ module SignatureFormatter =
           if unionField.Name.StartsWith "Item" then //TODO: Some better way of dettecting default names for the union cases' fields
             formatFSharpType displayContext unionField.FieldType
           else
-            unionField.Name ++ ":" ++ (formatFSharpType displayContext unionField.FieldType))
+            unionField.Name + ":" ++ (formatFSharpType displayContext unionField.FieldType))
         |> String.concat " * "
 
       unionCase.DisplayName + " of " + typeList

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -364,7 +364,8 @@ let tooltipTests state =
               [ "static member Start:"
                 "   body             : (MailboxProcessor<string> -> Async<unit>) *"
                 "   cancellationToken: option<System.Threading.CancellationToken>"
-                "                   -> MailboxProcessor<string>" ]) ] ]
+                "                   -> MailboxProcessor<string>" ])
+          verifySignature 54 9 "Case2 of string * newlineBefore: bool * newlineAfter: bool" ] ]
 
 let closeTests state =
   // Note: clear diagnostics also implies clear caches (-> remove file & project options from State).

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -49,3 +49,7 @@ let mailbox =
   MailboxProcessor<string>.Start(
     fun _ -> async.Return()
   )
+
+type DiscUnionWithCaseOfLabeledTuple =
+    | Case1
+    | Case2 of string * newlineBefore: bool * newlineAfter: bool


### PR DESCRIPTION
Honor the style guide in signatures of DU fields:

Before:

![Screenshot 2023-02-25 121701](https://user-images.githubusercontent.com/3221269/221356248-6dcb67c2-134d-41b1-8118-44b16fed21a5.png)

After:

![Screenshot 2023-02-25 121735](https://user-images.githubusercontent.com/3221269/221356263-393826f0-cbd2-4a8b-a6c2-7a5191d40516.png)
