### PR TITLE
Codefix to add private access modifier

### DIFF
--- a/src/FsAutoComplete/CodeFixes/AddPrivateAccessModifier.fs
+++ b/src/FsAutoComplete/CodeFixes/AddPrivateAccessModifier.fs
@@ -8,7 +8,7 @@ open FsAutoComplete.LspHelpers
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text.Range
 
-let title = "add private access modifier"
+let title = "Add private access modifier"
 
 let private isLetInsideObjectModel input pos =
   SyntaxTraversal.Traverse(
@@ -88,7 +88,6 @@ type SymbolUseWorkspace =
 
 let fix
   (getParseResultsForFile: GetParseResultsForFile)
-  (getRangeText: GetRangeText)
   (symbolUseWorkspace: SymbolUseWorkspace)
   : CodeFix =
   fun codeActionParams ->

--- a/src/FsAutoComplete/CodeFixes/AddPrivateAccessModifier.fs
+++ b/src/FsAutoComplete/CodeFixes/AddPrivateAccessModifier.fs
@@ -6,9 +6,25 @@ open Ionide.LanguageServerProtocol.Types
 open FsAutoComplete
 open FsAutoComplete.LspHelpers
 open FSharp.Compiler.Syntax
+open FSharp.Compiler.SyntaxTrivia
 open FSharp.Compiler.Text.Range
 
 let title = "Add private access modifier"
+
+type SymbolUseWorkspace =
+  bool
+    -> bool
+    -> bool
+    -> FSharp.Compiler.Text.Position
+    -> LineStr
+    -> NamedText
+    -> ParseAndCheckResults
+    -> Async<Result<FSharp.Compiler.Symbols.FSharpSymbol *
+    System.Collections.Generic.IDictionary<FSharp.UMX.string<LocalPath>, FSharp.Compiler.Text.range array>, string>>
+
+type private Placement =
+  | Before
+  | After
 
 let private isLetInsideObjectModel input pos =
   SyntaxTraversal.Traverse(
@@ -52,6 +68,54 @@ let private getRangeToEdit input pos =
       | SyntaxNode.SynModuleOrNamespace m when rangeContainsPos m.Range pos -> Some m.Range
       | _ -> None)
 
+  let rec findNested path decls =
+    decls
+    |> List.tryPick (fun d ->
+      match d with
+      | SynModuleDecl.NestedModule(
+          moduleInfo = SynComponentInfo(longId = longId; accessibility = None); trivia = { ModuleKeyword = Some r }) as m when
+        longId
+        |> List.tryFind (fun i -> rangeContainsPos i.idRange pos)
+        |> Option.isSome
+        ->
+        let editRange = r.WithStart r.End
+        let path = (SyntaxNode.SynModule m) :: path
+
+        match tryPickContainingRange path pos with
+        | Some r -> Some(editRange, r, After)
+        | _ -> None
+      | SynModuleDecl.NestedModule(moduleInfo = moduleInfo; decls = decls) as m ->
+        let path = (SyntaxNode.SynModule m) :: path
+
+        match moduleInfo with
+        | _ -> findNested path decls
+      | SynModuleDecl.Types(typeDefns = typeDefns) as t ->
+        let path = (SyntaxNode.SynModule t) :: path
+
+        typeDefns
+        |> List.tryPick (fun td ->
+          match td with
+          | SynTypeDefn(typeRepr = SynTypeDefnRepr.ObjectModel(_, members, _)) as d ->
+            let path = SyntaxNode.SynTypeDefn d :: path
+
+            members
+            |> List.tryPick (fun m ->
+              match m with
+              | SynMemberDefn.AutoProperty(accessibility = None; ident = ident; trivia = trivia) as a when
+                rangeContainsPos ident.idRange pos
+                ->
+                let editRange =
+                  trivia.LeadingKeyword.Range.WithStart trivia.LeadingKeyword.Range.End
+
+                let path = SyntaxNode.SynMemberDefn a :: path
+
+                match tryPickContainingRange path pos with
+                | Some r -> Some(editRange, r, After)
+                | _ -> None
+              | _ -> None)
+          | _ -> None)
+      | _ -> None)
+
   let visitor =
     { new SyntaxVisitorBase<_>() with
         member _.VisitBinding(path, _, synBinding) =
@@ -60,36 +124,56 @@ let private getRangeToEdit input pos =
             rangeContainsPos s.RangeOfHeadPattern pos
             ->
             match headPat with
-            | SynPat.Named(accessibility = None)
-            | SynPat.LongIdent(accessibility = None) ->
+            | SynPat.LongIdent(longDotId = longDotId; accessibility = None; argPats = synArgPats) ->
+              let posInArgs =
+                synArgPats.Patterns |> List.exists (fun p -> rangeContainsPos p.Range pos)
+
+              let posInFirstIdent =
+                longDotId.LongIdent.Length > 1
+                && rangeContainsPos longDotId.LongIdent[0].idRange pos
+
+              if posInArgs || posInFirstIdent then
+                None
+              else
+                let editRange = s.RangeOfHeadPattern.WithEnd s.RangeOfHeadPattern.Start
+
+                match tryPickContainingRange path pos with
+                | Some r -> Some(editRange, r, Before)
+                | _ -> None
+            | SynPat.Named(accessibility = None; isThisVal = false) ->
               let editRange = s.RangeOfHeadPattern.WithEnd s.RangeOfHeadPattern.Start
 
               match tryPickContainingRange path pos with
-              | Some r -> Some(editRange, r)
+              | Some r -> Some(editRange, r, Before)
               | _ -> None
             | _ -> None
-          | _ -> None }
+          | _ -> None
+
+        member _.VisitModuleOrNamespace(path, synModuleOrNamespace) =
+          match synModuleOrNamespace with
+          | SynModuleOrNamespace(
+              longId = longId
+              accessibility = None
+              trivia = { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Module r }) when
+            longId
+            |> List.tryFind (fun i -> rangeContainsPos i.idRange pos)
+            |> Option.isSome
+            ->
+            let editRange = r.WithStart r.End
+
+            match tryPickContainingRange path pos with
+            | Some r -> Some(editRange, r, After)
+            | _ -> None
+          | SynModuleOrNamespace(decls = decls) as mOrN ->
+            let path = SyntaxNode.SynModuleOrNamespace mOrN :: path
+            findNested path decls }
 
   if isLetInsideObjectModel input pos then
     None
   else
     SyntaxTraversal.Traverse(pos, input, visitor)
 
