### PR TITLE
Add fsproj/renameFilex

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Custom endpoints are using (for messages body) `PlainNotification` type and stri
 * `fsproj/addFile` - accepts `DotnetFileRequest`, create the file if needed and add it to the project if not already present
 * `fsproj/addExistingFile` - accepts `DotnetFileRequest`, add existing file to a project if not already present
 * `fsproj/removeFile` - accepts `DotnetFileRequest`, remove the file from the project
+* `fsproj/renameFile` - accepts `DotnetRenameFileRequest`, rename the file from the project
 
 ### Supported LSP notifications
 

--- a/src/FsAutoComplete.Core/FsprojEdit.fs
+++ b/src/FsAutoComplete.Core/FsprojEdit.fs
@@ -63,6 +63,14 @@ module FsProjEditor =
     itemGroup.InsertAfter(node, aboveNode) |> ignore
     xdoc.Save fsprojPath
 
+  let renameFile (fsprojPath: string) (oldFileName: string) (newFileName: string) =
+    let xdoc = System.Xml.XmlDocument()
+    xdoc.Load fsprojPath
+    let xpath = sprintf "//Compile[@Include='%s']" oldFileName
+    let node = xdoc.SelectSingleNode(xpath)
+    node.Attributes["Include"].InnerText <- newFileName
+    xdoc.Save fsprojPath
+
   let addFile (fsprojPath: string) (newFileName: string) =
     let xdoc = System.Xml.XmlDocument()
     xdoc.Load fsprojPath

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -581,6 +581,11 @@ type DotnetFile2Request =
     FileVirtualPath: string
     NewFile: string }
 
+type DotnetRenameFileRequest =
+  { FsProj: string
+    OldFileVirtualPath: string
+    NewFileName: string }
+
 type FSharpLiterateRequest =
   { TextDocument: TextDocumentIdentifier }
 

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -2527,6 +2527,24 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
         return res
       }
 
+    override __.FsProjRenameFile(p: DotnetRenameFileRequest) =
+      async {
+        logger.info (
+          Log.setMessage "FsProjRenameFile Request: {parms}"
+          >> Log.addContextDestructured "parms" p
+        )
+
+        let! res = commands.FsProjRenameFile p.FsProj p.OldFileVirtualPath p.NewFileName
+
+        let res =
+          match res with
+          | CoreResponse.InfoRes msg -> success None
+          | CoreResponse.ErrorRes msg -> LspResult.internalError msg
+          | CoreResponse.Res(_) -> success None
+
+        return res
+      }
+
     override __.FsProjAddFile(p: DotnetFileRequest) =
       async {
         logger.info (
@@ -2902,6 +2920,7 @@ module FSharpLspServer =
       |> Map.add "fsproj/addFileBelow" (serverRequestHandling (fun s p -> s.FsProjAddFileBelow(p)))
       |> Map.add "fsproj/addFile" (serverRequestHandling (fun s p -> s.FsProjAddFile(p)))
       |> Map.add "fsproj/addExistingFile" (serverRequestHandling (fun s p -> s.FsProjAddExistingFile(p)))
+      |> Map.add "fsproj/renameFile" (serverRequestHandling (fun s p -> s.FsProjRenameFile(p)))
       |> Map.add "fsproj/removeFile" (serverRequestHandling (fun s p -> s.FsProjRemoveFile(p)))
 
     let regularServer lspClient =

--- a/src/FsAutoComplete/LspServers/IFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/IFSharpLspServer.fs
@@ -42,6 +42,7 @@ type IFSharpLspServer =
   abstract FsProjMoveFileDown: DotnetFileRequest -> Async<LspResult<PlainNotification option>>
   abstract FsProjAddFileAbove: DotnetFile2Request -> Async<LspResult<PlainNotification option>>
   abstract FsProjAddFileBelow: DotnetFile2Request -> Async<LspResult<PlainNotification option>>
+  abstract FsProjRenameFile: DotnetRenameFileRequest -> Async<LspResult<PlainNotification option>>
   abstract FsProjAddFile: DotnetFileRequest -> Async<LspResult<PlainNotification option>>
   abstract FsProjRemoveFile: DotnetFileRequest -> Async<LspResult<PlainNotification option>>
   abstract FsProjAddExistingFile: DotnetFileRequest -> Async<LspResult<PlainNotification option>>


### PR DESCRIPTION
This PR add a new command `fsproj/renameFile` which takes a project, the virtual path of the file to rename and the new file name.

https://user-images.githubusercontent.com/4760796/224574201-d935ec77-1f29-4456-8dc5-3b131d95e5f2.mov

I created the PR against nightly branch but I am don't know if this is the correct place. If needed, I can rebase it for main.