### PR TITLE
Include module information on TestAdapterEntry

### DIFF
--- a/src/FsAutoComplete.Core/TestAdapter.fs
+++ b/src/FsAutoComplete.Core/TestAdapter.fs
@@ -4,18 +4,13 @@ module FsAutoComplete.TestAdapter
 open FSharp.Compiler.Text
 open FSharp.Compiler.Syntax
 
-type ModuleType =
-  | NoneModule
-  | Module
-  | ModuleWithSuffix
-
 type TestAdapterEntry<'range> =
   { Name: string
     Range: 'range
     Childs: ResizeArray<TestAdapterEntry<'range>>
     Id: int
     List: bool
-    ModuleType: ModuleType
+    ModuleType: string
     Type: string }
 
 [<Literal>]
@@ -26,6 +21,15 @@ let private NUnitType = "NUnit"
 
 [<Literal>]
 let private XUnitType = "XUnit"
+
+[<Literal>]
+let private NoneModuleType = "NoneModuleType"
+
+[<Literal>]
+let private ModuleType = "ModuleType"
+
+[<Literal>]
+let private ModuleWithSuffixType = "ModuleWithSuffixType"
 
 let rec private (|Sequentials|_|) =
   function
@@ -92,7 +96,7 @@ let getExpectoTests (ast: ParsedInput) : TestAdapterEntry<range> list =
             Childs = ResizeArray()
             Id = ident
             List = true
-            ModuleType = NoneModule
+            ModuleType = NoneModuleType
             Type = ExpectoType }
 
         parent.Childs.Add entry
@@ -110,7 +114,7 @@ let getExpectoTests (ast: ParsedInput) : TestAdapterEntry<range> list =
             Childs = ResizeArray()
             Id = ident
             List = false
-            ModuleType = NoneModule
+            ModuleType = NoneModuleType
             Type = ExpectoType }
 
         parent.Childs.Add entry
@@ -139,7 +143,7 @@ let getExpectoTests (ast: ParsedInput) : TestAdapterEntry<range> list =
             Childs = ResizeArray()
             Id = ident
             List = false
-            ModuleType = NoneModule
+            ModuleType = NoneModuleType
             Type = ExpectoType }
 
         parent.Childs.Add entry
@@ -217,7 +221,7 @@ let getExpectoTests (ast: ParsedInput) : TestAdapterEntry<range> list =
       Childs = ResizeArray()
       Id = -1
       List = false
-      ModuleType = NoneModule
+      ModuleType = NoneModuleType
       Type = "" }
 
   match ast with
@@ -274,7 +278,7 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
         Childs = ResizeArray()
         Id = ident
         List = true
-        ModuleType = NoneModule
+        ModuleType = NoneModuleType
         Type = NUnitType }
 
     parent.Childs.Add entry
@@ -303,7 +307,7 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
           Childs = ResizeArray()
           Id = ident
           List = false
-          ModuleType = NoneModule
+          ModuleType = NoneModuleType
           Type = NUnitType }
 
       parent.Childs.Add entry
@@ -332,7 +336,7 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
       | SynModuleDecl.NestedModule(moduleInfo = ci; decls = decls) ->
         let (SynComponentInfo(longId = ids; range = r)) = ci
         let name = String.concat "." [ for i in ids -> i.idText ]
-        let moduleType = if Set.contains name typeNames then ModuleWithSuffix else Module
+        let moduleType = if Set.contains name typeNames then ModuleWithSuffixType else ModuleType
         ident <- ident + 1
 
         let entry =
@@ -358,7 +362,7 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
     Seq.iter
       (fun (SynModuleOrNamespace(longId = ids; decls = decls; range = r; kind = kind)) ->
         let name = String.concat "." [ for i in ids -> i.idText ]
-        let moduleType = if kind.IsModule then Module else NoneModule
+        let moduleType = if kind.IsModule then ModuleType else NoneModuleType
         ident <- ident + 1
 
         let entry =
@@ -383,7 +387,7 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
       Childs = ResizeArray()
       Id = -1
       List = false
-      ModuleType = NoneModule
+      ModuleType = NoneModuleType
       Type = "" }
 
   match ast with
@@ -435,7 +439,7 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
         Childs = ResizeArray()
         Id = ident
         List = true
-        ModuleType = NoneModule
+        ModuleType = NoneModuleType
         Type = XUnitType }
 
     parent.Childs.Add entry
@@ -464,7 +468,7 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
           Childs = ResizeArray()
           Id = ident
           List = false