-type SymbolUseWorkspace =
-  bool
-    -> bool
-    -> bool
-    -> FSharp.Compiler.Text.Position
-    -> LineStr
-    -> NamedText
-    -> ParseAndCheckResults
-    -> Async<Result<FSharp.Compiler.Symbols.FSharpSymbol *
-    System.Collections.Generic.IDictionary<FSharp.UMX.string<LocalPath>, FSharp.Compiler.Text.range array>, string>>
-
-let fix
-  (getParseResultsForFile: GetParseResultsForFile)
-  (symbolUseWorkspace: SymbolUseWorkspace)
-  : CodeFix =
+let fix (getParseResultsForFile: GetParseResultsForFile) (symbolUseWorkspace: SymbolUseWorkspace) : CodeFix =
   fun codeActionParams ->
     asyncResult {
       let filePath = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
@@ -98,7 +182,7 @@ let fix
       let editRangeAndDeclRange = getRangeToEdit parseAndCheck.GetAST fcsPos
 
       match editRangeAndDeclRange with
-      | Some(r, declRange) ->
+      | Some(editRange, declRange, placement) ->
 
         let! (_, uses) = symbolUseWorkspace false true true fcsPos lineStr sourceText parseAndCheck
         let useRanges = uses.Values |> Array.concat
@@ -106,15 +190,20 @@ let fix
         let usedOutsideOfDecl =
           useRanges
           |> Array.exists (fun usingRange ->
-            usingRange.FileName <> r.FileName
+            usingRange.FileName <> editRange.FileName
             || not (rangeContainsRange declRange usingRange))
 
         if usedOutsideOfDecl then
           return []
         else
+          let text =
+            match placement with
+            | Before -> "private "
+            | After -> " private"
+
           let e =
-            { Range = fcsRangeToLsp r
-              NewText = "private " }
+            { Range = fcsRangeToLsp editRange
+              NewText = text }
 
           return
             [ { Edits = [| e |]

--- a/src/FsAutoComplete/CodeFixes/AddPrivateAccessModifier.fs
+++ b/src/FsAutoComplete/CodeFixes/AddPrivateAccessModifier.fs
@@ -1,0 +1,87 @@
+module FsAutoComplete.CodeFix.AddPrivateAccessModifier
+
+open FsToolkit.ErrorHandling
+open FsAutoComplete.CodeFix.Types
+open Ionide.LanguageServerProtocol.Types
+open FsAutoComplete
+open FsAutoComplete.LspHelpers
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text.Range
+
+let title = "add private access modifier"
+
+let private getRangeToEdit input pos =
+  SyntaxTraversal.Traverse(
+    pos,
+    input,
+    { new SyntaxVisitorBase<_>() with
+        member _.VisitBinding(path, _, synBinding) =
+          match synBinding with
+          | SynBinding(headPat = headPat) as s when rangeContainsPos s.RangeOfHeadPattern pos ->
+            match headPat with
+            | SynPat.Named(accessibility = None)
+            | SynPat.LongIdent(accessibility = None) ->
+              let r =
+                path
+                |> Seq.rev
+                |> Seq.tryPick (fun p ->
+                  match p with
+                  | SyntaxNode.SynModule m -> Some m
+                  | _ -> None)
+
+              Some((s.RangeOfHeadPattern.WithEnd s.RangeOfHeadPattern.Start), r)
+            | _ -> None
+          | _ -> None }
+  )
+
+type SymbolUseWorkspace =
+  bool
+    -> bool
+    -> bool
+    -> FSharp.Compiler.Text.Position
+    -> LineStr
+    -> NamedText
+    -> ParseAndCheckResults
+    -> Async<Result<FSharp.Compiler.Symbols.FSharpSymbol *
+    System.Collections.Generic.IDictionary<FSharp.UMX.string<LocalPath>, FSharp.Compiler.Text.range array>, string>>
+
+let fix
+  (getParseResultsForFile: GetParseResultsForFile)
+  (getRangeText: GetRangeText)
+  (symbolUseWorkspace: SymbolUseWorkspace)
+  : CodeFix =
+  fun codeActionParams ->
+    asyncResult {
+      let filePath = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
+      let fcsPos = protocolPosToPos codeActionParams.Range.Start
+      let! (parseAndCheck, lineStr, sourceText) = getParseResultsForFile filePath fcsPos
+      let rangeAndPath = getRangeToEdit parseAndCheck.GetAST fcsPos
+
+      match rangeAndPath with
+      | Some(r, Some path) ->
+
+        let! (s, uses) = symbolUseWorkspace false true false r.Start lineStr sourceText parseAndCheck
+        let useRanges = uses.Values |> Array.concat
+        let declRange = path.Range
+
+        let usedOutsideOfDecl =
+          useRanges
+          |> Array.exists (fun usingRange ->
+            usingRange.FileName <> r.FileName
+            || not (rangeContainsRange declRange usingRange))
+
+        if usedOutsideOfDecl then
+          return []
+        else
+          let e =
+            { Range = fcsRangeToLsp r
+              NewText = "private " }
+
+          return
+            [ { Edits = [| e |]
+                File = codeActionParams.TextDocument
+                Title = title
+                SourceDiagnostic = None
+                Kind = FixKind.Refactor } ]
+      | _ -> return []
+    }

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -839,7 +839,7 @@ type FSharpConfig =
       InterfaceStubGenerationObjectIdentifier = defaultArg dto.InterfaceStubGenerationObjectIdentifier "this"
       InterfaceStubGenerationMethodBody =
         defaultArg dto.InterfaceStubGenerationMethodBody "failwith \"Not Implemented\""
-      AddPrivateAccessModifier = defaultArg dto.AddPrivateAccessModifier false  
+      AddPrivateAccessModifier = defaultArg dto.AddPrivateAccessModifier false
       UnusedOpensAnalyzer = defaultArg dto.UnusedOpensAnalyzer false
       UnusedDeclarationsAnalyzer = defaultArg dto.UnusedDeclarationsAnalyzer false
       SimplifyNameAnalyzer = defaultArg dto.SimplifyNameAnalyzer false

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -638,6 +638,7 @@ type FSharpConfigDto =
     InterfaceStubGeneration: bool option
     InterfaceStubGenerationObjectIdentifier: string option
     InterfaceStubGenerationMethodBody: string option
+    AddPrivateAccessModifier: bool option
     UnusedOpensAnalyzer: bool option
     UnusedDeclarationsAnalyzer: bool option
     SimplifyNameAnalyzer: bool option
@@ -756,6 +757,7 @@ type FSharpConfig =
     InterfaceStubGeneration: bool
     InterfaceStubGenerationObjectIdentifier: string
     InterfaceStubGenerationMethodBody: string
+    AddPrivateAccessModifier: bool
     UnusedOpensAnalyzer: bool
     UnusedDeclarationsAnalyzer: bool
     SimplifyNameAnalyzer: bool
@@ -797,6 +799,7 @@ type FSharpConfig =
       InterfaceStubGeneration = false
       InterfaceStubGenerationObjectIdentifier = "this"
       InterfaceStubGenerationMethodBody = "failwith \"Not Implemented\""
+      AddPrivateAccessModifier = false
       UnusedOpensAnalyzer = false
       UnusedDeclarationsAnalyzer = false
       SimplifyNameAnalyzer = false
@@ -836,6 +839,7 @@ type FSharpConfig =
       InterfaceStubGenerationObjectIdentifier = defaultArg dto.InterfaceStubGenerationObjectIdentifier "this"
       InterfaceStubGenerationMethodBody =
         defaultArg dto.InterfaceStubGenerationMethodBody "failwith \"Not Implemented\""
+      AddPrivateAccessModifier = defaultArg dto.AddPrivateAccessModifier false  
       UnusedOpensAnalyzer = defaultArg dto.UnusedOpensAnalyzer false
       UnusedDeclarationsAnalyzer = defaultArg dto.UnusedDeclarationsAnalyzer false
       SimplifyNameAnalyzer = defaultArg dto.SimplifyNameAnalyzer false
@@ -926,6 +930,7 @@ type FSharpConfig =
         defaultArg dto.InterfaceStubGenerationObjectIdentifier x.InterfaceStubGenerationObjectIdentifier
       InterfaceStubGenerationMethodBody =
         defaultArg dto.InterfaceStubGenerationMethodBody x.InterfaceStubGenerationMethodBody
+      AddPrivateAccessModifier = defaultArg dto.AddPrivateAccessModifier x.AddPrivateAccessModifier
       UnusedOpensAnalyzer = defaultArg dto.UnusedOpensAnalyzer x.UnusedOpensAnalyzer
       UnusedDeclarationsAnalyzer = defaultArg dto.UnusedDeclarationsAnalyzer x.UnusedDeclarationsAnalyzer
       SimplifyNameAnalyzer = defaultArg dto.SimplifyNameAnalyzer x.SimplifyNameAnalyzer

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1386,6 +1386,102 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
         member x.ParseFileInProject(file) =
           forceGetParseResults file |> Option.ofResult }
 
+  let getDependentProjectsOfProjects ps =
+    let projectSnapshot = forceLoadProjects ()
+
+    let allDependents = System.Collections.Generic.HashSet<FSharpProjectOptions>()
+
+    let currentPass = ResizeArray()
+    currentPass.AddRange(ps |> List.map (fun p -> p.ProjectFileName))
+
+    let mutable continueAlong = true
+
+    while continueAlong do
+      let dependents =
+        projectSnapshot
+        |> Seq.filter (fun p ->
+          p.ReferencedProjects
+          |> Seq.exists (fun r ->
+            match r.ProjectFilePath with
+            | None -> false
+            | Some p -> currentPass.Contains(p)))
+
+      if Seq.isEmpty dependents then
+        continueAlong <- false
+        currentPass.Clear()
+      else
+        for d in dependents do
+          allDependents.Add d |> ignore<bool>
+
+        currentPass.Clear()
+        currentPass.AddRange(dependents |> Seq.map (fun p -> p.ProjectFileName))
+
+    Seq.toList allDependents
+
+
+  let getDeclarationLocation (symbolUse, text) =
+      let getProjectOptions file =
+        getProjectOptionsForFile file |> AVal.force |> selectProject
+
+      let projectsThatContainFile file =
+        getProjectOptionsForFile file |> AVal.force
+
+      SymbolLocation.getDeclarationLocation (
+        symbolUse,
+        text,
+        getProjectOptions,
+        projectsThatContainFile,
+        getDependentProjectsOfProjects
+      )
+
+  let symbolUseWorkspace
+      (includeDeclarations: bool)
+      (includeBackticks: bool)
+      (errorOnFailureToFixRange: bool)
+      pos
+      lineStr
+      text
+      tyRes
+      =
+
+      let findReferencesForSymbolInFile (file: string<LocalPath>, project, symbol) =
+        async {
+          let checker = checker |> AVal.force
+
+          if File.Exists(UMX.untag file) then
+            // `FSharpChecker.FindBackgroundReferencesInFile` only works with existing files
+            return! checker.FindReferencesForSymbolInFile(UMX.untag file, project, symbol)
+          else
+            // untitled script files
+            match forceGetRecentTypeCheckResults file with
+            | Error _ -> return [||]
+            | Ok tyRes ->
+              let! ct = Async.CancellationToken
+              let usages = tyRes.GetCheckResults.GetUsesOfSymbolInFile(symbol, ct)
+              return usages |> Seq.map (fun u -> u.Range)
+        }
+
+      let tryGetProjectOptionsForFsproj (file: string<LocalPath>) =
+        forceGetProjectOptions file |> Option.ofResult
+
+      let getAllProjectOptions () : _ seq =
+        allProjectOptions'.Content |> AVal.force :> _
+
+      Commands.symbolUseWorkspace
+        getDeclarationLocation
+        findReferencesForSymbolInFile
+        forceFindSourceText
+        tryGetProjectOptionsForFsproj
+        getAllProjectOptions
+        includeDeclarations
+        includeBackticks
+        errorOnFailureToFixRange
+        pos
+        lineStr
+        text
+        tyRes
+
+
   let codefixes =
     let getFileLines = forceFindSourceText
 
@@ -1438,6 +1534,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
     let writeAbstractClassStub =
       AbstractClassStubGenerator.writeAbstractClassStub codeGenServer
 
+    
 
     let getAbstractClassStub tyRes objExprRange lines lineStr =
       Commands.getAbstractClassStub
@@ -1504,6 +1601,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
          AddExplicitTypeAnnotation.fix tryGetParseResultsForFile
          ConvertPositionalDUToNamed.fix tryGetParseResultsForFile getRangeText
          ConvertTripleSlashCommentToXmlTaggedDoc.fix tryGetParseResultsForFile getRangeText
+         AddPrivateAccessModifier.fix tryGetParseResultsForFile getRangeText symbolUseWorkspace
          UseTripleQuotedInterpolation.fix tryGetParseResultsForFile getRangeText
          RenameParamToMatchSignature.fix tryGetParseResultsForFile |])
 
