### PR TITLE
More threadpool exhaustion fixes

### DIFF
--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -602,7 +602,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
 
         ()
       }
-      |> Async.RunSynchronouslyWithCT ct
+      |> fun work -> Async.StartImmediate(work, ct)
     with :? OperationCanceledException as e ->
       ()
 
@@ -717,7 +717,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
             use progressReport = new ServerProgressReport(lspClient)
 
             progressReport.Begin($"Loading {projects.Count} Projects")
-            |> Async.RunSynchronously
+            |> Async.StartImmediate
 
             let projectOptions =
               loader.LoadProjects(projects |> Seq.map (fst >> UMX.untag) |> Seq.toList, [], binlogConfig)
@@ -1015,8 +1015,18 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
 
 
   do
+    let filesystemShim file =
+      // GetLastWriteTimeShim gets called _alot_ and when we do checks on save we use Async.Parallel for type checking.
+      // Adaptive uses lots of locks under the covers, so many threads can get blocked waiting for data.
+      // We know we don't store anything other than Fsharp type files in open files so this so we shouldn't hit any locks
+      // when F# compiler asks for DLL timestamps
+      if Utils.isFileWithFSharp %file then
+        forceFindOpenFile file
+      else
+        None
+
     FSharp.Compiler.IO.FileSystemAutoOpens.FileSystem <-
-      FileSystem(FSharp.Compiler.IO.FileSystemAutoOpens.FileSystem, forceFindOpenFile)
+      FileSystem(FSharp.Compiler.IO.FileSystemAutoOpens.FileSystem, filesystemShim)
 
   let forceFindSourceText filePath =
     forceFindOpenFileOrRead filePath |> Result.map (fun f -> f.Lines)
@@ -1181,11 +1191,6 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
       let simpleName = Path.GetFileName(UMX.untag file.Lines.FileName)
       do! progressReport.Begin($"Typechecking {simpleName}", message = $"{file.Lines.FileName}")
 
-
-      // HACK: Insurance for a bug where FCS invalidates graph nodes incorrectly and seems to typecheck forever
-      use cts = new CancellationTokenSource()
-      cts.CancelAfter(TimeSpan.FromSeconds(60.))
-
       let! result =
         checker.ParseAndCheckFileInProject(
           file.Lines.FileName,
@@ -1194,7 +1199,6 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
           options,
           shouldCache = shouldCache
         )
-        |> Async.withCancellation cts.Token
         |> Debug.measureAsync $"checker.ParseAndCheckFileInProject - {file.Lines.FileName}"
 
       do! progressReport.End($"Typechecked {file.Lines.FileName}")

--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fs
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fs
@@ -139,7 +139,7 @@ type ServerProgressReport(lspClient: FSharpLspClient, ?token: ProgressToken) =
 
   interface IDisposable with
     member x.Dispose() =
-      (x :> IAsyncDisposable).DisposeAsync().GetAwaiter().GetResult()
+      (x :> IAsyncDisposable).DisposeAsync() |> ignore
 
 
 open System.Diagnostics.Tracing
@@ -279,7 +279,7 @@ type ProgressListener(lspClient: FSharpLspClient, traceNamespace: string array) 
 
   interface IDisposable with
     member this.Dispose() : unit =
-      (this :> IAsyncDisposable).DisposeAsync().GetAwaiter().GetResult()
+      (this :> IAsyncDisposable).DisposeAsync() |> ignore
 
   interface IAsyncDisposable with
     member this.DisposeAsync() : ValueTask =


### PR DESCRIPTION
Back with more threadpool exhaustion fixes!

- One of the main offenders is hitting Adaptive structures more often than needed. Since Adaptive uses lots of locks to ensure consistency, we end up getting threads blocked.

<details>
<summary>
Stackframes for FSAC showing where threadpool thread is getting blocked by Adaptive
</summary>
<pre>

