### PR TITLE
Reduced memory consumption of autocompletion cache

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -17,7 +17,7 @@ open FsToolkit.ErrorHandling
 
 type Version = int
 
-type FSharpCompilerServiceChecker(hasAnalyzers) =
+type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize) =
   let checker =
     FSharpChecker.Create(
       projectCacheSize = 200,
@@ -36,7 +36,7 @@ type FSharpCompilerServiceChecker(hasAnalyzers) =
   // This is used to hold previous check results for autocompletion.
   // We can't seem to rely on the checker for previous cached versions
   let memoryCache () =
-    new MemoryCache(MemoryCacheOptions(SizeLimit = Nullable<_>(200L)))
+    new MemoryCache(MemoryCacheOptions(SizeLimit = Nullable<_>(typecheckCacheSize)))
 
   let mutable lastCheckResults: IMemoryCache = memoryCache ()
 

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -615,6 +615,13 @@ type DebugDto =
     LogDurationBetweenCheckFiles: bool option
     LogCheckFileDuration: bool option }
 
+
+type FSACDto =
+  {
+    /// <summary>The <see cref='F:Microsoft.Extensions.Caching.Memory.MemoryCacheOptions.SizeLimit '/> for typecheck cache. </summary>
+    CachedTypeCheckCount: int64 option
+  }
+
 type FSharpConfigDto =
   { AutomaticWorkspaceInit: bool option
     WorkspaceModePeekDeepLevel: int option
@@ -652,6 +659,7 @@ type FSharpConfigDto =
     CodeLenses: CodeLensConfigDto option
     PipelineHints: InlineValueDto option
     InlayHints: InlayHintDto option
+    Fsac: FSACDto option
     Notifications: NotificationsDto option
     Debug: DebugDto option }
 
@@ -692,13 +700,30 @@ type NotificationsConfig =
       TraceNamespaces = [||] }
 
   static member FromDto(dto: NotificationsDto) : NotificationsConfig =
-    { Trace = defaultArg dto.Trace NotificationsConfig.Default.Trace
-      TraceNamespaces = defaultArg dto.TraceNamespaces NotificationsConfig.Default.TraceNamespaces }
+    let defaultConfig = NotificationsConfig.Default
+
+    { Trace = defaultArg dto.Trace defaultConfig.Trace
+      TraceNamespaces = defaultArg dto.TraceNamespaces defaultConfig.TraceNamespaces }
 
 
   member this.AddDto(dto: NotificationsDto) : NotificationsConfig =
     { Trace = defaultArg dto.Trace this.Trace
       TraceNamespaces = defaultArg dto.TraceNamespaces this.TraceNamespaces }
+
+type FSACConfig =
+  {
+    /// <summary>The <see cref='F:Microsoft.Extensions.Caching.Memory.MemoryCacheOptions.SizeLimit '/> for typecheck cache. </summary>
+    CachedTypeCheckCount: int64
+  }
+
+  static member Default = { CachedTypeCheckCount = 200L }
+
+  static member FromDto(dto: FSACDto) =
+    let defaultConfig = FSACConfig.Default
+    { CachedTypeCheckCount = defaultArg dto.CachedTypeCheckCount defaultConfig.CachedTypeCheckCount }
+
+  member this.AddDto(dto: FSACDto) =
+    { CachedTypeCheckCount = defaultArg dto.CachedTypeCheckCount this.CachedTypeCheckCount }
 
 type DebugConfig =
   { DontCheckRelatedFiles: bool
@@ -750,6 +775,7 @@ type FSharpConfig =
     InlayHints: InlayHintsConfig
     InlineValues: InlineValuesConfig
     Notifications: NotificationsConfig
+    Fsac: FSACConfig
     Debug: DebugConfig }
 
   static member Default: FSharpConfig =
@@ -790,6 +816,7 @@ type FSharpConfig =
       InlayHints = InlayHintsConfig.Default
       InlineValues = InlineValuesConfig.Default
       Notifications = NotificationsConfig.Default
+      Fsac = FSACConfig.Default
       Debug = DebugConfig.Default }
 
   static member FromDto(dto: FSharpConfigDto) : FSharpConfig =
@@ -858,6 +885,10 @@ type FSharpConfig =
         dto.Notifications
         |> Option.map NotificationsConfig.FromDto
         |> Option.defaultValue NotificationsConfig.Default
+      Fsac =
+        dto.Fsac
+        |> Option.map FSACConfig.FromDto
+        |> Option.defaultValue FSACConfig.Default
       Debug =
         match dto.Debug with
         | None -> DebugConfig.Default
@@ -944,6 +975,7 @@ type FSharpConfig =
         dto.Notifications
         |> Option.map x.Notifications.AddDto
         |> Option.defaultValue NotificationsConfig.Default
+      Fsac = dto.Fsac |> Option.map x.Fsac.AddDto |> Option.defaultValue FSACConfig.Default
       Debug =
         match dto.Debug with
         | None -> DebugConfig.Default

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -189,7 +189,10 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
 
   let analyzersEnabled = config |> AVal.map (fun c -> c.EnableAnalyzers)
 
-  let checker = analyzersEnabled |> AVal.map (FSharpCompilerServiceChecker)
+  let checker =
+    config
+    |> AVal.map (fun c -> c.EnableAnalyzers, c.Fsac.CachedTypeCheckCount)
+    |> AVal.map (FSharpCompilerServiceChecker)
 
   /// The reality is a file can be in multiple projects
   /// This is extracted to make it easier to do some type of customized select

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1148,12 +1148,18 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
                 Version = version } }
     }
 