-          ModuleType = NoneModule
+          ModuleType = NoneModuleType
           Type = XUnitType }
 
       parent.Childs.Add entry
@@ -493,7 +497,7 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
       | SynModuleDecl.NestedModule(moduleInfo = ci; decls = decls) ->
         let (SynComponentInfo(longId = ids; range = r)) = ci
         let name = String.concat "." [ for i in ids -> i.idText ]
-        let moduleType = if Set.contains name typeNames then ModuleWithSuffix else Module
+        let moduleType = if Set.contains name typeNames then ModuleWithSuffixType else ModuleType
         ident <- ident + 1
 
         let entry =
@@ -519,7 +523,7 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
     Seq.iter
       (fun (SynModuleOrNamespace(longId = ids; decls = decls; range = r; kind = kind)) ->
         let name = String.concat "." [ for i in ids -> i.idText ]
-        let moduleType = if kind.IsModule then Module else NoneModule
+        let moduleType = if kind.IsModule then ModuleType else NoneModuleType
         ident <- ident + 1
 
         let entry =
@@ -544,7 +548,7 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
       Childs = ResizeArray()
       Id = -1
       List = false
-      ModuleType = NoneModule
+      ModuleType = NoneModuleType
       Type = "" }
 
   match ast with

--- a/src/FsAutoComplete.Core/TestAdapter.fs
+++ b/src/FsAutoComplete.Core/TestAdapter.fs
@@ -23,13 +23,13 @@ let private NUnitType = "NUnit"
 let private XUnitType = "XUnit"
 
 [<Literal>]
-let private NoneModuleType = "NoneModuleType"
+let private NoneModuleType = "NoneModule"
 
 [<Literal>]
-let private ModuleType = "ModuleType"
+let private ModuleType = "Module"
 
 [<Literal>]
-let private ModuleWithSuffixType = "ModuleWithSuffixType"
+let private ModuleWithSuffixType = "ModuleWithSuffix"
 
 let rec private (|Sequentials|_|) =
   function

--- a/src/FsAutoComplete.Core/TestAdapter.fs
+++ b/src/FsAutoComplete.Core/TestAdapter.fs
@@ -29,6 +29,9 @@ let private NoneModuleType = "NoneModule"
 let private ModuleType = "Module"
 
 [<Literal>]
+let private TypeInModule = "TypeInModule"
+
+[<Literal>]
 let private ModuleWithSuffixType = "ModuleWithSuffix"
 
 let rec private (|Sequentials|_|) =
@@ -270,6 +273,7 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
     let (SynTypeDefn(typeInfo = ci; typeRepr = om; members = members)) = t
     let (SynComponentInfo(longId = ids; range = r)) = ci
     let name = String.concat "." [ for i in ids -> i.idText ]
+    let moduleType = if parent.ModuleType = ModuleType || parent.ModuleType = ModuleWithSuffixType then TypeInModule else NoneModuleType
     ident <- ident + 1
 
     let entry =
@@ -278,7 +282,7 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
         Childs = ResizeArray()
         Id = ident
         List = true
-        ModuleType = NoneModuleType
+        ModuleType = moduleType
         Type = NUnitType }
 
     parent.Childs.Add entry
@@ -437,6 +441,7 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
     let (SynTypeDefn(typeInfo = ci; typeRepr = om; members = members)) = t
     let (SynComponentInfo(longId = ids; range = r)) = ci
     let name = String.concat "." [ for i in ids -> i.idText ]
+    let moduleType = if parent.ModuleType = ModuleType || parent.ModuleType = ModuleWithSuffixType then TypeInModule else NoneModuleType
     ident <- ident + 1
 
     let entry =
@@ -445,7 +450,7 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
         Childs = ResizeArray()
         Id = ident
         List = true
-        ModuleType = NoneModuleType
+        ModuleType = moduleType
         Type = XUnitType }
 
     parent.Childs.Add entry

--- a/src/FsAutoComplete.Core/TestAdapter.fs
+++ b/src/FsAutoComplete.Core/TestAdapter.fs
@@ -10,6 +10,7 @@ type TestAdapterEntry<'range> =
     Childs: ResizeArray<TestAdapterEntry<'range>>
     Id: int
     List: bool
+    IsModule: bool
     Type: string }
 
 [<Literal>]
@@ -86,6 +87,7 @@ let getExpectoTests (ast: ParsedInput) : TestAdapterEntry<range> list =
             Childs = ResizeArray()
             Id = ident
             List = true
+            IsModule = false
             Type = ExpectoType }
 
         parent.Childs.Add entry
