### PR TITLE
Fix ConvertPositionalDUToNamed when other SynLongIdent.Pats are traversed

### DIFF
--- a/src/FsAutoComplete/CodeFixes/ConvertPositionalDUToNamed.fs
+++ b/src/FsAutoComplete/CodeFixes/ConvertPositionalDUToNamed.fs
@@ -39,7 +39,9 @@ type ParseAndCheckResults with
           argPats = SynArgPats.Pats [ SynPat.Paren(pat = SynPat.Tuple(elementPats = duFieldPatterns); range = parenRange) ]) ->
         Some(ident, duFieldPatterns, parenRange)
       | SynPat.LongIdent(
-          longDotId = ident; argPats = SynArgPats.Pats [ SynPat.Paren(pat = singleDUFieldPattern; range = parenRange) ]) ->
+          longDotId = ident; argPats = SynArgPats.Pats [ SynPat.Paren(pat = singleDUFieldPattern; range = parenRange) ]) when
+        rangeContainsPos parenRange pos
+        ->
         Some(ident, [ singleDUFieldPattern ], parenRange)
       | SynPat.Paren(pat = UnionNameAndPatterns(ident, duFieldPatterns, parenRange)) ->
         Some(ident, duFieldPatterns, parenRange)

--- a/src/FsAutoComplete/CodeFixes/ConvertPositionalDUToNamed.fs
+++ b/src/FsAutoComplete/CodeFixes/ConvertPositionalDUToNamed.fs
@@ -36,7 +36,9 @@ type ParseAndCheckResults with
       function
       | SynPat.LongIdent(
           longDotId = ident
-          argPats = SynArgPats.Pats [ SynPat.Paren(pat = SynPat.Tuple(elementPats = duFieldPatterns); range = parenRange) ]) ->
+          argPats = SynArgPats.Pats [ SynPat.Paren(pat = SynPat.Tuple(elementPats = duFieldPatterns); range = parenRange) ]) when
+        rangeContainsPos parenRange pos
+        ->
         Some(ident, duFieldPatterns, parenRange)
       | SynPat.LongIdent(
           longDotId = ident; argPats = SynArgPats.Pats [ SynPat.Paren(pat = singleDUFieldPattern; range = parenRange) ]) when


### PR DESCRIPTION
This fixes two bugs in the ConvertPositionalDUToNamed  code fix.
First, there was a wrong paren range selected when the surrounding member takes `()`  as parameters:

https://user-images.githubusercontent.com/3221269/227771222-dc28156a-b9cf-43e7-9d12-8dadb021f728.mp4

Second, there was no code fix offered when the surrounding function takes `()`  as parameters:

https://user-images.githubusercontent.com/3221269/227771309-7d6c0b39-e79d-428a-bbc6-e019d4047661.mp4

