### PR TITLE
Don't report InfoRes as internalErrors

### DIFF
--- a/src/FsAutoComplete/LspServers/Common.fs
+++ b/src/FsAutoComplete/LspServers/Common.fs
@@ -30,18 +30,15 @@ open FSharp.Compiler.Symbols
 open Fantomas.Client.Contracts
 open Fantomas.Client.LSPFantomasService
 
-
-
-
 module Result =
   let ofStringErr r =
     r |> Result.mapError JsonRpc.Error.InternalErrorMessage
 
   let ofCoreResponse (r: CoreResponse<'a>) =
     match r with
-    | CoreResponse.Res a -> Ok a
-    | CoreResponse.ErrorRes msg
-    | CoreResponse.InfoRes msg -> Error(JsonRpc.Error.InternalErrorMessage msg)
+    | CoreResponse.Res a -> Ok(Some a)
+    | CoreResponse.ErrorRes msg -> Error(JsonRpc.Error.InternalErrorMessage msg)
+    | CoreResponse.InfoRes _ -> Ok None
 
 module AsyncResult =
   let ofCoreResponse (ar: Async<CoreResponse<'a>>) = ar |> Async.map Result.ofCoreResponse

--- a/src/FsAutoComplete/LspServers/IFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/IFSharpLspServer.fs
@@ -19,30 +19,29 @@ type OptionallyVersionedTextDocumentPositionParams =
 [<Interface>]
 type IFSharpLspServer =
   inherit ILspServer
-  abstract FSharpSignature: TextDocumentPositionParams -> Async<LspResult<PlainNotification>>
-  abstract FSharpSignatureData: TextDocumentPositionParams -> Async<LspResult<PlainNotification>>
+  abstract FSharpSignature: TextDocumentPositionParams -> Async<LspResult<PlainNotification option>>
+  abstract FSharpSignatureData: TextDocumentPositionParams -> Async<LspResult<PlainNotification option>>
   abstract FSharpDocumentationGenerator: OptionallyVersionedTextDocumentPositionParams -> AsyncLspResult<unit>
-  abstract FSharpLineLense: ProjectParms -> Async<LspResult<PlainNotification>>
-  abstract FSharpCompilerLocation: obj -> Async<LspResult<PlainNotification>>
+  abstract FSharpLineLens: ProjectParms -> Async<LspResult<PlainNotification option>>
   abstract FSharpWorkspaceLoad: WorkspaceLoadParms -> Async<LspResult<PlainNotification>>
   abstract FSharpWorkspacePeek: WorkspacePeekRequest -> Async<LspResult<PlainNotification>>
   abstract FSharpProject: ProjectParms -> Async<LspResult<PlainNotification>>
   abstract FSharpFsdn: FsdnRequest -> Async<LspResult<PlainNotification>>
-  abstract FSharpDotnetNewList: DotnetNewListRequest -> Async<LspResult<PlainNotification>>
-  abstract FSharpDotnetNewRun: DotnetNewRunRequest -> Async<LspResult<PlainNotification>>
-  abstract FSharpDotnetAddProject: DotnetProjectRequest -> Async<LspResult<PlainNotification>>
-  abstract FSharpDotnetRemoveProject: DotnetProjectRequest -> Async<LspResult<PlainNotification>>
-  abstract FSharpDotnetSlnAdd: DotnetProjectRequest -> Async<LspResult<PlainNotification>>
-  abstract FSharpHelp: TextDocumentPositionParams -> Async<LspResult<PlainNotification>>
-  abstract FSharpDocumentation: TextDocumentPositionParams -> Async<LspResult<PlainNotification>>
-  abstract FSharpDocumentationSymbol: DocumentationForSymbolReuqest -> Async<LspResult<PlainNotification>>
+  abstract FSharpDotnetNewList: DotnetNewListRequest -> Async<LspResult<PlainNotification option>>
+  abstract FSharpDotnetNewRun: DotnetNewRunRequest -> Async<LspResult<PlainNotification option>>
+  abstract FSharpDotnetAddProject: DotnetProjectRequest -> Async<LspResult<PlainNotification option>>
+  abstract FSharpDotnetRemoveProject: DotnetProjectRequest -> Async<LspResult<PlainNotification option>>
+  abstract FSharpDotnetSlnAdd: DotnetProjectRequest -> Async<LspResult<PlainNotification option>>
+  abstract FSharpHelp: TextDocumentPositionParams -> Async<LspResult<PlainNotification option>>
+  abstract FSharpDocumentation: TextDocumentPositionParams -> Async<LspResult<PlainNotification option>>
+  abstract FSharpDocumentationSymbol: DocumentationForSymbolReuqest -> Async<LspResult<PlainNotification option>>
   abstract FSharpLiterateRequest: FSharpLiterateRequest -> Async<LspResult<PlainNotification>>
   abstract LoadAnalyzers: obj -> Async<LspResult<unit>>
-  abstract FSharpPipelineHints: FSharpPipelineHintRequest -> Async<LspResult<PlainNotification>>
-  abstract FsProjMoveFileUp: DotnetFileRequest -> Async<LspResult<PlainNotification>>
-  abstract FsProjMoveFileDown: DotnetFileRequest -> Async<LspResult<PlainNotification>>
-  abstract FsProjAddFileAbove: DotnetFile2Request -> Async<LspResult<PlainNotification>>
-  abstract FsProjAddFileBelow: DotnetFile2Request -> Async<LspResult<PlainNotification>>
-  abstract FsProjAddFile: DotnetFileRequest -> Async<LspResult<PlainNotification>>
-  abstract FsProjRemoveFile: DotnetFileRequest -> Async<LspResult<PlainNotification>>
-  abstract FsProjAddExistingFile: DotnetFileRequest -> Async<LspResult<PlainNotification>>
+  abstract FSharpPipelineHints: FSharpPipelineHintRequest -> Async<LspResult<PlainNotification option>>
+  abstract FsProjMoveFileUp: DotnetFileRequest -> Async<LspResult<PlainNotification option>>
+  abstract FsProjMoveFileDown: DotnetFileRequest -> Async<LspResult<PlainNotification option>>
+  abstract FsProjAddFileAbove: DotnetFile2Request -> Async<LspResult<PlainNotification option>>
+  abstract FsProjAddFileBelow: DotnetFile2Request -> Async<LspResult<PlainNotification option>>
+  abstract FsProjAddFile: DotnetFileRequest -> Async<LspResult<PlainNotification option>>
+  abstract FsProjRemoveFile: DotnetFileRequest -> Async<LspResult<PlainNotification option>>
+  abstract FsProjAddExistingFile: DotnetFileRequest -> Async<LspResult<PlainNotification option>>

--- a/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
@@ -380,7 +380,7 @@ let signatureTests state =
             Position = { Line = line; Character = character } }
 
         match! server.FSharpSignature pos with
-        | Ok { Content = content } ->
+        | Ok (Some { Content = content }) ->
           let r = JsonSerializer.readJson<CommandResponse.ResponseMsg<string>> (content)
           Expect.equal r.Kind "typesig" "Should have a kind of 'typesig'"
 
@@ -388,6 +388,7 @@ let signatureTests state =
             r.Data
             expectedSignature
             (sprintf "Should have a signature of '%s' at character %d" expectedSignature character)
+        | Ok None -> failtestf "No signature found at character %d" character
         | Result.Error errors -> failtestf "Error while getting signature: %A" errors
       }
 