Thread (0x111A4):
  [Native Frames]
  FSharp.Data.Adaptive!FSharp.Data.Traceable.History`2[FSharp.Data.Adaptive.FSharpHashMap`2[System.__Canon,System.__Canon],FSharp.Data.Adaptive.FSharpHashMapDelta`2[System.__Canon,System.__Canon]].GetValue(value class FSharp.Data.Adaptive.AdaptiveToken)
  FSharp.Data.Adaptive!FSharp.Data.Adaptive.AValModule+MapVal`2[FSharp.Data.Adaptive.FSharpHashMap`2[System.__Canon,System.__Canon],System.__Canon].Compute(value class FSharp.Data.Adaptive.AdaptiveToken)
  FSharp.Data.Adaptive!FSharp.Data.Adaptive.AValModule+AbstractVal`1[System.__Canon].GetValue(value class FSharp.Data.Adaptive.AdaptiveToken)
  FSharp.Data.Adaptive!FSharp.Data.Adaptive.AValModule+BindVal`2[System.__Canon,System.__Canon].Compute(value class FSharp.Data.Adaptive.AdaptiveToken)
  FSharp.Data.Adaptive!FSharp.Data.Adaptive.AValModule+AbstractVal`1[System.__Canon].GetValue(value class FSharp.Data.Adaptive.AdaptiveToken)
  fsautocomplete!FsAutoComplete.Lsp.AdaptiveFSharpLspServer.forceFindOpenFile(class System.String)
  fsautocomplete!<StartupCode$fsautocomplete>.$AdaptiveFSharpLspServer+-ctor@1046-82.Invoke(class System.String)
  FsAutoComplete.Core!FsAutoComplete.FileSystem.FSharp.Compiler.IO.IFileSystem.GetLastWriteTimeShim(class System.String)
  FSharp.Compiler.Service!FSharp.Compiler.CompilerConfig+TimeStampCache.GetFileTimeStamp(class System.String)
  FSharp.Compiler.Service!FSharp.Compiler.CodeAnalysis.IncrementalBuilderStateHelpers+computeStampedReferencedAssemblies@1116.Invoke(int32,class System.Tuple`2<class Microsoft.FSharp.Core.FSharpChoice`2<class System.String,class IProjectReference>,class Microsoft.FSharp.Core.FSharpFunc`2<class TimeStampCache,value class System.DateTime>>)
  FSharp.Compiler.Service!FSharp.Compiler.CodeAnalysis.IncrementalBuilderStateHelpers.computeStampedReferencedAssemblies(class FSharp.Compiler.CodeAnalysis.IncrementalBuilderInitialState,class FSharp.Compiler.CodeAnalysis.IncrementalBuilderState,bool,class TimeStampCache)
  FSharp.Compiler.Service!FSharp.Compiler.CodeAnalysis.IncrementalBuilder.get_IsReferencesInvalidated()
  FSharp.Compiler.Service!<StartupCode$FSharp-Compiler-Service>.$Service+clo@419-350.Invoke(class System.Tuple`2<class Microsoft.FSharp.Core.FSharpOption`1<class FSharp.Compiler.CodeAnalysis.IncrementalBuilder>,class FSharp.Compiler.Diagnostics.FSharpDiagnostic[]>)
  FSharp.Compiler.Service!FSharp.Compiler.BuildGraph+Bind@61-1[System.__Canon,System.__Canon].Invoke(!0)
  FSharp.Core!Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvokeNoHijackCheck(value class Microsoft.FSharp.Control.AsyncActivation`1<!!0>,!!1,class Microsoft.FSharp.Core.FSharpFunc`2<!!1,class Microsoft.FSharp.Control.FSharpAsync`1<!!0>>)
  FSharp.Core!Microsoft.FSharp.Control.Trampoline.Execute(class Microsoft.FSharp.Core.FSharpFunc`2<class Microsoft.FSharp.Core.Unit,class Microsoft.FSharp.Control.AsyncReturn>)
  FSharp.Core!Microsoft.FSharp.Control.AsyncPrimitives+AttachContinuationToUnitTask@1263.Invoke(class System.Threading.Tasks.Task)
  System.Private.CoreLib.il!System.Threading.ExecutionContext.RunInternal(class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object)
  System.Private.CoreLib.il!System.Threading.Tasks.Task.ExecuteWithThreadLocal(class System.Threading.Tasks.Task&,class System.Threading.Thread)
  System.Private.CoreLib.il!System.Threading.Tasks.ThreadPoolTaskScheduler.TryExecuteTaskInline(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.TaskScheduler.TryRunInline(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.TaskContinuation.InlineIfPossibleOrElseQueue(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.ContinueWithTaskContinuation.Run(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.Task.RunContinuations(class System.Object)
  System.Private.CoreLib.il!System.Threading.Tasks.Task.FinishSlow(bool)
  System.Private.CoreLib.il!System.Threading.Tasks.Task.ExecuteWithThreadLocal(class System.Threading.Tasks.Task&,class System.Threading.Thread)
  System.Private.CoreLib.il!System.Threading.Tasks.ThreadPoolTaskScheduler.TryExecuteTaskInline(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.TaskScheduler.TryRunInline(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.TaskContinuation.InlineIfPossibleOrElseQueue(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.ContinueWithTaskContinuation.Run(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.Task.RunContinuations(class System.Object)
  System.Private.CoreLib.il!System.Threading.SemaphoreSlim+<WaitUntilCountOrTimeoutAsync>d__31.MoveNext()
  System.Private.CoreLib.il!System.Threading.ExecutionContext.RunInternal(class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object)
  System.Private.CoreLib.il!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Boolean,System.Threading.SemaphoreSlim+<WaitUntilCountOrTimeoutAsync>d__31].MoveNext(class System.Threading.Thread)
  System.Private.CoreLib.il!System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(class System.Action,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.Task.RunContinuations(class System.Object)
  System.Private.CoreLib.il!System.Threading.Tasks.Task`1[System.Boolean].TrySetResult(!0)
  System.Private.CoreLib.il!System.Threading.Tasks.Task+CancellationPromise`1[System.Boolean].System.Threading.Tasks.ITaskCompletionAction.Invoke(class System.Threading.Tasks.Task)
  System.Private.CoreLib.il!System.Threading.ThreadPoolWorkQueue.Dispatch()
  System.Private.CoreLib.il!System.Threading.PortableThreadPool+WorkerThread.WorkerThreadStart()
  </pre>
</details>

- Changes some `RunSynchronously` calls to `StartImmediate` calls.
- Changes IDisposable calling IAsyncDisposable calls to not wait around. (We may be able to get rid of the `IDisposable` interfaces if I merge https://github.com/demystifyfp/FsToolkit.ErrorHandling/pull/212).


--- 

One of the threadpool exhaustion issues I can't fix yet is in the F# compiler itself. 


<details>
<summary>

[setCurrentState](https://github.com/dotnet/fsharp/blob/6f61d90bb68ebc4011d084af7d9b2d415d93fb4e/src/Compiler/Service/IncrementalBuild.fs#L1257-L1261) uses a lock in `node` CE code (which is effectively `async`) so this should probably use [SemaphoreSlim.WaitAsync](https://learn.microsoft.com/en-us/dotnet/api/system.threading.semaphoreslim.waitasync?view=net-7.0). We probably won't see this fix for a bit but just pointing it out for awareness.

</summary>
<pre>
Thread (0x1A138):
  [Native Frames]
  FSharp.Compiler.Service!FSharp.Compiler.CodeAnalysis.IncrementalBuilder.setCurrentState(class FSharp.Compiler.CodeAnalysis.IncrementalBuilderState,class TimeStampCache,value class System.Threading.CancellationToken)
  FSharp.Compiler.Service!<StartupCode$FSharp-Compiler-Service>.$IncrementalBuild+clo@1241-278.Invoke(value class System.Threading.CancellationToken)
  FSharp.Compiler.Service!FSharp.Compiler.BuildGraph+Bind@61-1[System.Threading.CancellationToken,System.__Canon].Invoke(!0)
  FSharp.Core!Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvokeNoHijackCheck(value class Microsoft.FSharp.Control.AsyncActivation`1<!!0>,!!1,class Microsoft.FSharp.Core.FSharpFunc`2<!!1,class Microsoft.FSharp.Control.FSharpAsync`1<!!0>>)
  FSharp.Core!Microsoft.FSharp.Control.Trampoline.Execute(class Microsoft.FSharp.Core.FSharpFunc`2<class Microsoft.FSharp.Core.Unit,class Microsoft.FSharp.Control.AsyncReturn>)
  FSharp.Core!Microsoft.FSharp.Control.AsyncPrimitives+AttachContinuationToUnitTask@1263.Invoke(class System.Threading.Tasks.Task)
  System.Private.CoreLib.il!System.Threading.ExecutionContext.RunInternal(class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object)
  System.Private.CoreLib.il!System.Threading.Tasks.Task.ExecuteWithThreadLocal(class System.Threading.Tasks.Task&,class System.Threading.Thread)
  System.Private.CoreLib.il!System.Threading.Tasks.ThreadPoolTaskScheduler.TryExecuteTaskInline(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.TaskScheduler.TryRunInline(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.TaskContinuation.InlineIfPossibleOrElseQueue(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.ContinueWithTaskContinuation.Run(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.Task.RunContinuations(class System.Object)
  System.Private.CoreLib.il!System.Threading.Tasks.Task.FinishSlow(bool)
  System.Private.CoreLib.il!System.Threading.Tasks.Task.ExecuteWithThreadLocal(class System.Threading.Tasks.Task&,class System.Threading.Thread)
  System.Private.CoreLib.il!System.Threading.Tasks.ThreadPoolTaskScheduler.TryExecuteTaskInline(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.TaskScheduler.TryRunInline(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.TaskContinuation.InlineIfPossibleOrElseQueue(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.ContinueWithTaskContinuation.Run(class System.Threading.Tasks.Task,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.Task.RunContinuations(class System.Object)
  System.Private.CoreLib.il!System.Threading.SemaphoreSlim+<WaitUntilCountOrTimeoutAsync>d__31.MoveNext()
  System.Private.CoreLib.il!System.Threading.ExecutionContext.RunInternal(class System.Threading.ExecutionContext,class System.Threading.ContextCallback,class System.Object)
  System.Private.CoreLib.il!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Boolean,System.Threading.SemaphoreSlim+<WaitUntilCountOrTimeoutAsync>d__31].MoveNext(class System.Threading.Thread)
  System.Private.CoreLib.il!System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(class System.Action,bool)
  System.Private.CoreLib.il!System.Threading.Tasks.Task.RunContinuations(class System.Object)
  System.Private.CoreLib.il!System.Threading.Tasks.Task`1[System.Boolean].TrySetResult(!0)
  System.Private.CoreLib.il!System.Threading.Tasks.Task+CancellationPromise`1[System.Boolean].System.Threading.Tasks.ITaskCompletionAction.Invoke(class System.Threading.Tasks.Task)
  System.Private.CoreLib.il!System.Threading.ThreadPoolWorkQueue.Dispatch()
  System.Private.CoreLib.il!System.Threading.PortableThreadPool+WorkerThread.WorkerThreadStart()
  </pre>
</details>