@@ -1590,38 +1688,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
       |> Array.map (fun sourceFile -> proj, sourceFile))
     |> Array.distinct
 
-  let getDependentProjectsOfProjects ps =
-    let projectSnapshot = forceLoadProjects ()
-
-    let allDependents = System.Collections.Generic.HashSet<FSharpProjectOptions>()
-
-    let currentPass = ResizeArray()
-    currentPass.AddRange(ps |> List.map (fun p -> p.ProjectFileName))
-
-    let mutable continueAlong = true
-
-    while continueAlong do
-      let dependents =
-        projectSnapshot
-        |> Seq.filter (fun p ->
-          p.ReferencedProjects
-          |> Seq.exists (fun r ->
-            match r.ProjectFilePath with
-            | None -> false
-            | Some p -> currentPass.Contains(p)))
-
-      if Seq.isEmpty dependents then
-        continueAlong <- false
-        currentPass.Clear()
-      else
-        for d in dependents do
-          allDependents.Add d |> ignore<bool>
-
-        currentPass.Clear()
-        currentPass.AddRange(dependents |> Seq.map (fun p -> p.ProjectFileName))
-
-    Seq.toList allDependents
-
+  
   let bypassAdaptiveAndCheckDepenenciesForFile (filePath: string<LocalPath>) =
     async {
       let tags = [ SemanticConventions.fsac_sourceCodePath, box (UMX.untag filePath) ]
@@ -1694,68 +1761,9 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
 
     }
 