@@ -103,6 +105,7 @@ let getExpectoTests (ast: ParsedInput) : TestAdapterEntry<range> list =
             Childs = ResizeArray()
             Id = ident
             List = false
+            IsModule = false
             Type = ExpectoType }
 
         parent.Childs.Add entry
@@ -131,6 +134,7 @@ let getExpectoTests (ast: ParsedInput) : TestAdapterEntry<range> list =
             Childs = ResizeArray()
             Id = ident
             List = false
+            IsModule = false
             Type = ExpectoType }
 
         parent.Childs.Add entry
@@ -208,6 +212,7 @@ let getExpectoTests (ast: ParsedInput) : TestAdapterEntry<range> list =
       Childs = ResizeArray()
       Id = -1
       List = false
+      IsModule = false
       Type = "" }
 
   match ast with
@@ -264,6 +269,7 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
         Childs = ResizeArray()
         Id = ident
         List = true
+        IsModule = false
         Type = NUnitType }
 
     parent.Childs.Add entry
@@ -292,6 +298,7 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
           Childs = ResizeArray()
           Id = ident
           List = false
+          IsModule = false
           Type = NUnitType }
 
       parent.Childs.Add entry
@@ -313,6 +320,7 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
             Childs = ResizeArray()
             Id = ident
             List = true
+            IsModule = true
             Type = NUnitType }
 
         parent.Childs.Add entry
@@ -327,7 +335,7 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
 
   let visitModulesAndNamespaces parent modulesOrNss =
     Seq.iter
-      (fun (SynModuleOrNamespace(longId = ids; decls = decls; range = r)) ->
+      (fun (SynModuleOrNamespace(longId = ids; decls = decls; range = r; kind = kind)) ->
         let name = String.concat "." [ for i in ids -> i.idText ]
         ident <- ident + 1
 
@@ -337,6 +345,7 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
             Childs = ResizeArray()
             Id = ident
             List = true
+            IsModule = kind.IsModule
             Type = NUnitType }
 
         parent.Childs.Add entry
@@ -352,6 +361,7 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
       Childs = ResizeArray()
       Id = -1
       List = false
+      IsModule = false
       Type = "" }
 
   match ast with
@@ -403,6 +413,7 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
         Childs = ResizeArray()
         Id = ident
         List = true
+        IsModule = false
         Type = XUnitType }
 
     parent.Childs.Add entry
@@ -431,9 +442,8 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
           Childs = ResizeArray()
           Id = ident
           List = false
-          Type = XUnitType
-
-        }
+          IsModule = false
+          Type = XUnitType }
 
       parent.Childs.Add entry
 
@@ -454,6 +464,7 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
             Childs = ResizeArray()
             Id = ident
             List = true
+            IsModule = true
             Type = XUnitType }
 
         parent.Childs.Add entry
@@ -468,7 +479,7 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
 
   let visitModulesAndNamespaces parent modulesOrNss =
     Seq.iter
-      (fun (SynModuleOrNamespace(longId = ids; decls = decls; range = r)) ->
+      (fun (SynModuleOrNamespace(longId = ids; decls = decls; range = r; kind = kind)) ->
         let name = String.concat "." [ for i in ids -> i.idText ]
         ident <- ident + 1
 
@@ -478,6 +489,7 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
             Childs = ResizeArray()
             Id = ident
             List = true
+            IsModule = kind.IsModule
             Type = XUnitType }
 
         parent.Childs.Add entry
@@ -493,6 +505,7 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
       Childs = ResizeArray()
       Id = -1
       List = false
+      IsModule = false
       Type = "" }
 
   match ast with

--- a/src/FsAutoComplete.Core/TestAdapter.fs
+++ b/src/FsAutoComplete.Core/TestAdapter.fs
@@ -315,17 +315,17 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
   let rec visitDeclarations (parent: TestAdapterEntry<range>) decls =
     let typeNames =
       decls
-      |> List.fold (fun types declaration ->
-        match declaration with
-        | SynModuleDecl.Types(typeDefns, _) ->
-          typeDefns
-          |> List.map (fun (SynTypeDefn(typeInfo = ci)) ->
-            let (SynComponentInfo(longId = ids)) = ci
-            String.concat "." [ for i in ids -> i.idText ]
-          )
-          |> List.append types
-        | _ -> types
-      ) ([])
+      |> List.fold
+        (fun types declaration ->
+          match declaration with
+          | SynModuleDecl.Types(typeDefns, _) ->
+            typeDefns
+            |> List.map (fun (SynTypeDefn(typeInfo = ci)) ->
+              let (SynComponentInfo(longId = ids)) = ci
+              String.concat "." [ for i in ids -> i.idText ])
+            |> List.append types
+          | _ -> types)
+        ([])
       |> Set.ofList
 
     for declaration in decls do
