### PR TITLE
Fix removeCommaEdits in ConvertPositionalDUToNamed to work for unformatted patterns

### DIFF
--- a/src/FsAutoComplete/CodeFixes/ConvertPositionalDUToNamed.fs
+++ b/src/FsAutoComplete/CodeFixes/ConvertPositionalDUToNamed.fs
@@ -146,10 +146,12 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getRangeText: GetRange
       let notInsidePatterns =
         let ranges = duFields |> List.map (fun f -> f.Range)
 
-        fun (pos: FSharp.Compiler.Text.Position) ->
-          ranges
-          |> List.forall (fun r -> not (FSharp.Compiler.Text.Range.rangeContainsPos r pos))
+        let rangeContainsPosLeftEdgeExclusive (r: FSharp.Compiler.Text.Range) p =
+          let r' = r.WithStart(r.Start.WithColumn(r.Start.Column + 1))
+          rangeContainsPos r' p
 
+        fun (pos: FSharp.Compiler.Text.Position) ->
+          ranges |> List.forall (fun r -> not (rangeContainsPosLeftEdgeExclusive r pos))
 
       let commasBetweenFields =
         toPosSeq (parenRange, sourceText)

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -629,6 +629,18 @@ let private convertPositionalDUToNamedTests state =
         type U = U of aValue: int * boolean: int * char: char * dec: decimal * element: int
         let (U(aValue = a; boolean = b; char = _; dec = _; element = _;)) = failwith "..."
         """
+    testCaseAsync "when the existing pattern isn't formatted well" <|
+      CodeFix.check server
+        """
+        type A = A of a: int * b: bool * c: bool * d: bool
+        let (A($0a,b, c,     d)) = A(1, true, false, false)
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        type A = A of a: int * b: bool * c: bool * d: bool
+        let (A(a = a;b = b; c = c;     d = d;)) = A(1, true, false, false)
+        """
   ])
 
 let private convertTripleSlashCommentToXmlTaggedDocTests state =


### PR DESCRIPTION


https://user-images.githubusercontent.com/3221269/224570301-61c1e192-3e1a-4318-a005-c33205ec5281.mp4



For unformatted patterns like (a,b) (please note the missing space after the coma) the left edge of the b range should be left out when checking if the comma pos is inside a pattern range. Otherwise the removeCommaEdits don't remove the comma and invalid syntax is produced, see video.