-  let getDeclarationLocation (symbolUse, text) =
-    let getProjectOptions file =
-      getProjectOptionsForFile file |> AVal.force |> selectProject
 
-    let projectsThatContainFile file =
-      getProjectOptionsForFile file |> AVal.force
 
-    SymbolLocation.getDeclarationLocation (
-      symbolUse,
-      text,
-      getProjectOptions,
-      projectsThatContainFile,
-      getDependentProjectsOfProjects
-    )
-
-  let symbolUseWorkspace
-    (includeDeclarations: bool)
-    (includeBackticks: bool)
-    (errorOnFailureToFixRange: bool)
-    pos
-    lineStr
-    text
-    tyRes
-    =
-
-    let findReferencesForSymbolInFile (file: string<LocalPath>, project, symbol) =
-      async {
-        let checker = checker |> AVal.force
-
-        if File.Exists(UMX.untag file) then
-          // `FSharpChecker.FindBackgroundReferencesInFile` only works with existing files
-          return! checker.FindReferencesForSymbolInFile(UMX.untag file, project, symbol)
-        else
-          // untitled script files
-          match forceGetRecentTypeCheckResults file with
-          | Error _ -> return [||]
-          | Ok tyRes ->
-            let! ct = Async.CancellationToken
-            let usages = tyRes.GetCheckResults.GetUsesOfSymbolInFile(symbol, ct)
-            return usages |> Seq.map (fun u -> u.Range)
-      }
-
-    let tryGetProjectOptionsForFsproj (file: string<LocalPath>) =
-      forceGetProjectOptions file |> Option.ofResult
-
-    let getAllProjectOptions () : _ seq =
-      allProjectOptions'.Content |> AVal.force :> _
-
-    Commands.symbolUseWorkspace
-      getDeclarationLocation
-      findReferencesForSymbolInFile
-      forceFindSourceText
-      tryGetProjectOptionsForFsproj
-      getAllProjectOptions
-      includeDeclarations
-      includeBackticks
-      errorOnFailureToFixRange
-      pos
-      lineStr
-      text
-      tyRes
-
+  
   member private x.handleSemanticTokens (filePath: string<LocalPath>) range : LspResult<SemanticTokens option> =
     result {
 

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1601,7 +1601,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
          AddExplicitTypeAnnotation.fix tryGetParseResultsForFile
          ConvertPositionalDUToNamed.fix tryGetParseResultsForFile getRangeText
          ConvertTripleSlashCommentToXmlTaggedDoc.fix tryGetParseResultsForFile getRangeText
-         AddPrivateAccessModifier.fix tryGetParseResultsForFile getRangeText symbolUseWorkspace
+         AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace
          UseTripleQuotedInterpolation.fix tryGetParseResultsForFile getRangeText
          RenameParamToMatchSignature.fix tryGetParseResultsForFile |])
 

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1599,7 +1599,9 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
          AddExplicitTypeAnnotation.fix tryGetParseResultsForFile
          ConvertPositionalDUToNamed.fix tryGetParseResultsForFile getRangeText
          ConvertTripleSlashCommentToXmlTaggedDoc.fix tryGetParseResultsForFile getRangeText
