### PR TITLE
Fix how workspace/didChangeConfiguration handles DTO w/o FSharp property

### DIFF
--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -663,7 +663,7 @@ type FSharpConfigDto =
     Notifications: NotificationsDto option
     Debug: DebugDto option }
 
-type FSharpConfigRequest = { FSharp: FSharpConfigDto }
+type FSharpConfigRequest = { FSharp: FSharpConfigDto option }
 
 type CodeLensConfig =
   { Signature: {| Enabled: bool |}

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -3386,9 +3386,12 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
           )
 
           let dto = p.Settings |> Server.deserialize<FSharpConfigRequest>
-          let c = config |> AVal.force
-          let c = c.AddDto dto.FSharp
-          updateConfig c
+
+          dto.FSharp
+          |> Option.iter (fun fsharpConfig ->
+            let c = config |> AVal.force
+            let c = c.AddDto fsharpConfig
+            updateConfig c)
 
         with e ->
           trace.SetStatusErrorSafe(e.Message).RecordExceptions(e) |> ignore

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -2106,13 +2106,15 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
           >> Log.addContextDestructured "parms" dto
         )
 
-        let c = config.AddDto dto.FSharp
-        updateConfig c
+        dto.FSharp
+        |> Option.iter (fun fsharpConfig ->
+          let c = config.AddDto fsharpConfig
+          updateConfig c
 
-        logger.info (
-          Log.setMessage "Workspace configuration changed"
-          >> Log.addContextDestructured "config" c
-        )
+          logger.info (
+            Log.setMessage "Workspace configuration changed"
+            >> Log.addContextDestructured "config" c
+          ))
 
         return ()
       }

--- a/test/FsAutoComplete.Tests.Lsp/ScriptTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/ScriptTests.fs
@@ -75,7 +75,7 @@ let scriptEvictionTests state =
 
               let configChange: DidChangeConfigurationParams =
                 let config: FSharpConfigRequest =
-                  { FSharp = { defaultConfigDto with FSIExtraParameters = Some [| "--nowarn:760" |] } }
+                  { FSharp = Some { defaultConfigDto with FSIExtraParameters = Some [| "--nowarn:760" |] } }
 
                 { Settings = Server.serialize config }
 


### PR DESCRIPTION
Some non-customized LSP clients, like `eglot` (from emacs) sends `workspace/didChangeConfiguration` but with no `FSharp` property set as it has now knowledge of it being required.

This updates `FSharpConfigRequest` type and `WorkspaceDidChangeConfiguration()` implementations so we will ignore incoming configurations where `FSharp` property is not set.