### PR TITLE
fix: documentHighlight sending internalErrors

### DIFF
--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -2832,14 +2832,19 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
           let! lineStr = tryGetLineStr pos namedText.Lines |> Result.ofStringErr
           and! tyRes = forceGetTypeCheckResults filePath |> Result.ofStringErr
 
-          let! (symbol, uses) = tyRes.TryGetSymbolUseAndUsages pos lineStr |> Result.ofStringErr
-
-          return
-            uses
-            |> Array.map (fun s ->
-              { DocumentHighlight.Range = fcsRangeToLsp s.Range
-                Kind = None })
-            |> Some
+          match
+            tyRes.TryGetSymbolUseAndUsages pos lineStr
+            |> Result.bimap CoreResponse.Res CoreResponse.InfoRes
+          with
+          | CoreResponse.InfoRes msg -> return None
+          | CoreResponse.ErrorRes msg -> return! LspResult.internalError msg
+          | CoreResponse.Res(symbol, uses) ->
+            return
+              uses
+              |> Array.map (fun s ->
+                { DocumentHighlight.Range = fcsRangeToLsp s.Range
+                  Kind = None })
+              |> Some
         with e ->
           trace.SetStatusErrorSafe(e.Message).RecordExceptions(e) |> ignore
 


### PR DESCRIPTION
Fixes #1078 

This fixes a user experience issue in neovim, where too many errors appear from LSP responses to `documentHighlight`.

Modifies `TextDocumentDocumentHighlight` in the adaptive LSP server so when Error "No symbol information found" is returned from `TryGetSymbolUseAndUsages` it is converted to `InfoRes -> None` instead of being raised as an internalError.