### PR TITLE
Vendors FsLibLog and FsOpenTelemetry

### DIFF
--- a/build/Program.fs
+++ b/build/Program.fs
@@ -101,17 +101,6 @@ let init args =
       (fun p -> { p with Configuration = DotNet.BuildConfiguration.fromString configuration })
       "FsAutoComplete.sln")
 
-  Target.create "ReplaceFsLibLogNamespaces"
-  <| fun _ ->
-       let replacements =
-         [ "FsLibLog\\n", "FsAutoComplete.Logging\n"
-           "FsLibLog\\.", "FsAutoComplete.Logging" ]
-
-       replacements
-       |> List.iter (fun (``match``, replace) ->
-         (!! "paket-files/TheAngryByrd/FsLibLog/**/FsLibLog*.fs")
-         |> Shell.regexReplaceInFilesWithEncoding ``match`` replace System.Text.Encoding.UTF8)
-
   Target.create "EnsureRepoConfig" (fun _ ->
     // Configure custom git hooks
     // * Currently only used to ensure that code is formatted before pushing
@@ -184,13 +173,12 @@ let init args =
   "PromoteUnreleasedToVersion" ==> "CreateVersionTag" ==> "Promote"
   |> ignore<string>
 
-  "Restore" ==> "ReplaceFsLibLogNamespaces" ==> "Build" |> ignore<string>
+  "Restore" ==> "Build" |> ignore<string>
 
   "Build" ==> "LspTest" ==> "Coverage" ==> "Test" ==> "All"
   |> ignore<string>
 
-  "ReplaceFsLibLogNamespaces"
-  ==> "LocalRelease"
+  "LocalRelease"
   ==> "ReleaseArchive"
   ==> "Release"
   |> ignore<string>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -9,9 +9,6 @@ source https://api.nuget.org/v3/index.json
 storage: none
 
 
-github TheAngryByrd/FsLibLog:64f118ae8df2f2944ef69758052cb3b148b87e79 src/FsLibLog/FsLibLog.fs
-github TheAngryByrd/FsOpenTelemetry src/FsOpenTelemetry/FsOpenTelemetry.fs
-
 nuget Fantomas.Client
 nuget FSharp.Compiler.Service
 nuget Ionide.ProjInfo

--- a/paket.lock
+++ b/paket.lock
@@ -389,11 +389,7 @@ NUGET
       Expecto (>= 9.0 < 10.0) - restriction: || (== net6.0) (== net7.0) (&& (== netstandard2.0) (>= netcoreapp3.1))
       FSharp.Core (>= 4.6.2) - restriction: || (== net6.0) (== net7.0) (&& (== netstandard2.0) (>= netcoreapp3.1))
       System.Collections.Immutable (>= 6.0) - restriction: || (== net6.0) (== net7.0) (&& (== netstandard2.0) (>= netcoreapp3.1))
-GITHUB
-  remote: TheAngryByrd/FsLibLog
-    src/FsLibLog/FsLibLog.fs (64f118ae8df2f2944ef69758052cb3b148b87e79)
-  remote: TheAngryByrd/FsOpenTelemetry
-    src/FsOpenTelemetry/FsOpenTelemetry.fs (fb24e8d4dc8ad14187b9b4631854fc8f17fb244d)
+
 GROUP Build
 STORAGE: NONE
 RESTRICTION: || (== net6.0) (== net7.0)

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -865,7 +865,7 @@ type FSharpSymbol with
 module Tracing =
 
   open System.Diagnostics
-  open FsOpenTelemetry
+  open FsAutoComplete.Telemetry
   open StreamJsonRpc
   open System.Collections.Generic
 

--- a/src/FsAutoComplete.Logging/FsAutoComplete.Logging.fsproj
+++ b/src/FsAutoComplete.Logging/FsAutoComplete.Logging.fsproj
@@ -5,14 +5,8 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\paket-files\TheAngryByrd\FsOpenTelemetry\src\FsOpenTelemetry\FsOpenTelemetry.fs">
-      <Paket>True</Paket>
-      <Link>paket-files/FsOpenTelemetry.fs</Link>
-    </Compile>
-    <Compile Include="..\..\paket-files\TheAngryByrd\FsLibLog\src\FsLibLog\FsLibLog.fs">
-      <Paket>True</Paket>
-      <Link>paket-files/FsLibLog.fs</Link>
-    </Compile>
+    <Compile Include="FsLibLog.fs" />
+    <Compile Include="FsOpenTelemetry.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/FsAutoComplete.Logging/FsLibLog.fs
+++ b/src/FsAutoComplete.Logging/FsLibLog.fs
@@ -1,0 +1,1081 @@
+// https://github.com/TheAngryByrd/FsLibLog/blob/64f118ae8df2f2944ef69758052cb3b148b87e79/src/FsLibLog/FsLibLog.fs
+
+namespace FsAutoComplete.Logging
+
+open System.Text.RegularExpressions
+
+
+[<AutoOpen>]
+module Types =
+  open System
+
+  type LogLevel =
+    | Trace = 0
+    | Debug = 1
+    | Info = 2
+    | Warn = 3
+    | Error = 4
+    | Fatal = 5
+
+  /// An optional message thunk.
+  ///
+  /// - If <see cref="T:Microsoft.FSharp.Core.Option<_>.None">None</see> is provided, this typically signals to the logger to do a isEnabled check.
+  /// - If <see cref="T:Microsoft.FSharp.Core.Option<_>.Some">Some</see> is provided, this signals the logger to log.
+  type MessageThunk = (unit -> string) option
+
+  /// The signature of a log message function
+  type Logger = LogLevel -> MessageThunk -> exn option -> obj array -> bool
+  type MappedContext = string -> obj -> bool -> IDisposable
+
+  /// Type representing a Log
+  [<NoEquality; NoComparison>]
+  type Log =
+    { LogLevel: LogLevel
+      Message: MessageThunk
+      Exception: exn option
+      Parameters: obj list
+      AdditionalNamedParameters: ((string * obj * bool) list) }
+
+    static member StartLogLevel(logLevel: LogLevel) =
+      { LogLevel = logLevel
+        Message = None
+        Exception = None
+        Parameters = List.empty
+        AdditionalNamedParameters = List.empty }
+
+  /// An interface wrapper for a<see cref="T:FsLibLog.Types.Logger">Logger</see>. Useful when using depedency injection frameworks.
+  type ILog =
+    abstract member Log: Logger
+    abstract member MappedContext: MappedContext
+
+#if FABLE_COMPILER
+  // Fable doesn't support System.Collections.Generic.Stack, so this implementation (from FCS)
+  // is used instead.
+  type Stack<'a>() =
+    let mutable contents = Array.zeroCreate<'a> (2)
+    let mutable count = 0
+
+    member buf.Ensure newSize =
+      let oldSize = contents.Length
+
+      if newSize > oldSize then
+        let old = contents
+        contents <- Array.zeroCreate (max newSize (oldSize * 2))
+        Array.blit old 0 contents 0 count
+
+    member buf.Count = count
+
+    member buf.Pop() =
+      let item = contents.[count - 1]
+      count <- count - 1
+      item
+
+    member buf.Peep() = contents.[count - 1]
+
+    member buf.Top(n) =
+      [ for x in contents.[max 0 (count - n) .. count - 1] -> x ] |> List.rev
+
+    member buf.Push(x) =
+      buf.Ensure(count + 1)
+      contents.[count] <- x
+      count <- count + 1
+
+    member buf.IsEmpty = (count = 0)
+#endif
+
+  [<AutoOpen>]
+  module Inner =
+#if !FABLE_COMPILER
+    open System.Collections.Generic
+#endif
+
+    /// <summary>
+    /// DisposableStack on Dispose will call dispose on items appended to its stack in Last In First Out.
+    /// </summary>
+    type DisposableStack() =
+      let stack = Stack<IDisposable>()
+
+      interface IDisposable with
+        member __.Dispose() =
+          while stack.Count > 0 do
+            stack.Pop().Dispose()
+
+      member __.Push(item: IDisposable) = stack.Push item
+
+      member __.Push(items: IDisposable list) = items |> List.iter stack.Push
+
+      static member Create(items: IDisposable list) =
+        let ds = new DisposableStack()
+        ds.Push items
+        ds
+
+    type ILog with
+
+      /// <summary>
+      /// Logs a log
+      /// </summary>
+      /// <param name="log">The type representing a log message to be logged</param>
+      /// <returns><see langword="true"/> if the log message was logged</returns>
+      member logger.fromLog(log: Log) =
+        use __ =
+          log.AdditionalNamedParameters
+          |> List.map (fun (key, value, destructure) -> logger.MappedContext key value destructure)
+          // This stack is important, it causes us to unwind as if you have multiple uses in a row
+          |> DisposableStack.Create
+
+        log.Parameters
+        |> List.toArray
+        |> logger.Log log.LogLevel log.Message log.Exception
+
+      /// <summary>
+      /// Logs a fatal log message given a log configurer.
+      /// </summary>
+      /// <param name="logConfig">A function to configure a log</param>
+      /// <returns><see langword="true"/>  if the log message was logged</returns>
+      member logger.fatal'(logConfig: Log -> Log) =
+        Log.StartLogLevel LogLevel.Fatal |> logConfig |> logger.fromLog
+
+      /// <summary>
+      /// Logs a fatal log message given a log configurer.
+      /// </summary>
+      /// <param name="logConfig">A function to configure a log</param>
+      member logger.fatal(logConfig: Log -> Log) = logger.fatal' logConfig |> ignore
+
+      /// <summary>
+      /// Logs an error log message given a log configurer.
+      /// </summary>
+      /// <param name="logConfig">A function to configure a log</param>
+      /// <returns><see langword="true"/>  if the log message was logged</returns>
+      member logger.error'(logConfig: Log -> Log) =
+        Log.StartLogLevel LogLevel.Error |> logConfig |> logger.fromLog
+
+      /// <summary>
+      /// Logs an error log message given a log configurer.
+      /// </summary>
+      /// <param name="logConfig">A function to configure a log</param>
+      member logger.error(logConfig: Log -> Log) = logger.error' logConfig |> ignore
+
+      /// <summary>
+      /// Logs a warn log message given a log configurer.
+      /// </summary>
+      /// <param name="logConfig">A function to configure a log</param>
+      /// <returns><see langword="true"/>  if the log message was logged</returns>
+      member logger.warn'(logConfig: Log -> Log) =
+        Log.StartLogLevel LogLevel.Warn |> logConfig |> logger.fromLog
+
+      /// <summary>
+      /// Logs a warn log message given a log configurer.
+      /// </summary>
+      /// <param name="logConfig">A function to configure a log</param>
+      member logger.warn(logConfig: Log -> Log) = logger.warn' logConfig |> ignore
+
+      /// <summary>
+      /// Logs an info log message given a log configurer.
+      /// </summary>
+      /// <param name="logConfig">A function to configure a log</param>
+      /// <returns><see langword="true"/>  if the log message was logged</returns>
+      member logger.info'(logConfig: Log -> Log) =
+        Log.StartLogLevel LogLevel.Info |> logConfig |> logger.fromLog
+
+      /// <summary>
+      /// Logs an info log message given a log configurer.
+      /// </summary>
+      /// <param name="logConfig">A function to configure a log</param>
+      member logger.info(logConfig: Log -> Log) = logger.info' logConfig |> ignore
+
+      /// <summary>
+      /// Logs a debug log message given a log configurer.
+      /// </summary>
+      /// <param name="logConfig">A function to configure a log</param>
+      /// <returns><see langword="true"/>  if the log message was logged</returns>
+      member logger.debug'(logConfig: Log -> Log) =
+        Log.StartLogLevel LogLevel.Debug |> logConfig |> logger.fromLog
+
+      /// <summary>
+      /// Logs a debug log message given a log configurer.
+      /// </summary>
+      /// <param name="logConfig">A function to configure a log</param>
+      member logger.debug(logConfig: Log -> Log) = logger.debug' logConfig |> ignore
+
+      /// <summary>
+      /// Logs a trace log message given a log configurer.
+      /// </summary>
+      /// <param name="logConfig">A function to configure a log</param>
+      /// <returns><see langword="true"/>  if the log message was logged</returns>
+      member logger.trace'(logConfig: Log -> Log) =
+        Log.StartLogLevel LogLevel.Trace |> logConfig |> logger.fromLog
+
+      /// <summary>
+      /// Logs a trace log message given a log configurer.
+      /// </summary>
+      /// <param name="logConfig">A function to configure a log</param>
+      member logger.trace(logConfig: Log -> Log) = logger.trace' logConfig |> ignore
+
+
+  /// An interface for retrieving a concrete logger such as Serilog, Nlog, etc.
+  type ILogProvider =
+    abstract member GetLogger: string -> Logger
+    abstract member OpenNestedContext: string -> IDisposable
+    abstract member OpenMappedContext: string -> obj -> bool -> IDisposable
+
+  module Log =
+
+    /// <summary>
+    /// Amends a <see cref="T:FsLibLog.Types.Log">Log</see> with a message.
+    /// </summary>
+    /// <param name="message">The message to set for the log.</param>
+    /// <param name="log">The log to amend.</param>
+    /// <returns>The amended log.</returns>
+    let setMessage (message: string) (log: Log) =
+      { log with
+          Message = Some(fun () -> message) }
+
+    /// <summary>
+    /// Amends a <see cref="T:FsLibLog.Types.Log">Log</see> with a message thunk.  Useful for "expensive" string construction scenarios.
+    /// </summary>
+    /// <param name="messageThunk">The function that generates a message to add to a Log.</param>
+    /// <param name="log">The log to amend.</param>
+    /// <returns>The amended log.</returns>
+    let setMessageThunk (messageThunk: unit -> string) (log: Log) =
+      { log with Message = Some messageThunk }
+
+    /// <summary>
+    /// Amends a <see cref="T:FsLibLog.Types.Log">Log</see> with a parameter.
+    /// </summary>
+    /// <param name="param">The value to add to the log</param>
+    /// <param name="log">The log to amend.</param>
+    /// <returns>The amended log.</returns>
+    let addParameter (param: 'a) (log: Log) =
+      { log with
+          Parameters = List.append log.Parameters [ (box param) ] }
+
+    /// <summary>
+    /// Amends a <see cref="T:FsLibLog.Types.Log">Log</see> with a list of parameters.
+    /// </summary>
+    /// <param name="params">The values to add to the log, in the form of an `obj list`.</param>
+    /// <param name="log">The log to amend.</param>
+    /// <returns>The amended log.</returns>
+    let addParameters (``params``: obj list) (log: Log) =
+      let ``params`` = ``params`` |> List.map box
+
+      { log with
+          Parameters = log.Parameters @ ``params`` }
+
+
+    /// <summary>
+    /// Amends a <see cref="T:FsLibLog.Types.Log">Log</see> with additional named parameters for context. This helper adds more context to a log.
+    /// This DOES NOT affect the parameters set for a message template.
+    /// This is the same calling OpenMappedContext right before logging.
+    /// </summary>
+    /// <param name="key">The key of the parameter to add to the log.</param>
+    /// <param name="value">The value of the parameter to add to the log.</param>
+    /// <param name="log">The log to amend.</param>
+    /// <returns>The amended log.</returns>
+    let addContext (key: string) (value: obj) (log: Log) =
+      { log with
+          AdditionalNamedParameters = List.append log.AdditionalNamedParameters [ key, (box value), false ] }
+
+
+    /// <summary>
+    /// Amends a <see cref="T:FsLibLog.Types.Log">Log</see> with additional named parameters for context. This helper adds more context to a log.
+    /// This DOES NOT affect the parameters set for a message template.
+    /// This is the same calling OpenMappedContext right before logging.
+    /// This destructures an object rather than calling `ToString()` on it.
+    /// WARNING: Destructring can be expensive.
+    /// </summary>
+    /// <param name="key">The key of the parameter to add to the log.</param>
+    /// <param name="value">The value of the parameter to add to the log.</param>
+    /// <param name="log">The log to amend.</param>
+    /// <returns>The amended log.</returns>
+    let addContextDestructured (key: string) (value: obj) (log: Log) =
+      { log with
+          AdditionalNamedParameters = List.append log.AdditionalNamedParameters [ key, (box value), true ] }
+
+
+    /// <summary>
+    /// Amends a <see cref="T:FsLibLog.Types.Log">Log</see> with an <see cref="T:System.Exception">exn</see>. Handles nulls.
+    /// </summary>
+    /// <param name="exception">The exception to add to the log.</param>
+    /// <param name="log">The log to amend.</param>
+    /// <returns>The amended log.</returns>
+    let addException (``exception``: exn) (log: Log) =
+      { log with
+          Exception = Option.ofObj ``exception`` }
+
+    /// <summary>
+    /// Amends a <see cref="T:FsLibLog.Types.Log">Log</see> with an <see cref="T:System.Exception">exn</see>. Handles nulls.
+    /// </summary>
+    /// <param name="exception">The exception to add to the log.</param>
+    /// <param name="log">The log to amend.</param>
+    /// <returns>The amended log.</returns>
+    let addExn (``exception``: exn) (log: Log) = addException ``exception`` log
+
+    /// <summary>
+    /// Amends a <see cref="T:FsLibLog.Types.Log">Log</see> with a given <see cref="T:FsLibLog.Types.LogLevel">LogLevel</see>
+    /// </summary>
+    /// <param name="logLevel">The level to set for the log.</param>
+    /// <param name="log">The log to amend.</param>
+    /// <returns>The amended log.</returns>
+    let setLogLevel (logLevel: LogLevel) (log: Log) = { log with LogLevel = logLevel }
+
+#if !FABLE_COMPILER
+
+    let private formatterRegex =
+      Regex(@"(?<!{){(?<number>\d+)(?<columnFormat>:(?<format>[^}]+))?}(?!})", RegexOptions.Compiled)
+
+    let private isAnObject value =
+      Convert.GetTypeCode(value) = TypeCode.Object
+
+    /// <summary>
+    /// Amends a <see cref="T:FsLibLog.Types.Log">Log</see> with a given interpolated string. This will generate a message template from a special syntax within the interpolation. The syntax for the interplated string is <code> $"I want to log {myVariable:MyLogVariableName}". </code>
+    ///
+    /// This would be equivalent of calling <code>(setMessage "I want to log {MyLogVariableName}" >> addContextDestructured "MyLogVariable" myVariable)</code>
+    /// </summary>
+    /// <param name="message">An interpolated string</param>
+    /// <param name="log">The log to amend.</param>
+    /// <returns>The amended log.</returns>
+    let setMessageInterpolated (message: FormattableString) (log: Log) =
+      let mutable messageFormat = message.Format
+
+      let args =
+        formatterRegex.Matches(messageFormat)
+        |> Seq.cast<Match>
+        |> Seq.map (fun m ->
+          let number = Int32.Parse(m.Groups.["number"].Value)
+          let formatGroup = m.Groups.["format"]
+          let propertyValue = message.GetArgument(number)
+          let propertyName = formatGroup.Value
+          let columnFormatGroup = m.Groups.["columnFormat"]
+          propertyName, propertyValue, columnFormatGroup.Index, columnFormatGroup.Length)
+      // Reverse the args so we won't change the indexes earlier in the string
+      args
+      |> Seq.rev
+      |> Seq.iter (fun (_, _, removeStart, removeLength) ->
+        if removeLength > 0 then
+          messageFormat <- messageFormat.Remove(removeStart, removeLength))
+
+      let namedArgs =
+        args |> Seq.map (fun (name, _, _, _) -> box $"{{{name}}}") |> Seq.toArray
+
+      messageFormat <- messageFormat.Replace("{{", "{{{{").Replace("}}", "}}}}")
+      // Replace numbered args with named args from regex match
+      messageFormat <- String.Format(messageFormat, args = namedArgs)
+
+      let addContexts args (log: Log) =
+        let addArgsToContext =
+          (id, args)
+          ||> Seq.fold (fun state (name, value, _, _) ->
+            let contextAdder =
+              if value |> isAnObject then
+                addContextDestructured
+              else
+                addContext
+
+            state >> contextAdder name value)
+
+        addArgsToContext log
+
+      log |> setMessage messageFormat |> addContexts args
+
+    /// <summary>
+    /// Amends a <see cref="T:FsLibLog.Types.Log">Log</see> with a given interpolated string. This will generate a message template from a special syntax within the interpolation. The syntax for the interplated string is <code> $"I want to log {myVariable:MyLogVariableName}". </code>
+    ///
+    /// This would be equivalent of calling <code>(setMessage "I want to log {MyLogVariableName}" >> addContextDestructured "MyLogVariable" myVariable)</code>
+    /// </summary>
+    /// <param name="message">An interpolated string</param>
+    /// <param name="log">The log to amend.</param>
+    /// <returns>The amended log.</returns>
+    let setMessageI (message: FormattableString) (log: Log) = setMessageInterpolated message log
+#endif
+
+/// Provides operators to make writing logs more streamlined.
+module Operators =
+
+  /// <summary>
+  /// Amend a log with a message. Wrapper for <see cref="M:FsLibLog.Types.LogModule.setMessage">Log.setMessage</see>.
+  /// </summary>
+  /// <param name="message">The string of the base message.</param>
+  /// <returns>A new Log instance with the specified message.</returns>
+  let (!!!) message = Log.setMessage message
+
+  /// <summary>
+  /// Amends a log with a parameter. Wrapper for <see cref="M:FsLibLog.Types.LogModule.addParameter">Log.addParameter</see>.
+  /// </summary>
+  /// <param name="log">The Log to add the parameter to.</param>
+  /// <param name="value">The value for the parameter.</param>
+  /// <returns>The Log with the added parameter.</returns>
+  let (>>!) log value = log >> Log.addParameter value
+
+  /// <summary>
+  /// Amends a Log with additional named parameters for context. This helper adds more context to a log.
+  /// This DOES NOT affect the parameters set for a message template. This is the same calling OpenMappedContext right before logging.
+  ///
+  /// Wrapper for <see cref="M:FsLibLog.Types.LogModule.addContext">Log.addContext</see>.
+  /// </summary>
+  /// <param name="log">The log to add the parameter to.</param>
+  /// <param name="key">The name for the parameter.</param>
+  /// <param name="value">The value for the parameter.</param>
+  /// <returns>The amended log with the parameter added.</returns>
+  let (>>!-) log (key, value) = log >> Log.addContext key value
+
+  /// <summary>
+  /// Amends a Log with additional named parameters for context. This helper adds more context to a log. This DOES NOT affect the parameters set for a message template.
+  /// This is the same calling OpenMappedContext right before logging. This destructures an object rather than calling ToString() on it. WARNING: Destructring can be expensive.
+  ///
+  /// Wrapper for <see cref="M:FsLibLog.Types.LogModule.addContextDestructured">Log.addContextDestructured</see>.
+  /// </summary>
+  /// <param name="log">The log to add the parameter to.</param>
+  /// <param name="key">The name for the parameter.</param>
+  /// <param name="value">The value for the parameter.</param>
+  /// <returns>The amended log with the parameter added.</returns>
+  let (>>!+) log (key, value) =
+    log >> Log.addContextDestructured key value
+
+  /// <summary>
+  /// Amends a Log with an exn. Handles nulls.
+  ///
+  /// Wrapper for <see cref="M:FsLibLog.Types.LogModule.addException">Log.addException</see>.
+  /// </summary>
+  /// <param name="log">The log to add the parameter to.</param>
+  /// <param name="e">The exception to add to the log.</param>
+  /// <returns>The amended log with the parameter added.</returns>
+  let (>>!!) log e = log >> Log.addException e
+
+
+#if !FABLE_COMPILER
+module Providers =
+  module SerilogProvider =
+    open System
+    open System.Linq.Expressions
+
+    let getLogManagerType () = Type.GetType("Serilog.Log, Serilog")
+
+    let isAvailable () = getLogManagerType () |> isNull |> not
+
+    let getPushProperty () =
+
+      let ndcContextType =
+        Type.GetType("Serilog.Context.LogContext, Serilog")
+        |> Option.ofObj
+        |> Option.defaultWith (fun () -> Type.GetType("Serilog.Context.LogContext, Serilog.FullNetFx"))
+
+      ()
+
+      let pushPropertyMethod =
+        ndcContextType.GetMethod("PushProperty", [| typedefof<string>; typedefof<obj>; typedefof<bool> |])
+
+      let nameParam = Expression.Parameter(typedefof<string>, "name")
+
+      let valueParam = Expression.Parameter(typedefof<obj>, "value")
+
+      let destructureObjectParam =
+        Expression.Parameter(typedefof<bool>, "destructureObjects")
+
+      let pushPropertyMethodCall =
+        Expression.Call(null, pushPropertyMethod, nameParam, valueParam, destructureObjectParam)
+
+      let pushProperty =
+        Expression
+          .Lambda<Func<string, obj, bool, IDisposable>>(
+            pushPropertyMethodCall,
+            nameParam,
+            valueParam,
+            destructureObjectParam
+          )
+          .Compile()
+
+      fun key value destructure -> pushProperty.Invoke(key, value, destructure)
+
+
+    let getForContextMethodCall () =
+      let logManagerType = getLogManagerType ()
+
+      let method =
+        logManagerType.GetMethod("ForContext", [| typedefof<string>; typedefof<obj>; typedefof<bool> |])
+
+      let propertyNameParam = Expression.Parameter(typedefof<string>, "propertyName")
+
+      let valueParam = Expression.Parameter(typedefof<obj>, "value")
+
+      let destructureObjectsParam =
+        Expression.Parameter(typedefof<bool>, "destructureObjects")
+
+      let exrs: Expression[] =
+        [| propertyNameParam; valueParam; destructureObjectsParam |]
+
+      let methodCall = Expression.Call(null, method, exrs)
+
+      let func =
+        Expression
+          .Lambda<Func<string, obj, bool, obj>>(methodCall, propertyNameParam, valueParam, destructureObjectsParam)
+          .Compile()
+
+      fun name -> func.Invoke("SourceContext", name, false)
+
+    [<NoEquality; NoComparison>]
+    type SerilogGateway =
+      { Write: obj -> obj -> string -> obj[] -> unit
+        WriteException: obj -> obj -> exn -> string -> obj[] -> unit
+        IsEnabled: obj -> obj -> bool
+        TranslateLevel: LogLevel -> obj }
+
+      static member Create() =
+        let logEventLevelType = Type.GetType("Serilog.Events.LogEventLevel, Serilog")
+
+        if (logEventLevelType |> isNull) then
+          failwith ("Type Serilog.Events.LogEventLevel was not found.")
+
+        let debugLevel = Enum.Parse(logEventLevelType, "Debug", false)
+
+        let errorLevel = Enum.Parse(logEventLevelType, "Error", false)
+
+        let fatalLevel = Enum.Parse(logEventLevelType, "Fatal", false)
+
+        let informationLevel = Enum.Parse(logEventLevelType, "Information", false)
+
+        let verboseLevel = Enum.Parse(logEventLevelType, "Verbose", false)
+
+        let warningLevel = Enum.Parse(logEventLevelType, "Warning", false)
+
+        let translateLevel (level: LogLevel) =
+          match level with
+          | LogLevel.Fatal -> fatalLevel
+          | LogLevel.Error -> errorLevel
+          | LogLevel.Warn -> warningLevel
+          | LogLevel.Info -> informationLevel
+          | LogLevel.Debug -> debugLevel
+          | LogLevel.Trace -> verboseLevel
+          | _ -> debugLevel
+
+        let loggerType = Type.GetType("Serilog.ILogger, Serilog")
+
+        if (loggerType |> isNull) then
+          failwith ("Type Serilog.ILogger was not found.")
+
+        let isEnabledMethodInfo = loggerType.GetMethod("IsEnabled", [| logEventLevelType |])
+
+        let instanceParam = Expression.Parameter(typedefof<obj>)
+
+        let instanceCast = Expression.Convert(instanceParam, loggerType)
+
+        let levelParam = Expression.Parameter(typedefof<obj>)
+
+        let levelCast = Expression.Convert(levelParam, logEventLevelType)
+
+        let isEnabledMethodCall =
+          Expression.Call(instanceCast, isEnabledMethodInfo, levelCast)
+
+        let isEnabled =
+          Expression
+            .Lambda<Func<obj, obj, bool>>(isEnabledMethodCall, instanceParam, levelParam)
+            .Compile()
+
+        let writeMethodInfo =
+          loggerType.GetMethod("Write", [| logEventLevelType; typedefof<string>; typedefof<obj[]> |])
+
+        let messageParam = Expression.Parameter(typedefof<string>)
+        let propertyValuesParam = Expression.Parameter(typedefof<obj[]>)
+
+        let writeMethodExp =
+          Expression.Call(instanceCast, writeMethodInfo, levelCast, messageParam, propertyValuesParam)
+
+        let expression =
+          Expression.Lambda<Action<obj, obj, string, obj[]>>(
+            writeMethodExp,
+            instanceParam,
+            levelParam,
+            messageParam,
+            propertyValuesParam
+          )
+
+        let write = expression.Compile()
+
+        let writeExceptionMethodInfo =
+          loggerType.GetMethod("Write", [| logEventLevelType; typedefof<exn>; typedefof<string>; typedefof<obj[]> |])
+
+        let exceptionParam = Expression.Parameter(typedefof<exn>)
+
+        let writeMethodExp =
+          Expression.Call(
+            instanceCast,
+            writeExceptionMethodInfo,
+            levelCast,
+            exceptionParam,
+            messageParam,
+            propertyValuesParam
+          )
+
+        let writeException =
+          Expression
+            .Lambda<Action<obj, obj, exn, string, obj[]>>(
+              writeMethodExp,
+              instanceParam,
+              levelParam,
+              exceptionParam,
+              messageParam,
+              propertyValuesParam
+            )
+            .Compile()
+
+        { Write =
+            (fun logger level message formattedParmeters -> write.Invoke(logger, level, message, formattedParmeters))
+          WriteException =
+            fun logger level ex message formattedParmeters ->
+              writeException.Invoke(logger, level, ex, message, formattedParmeters)
+          IsEnabled = fun logger level -> isEnabled.Invoke(logger, level)
+          TranslateLevel = translateLevel }
+
+    type private SeriLogProvider() =
+      let getLoggerByName = getForContextMethodCall ()
+      let pushProperty = getPushProperty ()
+      let serilogGatewayInit = lazy (SerilogGateway.Create())
+
+      let writeMessage logger logLevel (messageFunc: MessageThunk) ``exception`` formatParams =
+        let serilogGateway = serilogGatewayInit.Value
+        let translatedValue = serilogGateway.TranslateLevel logLevel
+
+        match messageFunc with
+        | None -> serilogGateway.IsEnabled logger translatedValue
+        | Some _ when serilogGateway.IsEnabled logger translatedValue |> not -> false
+        | Some m ->
+          match ``exception`` with
+          | Some ex -> serilogGateway.WriteException logger translatedValue ex (m ()) formatParams
+          | None -> serilogGateway.Write logger translatedValue (m ()) formatParams
+
+          true
+
+      interface ILogProvider with
+        member this.GetLogger(name: string) : Logger = getLoggerByName name |> writeMessage
+
+        member this.OpenMappedContext (key: string) (value: obj) (destructure: bool) : IDisposable =
+          pushProperty key value destructure
+
+        member this.OpenNestedContext(message: string) : IDisposable = pushProperty "NDC" message false
+
+    let create () = SeriLogProvider() :> ILogProvider
+
+
+  module MicrosoftExtensionsLoggingProvider =
+    open System
+    open System.Linq.Expressions
+    open System.Reflection
+    open System.Collections.Generic
+
+    type ILoggerFactory = obj
+    // This has to be set from usercode for this to light up
+    let mutable private microsoftLoggerFactory: ILoggerFactory option = None
+
+    let setMicrosoftLoggerFactory (factory: ILoggerFactory) =
+      microsoftLoggerFactory <- Option.ofObj factory
+
+    let getLogFactoryType =
+      lazy (Type.GetType("Microsoft.Extensions.Logging.ILoggerFactory, Microsoft.Extensions.Logging.Abstractions"))
+
+    let isAvailable () =
+      getLogFactoryType.Value |> isNull |> not
+      && microsoftLoggerFactory |> Option.isSome
+
+
+    type ILogger = obj
+    type LoggerName = string
+    type MicrosoftLogLevel = obj
+    type MessageFormat = string
+    type MessageArgs = obj array
+
+    [<NoEquality; NoComparison>]
+    type LoggerFactoryGateway =
+      { CreateLogger: ILoggerFactory -> LoggerName -> ILogger }
+
+      static member Create() =
+        let createLogger =
+          let factoryType = getLogFactoryType.Value
+
+          let createLoggerMethodInfo =
+            factoryType.GetMethod("CreateLogger", [| typedefof<string> |])
+
+          let instanceParam = Expression.Parameter(typedefof<ILoggerFactory>)
+          let nameParam = Expression.Parameter(typedefof<string>)
+          let instanceCast = Expression.Convert(instanceParam, factoryType)
+
+          let createLoggerMethodExp =
+            Expression.Call(instanceCast, createLoggerMethodInfo, nameParam)
+
+          let createLogger =
+            Expression
+              .Lambda<Func<ILoggerFactory, string, ILogger>>(createLoggerMethodExp, instanceParam, nameParam)
+              .Compile()
+
+          createLogger |> FuncConvert.FromFunc
+
+        { CreateLogger = createLogger }
+
+    type LoggerGateway =
+      { Write: ILogger -> MicrosoftLogLevel -> MessageFormat -> MessageArgs -> unit
+        WriteError: ILogger -> MicrosoftLogLevel -> exn -> MessageFormat -> MessageArgs -> unit
+        IsEnabled: ILogger -> MicrosoftLogLevel -> bool
+        TranslateLevel: LogLevel -> MicrosoftLogLevel
+        BeginScope: ILogger -> obj -> IDisposable }
+
+      static member Create() =
+        let loggerExtensions =
+          Type.GetType("Microsoft.Extensions.Logging.LoggerExtensions, Microsoft.Extensions.Logging.Abstractions")
+
+        let loggerType =
+          Type.GetType("Microsoft.Extensions.Logging.ILogger, Microsoft.Extensions.Logging.Abstractions")
+
+        let logEventLevelType =
+          Type.GetType("Microsoft.Extensions.Logging.LogLevel, Microsoft.Extensions.Logging.Abstractions")
+
+        let instanceParam = Expression.Parameter(typedefof<ILogger>)
+
+        let instanceCast = Expression.Convert(instanceParam, loggerType)
+        let levelParam = Expression.Parameter(typedefof<MicrosoftLogLevel>)
+
+        let levelCast = Expression.Convert(levelParam, logEventLevelType)
+
+        let isEnabled =
+          let isEnabledMethodInfo = loggerType.GetMethod("IsEnabled", [| logEventLevelType |])
+
+          let isEnabledMethodCall =
+            Expression.Call(instanceCast, isEnabledMethodInfo, levelCast)
+
+
+          Expression
+            .Lambda<Func<ILogger, MicrosoftLogLevel, bool>>(isEnabledMethodCall, instanceParam, levelParam)
+            .Compile()
+          |> FuncConvert.FromFunc
+
+        let write, writeError =
+          let messageParam = Expression.Parameter(typedefof<MessageFormat>)
+          let propertyValuesParam = Expression.Parameter(typedefof<MessageArgs>)
+
+          let write =
+            let writeMethodInfo =
+              loggerExtensions.GetMethod(
+                "Log",
+                BindingFlags.Static ||| BindingFlags.Public,
+                null,
+                [| loggerType
+                   logEventLevelType
+                   typedefof<MessageFormat>
+                   typedefof<MessageArgs> |],
+                null
+              )
+
+            let writeMethodExp =
+              Expression.Call(null, writeMethodInfo, instanceCast, levelCast, messageParam, propertyValuesParam)
+
+            let expression =
+              Expression.Lambda<Action<ILogger, MicrosoftLogLevel, MessageFormat, MessageArgs>>(
+                writeMethodExp,
+                instanceParam,
+                levelParam,
+                messageParam,
+                propertyValuesParam
+              )
+
+            expression.Compile() |> FuncConvert.FromAction
+
+
+          let writeError =
+            let writeMethodInfo =
+              loggerExtensions.GetMethod(
+                "Log",
+                BindingFlags.Static ||| BindingFlags.Public,
+                null,
+                [| loggerType
+                   logEventLevelType
+                   typedefof<exn>
+                   typedefof<MessageFormat>
+                   typedefof<MessageArgs> |],
+                null
+
+              )
+
+            let exnParam = Expression.Parameter(typedefof<exn>)
+
+            let writeMethodExp =
+              Expression.Call(
+                null,
+                writeMethodInfo,
+                instanceCast,
+                levelCast,
+                exnParam,
+                messageParam,
+                propertyValuesParam
+              )
+
+            let expression =
+              Expression.Lambda<Action<ILogger, MicrosoftLogLevel, exn, MessageFormat, MessageArgs>>(
+                writeMethodExp,
+                instanceParam,
+                levelParam,
+                exnParam,
+                messageParam,
+                propertyValuesParam
+              )
+
+            expression.Compile() |> FuncConvert.FromAction
+
+          write, writeError
+
+        let translateLevel =
+
+          let debugLevel = Enum.Parse(logEventLevelType, "Debug", false)
+
+          let errorLevel = Enum.Parse(logEventLevelType, "Error", false)
+
+          let criticalLevel = Enum.Parse(logEventLevelType, "Critical", false)
+
+          let informationLevel = Enum.Parse(logEventLevelType, "Information", false)
+
+          let traceLevel = Enum.Parse(logEventLevelType, "Trace", false)
+
+          let warningLevel = Enum.Parse(logEventLevelType, "Warning", false)
+
+          fun (level: LogLevel) ->
+            match level with
+            | LogLevel.Fatal -> criticalLevel
+            | LogLevel.Error -> errorLevel
+            | LogLevel.Warn -> warningLevel
+            | LogLevel.Info -> informationLevel
+            | LogLevel.Debug -> debugLevel
+            | LogLevel.Trace -> traceLevel
+            | _ -> debugLevel
+
+        let beginScope =
+          let beginScopeMethodInfo =
+            loggerType.GetMethod("BeginScope").MakeGenericMethod(typedefof<obj>)
+
+          let stateParam = Expression.Parameter(typedefof<obj>)
+
+          let beginScopeMethodCall =
+            Expression.Call(instanceCast, beginScopeMethodInfo, stateParam)
+
+          Expression
+            .Lambda<Func<ILogger, obj, IDisposable>>(beginScopeMethodCall, instanceParam, stateParam)
+            .Compile()
+          |> FuncConvert.FromFunc
+
+        { Write = write
+          WriteError = writeError
+          IsEnabled = isEnabled
+          TranslateLevel = translateLevel
+          BeginScope = beginScope }
+
+
+    type private MicrosoftProvider() =
+      let factoryGateway = lazy (LoggerFactoryGateway.Create())
+      let loggerGateway = lazy (LoggerGateway.Create())
+
+      interface ILogProvider with
+        member this.GetLogger(name: string) : Logger =
+          match microsoftLoggerFactory with
+          | None -> fun _ _ _ _ -> false
+          | Some factory ->
+            let logger = factoryGateway.Value.CreateLogger factory name
+
+            fun logLevel message exn args ->
+              let microsoftLevel = loggerGateway.Value.TranslateLevel logLevel
+
+              match message with
+              | Some message ->
+                let message = message ()
+
+                match exn with
+                | Some ex -> loggerGateway.Value.WriteError logger microsoftLevel ex message args
+                | None -> loggerGateway.Value.Write logger microsoftLevel message args
+
+                true
+              | None -> loggerGateway.Value.IsEnabled logger microsoftLevel
+
+        member this.OpenMappedContext (key: string) (value: obj) (destructure: bool) : IDisposable =
+          match microsoftLoggerFactory with
+          | None ->
+            { new IDisposable with
+                member x.Dispose() = () }
+          | Some factory ->
+            // Create bogus logger that will propagate to a real logger later
+            let logger = factoryGateway.Value.CreateLogger factory (Guid.NewGuid().ToString())
+            // Requires a IEnumerable<KeyValuePair> to make sense
+            // https://nblumhardt.com/2016/11/ilogger-beginscope/
+            [ KeyValuePair(key, value) ] |> box |> loggerGateway.Value.BeginScope logger
+
+
+        member this.OpenNestedContext(message: string) : IDisposable =
+          match microsoftLoggerFactory with
+          | None ->
+            { new IDisposable with
+                member x.Dispose() = () }
+          | Some factory ->
+            // Create bogus logger that will propagate to a real logger later
+            let logger = factoryGateway.Value.CreateLogger factory (Guid.NewGuid().ToString())
+
+            loggerGateway.Value.BeginScope logger (box message)
+
+    let create () = MicrosoftProvider() :> ILogProvider
+
+#endif
+
+
+module LogProvider =
+  open System
+  open Types
+#if !FABLE_COMPILER
+  open Providers
+#endif
+  open System.Diagnostics
+  open Microsoft.FSharp.Quotations.Patterns
+
+  let mutable private currentLogProvider = None
+
+  let private knownProviders =
+    [
+#if !FABLE_COMPILER
+      (SerilogProvider.isAvailable, SerilogProvider.create)
+      (MicrosoftExtensionsLoggingProvider.isAvailable, MicrosoftExtensionsLoggingProvider.create)
+#endif
+    ]
+
+  /// Greedy search for first available LogProvider. Order of known providers matters.
+  let private resolvedLogger =
+    lazy
+      (knownProviders
+       |> Seq.tryFind (fun (isAvailable, _) -> isAvailable ())
+       |> Option.map (fun (_, create) -> create ()))
+
+  let private noopLogger _ _ _ _ = false
+
+  let private noopDisposable =
+    { new IDisposable with
+        member __.Dispose() = () }
+
+  /// <summary>
+  /// Allows custom override when a <c>getLogger</c> function searches for a LogProvider.
+  /// </summary>
+  /// <param name="logProvider">The <see cref="M:FsLibLog.Types.ILogProvider"/> to set</param>
+  /// <returns></returns>
+  let setLoggerProvider (logProvider: ILogProvider) = currentLogProvider <- Some logProvider
+
+  /// <summary>
+  /// Gets the currently set LogProvider or attempts to find known built in providers
+  /// </summary>
+  /// <returns></returns>
+  let getCurrentLogProvider () =
+    match currentLogProvider with
+    | None -> resolvedLogger.Value
+    | Some p -> Some p
+
+  /// <summary>
+  /// Opens a mapped diagnostic context.  This will allow you to set additional parameters to a log given a scope.
+  /// </summary>
+  /// <param name="key">The name of the property.</param>
+  /// <param name="value">The value of the property.</param>
+  /// <param name="destructureObjects">If true, and the value is a non-primitive, non-array type, then the value will be converted to a structure; otherwise, unknown types will be converted to scalars, which are generally stored as strings. WARNING: Destructring can be expensive.</param>
+  /// <returns>An IDisposable upon disposing will remove this value from a loggers scope</returns>
+  let openMappedContextDestucturable (key: string) (value: obj) (destructureObjects: bool) =
+    let provider = getCurrentLogProvider ()
+
+    match provider with
+    | Some p -> p.OpenMappedContext key value destructureObjects
+    | None -> noopDisposable
+
+
+  /// <summary>
+  /// Opens a mapped diagnostic context.  This will allow you to set additional parameters to a log given a scope. Sets destructureObjects to false.
+  /// </summary>
+  /// <param name="key">The name of the property.</param>
+  /// <param name="value">The value of the property.</param>
+  /// <returns>An IDisposable upon disposing will remove this value from a loggers scope</returns>
+  let openMappedContext (key: string) (value: obj) =
+    //TODO: We should try to find out if the value is a primitive
+    openMappedContextDestucturable key value false
+
+
+  /// <summary>
+  /// Opens a nested diagnostic context.  This will allow you to set additional parameters to a log given a scope.
+  /// </summary>
+  /// <param name="value">The value of the property</param>
+  /// <returns>An IDisposable upon disposing will remove this value from a loggers scope</returns>
+  let openNestedContext (value: string) =
+    let provider = getCurrentLogProvider ()
+
+    match provider with
+    | Some p -> p.OpenNestedContext value
+    | None -> noopDisposable
+
+  /// <summary>
+  /// Creates a logger given a <see cref="T:System.String">string</see>. This will attempt to retrieve any loggers set with <see cref="M:FsLibLog.LogProviderModule.setLoggerProvider">Log.setLoggerProvider</see>.  It will fallback to a known list of providers.
+  /// </summary>
+  /// <param name="name">A name to give a logger. This can help you identify the location of where the log occurred upon reviewing the logs.</param>
+  /// <returns></returns>
+  let getLoggerByName (name: string) =
+    let loggerProvider = getCurrentLogProvider ()
+
+    let logFunc =
+      match loggerProvider with
+      | Some loggerProvider -> loggerProvider.GetLogger(name)
+      | None -> noopLogger
+
+    { new ILog with
+        member x.Log = logFunc
+        member x.MappedContext = openMappedContextDestucturable }
+
+  /// <summary>
+  /// Creates a logger given a <see cref="T:System.Type">Type</see>.  This will attempt to retrieve any loggers set with <see cref="M:FsLibLog.LogProviderModule.setLoggerProvider">Log.setLoggerProvider</see>.  It will fallback to a known list of providers.
+  /// </summary>
+  /// <param name="objectType">The type to generate a logger name from. </param>
+  /// <returns></returns>
+  let getLoggerByType (objectType: Type) = objectType |> string |> getLoggerByName
+
+  /// <summary>
+  /// Creates a logger given a <c>'a</c> type. This will attempt to retrieve any loggers set with <see cref="M:FsLibLog.LogProviderModule.setLoggerProvider">Log.setLoggerProvider</see>.  It will fallback to a known list of providers.
+  /// </summary>
+  /// <typeparam name="'a">The type to generate a name from.</typeparam>
+  /// <returns></returns>
+  let inline getLoggerFor<'a> () = getLoggerByType (typeof<'a>)
+
+#if !FABLE_COMPILER
+  let rec private getModuleType =
+    function
+    | PropertyGet(_, propertyInfo, _) -> propertyInfo.DeclaringType
+    // | Call (_, methInfo, _) -> sprintf "%s.%s" methInfo.DeclaringType.FullName methInfo.Name
+    // | Lambda(_, expr) -> getModuleType expr
+    // | ValueWithName(_,_,instance) -> instance
+    | x -> failwithf "Expression is not a property. %A" x
+
+
+  /// <summary>
+  /// Creates a logger given a Quotations.Expr type. This is only useful for module level declarations. It uses the DeclaringType on the PropertyInfo of the PropertyGet.
+  ///
+  /// It can be utilized like:
+  ///
+  /// <code>
+  /// let rec logger = LogProvider.getLoggerByQuotation &lt;@ logger @&gt;
+  /// </code>
+  ///
+  /// inside a module to get the modules full qualitfied name.
+  /// </summary>
+  /// <param name="quotation">The quotation to generate a logger name from.</param>
+  /// <returns></returns>
+  let getLoggerByQuotation (quotation: Quotations.Expr) =
+    getModuleType quotation |> getLoggerByType
+
+
+type LogProvider =
+  /// <summary>
+  /// Creates a logger based on `Reflection.MethodBase.GetCurrentMethod().FullName` and `CallerMemberName`. This is only useful for calls within functions. Results may vary on lambda and inlined functions.
+  /// </summary>
+  /// <param name="memberName">Do not pass anything to this parameter to get `CallerMemberName` to work.</param>
+  /// <returns></returns>
+  static member inline getLoggerByFunc([<System.Runtime.CompilerServices.CallerMemberName>] ?memberName: string) =
+    let mi = System.Reflection.MethodBase.GetCurrentMethod()
+    // When we're in a CE we get something like `WebBackend.App+thingsToCall2@130`.
+    // CallerMemberName gets us the function that actually called it
+    // Splitting off + seems like the best option to get the Fully Qualified Path
+    let location =
+      mi.DeclaringType.FullName.Split('+') |> Seq.tryHead |> Option.defaultValue ""
+
+    sprintf "%s.%s" location memberName.Value |> LogProvider.getLoggerByName
+
+#endif

--- a/src/FsAutoComplete.Logging/FsOpenTelemetry.fs
+++ b/src/FsAutoComplete.Logging/FsOpenTelemetry.fs
@@ -1,0 +1,818 @@
+// https://github.com/TheAngryByrd/FsOpenTelemetry/blob/fb24e8d4dc8ad14187b9b4631854fc8f17fb244d/src/FsOpenTelemetry/FsOpenTelemetry.fs
+
+namespace FsAutoComplete.Telemetry
+
+open System
+open System.Diagnostics
+open System.Runtime.CompilerServices
+open System.Collections.Generic
+open Microsoft.FSharp.Quotations.Patterns
+
+
+// Thanks https://github.com/fsprojects/FSharp.UMX
+[<MeasureAnnotatedAbbreviation>]
+type string<[<Measure>] 'm> = string
+
+
+module private Funcs =
+  /// <summary>
+  /// Determines whether the given value is not null.
+  /// </summary>
+  /// <param name="value">The value to check</param>
+  /// <returns>True when value is not null, false otherwise.</returns>
+  let inline isNotNull value = value |> isNull |> not
+
+module private Unsafe =
+  let inline cast<'a, 'b> (a: 'a) : 'b = (# "" a : 'b #)
+
+type UMX =
+  static member inline tag<[<Measure>] 'm>(x: string) : string<'m> = Unsafe.cast x
+  static member inline untag<[<Measure>] 'm>(x: string<'m>) : string = Unsafe.cast x
+
+  static member inline cast<[<Measure>] 'm1, [<Measure>] 'm2>(x: string<'m1>) : string<'m2> = Unsafe.cast x
+
+/// In OpenTelemetry spans can be created freely and it’s up to the implementor to annotate them with attributes specific to the represented operation. Spans represent specific operations in and between systems. Some of these operations represent calls that use well-known protocols like HTTP or database calls. Depending on the protocol and the type of operation, additional information is needed to represent and analyze a span correctly in monitoring systems. It is also important to unify how this attribution is made in different languages. This way, the operator will not need to learn specifics of a language and telemetry collected from polyglot (multi-language) micro-service environments can still be easily correlated and cross-analyzed.
+module SemanticConventions =
+  /// The attributes described in this section are not specific to a particular operation but rather generic. They may be used in any Span they apply to. Particular operations may refer to or require some of these attributes.
+  module General =
+    /// These attributes may be used for any network related operation. The net.peer.* attributes describe properties of the remote end of the network connection (usually the transport-layer peer, e.g. the node to which a TCP connection was established), while the net.host.* properties describe the local end. In an ideal situation, not accounting for proxies, multiple IP addresses or host names, the net.peer.* properties of a client are equal to the net.host.* properties of the server and vice versa.
+    ///
+    /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes
+    module Network =
+      /// Transport protocol used.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: ip_tcp
+      ///
+      /// Should use a net_transport_values
+      ///
+      /// Required: No
+      [<Literal>]
+      let net_transport = "net.transport"
+
+      /// net.transport MUST be one of the following
+      [<Measure>]
+      type net_transport_values
+
+      /// tcp_ip
+      let net_transport_values_ip_tcp: string<net_transport_values> = UMX.tag "icp_tcp"
+      /// ip_udp
+      let net_transport_values_ip_udp: string<net_transport_values> = UMX.tag "ip_udp"
+      // /// Another IP-based protocol
+      let net_transport_values_ip: string<net_transport_values> = UMX.tag "ip"
+      /// Unix Domain socket.
+      let net_transport_values_unix: string<net_transport_values> = UMX.tag "unix"
+      // Named or anonymous pipe.
+      let net_transport_values_pipe: string<net_transport_values> = UMX.tag "pipe"
+      ///Signals that there is only in-process communication not using a "real" network protocol in cases where network attributes would normally be expected. Usually all other network attributes can be left out in that case.
+      let net_transport_values_inproc: string<net_transport_values> = UMX.tag "inproc"
+      /// Something else (non IP-based).
+      let net_transport_values_Other: string<net_transport_values> = UMX.tag "Other"
+
+      /// Remote address of the peer (dotted decimal for IPv4 or RFC5952 for IPv6)
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: 127.0.0.1
+      ///
+      /// Required: No
+      [<Literal>]
+      let net_peer_ip = "net.peer.ip"
+
+      /// Remote port number.
+      ///
+      /// ValueType: int
+      ///
+      /// Examples: 80; 8080; 443
+      ///
+      /// Required: No
+      [<Literal>]
+      let net_peer_port = "net.peer.port"
+
+      /// Remote hostname or similar.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: example.com
+      ///
+      /// Required: No
+      // TODO: "See Note below"
+      [<Literal>]
+      let net_peer_name = "net.peer.name"
+
+      /// Like net.peer.ip but for the host IP. Useful in case of a multi-IP host.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: example.com
+      ///
+      /// Required: No
+      [<Literal>]
+      let net_host_ip = "net.host.ip"
+
+      /// Like net.peer.port but for the host port.
+      ///
+      /// ValueType: int
+      ///
+      /// Examples: 80; 8080; 443
+      ///
+      /// Required: No
+      [<Literal>]
+      let net_host_port = "net.host.port"
+
+      /// Local hostname or similar
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: localhost
+      ///
+      /// Required: No
+      // TODO: "See Note below"
+      [<Literal>]
+      let net_host_name = "net.host.name"
+
+      /// The internet connection type currently being used by the host.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: wifi
+      ///
+      /// Required: No
+      [<Literal>]
+      let net_host_connection_type = "net.host.connection.type"
+
+      /// net.host.connection.type MUST be one of the following or, if none of the listed values apply, a custom value:
+      [<Measure>]
+      type net_host_connection_type_values
+
+      let net_host_connection_type_values_wifi: string<net_host_connection_type_values> =
+        UMX.tag "wifi"
+
+      let net_host_connection_type_values_wired: string<net_host_connection_type_values> =
+        UMX.tag "wired"
+
+      let net_host_connection_type_values_cell: string<net_host_connection_type_values> =
+        UMX.tag "cell"
+
+      let net_host_connection_type_values_unavailable: string<net_host_connection_type_values> =
+        UMX.tag "unavailable"
+
+      let net_host_connection_type_values_unknown: string<net_host_connection_type_values> =
+        UMX.tag "unknown"
+
+
+      /// This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: lte
+      ///
+      /// Required: No
+      [<Literal>]
+      let net_host_connection_subtype = "net.host.connection.subtype"
+
+      /// net.host.connection.subtype MUST be one of the following or, if none of the listed values apply, a custom value:
+      [<Measure>]
+      type net_host_connection_subtype_values
+
+
+      let net_host_connection_subtype_values_gprs: string<net_host_connection_type_values> =
+        UMX.tag "gprs"
+
+      let net_host_connection_subtype_values_edge: string<net_host_connection_type_values> =
+        UMX.tag "edge"
+
+      let net_host_connection_subtype_values_umts: string<net_host_connection_type_values> =
+        UMX.tag "umts"
+
+      let net_host_connection_subtype_values_cdma: string<net_host_connection_type_values> =
+        UMX.tag "cdma"
+
+      let net_host_connection_subtype_values_evdo_0: string<net_host_connection_type_values> =
+        UMX.tag "evdo_0"
+
+      let net_host_connection_subtype_values_evdo_a: string<net_host_connection_type_values> =
+        UMX.tag "evdo_a"
+
+      let net_host_connection_subtype_values_cdma2000_1xrtt: string<net_host_connection_type_values> =
+        UMX.tag "cdma2000_1xrtt"
+
+      let net_host_connection_subtype_values_hsdpa: string<net_host_connection_type_values> =
+        UMX.tag "hsdpa"
+
+      let net_host_connection_subtype_values_hsupa: string<net_host_connection_type_values> =
+        UMX.tag "hsupa"
+
+      let net_host_connection_subtype_values_iden: string<net_host_connection_type_values> =
+        UMX.tag "iden"
+
+      let net_host_connection_subtype_values_ehrpd: string<net_host_connection_type_values> =
+        UMX.tag "ehrpd"
+
+      let net_host_connection_subtype_values_hspap: string<net_host_connection_type_values> =
+        UMX.tag "hspap"
+
+      let net_host_connection_subtype_values_gsm: string<net_host_connection_type_values> =
+        UMX.tag "gsm"
+
+      let net_host_connection_subtype_values_td_scdma: string<net_host_connection_type_values> =
+        UMX.tag "td_scdma"
+
+      let net_host_connection_subtype_values_iwlan: string<net_host_connection_type_values> =
+        UMX.tag "iwlan"
+
+      let net_host_connection_subtype_values_nr: string<net_host_connection_type_values> =
+        UMX.tag "nr"
+
+      let net_host_connection_subtype_values_nrnsa: string<net_host_connection_type_values> =
+        UMX.tag "nrnsa"
+
+      let net_host_connection_subtype_values_lte_ca: string<net_host_connection_type_values> =
+        UMX.tag "lte_ca"
+
+
+      /// The name of the mobile carrier.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: sprint
+      ///
+      /// Required: No
+      [<Literal>]
+      let net_host_carrier_name = "net.host.carrier.name"
+
+      /// The mobile carrier country code.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: 310
+      ///
+      /// Required: No
+      [<Literal>]
+      let net_host_carrier_mcc = "net.host.carrier.mcc"
+
+      /// The mobile carrier network code.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: 001
+      ///
+      /// Required: No
+      [<Literal>]
+      let net_host_carrier_mnc = "net.host.carrier.mnc"
+
+      /// The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: DE
+      ///
+      /// Required: No
+      [<Literal>]
+      let net_host_carrier_icc = "net.host.carrier.icc"
+
+    /// This attribute may be used for any operation that accesses some remote service. Users can define what the name of a service is based on their particular semantics in their distributed system. Instrumentations SHOULD provide a way for users to configure this name.
+    ///
+    /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-remote-service-attributes
+    module Remote =
+      /// The service.name of the remote service. SHOULD be equal to the actual service.name resource attribute of the remote service if any.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: AuthTokenCache
+      ///
+      /// Examples of peer.service that users may specify:
+      ///
+      /// A Redis cache of auth tokens as peer.service="AuthTokenCache".
+      ///
+      /// A gRPC service rpc.service="io.opentelemetry.AuthService" may be hosted in both a gateway, peer.service="ExternalApiService" and a backend, peer.service="AuthService".
+      ///
+      /// Required: No
+      [<Literal>]
+      let peer_service = "peer.service"
+
+    /// These attributes may be used for any operation with an authenticated and/or authorized enduser.
+    ///
+    /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-identity-attributes
+    module Identity =
+
+      /// Username or client_id extracted from the access token or Authorization header in the inbound request from outside the system.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: username
+      ///
+      /// Required: No
+      [<Literal>]
+      let enduser_id = "enduser.id"
+
+      /// Actual/assumed role the client is making the request under extracted from token or application security context.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: admin
+      ///
+      /// Required: No
+      [<Literal>]
+      let enduser_role = "enduser.role"
+
+      /// Scopes or granted authorities the client currently possesses extracted from token or application security context. The value would come from the scope associated with an OAuth 2.0 Access Token or an attribute value in a SAML 2.0 Assertion.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: read:message, write:files
+      ///
+      /// Required: No
+      [<Literal>]
+      let enduser_scope = "enduser.scope"
+
+    /// These attributes may be used for any operation to store information about a thread that started a span.
+    ///
+    /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-thread-attributes
+    module Thread =
+
+      /// Current "managed" thread ID (as opposed to OS thread ID).
+      ///
+      /// ValueType: int
+      ///
+      /// Examples: 42
+      ///
+      /// Can use Thread.CurrentThread.ManagedThreadId
+      ///
+      /// Required: No
+      [<Literal>]
+      let thread_id = "thread.id"
+
+      /// Current thread name.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: main
+      ///
+      /// Can use Thread.CurrentThread.Name
+      ///
+      /// Required: No
+      [<Literal>]
+      let thread_name = "thread.name"
+
+    /// Often a span is closely tied to a certain unit of code that is logically responsible for handling the operation that the span describes (usually the method that starts the span). For an HTTP server span, this would be the function that handles the incoming request, for example. The attributes listed below allow to report this unit of code and therefore to provide more context about the span.
+    ///
+    /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#source-code-attributes
+    module SourceCode =
+      /// The method or function name, or equivalent (usually rightmost part of the code unit's name).
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: serveRequest
+      ///
+      /// Required: No
+      [<Literal>]
+      let code_function = "code.function"
+
+      /// The "namespace" within which code.function is defined. Usually the qualified class or module name, such that code.namespace + some separator + code.function form a unique identifier for the code unit.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: com.example.MyHttpService
+      ///
+      /// Required: No
+      [<Literal>]
+      let code_namespace = "code.namespace"
+
+      /// The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: /usr/local/MyApplication/content_root/app/index.php
+      ///
+      /// Required: No
+      [<Literal>]
+      let code_filepath = "code.filepath"
+
+      /// The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: 42
+      ///
+      /// Required: No
+      [<Literal>]
+      let code_lineno = "code.lineno"
+
+    module Exceptions =
+
+
+      [<Literal>]
+      let exception_ = "exception"
+
+      /// The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: java.net.ConnectException; OSError
+      ///
+      /// Required: No
+      [<Literal>]
+      let exception_type = "exception.type"
+
+      /// The exception message.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: Division by zero; Can't convert 'int' object to str implicitly
+      ///
+      /// Required: No
+      [<Literal>]
+      let exception_message = "exception.message"
+
+      /// A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.
+      ///
+      /// ValueType: string
+      ///
+      /// Examples: Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)
+      ///
+      /// Required: No
+      [<Literal>]
+      let exception_stacktrace = "exception.stacktrace"
+
+      /// SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span.
+      ///
+      /// An exception is considered to have escaped (or left) the scope of a span, if that span is ended while the exception is still logically "in flight". This may be actually "in flight" in some languages (e.g. if the exception is passed to a Context manager's __exit__ method in Python) but will usually be caught at the point of recording the exception in most languages.
+      ///
+      /// It is usually not possible to determine at the point where an exception is thrown whether it will escape the scope of a span. However, it is trivial to know that an exception will escape, if one checks for an active exception just before ending the span, as done in the example above.
+      ///
+      /// It follows that an exception may still escape the scope of the span even if the exception.escaped attribute was not set or set to false, since the event might have been recorded at a time where it was not clear whether the exception will escape.
+      ///
+      /// ValueType: boolean
+      ///
+      /// Required: No
+      [<Literal>]
+      let exception_escaped = "exception.escaped"
+
+module private SemanticHelpers =
+  let inline createSourceCodeTags (filePath: string) (codeLine: int) (name_space: string) (functionName: string) =
+    seq {
+      SemanticConventions.General.SourceCode.code_filepath, box filePath
+      SemanticConventions.General.SourceCode.code_lineno, box codeLine
+      SemanticConventions.General.SourceCode.code_namespace, box name_space
+      SemanticConventions.General.SourceCode.code_function, box functionName
+    }
+
+[<Extension>]
+type ActivityExtensions =
+  [<Extension>]
+
+  /// <summary>
+  /// Add or update the Activity baggage with the input key and value.
+  ///
+  /// If the input value is null
+  ///     - if the collection has any baggage with the same key, then this baggage will get removed from the collection.
+  ///     - otherwise, nothing will happen and the collection will not change.
+  ///
+  /// If the input value is not null
+  ///     - if the collection has any baggage with the same key, then the value mapped to this key will get updated with the new input value.
+  ///     - otherwise, the key and value will get added as a new baggage to the collection.
+  ///
+  ///
+  /// https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activity.setbaggage?view=net-6.0
+  /// </summary>
+  /// <param name="span">The activity to add the baggage to</param>
+  /// <param name="key">The baggage key name</param>
+  /// <param name="value">The baggage value mapped to the input key</param>
+  /// <returns><see langword="this" /> for convenient chaining.</returns>
+  static member inline SetBaggageSafe(span: Activity, key: string, value: string) =
+    if not (isNull span) then
+      span.AddBaggage(key, value)
+    else
+      span
+
+  [<Extension>]
+  /// <summary>
+  /// Add <see cref="ActivityEvent" /> object to the <see cref="Events" /> list.
+  ///
+  /// https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activity.addevent?view=net-6.0
+  /// </summary>
+  /// <param name="span">The activity to add the baggage to</param>
+  /// <param name="e"> object of <see cref="ActivityEvent"/> to add to the attached events list.</param>
+  /// <returns><see langword="this" /> for convenient chaining.</returns>
+  static member inline AddEventSafe(span: Activity, e: ActivityEvent) =
+    if Funcs.isNotNull span then span.AddEvent(e) else span
+
+  [<Extension>]
+  /// <summary>
+  /// Add or update the Activity tag with the input key and value.
+  ///
+  /// If the input value is null
+  ///     - if the collection has any tag with the same key, then this tag will get removed from the collection.
+  ///     - otherwise, nothing will happen and the collection will not change.
+  ///
+  /// If the input value is not null
+  ///     - if the collection has any tag with the same key, then the value mapped to this key will get updated with the new input value.
+  ///     - otherwise, the key and value will get added as a new tag to the collection.
+  /// </summary>
+  /// <param name="span">The activity to add the baggage to</param>
+  /// <param name="key">The tag key name</param>
+  /// <param name="value">The tag value mapped to the input key</param>
+  /// <returns><see langword="this" /> for convenient chaining.</returns>
+  static member inline SetTagSafe(span: Activity, key, value: obj) =
+    if Funcs.isNotNull span then
+      span.SetTag(key, value)
+    else
+      span
+
+  [<Extension>]
+  static member inline SetStatusErrorSafe(span: Activity, description: string) =
+    span
+      .SetTagSafe("otel.status_code", "ERROR")
+      .SetTagSafe("otel.status_description", description)
+
+  [<Extension>]
+  static member inline SetSourceCodeFilePath(span: Activity, value: string) =
+    span.SetTagSafe(SemanticConventions.General.SourceCode.code_filepath, value)
+
+  [<Extension>]
+  static member inline SetSourceCodeLineNumber(span: Activity, value: int) =
+    span.SetTagSafe(SemanticConventions.General.SourceCode.code_lineno, value)
+
+  [<Extension>]
+  static member inline SetSourceCodeNamespace(span: Activity, value: string) =
+    span.SetTagSafe(SemanticConventions.General.SourceCode.code_namespace, value)
+
+  [<Extension>]
+  static member inline SetSourceCodeFunction(span: Activity, value: string) =
+    span.SetTagSafe(SemanticConventions.General.SourceCode.code_function, value)
+
+  [<Extension>]
+  static member inline SetNetworkNetTransport
+    (
+      span: Activity,
+      value: string<SemanticConventions.General.Network.net_transport_values>
+    ) =
+    span.SetTagSafe(SemanticConventions.General.Network.net_transport, UMX.untag value)
+
+  [<Extension>]
+  static member inline SetNetworkNetHostConnectionType
+    (
+      span: Activity,
+      value: string<SemanticConventions.General.Network.net_host_connection_type_values>
+    ) =
+    span.SetTagSafe(SemanticConventions.General.Network.net_host_connection_type, UMX.untag value)
+
+  [<Extension>]
+  static member inline SetNetworkNetHostConnectionSubType
+    (
+      span: Activity,
+      value: string<SemanticConventions.General.Network.net_host_connection_subtype_values>
+    ) =
+    span.SetTagSafe(SemanticConventions.General.Network.net_host_connection_subtype, UMX.untag value)
+
+
+  /// <summary>https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md#semantic-conventions-for-exceptions</summary>
+  /// <param name="span">The span to add the error information to</param>
+  /// <param name="errorMessage">The exception message.</param>
+  /// <param name="errorType">The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.</param>
+  /// <param name="stacktrace">A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.</param>
+  /// <param name="escaped">SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span. </param>
+  [<Extension>]
+  static member inline RecordError
+    (
+      span: Activity,
+      errorMessage: string,
+      errorType: string,
+      ?stacktrace: string,
+      ?escaped: bool
+    ) =
+    if Funcs.isNotNull span then
+      let escaped = defaultArg escaped false
+
+      let tags =
+        ActivityTagsCollection(
+          [ yield KeyValuePair(SemanticConventions.General.Exceptions.exception_escaped, box escaped)
+            yield KeyValuePair(SemanticConventions.General.Exceptions.exception_type, box errorType)
+
+            if Option.isSome stacktrace then
+              yield KeyValuePair(SemanticConventions.General.Exceptions.exception_stacktrace, box stacktrace.Value)
+
+            yield KeyValuePair(SemanticConventions.General.Exceptions.exception_message, box errorMessage) ]
+        )
+
+      ActivityEvent(SemanticConventions.General.Exceptions.exception_, tags = tags)
+      |> span.AddEvent
+    else
+      span
+
+  /// <summary>https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md#semantic-conventions-for-exceptions</summary>
+  /// <param name="span">The span to add the error information to</param>
+  /// <param name="errorMessage">The exception message.</param>
+  /// <param name="errorType">The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.</param>
+  /// <param name="stacktrace">A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.</param>
+  /// <param name="escaped">SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span. </param>
+  [<Extension>]
+  static member inline RecordExceptions(span: Activity, e: exn, ?escaped: bool) =
+    if Funcs.isNotNull span then
+      let escaped = defaultArg escaped false
+      let exceptionType = e.GetType().Name
+      let exceptionStackTrace = e.ToString()
+      let exceptionMessage = e.Message
+
+      let tags =
+        ActivityTagsCollection(
+          [ yield KeyValuePair(SemanticConventions.General.Exceptions.exception_escaped, box escaped)
+            yield KeyValuePair(SemanticConventions.General.Exceptions.exception_type, box exceptionType)
+            yield KeyValuePair(SemanticConventions.General.Exceptions.exception_stacktrace, box exceptionStackTrace)
+            if not <| String.IsNullOrEmpty(exceptionMessage) then
+              yield KeyValuePair(SemanticConventions.General.Exceptions.exception_message, box exceptionMessage) ]
+        )
+
+      ActivityEvent(SemanticConventions.General.Exceptions.exception_, tags = tags)
+      |> span.AddEvent
+    else
+      span
+
+[<Extension>]
+type ActivitySourceExtensions =
+
+  /// <summary>Creates and starts a new System.Diagnostics.Activity object if there is any listener to the Activity events, returns null otherwise.</summary>
+  /// <param name="tracer">Provides APIs to create and start System.Diagnostics.Activity objects.</param>
+  /// <param name="name">The operation name of the Activity.</param>
+  /// <param name="name_space">The namespace where this code is located.</param>
+  /// <param name="activityKind">The System.Diagnostics.ActivityKind</param>
+  /// <param name="parentContext">The parent System.Diagnostics.ActivityContext object to initialize the created Activity object with.</param>
+  /// <param name="tags">The optional tags list to initialize the created Activity object with.</param>
+  /// <param name="links">The optional System.Diagnostics.ActivityLink list to initialize the created Activity object with.</param>
+  /// <param name="startTime">The optional start timestamp to set on the created Activity object.</param>
+  /// <param name="memberName">Uses CallerMemberName, should not be set unless you know what you're doing.</param>
+  /// <param name="path">Uses CallerFilePath, should not be set unless you know what you're doing.</param>
+  /// <param name="line">Uses CallerLineNumberAttribute, should not be set unless you know what you're doing.</param>
+  /// <returns>The created System.Diagnostics.Activity object or null if there is no any listener.</returns>
+  [<Extension>]
+  static member inline StartActivityExt
+    (
+      tracer: ActivitySource,
+      ?name: string,
+      ?name_space: string,
+      ?activityKind: ActivityKind,
+      ?parentContext: ActivityContext,
+      ?tags: IEnumerable<string * obj>,
+      ?links: IEnumerable<ActivityLink>,
+      ?startTime: DateTimeOffset,
+      [<CallerMemberName>] ?memberName: string,
+      [<CallerFilePath>] ?path: string,
+      [<CallerLineNumberAttribute>] ?line: int
+    ) =
+
+    let name_space =
+      name_space
+      |> Option.defaultWith (fun () ->
+        Reflection.MethodBase.GetCurrentMethod().DeclaringType.FullName.Split("+")
+        |> Seq.tryHead
+        |> Option.defaultValue "")
+
+
+    let kind = defaultArg activityKind ActivityKind.Internal
+
+    let tags =
+      seq {
+        yield! SemanticHelpers.createSourceCodeTags path.Value line.Value name_space memberName.Value
+
+        match tags with
+        | Some t -> yield! t
+        | None -> ()
+      }
+      |> Seq.map KeyValuePair
+
+    let name = name |> Option.defaultWith (fun () -> $"{name_space}.{memberName.Value}")
+
+    let span =
+      tracer.StartActivity(
+        name = name,
+        kind = kind,
+        ?parentContext = parentContext,
+        tags = tags,
+        ?links = links,
+        ?startTime = startTime
+      )
+
+    span
+
+  /// <summary>This should be used by methods in classes. Creates and starts a new System.Diagnostics.Activity object if there is any listener to the Activity events, returns null otherwise.</summary>
+  /// <param name="tracer">Provides APIs to create and start System.Diagnostics.Activity objects.</param>
+  /// <param name="ty">The type where the trace is located.</param>
+  /// <param name="name_space">The namespace where this code is located.</param>
+  /// <param name="activityKind">The System.Diagnostics.ActivityKind</param>
+  /// <param name="parentContext">The parent System.Diagnostics.ActivityContext object to initialize the created Activity object with.</param>
+  /// <param name="tags">The optional tags list to initialize the created Activity object with.</param>
+  /// <param name="links">The optional System.Diagnostics.ActivityLink list to initialize the created Activity object with.</param>
+  /// <param name="startTime">The optional start timestamp to set on the created Activity object.</param>
+  /// <param name="memberName">Uses CallerMemberName, should not be set unless you know what you're doing.</param>
+  /// <param name="path">Uses CallerFilePath, should not be set unless you know what you're doing.</param>
+  /// <param name="line">Uses CallerLineNumberAttribute, should not be set unless you know what you're doing.</param>
+  /// <returns>The created System.Diagnostics.Activity object or null if there is no any listener.</returns>
+  [<Extension>]
+  static member inline StartActivityForType
+    (
+      tracer: ActivitySource,
+      ty: Type,
+      ?activityKind: ActivityKind,
+      ?parentContext: ActivityContext,
+      ?tags: IEnumerable<string * obj>,
+      ?links: IEnumerable<ActivityLink>,
+      ?startTime: DateTimeOffset,
+      [<CallerMemberName>] ?memberName: string,
+      [<CallerFilePath>] ?path: string,
+      [<CallerLineNumberAttribute>] ?line: int
+    ) =
+    let name_space = ty.FullName
+    let name = $"{name_space}.{memberName.Value}"
+
+    tracer.StartActivityExt(
+      name,
+      name_space = name_space,
+      ?activityKind = activityKind,
+      ?parentContext = parentContext,
+      ?tags = tags,
+      ?links = links,
+      ?startTime = startTime,
+      ?memberName = memberName,
+      ?path = path,
+      ?line = line
+    )
+
+
+  /// <summary>This should be used by methods in classes. Creates and starts a new System.Diagnostics.Activity object if there is any listener to the Activity events, returns null otherwise.</summary>
+  /// <param name="tracer">Provides APIs to create and start System.Diagnostics.Activity objects.</param>
+  /// <param name="activityKind">The System.Diagnostics.ActivityKind</param>
+  /// <param name="parentContext">The parent System.Diagnostics.ActivityContext object to initialize the created Activity object with.</param>
+  /// <param name="tags">The optional tags list to initialize the created Activity object with.</param>
+  /// <param name="links">The optional System.Diagnostics.ActivityLink list to initialize the created Activity object with.</param>
+  /// <param name="startTime">The optional start timestamp to set on the created Activity object.</param>
+  /// <param name="memberName">Uses CallerMemberName, should not be set unless you know what you're doing.</param>
+  /// <param name="path">Uses CallerFilePath, should not be set unless you know what you're doing.</param>
+  /// <param name="line">Uses CallerLineNumberAttribute, should not be set unless you know what you're doing.</param>
+  /// <typeparam name="'typAr">The type where the trace is located.</typeparam>
+  /// <returns>The created System.Diagnostics.Activity object or null if there is no any listener.</returns>
+  [<Extension>]
+  static member inline StartActivityForType<'typAr>
+    (
+      tracer: ActivitySource,
+      ?activityKind: ActivityKind,
+      ?parentContext: ActivityContext,
+      ?tags: IEnumerable<string * obj>,
+      ?links: IEnumerable<ActivityLink>,
+      ?startTime: DateTimeOffset,
+      [<CallerMemberName>] ?memberName: string,
+      [<CallerFilePath>] ?path: string,
+      [<CallerLineNumberAttribute>] ?line: int
+    ) =
+    let ty = typeof<'typAr>
+
+    tracer.StartActivityForType(
+      ty,
+      ?activityKind = activityKind,
+      ?parentContext = parentContext,
+      ?tags = tags,
+      ?links = links,
+      ?startTime = startTime,
+      ?memberName = memberName,
+      ?path = path,
+      ?line = line
+    )
+
+  /// <summary>This should be used by functions in modules. Creates and starts a new System.Diagnostics.Activity object if there is any listener to the Activity events, returns null otherwise.</summary>
+  /// <param name="tracer">Provides APIs to create and start System.Diagnostics.Activity objects.</param>
+  /// <param name="activityKind">The System.Diagnostics.ActivityKind</param>
+  /// <param name="parentContext">The parent System.Diagnostics.ActivityContext object to initialize the created Activity object with.</param>
+  /// <param name="tags">The optional tags list to initialize the created Activity object with.</param>
+  /// <param name="links">The optional System.Diagnostics.ActivityLink list to initialize the created Activity object with.</param>
+  /// <param name="startTime">The optional start timestamp to set on the created Activity object.</param>
+  /// <param name="memberName">Uses CallerMemberName, should not be set unless you know what you're doing.</param>
+  /// <param name="path">Uses CallerFilePath, should not be set unless you know what you're doing.</param>
+  /// <param name="line">Uses CallerLineNumberAttribute, should not be set unless you know what you're doing.</param>
+  /// <returns>The created System.Diagnostics.Activity object or null if there is no any listener.</returns>
+  [<Extension>]
+  static member inline StartActivityForFunc
+    (
+      tracer: ActivitySource,
+      ?activityKind: ActivityKind,
+      ?parentContext: ActivityContext,
+      ?tags: IEnumerable<string * obj>,
+      ?links: IEnumerable<ActivityLink>,
+      ?startTime: DateTimeOffset,
+      [<CallerMemberName>] ?memberName: string,
+      [<CallerFilePath>] ?path: string,
+      [<CallerLineNumberAttribute>] ?line: int
+    ) =
+
+    tracer.StartActivityExt(
+      ?name = None,
+      ?name_space = None,
+      ?activityKind = activityKind,
+      ?parentContext = parentContext,
+      ?tags = tags,
+      ?links = links,
+      ?startTime = startTime,
+      ?memberName = memberName,
+      ?path = path,
+      ?line = line
+    )

--- a/src/FsAutoComplete.Logging/paket.references
+++ b/src/FsAutoComplete.Logging/paket.references
@@ -1,7 +1,4 @@
 FSharp.Core
 
-File: FsLibLog.fs
-File: FsOpenTelemetry.fs
-
 Microsoft.NETFramework.ReferenceAssemblies
 Ionide.KeepAChangelog.Tasks

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -20,7 +20,7 @@ open FsAutoComplete.Adaptive
 
 open FSharp.Control.Reactive
 open FsToolkit.ErrorHandling
-open FsOpenTelemetry
+open FsAutoComplete.Telemetry
 open FsAutoComplete.Utils.Tracing
 open FSharp.UMX
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 420865f</samp>

This pull request simplifies the dependency management and telemetry features of FsAutoComplete by using official NuGet packages instead of source files for `FsLibLog` and `FsOpenTelemetry`, and by wrapping the latter in a custom namespace `FsAutoComplete.Telemetry`. It also updates the build process and the namespace references accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 420865f</samp>

> _Sing, O Muse, of the clever pull request_
> _That simplified the build of `FsAutoComplete`,_
> _The glorious tool that aids the F# code_
> _And makes it shine like the sun-god's chariot._

<!--
copilot:emoji
-->

📦🚀🛠️

<!--
1.  📦 This emoji represents the removal of the GitHub dependencies and the use of the official NuGet packages instead. It conveys the idea of packaging and dependency management.
2.  🚀 This emoji represents the update of the namespace references and the use of the custom wrapper around FsOpenTelemetry. It conveys the idea of performance and improvement.
3.  🛠️ This emoji represents the update of the project file and the removal of the unnecessary file references. It conveys the idea of fixing and simplifying.
-->

### WHY
closes #1045 

In addition to the issue, Paket hits github asking for hashes and can cause hitting API limits.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 420865f</samp>

*  Remove the target `ReplaceFsLibLogNamespaces` and its dependencies from the `build/Program.fs` file, as it is no longer needed after replacing FsLibLog with FsAutoComplete.Logging as a direct dependency ([link](https://github.com/fsharp/FsAutoComplete/pull/1095/files?diff=unified&w=0#diff-94ffc46e61f81d91dcfd52f84be2cc1b568180654c3db088a71f9a2c8e0b5a97L104-L114), [link](https://github.com/fsharp/FsAutoComplete/pull/1095/files?diff=unified&w=0#diff-94ffc46e61f81d91dcfd52f84be2cc1b568180654c3db088a71f9a2c8e0b5a97L187-R181))
* Remove the GitHub dependencies on FsLibLog and FsOpenTelemetry from the `paket.dependencies` file, and use the official NuGet packages instead of the source files ([link](https://github.com/fsharp/FsAutoComplete/pull/1095/files?diff=unified&w=0#diff-377fe73bf860b37e7d9a8ca5be27762668b3a08aac581b435d4c31b737d905cdL12-L14))
* Copy FsLibLog and FsOpenTelemetry from the paket-files folder to the `src/FsAutoComplete.Logging` project folder, and rename them to avoid conflicts with the original libraries ([link](https://github.com/fsharp/FsAutoComplete/pull/1095/files?diff=unified&w=0#diff-8d253abc8118a2f1cb94279394e95a476b02958d49014de634daae53c471e183L8-R11), [link](https://github.com/fsharp/FsAutoComplete/pull/1095/files?diff=unified&w=0#diff-3e872bf197dc6ef9fcb9873aa80ca6d19fc6d70185a84eada2db4e4344ee8bf1L3-L5))
* Wrap FsOpenTelemetry with FsAutoComplete.Telemetry, which provides a unified interface for tracing and metrics across the project, and update the namespace references accordingly in the source files ([link](https://github.com/fsharp/FsAutoComplete/pull/1095/files?diff=unified&w=0#diff-9af59b386f0d6d11954514dbf9d61c88cb09fbed23c39b4412f5e7c5a63b32a6L868-R868), [link](https://github.com/fsharp/FsAutoComplete/pull/1095/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L23-R23))