-         Run.ifEnabled (fun _ -> config.AddPrivateAccessModifier) (AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace)
+         Run.ifEnabled
+           (fun _ -> config.AddPrivateAccessModifier)
+           (AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace)
          UseTripleQuotedInterpolation.fix tryGetParseResultsForFile getRangeText
          RenameParamToMatchSignature.fix tryGetParseResultsForFile |])
 

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1599,7 +1599,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
          AddExplicitTypeAnnotation.fix tryGetParseResultsForFile
          ConvertPositionalDUToNamed.fix tryGetParseResultsForFile getRangeText
          ConvertTripleSlashCommentToXmlTaggedDoc.fix tryGetParseResultsForFile getRangeText
-         AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace
+         Run.ifEnabled (fun _ -> config.AddPrivateAccessModifier) (AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace)
          UseTripleQuotedInterpolation.fix tryGetParseResultsForFile getRangeText
          RenameParamToMatchSignature.fix tryGetParseResultsForFile |])
 

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1418,7 +1418,6 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
 
     Seq.toList allDependents
 
-
   let getDeclarationLocation (symbolUse, text) =
       let getProjectOptions file =
         getProjectOptionsForFile file |> AVal.force |> selectProject
@@ -1535,7 +1534,6 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
       AbstractClassStubGenerator.writeAbstractClassStub codeGenServer
 
     
-
     let getAbstractClassStub tyRes objExprRange lines lineStr =
       Commands.getAbstractClassStub
         tryFindAbstractClassExprInBufferAtPos

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -1210,7 +1210,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
              AddExplicitTypeAnnotation.fix tryGetParseResultsForFile
              ConvertPositionalDUToNamed.fix tryGetParseResultsForFile getRangeText
              ConvertTripleSlashCommentToXmlTaggedDoc.fix tryGetParseResultsForFile getRangeText
-             AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace
+             Run.ifEnabled (fun _ -> config.AddPrivateAccessModifier) (AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace)
              UseTripleQuotedInterpolation.fix tryGetParseResultsForFile getRangeText
              RenameParamToMatchSignature.fix tryGetParseResultsForFile |]
 

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -1135,6 +1135,25 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
 
         let getAbstractClassStubReplacements () = abstractClassStubReplacements ()
 
+        let symbolUseWorkspace
+          (includeDeclarations: bool)
+          (includeBackticks: bool)
+          (errorOnFailureToFixRange: bool)
+          pos
+          lineStr
+          text
+          tyRes
+          =
+          commands.SymbolUseWorkspace(
+            pos,
+            lineStr,
+            text,
+            tyRes,
+            includeDeclarations,
+            includeBackticks,
+            errorOnFailureToFixRange
+          )
+
         codefixes <-
           [| Run.ifEnabled (fun _ -> config.UnusedOpensAnalyzer) (RemoveUnusedOpens.fix getFileLines)
              Run.ifEnabled
@@ -1191,6 +1210,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
              AddExplicitTypeAnnotation.fix tryGetParseResultsForFile
              ConvertPositionalDUToNamed.fix tryGetParseResultsForFile getRangeText
              ConvertTripleSlashCommentToXmlTaggedDoc.fix tryGetParseResultsForFile getRangeText
+             AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace
              UseTripleQuotedInterpolation.fix tryGetParseResultsForFile getRangeText
              RenameParamToMatchSignature.fix tryGetParseResultsForFile |]
 

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -1210,7 +1210,9 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
              AddExplicitTypeAnnotation.fix tryGetParseResultsForFile
              ConvertPositionalDUToNamed.fix tryGetParseResultsForFile getRangeText
              ConvertTripleSlashCommentToXmlTaggedDoc.fix tryGetParseResultsForFile getRangeText
-             Run.ifEnabled (fun _ -> config.AddPrivateAccessModifier) (AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace)
+             Run.ifEnabled
+               (fun _ -> config.AddPrivateAccessModifier)
+               (AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace)
              UseTripleQuotedInterpolation.fix tryGetParseResultsForFile getRangeText
              RenameParamToMatchSignature.fix tryGetParseResultsForFile |]
 

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -644,7 +644,8 @@ let private convertPositionalDUToNamedTests state =
   ])
 
 let private addPrivateAccessModifierTests state =
