### PR TITLE
Fixes ThreadPool Exhaustion with ProgressListener

### DIFF
--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fs
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fs
@@ -219,7 +219,7 @@ type ProgressListener(lspClient: FSharpLspClient, traceNamespace: string array) 
           | None ->
             // if we don't get an event in 250 ms just loop again so we can analyze inflightEvents
             ()
-          | Some(action, activity: Activity, reply: AsyncReplyChannel<unit>) ->
+          | Some(action, activity: Activity) ->
 
             match action with
             | "start" ->
@@ -258,17 +258,14 @@ type ProgressListener(lspClient: FSharpLspClient, traceNamespace: string array) 
 
             | _ -> ()
 
-            reply.Reply()
       })
 
 
   let shouldListenTo (act: ActivitySource) = act.Name = Tracing.fscServiceName
 
-  let activityStarted (act: Activity) =
-    mbp.PostAndReply(fun reply -> "start", act, reply)
+  let activityStarted (act: Activity) = mbp.Post("start", act)
 
-  let activityStopped (act: Activity) =
-    mbp.PostAndReply(fun reply -> "stop", act, reply)
+  let activityStopped (act: Activity) = mbp.Post("stop", act)
 
   let listener =
     new ActivityListener(


### PR DESCRIPTION


When using `FindAllReferences`, I noticed it was taking extremely long to get results back.  I noticed the logs coming in about every second which gave me a hunch that it might be threadpool exhaustion.  I went digging and found a good article [for debugging](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/debug-threadpool-starvation) this sort of things.  

Using `dotnet-stack` I was able to trace down the culprit: 

```
Thread (0x19844):
  [Native Frames]
  System.Private.CoreLib.il!System.Threading.WaitHandle.WaitOneNoCheck(int32)
  FSharp.Core!Microsoft.FSharp.Control.AsyncPrimitives+ResultCell`1[System.__Canon].TryWaitForResultSynchronously(class Microsoft.FSharp.Core.FSharpOption`1<int32>)
  FSharp.Core!Microsoft.FSharp.Control.FSharpMailboxProcessor`1[System.__Canon].TryPostAndReply(class Microsoft.FSharp.Core.FSharpFunc`2<class Microsoft.FSharp.Control.FSharpAsyncReplyChannel`1<!!0>,!0>,class Microsoft.FSharp.Core.FSharpOption`1<int32>)
  fsautocomplete!<StartupCode$fsautocomplete>.$FSharpLspClient+-ctor@277-28.Invoke(class System.Diagnostics.Activity)
  System.Diagnostics.DiagnosticSource.il!System.Diagnostics.SynchronizedList`1[System.__Canon].EnumWithAction(class System.Action`2<!0,class System.Object>,class System.Object)
  System.Diagnostics.DiagnosticSource.il!System.Diagnostics.Activity.Start()
  System.Diagnostics.DiagnosticSource.il!System.Diagnostics.Activity.Create(class System.Diagnostics.ActivitySource,class System.String,value class System.Diagnostics.ActivityKind,class System.String,value class System.Diagnostics.ActivityContext,class System.Collections.Generic.IEnumerable`1<value class System.Collections.Generic.KeyValuePair`2<class System.String,class System.Object>>,class System.Collections.Generic.IEnumerable`1<value class System.Diagnostics.ActivityLink>,value class System.DateTimeOffset,class System.Diagnostics.ActivityTagsCollection,value class System.Diagnostics.ActivitySamplingResult,bool,value class System.Diagnostics.ActivityIdFormat,class System.String)
  System.Diagnostics.DiagnosticSource.il!System.Diagnostics.ActivitySource.CreateActivity(class System.String,value class System.Diagnostics.ActivityKind,value class System.Diagnostics.ActivityContext,class System.String,class System.Collections.Generic.IEnumerable`1<value class System.Collections.Generic.KeyValuePair`2<class System.String,class System.Object>>,class System.Collections.Generic.IEnumerable`1<value class System.Diagnostics.ActivityLink>,value class System.DateTimeOffset,bool,value class System.Diagnostics.ActivityIdFormat)
  FSharp.Compiler.Service!FSharp.Compiler.Diagnostics.Activity.start(class System.String,class System.Collections.Generic.IEnumerable`1<class System.Tuple`2<class System.String,class System.String>>)
  FSharp.Compiler.Service!<StartupCode$FSharp-Compiler-Service>.$Service+FindReferencesInFile@859.Invoke(class Microsoft.FSharp.Core.Unit)
  FSharp.Compiler.Service!FSharp.Compiler.BuildGraph+Delay@45-2[System.__Canon].Invoke(class Microsoft.FSharp.Core.Unit)
  FSharp.Core!Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke(value class Microsoft.FSharp.Control.AsyncActivation`1<!!0>,!!1,class Microsoft.FSharp.Core.FSharpFunc`2<!!1,class Microsoft.FSharp.Control.FSharpAsync`1<!!0>>)
  FSharp.Core!Microsoft.FSharp.Control.Trampoline.Execute(class Microsoft.FSharp.Core.FSharpFunc`2<class Microsoft.FSharp.Core.Unit,class Microsoft.FSharp.Control.AsyncReturn>)
  FSharp.Core!<StartupCode$FSharp-Core>.$Async+clo@193-15.Invoke(class System.Object)
  System.Private.CoreLib.il!System.Threading.QueueUserWorkItemCallback.Execute()
  System.Private.CoreLib.il!System.Threading.ThreadPoolWorkQueue.Dispatch()
  System.Private.CoreLib.il!System.Threading.PortableThreadPool+WorkerThread.WorkerThreadStart()
```

Turns out I shouldn't be using `PostAndReply` as it blocks threads.