@@ -336,7 +336,13 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
       | SynModuleDecl.NestedModule(moduleInfo = ci; decls = decls) ->
         let (SynComponentInfo(longId = ids; range = r)) = ci
         let name = String.concat "." [ for i in ids -> i.idText ]
-        let moduleType = if Set.contains name typeNames then ModuleWithSuffixType else ModuleType
+
+        let moduleType =
+          if Set.contains name typeNames then
+            ModuleWithSuffixType
+          else
+            ModuleType
+
         ident <- ident + 1
 
         let entry =
@@ -476,17 +482,17 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
   let rec visitDeclarations (parent: TestAdapterEntry<range>) decls =
     let typeNames =
       decls
-      |> List.fold (fun types declaration ->
-        match declaration with
-        | SynModuleDecl.Types(typeDefns, _) ->
-          typeDefns
-          |> List.map (fun (SynTypeDefn(typeInfo = ci)) ->
-            let (SynComponentInfo(longId = ids)) = ci
-            String.concat "." [ for i in ids -> i.idText ]
-          )
-          |> List.append types
-        | _ -> types
-      ) ([])
+      |> List.fold
+        (fun types declaration ->
+          match declaration with
+          | SynModuleDecl.Types(typeDefns, _) ->
+            typeDefns
+            |> List.map (fun (SynTypeDefn(typeInfo = ci)) ->
+              let (SynComponentInfo(longId = ids)) = ci
+              String.concat "." [ for i in ids -> i.idText ])
+            |> List.append types
+          | _ -> types)
+        ([])
       |> Set.ofList
 
     for declaration in decls do
@@ -497,7 +503,13 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
       | SynModuleDecl.NestedModule(moduleInfo = ci; decls = decls) ->
         let (SynComponentInfo(longId = ids; range = r)) = ci
         let name = String.concat "." [ for i in ids -> i.idText ]
-        let moduleType = if Set.contains name typeNames then ModuleWithSuffixType else ModuleType
+
+        let moduleType =
+          if Set.contains name typeNames then
+            ModuleWithSuffixType
+          else
+            ModuleType
+
         ident <- ident + 1
 
         let entry =

--- a/src/FsAutoComplete.Core/TestAdapter.fs
+++ b/src/FsAutoComplete.Core/TestAdapter.fs
@@ -273,7 +273,13 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
     let (SynTypeDefn(typeInfo = ci; typeRepr = om; members = members)) = t
     let (SynComponentInfo(longId = ids; range = r)) = ci
     let name = String.concat "." [ for i in ids -> i.idText ]
-    let moduleType = if parent.ModuleType = ModuleType || parent.ModuleType = ModuleWithSuffixType then TypeInModule else NoneModuleType
+
+    let moduleType =
+      if parent.ModuleType = ModuleType || parent.ModuleType = ModuleWithSuffixType then
+        TypeInModule
+      else
+        NoneModuleType
+
     ident <- ident + 1
 
     let entry =
@@ -441,7 +447,13 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
     let (SynTypeDefn(typeInfo = ci; typeRepr = om; members = members)) = t
     let (SynComponentInfo(longId = ids; range = r)) = ci
     let name = String.concat "." [ for i in ids -> i.idText ]
-    let moduleType = if parent.ModuleType = ModuleType || parent.ModuleType = ModuleWithSuffixType then TypeInModule else NoneModuleType
+
+    let moduleType =
+      if parent.ModuleType = ModuleType || parent.ModuleType = ModuleWithSuffixType then
+        TypeInModule
+      else
+        NoneModuleType
+
     ident <- ident + 1
 
     let entry =

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -582,6 +582,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
                 List = r.List
                 Name = r.Name
                 Type = r.Type
+                ModuleType = r.ModuleType
                 Range = fcsRangeToLsp r.Range
                 Childs = ResizeArray(r.Childs |> Seq.map map) }
 

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -368,6 +368,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
             List = r.List
             Name = r.Name
             Type = r.Type
+            ModuleType = r.ModuleType
             Range = fcsRangeToLsp r.Range
             Childs = ResizeArray(r.Childs |> Seq.map map) }
 

