### PR TITLE
don't trigger "Replace/Prefix with _" on Wild

### DIFF
--- a/src/FsAutoComplete/CodeFixes/RenameUnusedValue.fs
+++ b/src/FsAutoComplete/CodeFixes/RenameUnusedValue.fs
@@ -81,9 +81,18 @@ let fix (getParseResultsForFile: GetParseResultsForFile) =
           if mfv.IsMemberThisValue then
             return [ mkReplaceFix diagnostic.Range ]
           elif mfv.IsValue then
-            return
-              [ tryMkValueReplaceFix diagnostic.Range; tryMkPrefixFix diagnostic.Range ]
-              |> List.choose id
+            let symbolString =
+              if symbolUse.Range.StartLine = symbolUse.Range.EndLine then
+                line.Substring(symbolUse.Range.StartColumn, symbolUse.Range.EndColumn - symbolUse.Range.StartColumn)
+              else
+                ""
+
+            if symbolString <> "_" then
+              return
+                [ tryMkValueReplaceFix diagnostic.Range; tryMkPrefixFix diagnostic.Range ]
+                |> List.choose id
+            else
+              return []
           else
             return []
         | _ -> return []

--- a/src/FsAutoComplete/CodeFixes/RenameUnusedValue.fs
+++ b/src/FsAutoComplete/CodeFixes/RenameUnusedValue.fs
@@ -81,13 +81,13 @@ let fix (getParseResultsForFile: GetParseResultsForFile) =
           if mfv.IsMemberThisValue then
             return [ mkReplaceFix diagnostic.Range ]
           elif mfv.IsValue then
-            let symbolString =
-              if symbolUse.Range.StartLine = symbolUse.Range.EndLine then
-                line.Substring(symbolUse.Range.StartColumn, symbolUse.Range.EndColumn - symbolUse.Range.StartColumn)
-              else
-                ""
+            let symbolText =
+              lines.GetText symbolUse.Range
+              |> function
+                | Ok r -> r
+                | Error _ -> ""
 
-            if symbolString <> "_" then
+            if symbolText <> "_" then
               return
                 [ tryMkValueReplaceFix diagnostic.Range; tryMkPrefixFix diagnostic.Range ]
                 |> List.choose id

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -1698,6 +1698,22 @@ let private renameUnusedValue state =
         """
         (Diagnostics.acceptAll)
         selectPrefix
+
+    testCaseAsync "prefix doesn't trigger for _" <|
+      CodeFix.checkNotApplicable server
+        """
+        let $0_ = 6
+        """
+        (Diagnostics.acceptAll)
+        selectPrefix
+
+    testCaseAsync "replace doesn't trigger for _" <|
+      CodeFix.checkNotApplicable server
+        """
+        let $0_ = 6
+        """
+        (Diagnostics.acceptAll)
+        selectReplace
   ])
 
 let private replaceWithSuggestionTests state =


### PR DESCRIPTION
I think we shouldn't offer to replace a `_` with another `_` or prefix it with another `_` to be `__`