-
-  let parseAndCheckFile (checker: FSharpCompilerServiceChecker) (file: VolatileFile) opts config =
+  /// <summary>Gets Parse and Check results of a given file while also handling other concerns like Progress, Logging, Eventing.</summary>
+  /// <param name="checker">The FSharpCompilerServiceChecker.</param>
+  /// <param name="file">The name of the file in the project whose source to find a typecheck.</param>
+  /// <param name="options">The options for the project or script.</param>
+  /// <param name="config">The FSharpConfig.</param>
+  /// <param name="shouldCache">Determines if the typecheck should be cached for autocompletions.</param>
+  /// <returns></returns>
+  let parseAndCheckFile (checker: FSharpCompilerServiceChecker) (file: VolatileFile) options config shouldCache =
     async {
       let tags =
         [ SemanticConventions.fsac_sourceCodePath, box (UMX.untag file.Lines.FileName)
-          SemanticConventions.projectFilePath, box (opts.ProjectFileName) ]
+          SemanticConventions.projectFilePath, box (options.ProjectFileName) ]
 
       use _ = fsacActivitySource.StartActivityForType(thisType, tags = tags)
 
@@ -1178,7 +1184,13 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
       cts.CancelAfter(TimeSpan.FromSeconds(60.))
 
       let! result =
-        checker.ParseAndCheckFileInProject(file.Lines.FileName, (file.Lines.GetHashCode()), file.Lines, opts)
+        checker.ParseAndCheckFileInProject(
+          file.Lines.FileName,
+          (file.Lines.GetHashCode()),
+          file.Lines,
+          options,
+          shouldCache = shouldCache
+        )
         |> Async.withCancellation cts.Token
         |> Debug.measureAsync $"checker.ParseAndCheckFileInProject - {file.Lines.FileName}"
 
@@ -1204,7 +1216,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
         Async.Start(
           async {
 
-            fileParsed.Trigger(parseAndCheck.GetParseResults, opts, ct)
+            fileParsed.Trigger(parseAndCheck.GetParseResults, options, ct)
             fileChecked.Trigger(parseAndCheck, file, ct)
             let checkErrors = parseAndCheck.GetParseResults.Diagnostics
             let parseErrors = parseAndCheck.GetCheckResults.Diagnostics
@@ -1238,7 +1250,8 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
         let config = config |> AVal.force
 
         match forceFindOpenFileOrRead filePath with
-        | Ok(fileInfo) -> return! parseAndCheckFile checker fileInfo opts config |> Async.Ignore
+        // Don't cache for autocompletions as we really only want to cache "Opened" files.
+        | Ok(fileInfo) -> return! parseAndCheckFile checker fileInfo opts config false |> Async.Ignore
         | _ -> ()
       with e ->
 
@@ -1304,7 +1317,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
             return!
               Debug.measure $"parseAndCheckFile - {file}"
               <| fun () ->
-                parseAndCheckFile checker info opts config
+                parseAndCheckFile checker info opts config true
                 |> Async.RunSynchronouslyWithCTSafe(fun () -> cts.Token)
           }
 
@@ -1338,6 +1351,17 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
     |> AVal.force
     |> Result.ofOption (fun () -> $"No typecheck results for {filePath}")
 
+  /// <summary>
+  /// This will attempt to get typecheck results in this order
+  ///
+  /// 1. From our internal typecheck cache
+  /// 2. From checker.TryGetRecentCheckResultsForFile
+  /// 3. Failing both, will type check the file.
+  ///
+  /// Additionally, it will start typechecking the file in the background to force latest results on the next request.
+  /// </summary>
+  /// <param name="filePath">The name of the file in the project whose source to find a typecheck.</param>
+  /// <returns>A Result of ParseAndCheckResults</returns>
   let forceGetTypeCheckResultsStale (filePath: string<LocalPath>) =
     aval {
       let! checker = checker

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -44,7 +44,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
   let mutable rootPath: string option = None
 
   let mutable commands =
-    new Commands(FSharpCompilerServiceChecker(false), state, false, rootPath)
+    new Commands(FSharpCompilerServiceChecker(false, 200L), state, false, rootPath)
 
   let mutable commandDisposables = ResizeArray()
   let mutable clientCapabilities: ClientCapabilities option = None
@@ -478,7 +478,12 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
       let oldDisposables = commandDisposables
 
       let newCommands =
-        new Commands(FSharpCompilerServiceChecker(hasAnalyzersNow), state, hasAnalyzersNow, rootPath)
+        new Commands(
+          FSharpCompilerServiceChecker(hasAnalyzersNow, config.Fsac.CachedTypeCheckCount),
+          state,
+          hasAnalyzersNow,
+          rootPath
+        )
 
       commands <- newCommands
       commandDisposables <- ResizeArray()

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -270,6 +270,7 @@ let defaultConfigDto: FSharpConfigDto =
         { Enabled = Some true
           Prefix = Some "//" }
     Notifications = None
+    Fsac = None
     Debug = None }
 
 let clientCaps: ClientCapabilities =


### PR DESCRIPTION
Previously, on save, we would cache all typechecks. This could cause large solutions to use a lot of memory for no real purpose. This lets the caller of ParseAndCheckFileInProject determine if it should cache type checks for autocompletions. Typically we don't want to store them for anything other the already open files. 