--- a/test/FsAutoComplete.Tests.Lsp/DetectUnitTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/DetectUnitTests.fs
@@ -31,12 +31,20 @@ let tests state =
         (async {
           let! testNotification = geTestNotification "NUnitTests" "UnitTest1.fs"
           Expect.hasLength testNotification.Tests 1 "Expected to have found 1 nunit test"
+
+          Expect.equal testNotification.Tests[0].Childs[1].Childs[0].Name "Inner" "Expect nested module to be named Inner"
+          Expect.equal testNotification.Tests[0].Childs[1].Childs[0].ModuleType "Module" "Expect nested module to be a module type"
         })
       testCaseAsync
         "Find xunit test"
         (async {
           let! testNotification = geTestNotification "XUnitTests" "Tests.fs"
-          Expect.hasLength testNotification.Tests 1 "Expected to have found 1 xunit test"
+          Expect.hasLength testNotification.Tests 1 "Expected to have found 1 xunit test list"
+          Expect.equal testNotification.Tests[0].ModuleType "Module" "Expected top list to be module"
+
+          Expect.hasLength testNotification.Tests[0].Childs 3 "Expected to have found 3 child tests of top test"
+          Expect.equal testNotification.Tests[0].Childs[0].ModuleType "NoneModule" "Expect My test to be none module type"
+          Expect.equal testNotification.Tests[0].Childs[2].ModuleType "ModuleWithSuffix" "Expect Clashing test to be a module with suffix"
         })
       testCaseAsync
         "Find expecto tests"

--- a/test/FsAutoComplete.Tests.Lsp/DetectUnitTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/DetectUnitTests.fs
@@ -34,6 +34,9 @@ let tests state =
 
           Expect.equal testNotification.Tests[0].Childs[1].Childs[0].Name "Inner" "Expect nested module to be named Inner"
           Expect.equal testNotification.Tests[0].Childs[1].Childs[0].ModuleType "Module" "Expect nested module to be a module type"
+
+          Expect.equal testNotification.Tests[0].Childs[1].Childs[1].Name "InnerClass" "Expect nested module to be named Inner"
+          Expect.equal testNotification.Tests[0].Childs[1].Childs[1].ModuleType "TypeInModule" "Expect nested module to be a module type"
         })
       testCaseAsync
         "Find xunit test"

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/NUnitTests/UnitTest1.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/NUnitTests/UnitTest1.fs
@@ -15,3 +15,8 @@ module Outer =
         [<TestCase (0)>]
         let Test2 (i: int) =
             Assert.Pass()
+
+    type InnerClass() =
+        [<Test>]
+        member this.Test1 () =
+            Assert.Pass()

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/NUnitTests/UnitTest1.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/NUnitTests/UnitTest1.fs
@@ -9,3 +9,9 @@ let Setup () =
 [<Test>]
 let Test1 () =
     Assert.Pass()
+
+module Outer =
+    module Inner =
+        [<TestCase (0)>]
+        let Test2 (i: int) =
+            Assert.Pass()

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/XUnitTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/XUnitTests/Tests.fs
@@ -6,3 +6,16 @@ open Xunit
 [<Fact>]
 let ``My test`` () =
     Assert.True(true)
+
+module Inner =
+    [<Fact>]
+    let ``Other test`` () =
+        Assert.True(true)
+
+type NameClash () =
+    do ()
+
+module NameClash =
+    [<Fact>]
+    let ``Clashing test`` () =
+        Assert.True(true)


### PR DESCRIPTION
Add a new field `TestAdapterEntry.ModuleType`, to show whether the given entry is a module, and separately a module with a suffix (in IL). The allows for handling the following two cases which previously couldn't be handled by the existing record:

```fsharp
namespace TestNameSpace

module Outer =
    [<TestFixture>]
    module Inner =
        [<Test>]
        let Test1 () =
            Assert.Pass ()

        module Innermost =
            [<Test>]
            let Test2 () =
                Assert.Pass()

module Outer2 =
    [<TestFixture>]
    type InnerClass() =
        [<Test>]
        member this.Test1 () =
            Assert.Pass()

type SharedName() =
    do ()

[<TestFixture>]
module SharedName =
    [<Test>]
    let Test1 () =
        Assert.Pass()
```

Test Class Name | FullName in Code
--- | ---
`TestNameSpace.Outer+Inner+Innermost.Test2` | `TestNameSpace.Outer.Inner.Innermost.Test2`
`TestNameSpace.SharedNameModule.Test1` | `TestNameSpace.SharedName`

See https://github.com/ionide/ionide-vscode-fsharp/issues/1756 for more context.