### PR TITLE
Fix "Convert to named patterns" code fix for multiple clauses

### DIFF
--- a/src/FsAutoComplete/CodeFixes/ConvertPositionalDUToNamed.fs
+++ b/src/FsAutoComplete/CodeFixes/ConvertPositionalDUToNamed.fs
@@ -24,6 +24,7 @@ open FsAutoComplete
 open FsAutoComplete.LspHelpers
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Symbols
+open FSharp.Compiler.Text.Range
 open FsAutoComplete.FCSPatches
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Syntax.SyntaxTraversal
@@ -65,14 +66,18 @@ type ParseAndCheckResults with
               | None ->
                 clauses
                 |> List.tryPick (function
-                  | SynMatchClause(pat = UnionNameAndPatterns(ident, duFieldPatterns, parenRange)) ->
+                  | SynMatchClause(pat = UnionNameAndPatterns(ident, duFieldPatterns, parenRange)) when
+                    rangeContainsPos parenRange pos
+                    ->
                     Some(ident, duFieldPatterns, parenRange)
                   | _ -> None)
             | _ -> defaultTraverse expr
 
           member x.VisitMatchClause(path, defaultTraverse, matchClause) =
             match matchClause with
-            | SynMatchClause(pat = UnionNameAndPatterns(ident, duFieldPatterns, parenRange)) ->
+            | SynMatchClause(pat = UnionNameAndPatterns(ident, duFieldPatterns, parenRange)) when
+              rangeContainsPos parenRange pos
+              ->
               Some(ident, duFieldPatterns, parenRange)
             | _ -> defaultTraverse matchClause }
 

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -573,6 +573,7 @@ let private convertPositionalDUToNamedTests state =
         type A = A of a: int * b: bool
 
         match A(1, true) with
+        | A(_, 23) -> ()
         | A(a$0, b) -> ()
         """
         Diagnostics.acceptAll
@@ -581,6 +582,7 @@ let private convertPositionalDUToNamedTests state =
         type A = A of a: int * b: bool
 
         match A(1, true) with
+        | A(_, 23) -> ()
         | A(a = a; b = b;) -> ()
         """
     testCaseAsync "in parenthesized match" <|
@@ -589,6 +591,7 @@ let private convertPositionalDUToNamedTests state =
         type A = A of a: int * b: bool
 
         match A(1, true) with
+        | (A(_, 23)) -> ()
         | (A(a$0, b)) -> ()
         """
         Diagnostics.acceptAll
@@ -597,6 +600,7 @@ let private convertPositionalDUToNamedTests state =
         type A = A of a: int * b: bool
 
         match A(1, true) with
+        | (A(_, 23)) -> ()
         | (A(a = a; b = b;)) -> ()
         """
     testCaseAsync "when there is one new field on the DU" <|


### PR DESCRIPTION

https://user-images.githubusercontent.com/3221269/224517587-fe8891b7-49cc-4f56-87a4-b8cb7a9bb35c.mp4

Please note the cursor is on line 28, but 25 gets modified.
Fix this by taking the position into account in the visitor