### PR TITLE
Run parse for tests

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -253,10 +253,12 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize) =
     checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
 
   member __.ParseFile(fn: string<LocalPath>, source, fpo) =
-    checkerLogger.info (Log.setMessage "ParseFile - {file}" >> Log.addContextDestructured "file" fn)
+    async {
+      checkerLogger.info (Log.setMessage "ParseFile - {file}" >> Log.addContextDestructured "file" fn)
 
-    let path = UMX.untag fn
-    checker.ParseFile(path, source, fpo)
+      let path = UMX.untag fn
+      return! checker.ParseFile(path, source, fpo)
+    }
 
   /// <summary>Parse and check a source code file, returning a handle to the results</summary>
   /// <param name="filePath">The name of the file in the project whose source is being checked.</param>

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1045,6 +1045,35 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
     FSharp.Compiler.IO.FileSystemAutoOpens.FileSystem <-
       FileSystem(FSharp.Compiler.IO.FileSystemAutoOpens.FileSystem, forceFindOpenFile)
 
+  /// <summary>Parses all files in the workspace. This is mostly used to trigger finding tests.</summary>
+  let parseAllFiles () =
+    aval {
+      let! projects = loadedProjectOptions
+      and! checker = checker
+
+      return
+        projects
+        |> Array.ofList
+        |> Array.Parallel.collect (fun p ->
+          let parseOpts = Utils.projectOptionsToParseOptions p
+          p.SourceFiles |> Array.map (fun s -> p, parseOpts, s))
+        |> Array.Parallel.choose (fun (opts, parseOpts, fileName) ->
+          let fileName = %fileName
+          let file = forceFindOpenFileOrRead fileName
+
+          file
+          |> Result.toOption
+          |> Option.map (fun file ->
+            async {
+              let! parseResult = checker.ParseFile(fileName, file.Lines, parseOpts)
+              let! ct = Async.CancellationToken
+              fileParsed.Trigger(parseResult, opts, ct)
+              return parseResult
+            }))
+        |> Async.parallel75
+
+    }
+
   let forceFindSourceText filePath =
     forceFindOpenFileOrRead filePath |> Result.map (fun f -> f.Lines)
 
@@ -1775,7 +1804,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
       let maxConcurrency =
         Math.Max(1.0, Math.Floor((float System.Environment.ProcessorCount) * 0.75))
 
-      do! Async.Parallel(checksToPerform, int maxConcurrency) |> Async.Ignore<unit array>
+      do! checksToPerform |> Async.parallel75 |> Async.Ignore<unit array>
 
     }
 
@@ -2111,7 +2140,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
 
         try
           logger.info (Log.setMessage "Initialized request {p}" >> Log.addContextDestructured "p" p)
-          forceLoadProjects () |> ignore
+          let! _ = parseAllFiles () |> AVal.force
           return ()
         with e ->
 
@@ -4038,7 +4067,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
             |> HashSet.ofArray
 
           transact (fun () -> workspacePaths.Value <- (WorkspaceChosen.Projs projs))
-          forceLoadProjects () |> ignore
+          let! _ = parseAllFiles () |> AVal.force
 
           return { Content = CommandResponse.workspaceLoad FsAutoComplete.JsonSerializer.writeJson true }
 

--- a/src/FsAutoComplete/LspServers/Common.fs
+++ b/src/FsAutoComplete/LspServers/Common.fs
@@ -144,6 +144,14 @@ module Async =
   let inline logCancelled e =
     logger.trace (Log.setMessage "Operation Cancelled" >> Log.addExn e)
 
+  /// <summary>Creates an asynchronous computation that executes all the given asynchronous computations, using 75% of the Environment.ProcessorCount</summary>
+  /// <param name="computations">A sequence of distinct computations to be parallelized.</param>
+  let parallel75 computations =
+    let maxConcurrency =
+      Math.Max(1.0, Math.Floor((float System.Environment.ProcessorCount) * 0.75))
+
+    Async.Parallel(computations, int maxConcurrency)
+
   let withCancellation (ct: CancellationToken) (a: Async<'a>) : Async<'a> =
     async {
       let! ct2 = Async.CancellationToken


### PR DESCRIPTION
This runs parsing on startup so we can identify tests immediately.  Could also make this limited to the projects that we detect xunit/nunit/expecto.

https://user-images.githubusercontent.com/1490044/225778087-18bf01de-30ec-4fad-8e5b-7bf6ddab630d.mp4

Built on top of https://github.com/fsharp/FsAutoComplete/pull/1079 to prevent conflicts.