--- a/test/FsAutoComplete.Tests.Lsp/InfoPanelTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InfoPanelTests.fs
@@ -40,7 +40,7 @@ let docFormattingTest state =
 
           match doc with
           | Result.Error err -> failtest $"Doc error: {err.Message}"
-          | Result.Ok (As ([ [ model: FsAutoComplete.CommandResponse.DocumentationDescription ] ])) ->
+          | Result.Ok (Some(As ([ [ model: FsAutoComplete.CommandResponse.DocumentationDescription ] ]))) ->
             Expect.stringContains model.Signature "'Key, 'U" "Formatted doc contains both params separated by (, )"
           | Result.Ok _ -> failtest "couldn't parse doc as the json type we expected"
         })
@@ -57,7 +57,7 @@ let docFormattingTest state =
 
           match doc with
           | Result.Error err -> failtest $"Doc error: {err.Message}"
-          | Result.Ok (As ([ [ model: FsAutoComplete.CommandResponse.DocumentationDescription ] ])) ->
+          | Result.Ok (Some (As ([ [ model: FsAutoComplete.CommandResponse.DocumentationDescription ] ]))) ->
             Expect.stringContains model.Signature "'T1 * 'T2 * 'T3" "Formatted doc contains 3 params separated by ( * )"
           | Result.Ok _ -> failtest "couldn't parse doc as the json type we expected"
         }) ]


### PR DESCRIPTION
Closes https://github.com/fsharp/FsAutoComplete/issues/833

Logging InfoRes events as internal errors is client-hostile and makes the user experience quite bad in some editors.  Instead, since LSP endpoints generally accept null when no valid response can be returned, we should send that.