-  serverTestList (nameof AddPrivateAccessModifier) state defaultConfigDto None (fun server ->
+  let config = { defaultConfigDto with AddPrivateAccessModifier = Some true }
+  serverTestList (nameof AddPrivateAccessModifier) state config None (fun server ->
     [ let selectCodeFix = CodeFix.withTitle AddPrivateAccessModifier.title
 
       testCaseAsync "add private works for simple function"

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -727,6 +727,20 @@ let private addPrivateAccessModifierTests state =
         Diagnostics.acceptAll
         selectCodeFix
       
+      testCaseAsync "add private works for class type definition"
+      <| CodeFix.check
+        server
+        """
+        type [<System.Obsolete>] MyCla$0ss() =
+          member _.X = 10
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        type [<System.Obsolete>] private MyClass() =
+          member _.X = 10
+        """
+
       testCaseAsync "add private is not offered for member with reference outside its declaring class"
       <| CodeFix.checkNotApplicable
         server
@@ -814,6 +828,22 @@ let private addPrivateAccessModifierTests state =
         Diagnostics.acceptAll
         selectCodeFix
 
+      testCaseAsync "add private works for DU type definition"
+      <| CodeFix.check
+        server
+        """
+        type [<System.Obsolete>] MyDi$0scUnion =
+        | Case1
+        | Case2
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        type [<System.Obsolete>] private MyDiscUnion =
+        | Case1
+        | Case2
+        """
+
       testCaseAsync "add private is not offered for member with reference outside its declaring DU"
       <| CodeFix.checkNotApplicable
         server
@@ -877,6 +907,22 @@ let private addPrivateAccessModifierTests state =
         | Case2
         with
           member private _.Foo x = x
+        """
+      
+      testCaseAsync "add private works for Record definition"
+      <| CodeFix.check
+        server
+        """
+        type [<System.Obsolete>] My$0Record =
+          { Field1: int
+            Field2: string }
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        type [<System.Obsolete>] private MyRecord =
+          { Field1: int
+            Field2: string }
         """
       
       testCaseAsync "add private is not offered for member with reference outside its declaring Record"

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -712,7 +712,7 @@ let private addPrivateAccessModifierTests state =
         Diagnostics.acceptAll
         selectCodeFix
 
-      testCaseAsync "addprivate is not offered for function with outside reference"
+      testCaseAsync "addprivate is not offered for function with reference outside its declaring module"
       <| CodeFix.checkNotApplicable
         server
         """
@@ -726,9 +726,43 @@ let private addPrivateAccessModifierTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
+      
+      testCaseAsync "addprivate is not offered for member with reference outside its declaring class"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyClass() =
+          member _.$0X = 10
 
+        let myInst = MyClass()
+        myInst.X |> ignore
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
 
-
+      testCaseAsync "addprivate is not offered for let bindings inside a class"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyClass() =
+          let $0f x = x * x
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+      
+      testCaseAsync "addprivate works for class member"
+      <| CodeFix.check
+        server
+        """
+        type MyClass() =
+          member _.$0X = 10
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        type MyClass() =
+          member private _.X = 10
+        """
     ])
 
 let private convertTripleSlashCommentToXmlTaggedDocTests state =

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -936,7 +936,7 @@ let private addPrivateAccessModifierTests state =
         with
           member private _.Foo x = x
         """
-      
+
       testCaseAsync "add private is not offered for Record type definition" // ref finding might not show us type inferred usages
       <| CodeFix.checkNotApplicable
         server
@@ -1052,6 +1052,30 @@ let private addPrivateAccessModifierTests state =
               let foofoo = 10
     
         M.N.foofoo |> ignore
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+
+      testCaseAsync "add private works for type abbreviation"
+      <| CodeFix.check
+        server
+        """
+        type My$0Int = int
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        type private MyInt = int
+        """
+
+      testCaseAsync "add private is not offered for type abbreviation with reference outside its declaring module"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        module M =
+          type My$0Int = int
+        
+        let x: M.MyInt = 23
         """
         Diagnostics.acceptAll
         selectCodeFix

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -647,7 +647,7 @@ let private addPrivateAccessModifierTests state =
   serverTestList (nameof AddPrivateAccessModifier) state defaultConfigDto None (fun server ->
     [ let selectCodeFix = CodeFix.withTitle AddPrivateAccessModifier.title
 
-      testCaseAsync "addprivate works for simle function"
+      testCaseAsync "addprivate works for simple function"
       <| CodeFix.check
         server
         """
@@ -659,7 +659,7 @@ let private addPrivateAccessModifierTests state =
         let private f x = x * x
         """
       
-      testCaseAsync "addprivate works for simle identifier"
+      testCaseAsync "addprivate works for simple identifier"
       <| CodeFix.check
         server
         """
@@ -669,6 +669,38 @@ let private addPrivateAccessModifierTests state =
         selectCodeFix
         """
         let private x = 23
+        """
+
+      testCaseAsync "addprivate works for simple identifier used in other private function"
+      <| CodeFix.check
+        server
+        """
+        module PMod =
+          let xx$0x = 10
+
+          module PMod2 =
+            let insidePMod2 = 23
+
+          let private a = 23
+
+          let private g z =
+            let sF y = y + xxx
+            z
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        module PMod =
+          let private xxx = 10
+
+          module PMod2 =
+            let insidePMod2 = 23
+
+          let private a = 23
+
+          let private g z =
+            let sF y = y + xxx
+            z
         """
 
       testCaseAsync "addprivate is not offered for already private functions"
@@ -694,6 +726,9 @@ let private addPrivateAccessModifierTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
+
+
+
     ])
 
 let private convertTripleSlashCommentToXmlTaggedDocTests state =

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -740,6 +740,29 @@ let private addPrivateAccessModifierTests state =
         type [<System.Obsolete>] private MyClass() =
           member _.X = 10
         """
+      
+      testCaseAsync "add private is not offered for class type definition with reference"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyCla$0ss() =
+          member _.X = 10
+
+        let _ = MyClass()
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+      
+      testCaseAsync "add private is not offered for explicit ctor" // ref finding might not show us usages
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyC(x: int) =
+          ne$0w() =
+            MyC(23)
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
 
       testCaseAsync "add private is not offered for member with reference outside its declaring class"
       <| CodeFix.checkNotApplicable
@@ -763,6 +786,16 @@ let private addPrivateAccessModifierTests state =
 
         let myInst = MyClass()
         myInst.X |> ignore
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+
+      testCaseAsync "add private is not offered for member when caret is in SynTypArDecl"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyC() =
+          member _.X<'T$0> a = a
         """
         Diagnostics.acceptAll
         selectCodeFix
@@ -828,8 +861,8 @@ let private addPrivateAccessModifierTests state =
         Diagnostics.acceptAll
         selectCodeFix
 
-      testCaseAsync "add private works for DU type definition"
-      <| CodeFix.check
+      testCaseAsync "add private is not offered for DU type definition" // ref finding might not show us type inferred usages
+      <| CodeFix.checkNotApplicable
         server
         """
         type [<System.Obsolete>] MyDi$0scUnion =
@@ -838,12 +871,7 @@ let private addPrivateAccessModifierTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
-        """
-        type [<System.Obsolete>] private MyDiscUnion =
-        | Case1
-        | Case2
-        """
-
+        
       testCaseAsync "add private is not offered for member with reference outside its declaring DU"
       <| CodeFix.checkNotApplicable
         server
@@ -909,8 +937,8 @@ let private addPrivateAccessModifierTests state =
           member private _.Foo x = x
         """
       
-      testCaseAsync "add private works for Record definition"
-      <| CodeFix.check
+      testCaseAsync "add private is not offered for Record type definition" // ref finding might not show us type inferred usages
+      <| CodeFix.checkNotApplicable
         server
         """
         type [<System.Obsolete>] My$0Record =
@@ -919,11 +947,6 @@ let private addPrivateAccessModifierTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
-        """
-        type [<System.Obsolete>] private MyRecord =
-          { Field1: int
-            Field2: string }
-        """
       
       testCaseAsync "add private is not offered for member with reference outside its declaring Record"
       <| CodeFix.checkNotApplicable

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -753,7 +753,7 @@ let private addPrivateAccessModifierTests state =
         Diagnostics.acceptAll
         selectCodeFix
 
-      testCaseAsync "add private is not offered for member when caret is on parameter"
+      testCaseAsync "add private is not offered for class member when caret is on parameter"
       <| CodeFix.checkNotApplicable
         server
         """
@@ -813,18 +813,164 @@ let private addPrivateAccessModifierTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
+
+      testCaseAsync "add private is not offered for member with reference outside its declaring DU"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyDiscUnion =
+        | Case1
+        | Case2
+        with
+          member _.F$0oo x = x
+
+        let x = MyDiscUnion.Case1
+        x.Foo 10
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+      
+      testCaseAsync "add private is not offered for member with reference outside its declaring DU when caret is on thisValue"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyDiscUnion =
+        | Case1
+        | Case2
+        with
+          member $0_.Foo x = x
+
+        let x = MyDiscUnion.Case1
+        x.Foo 10
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+
+      testCaseAsync "add private is not offered for DU member when caret is on parameter"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyDiscUnion =
+        | Case1
+        | Case2
+        with
+          member _.Foo $0x = x
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+
+      testCaseAsync "add private works for DU member"
+      <| CodeFix.check
+        server
+        """
+        type MyDiscUnion =
+        | Case1
+        | Case2
+        with
+          member _.Fo$0o x = x
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        type MyDiscUnion =
+        | Case1
+        | Case2
+        with
+          member private _.Foo x = x
+        """
+      
+      testCaseAsync "add private is not offered for member with reference outside its declaring Record"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyRecord =
+          { Field1: int
+            Field2: string }
+        with
+          member _.F$0oo x = x
+
+        let x = { Field1 = 23; Field2 = "bla" }
+        x.Foo 10
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+      
+      testCaseAsync "add private is not offered for member with reference outside its declaring Record when caret is on thisValue"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyRecord =
+          { Field1: int
+            Field2: string }
+        with
+          member _$0.Foo x = x
+
+        let x = { Field1 = 23; Field2 = "bla" }
+        x.Foo 10
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+
+      testCaseAsync "add private is not offered for Record member when caret is on parameter"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyRecord =
+          { Field1: int
+            Field2: string }
+        with
+          member _.Foo $0x = x
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+
+      testCaseAsync "add private works for Record member"
+      <| CodeFix.check
+        server
+        """
+        type MyRecord =
+          { Field1: int
+            Field2: string }
+        with
+          member _.Fo$0o x = x
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        type MyRecord =
+          { Field1: int
+            Field2: string }
+        with
+          member private _.Foo x = x
+        """
+      
+      testCaseAsync "add private works for top level module"
+      <| CodeFix.check
+        server
+        """
+        module [<System.Obsolete>] rec M$0
+
+          module Sub = ()
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        module [<System.Obsolete>] private rec M
+
+          module Sub = ()
+        """
       
       testCaseAsync "add private works for module"
       <| CodeFix.check
         server
         """
-        module M$0 =
+        module [<System.Obsolete>] rec M$0 =
           ()
         """
         Diagnostics.acceptAll
         selectCodeFix
         """
-        module private M =
+        module [<System.Obsolete>] private rec M =
           ()
         """
 

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -647,7 +647,7 @@ let private addPrivateAccessModifierTests state =
   serverTestList (nameof AddPrivateAccessModifier) state defaultConfigDto None (fun server ->
     [ let selectCodeFix = CodeFix.withTitle AddPrivateAccessModifier.title
 
-      testCaseAsync "addprivate works for simple function"
+      testCaseAsync "add private works for simple function"
       <| CodeFix.check
         server
         """
@@ -659,7 +659,7 @@ let private addPrivateAccessModifierTests state =
         let private f x = x * x
         """
       
-      testCaseAsync "addprivate works for simple identifier"
+      testCaseAsync "add private works for simple identifier"
       <| CodeFix.check
         server
         """
@@ -671,7 +671,7 @@ let private addPrivateAccessModifierTests state =
         let private x = 23
         """
 
-      testCaseAsync "addprivate works for simple identifier used in other private function"
+      testCaseAsync "add private works for simple identifier used in other private function"
       <| CodeFix.check
         server
         """
@@ -703,7 +703,7 @@ let private addPrivateAccessModifierTests state =
             z
         """
 
-      testCaseAsync "addprivate is not offered for already private functions"
+      testCaseAsync "add private is not offered for already private functions"
       <| CodeFix.checkNotApplicable
         server
         """
@@ -712,7 +712,7 @@ let private addPrivateAccessModifierTests state =
         Diagnostics.acceptAll
         selectCodeFix
 
-      testCaseAsync "addprivate is not offered for function with reference outside its declaring module"
+      testCaseAsync "add private is not offered for function with reference outside its declaring module"
       <| CodeFix.checkNotApplicable
         server
         """
@@ -727,7 +727,7 @@ let private addPrivateAccessModifierTests state =
         Diagnostics.acceptAll
         selectCodeFix
       
-      testCaseAsync "addprivate is not offered for member with reference outside its declaring class"
+      testCaseAsync "add private is not offered for member with reference outside its declaring class"
       <| CodeFix.checkNotApplicable
         server
         """
@@ -739,8 +739,31 @@ let private addPrivateAccessModifierTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
+      
+      testCaseAsync "add private is not offered for member with reference outside its declaring class when caret is on thisValue"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyClass() =
+          member _$0.X = 10
 
-      testCaseAsync "addprivate is not offered for let bindings inside a class"
+        let myInst = MyClass()
+        myInst.X |> ignore
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+
+      testCaseAsync "add private is not offered for member when caret is on parameter"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyClass() =
+          member _.Func x$0 = x
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+
+      testCaseAsync "add private is not offered for let bindings inside a class"
       <| CodeFix.checkNotApplicable
         server
         """
@@ -750,7 +773,7 @@ let private addPrivateAccessModifierTests state =
         Diagnostics.acceptAll
         selectCodeFix
       
-      testCaseAsync "addprivate works for class member"
+      testCaseAsync "add private works for class member"
       <| CodeFix.check
         server
         """
@@ -763,6 +786,60 @@ let private addPrivateAccessModifierTests state =
         type MyClass() =
           member private _.X = 10
         """
+
+      testCaseAsync "add private works for autoproperty"
+      <| CodeFix.check
+        server
+        """
+        type MyClass() =
+          member val Name$0 = "" with get, set
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        type MyClass() =
+          member val private Name = "" with get, set
+        """
+
+      testCaseAsync "add private is not offered for autoproperty with references outside its class"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyClass() =
+          member val Name$0 = "" with get, set
+        
+        let myInst = MyClass()
+        myInst.Name |> ignore
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+      
+      testCaseAsync "add private works for module"
+      <| CodeFix.check
+        server
+        """
+        module M$0 =
+          ()
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        module private M =
+          ()
+        """
+
+      testCaseAsync "add private is not offered for module with references outside its declaring module"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        module M =
+          module N$0 =
+              let foofoo = 10
+    
+        M.N.foofoo |> ignore
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
     ])
 
 let private convertTripleSlashCommentToXmlTaggedDocTests state =

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -234,6 +234,7 @@ let defaultConfigDto: FSharpConfigDto =
     UnionCaseStubGenerationBody = None
     RecordStubGeneration = None
     RecordStubGenerationBody = None
+    AddPrivateAccessModifier = None
     UnusedOpensAnalyzer = None
     UnusedDeclarationsAnalyzer = None
     SimplifyNameAnalyzer = None

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -131,6 +131,7 @@ let tests =
       lspTests 
     ]
 
+
 [<EntryPoint>]
 let main args =
   let outputTemplate =

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -130,7 +130,6 @@ let tests =
       generalTests
       lspTests 
     ]
-  |> Test.filter defaultConfig.joinWith.asString (fun z -> (defaultConfig.joinWith.format z).Contains "addprivate" )
 
 [<EntryPoint>]
 let main args =

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -130,7 +130,7 @@ let tests =
       generalTests
       lspTests 
     ]
-
+  |> Test.filter defaultConfig.joinWith.asString (fun z -> (defaultConfig.joinWith.format z).Contains "addprivate" )
 
 [<EntryPoint>]
 let main args =


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a2c771</samp>

This pull request refactors some functions in the adaptive F# LSP server, implements a code fix for adding a private access modifier in both LSP servers, and adds a new module for the code fix logic. The code fix helps users avoid exposing unnecessary symbols and follows the F# style guide. The refactoring improves the code structure and avoids circular dependencies.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2a2c771</samp>

> _We are the masters of the code, we fix the errors and the flaws_
> _We use the syntax visitor, we add the private modifier_
> _We refactor and we improve, we move the functions and we groove_
> _We support the LSP server, we are the `symbolUseWorkspace` lovers_

<!--
copilot:emoji
-->

🛠️♻️🚀

<!--
1.  🛠️ for adding a new code fix module
2.  ♻️ for refactoring existing functions
3.  🚀 for implementing the code fix for the non-adaptive LSP server
-->

### WHY
<!-- author to complete -->

This is the somewhat escalated result of yesterdays [Amplify F#](https://amplifying-fsharp.github.io/sessions/2023/03/24/) session.
As Jimmy pointed out, it might be too expensive to have something like this enabled by default.
But if there is interest in having this behind a config option or maybe in a trimmed down version, I'd be happy to adjust it.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2a2c771</samp>

*  Add a new module `AddPrivateAccessModifier` that implements a code fix for adding a private access modifier to a declaration that is not used outside of its scope ([link](https://github.com/fsharp/FsAutoComplete/pull/1089/files?diff=unified&w=0#diff-48268971225b92f423d2b39de1417c2a2818a44c6961569b9cd67c061e684db9R1-R235))
*  Move the `getDependentProjectsOfProjects` function to the top of the file `AdaptiveFSharpLspServer.fs` to avoid a circular dependency between the `getDeclarationLocation` and the `symbolUseWorkspace` functions ([link](https://github.com/fsharp/FsAutoComplete/pull/1089/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L1593-R1689))
*  Move the `getDeclarationLocation` and the `symbolUseWorkspace` functions to the top of the file `AdaptiveFSharpLspServer.fs` to avoid a circular dependency between them ([link](https://github.com/fsharp/FsAutoComplete/pull/1089/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L1697-R1764))
*  Add a new function `symbolUseWorkspace` to the type `AdaptiveFSharpLspServer` that wraps the `Commands.symbolUseWorkspace` function with the specific arguments and functions needed for the adaptive server ([link](https://github.com/fsharp/FsAutoComplete/pull/1089/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0R1602))
*  Add a new function `symbolUseWorkspace` to the type `FSharpLspServer` that wraps the `commands.SymbolUseWorkspace` function with the specific arguments and functions needed for the non-adaptive server ([link](https://github.com/fsharp/FsAutoComplete/pull/1089/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01R1138-R1156))
*  Add the code fix for adding a private access modifier to the list of code fixes supported by the type `FSharpLspServer` ([link](https://github.com/fsharp/FsAutoComplete/pull/1089/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01R1213))
