### PR TITLE
bump LanguageServerProtocol and react to API changes

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -97,7 +97,7 @@ NUGET
       System.Collections.Immutable (>= 5.0)
       System.Reflection.Metadata (>= 5.0)
     Ionide.KeepAChangelog.Tasks (0.1.8) - copy_local: true
-    Ionide.LanguageServerProtocol (0.4.12)
+    Ionide.LanguageServerProtocol (0.4.14)
       FSharp.Core (>= 6.0)
       Newtonsoft.Json (>= 13.0.1)
       StreamJsonRpc (>= 2.10.44)

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -2002,6 +2002,10 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
             rootPath.Value <- actualRootPath
             clientCapabilities.Value <- p.Capabilities
             lspClient.ClientCapabilities <- p.Capabilities
+            diagnosticCollections.ClientSupportsDiagnostics <-
+              match p.Capabilities with
+              | Some { TextDocument = Some { PublishDiagnostics = Some _ } } -> true
+              | _ -> false
             updateConfig c
             workspacePaths.Value <- projs)
 
@@ -4653,6 +4657,18 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
 
         return ()
       }
+    member this.CallHierarchyIncomingCalls(arg1: CallHierarchyIncomingCallsParams): AsyncLspResult<CallHierarchyIncomingCall array option> =
+        failwith "Not Implemented"
+    member this.CallHierarchyOutgoingCalls(arg1: CallHierarchyOutgoingCallsParams): AsyncLspResult<CallHierarchyOutgoingCall array option> =
+        failwith "Not Implemented"
+    member this.TextDocumentPrepareCallHierarchy(arg1: CallHierarchyPrepareParams): AsyncLspResult<CallHierarchyItem array option> =
+        failwith "Not Implemented"
+    member this.TextDocumentPrepareTypeHierarchy(arg1: TypeHierarchyPrepareParams): AsyncLspResult<TypeHierarchyItem array option> =
+        failwith "Not Implemented"
+    member this.TypeHierarchySubtypes(arg1: TypeHierarchySubtypesParams): AsyncLspResult<TypeHierarchyItem array option> =
+        failwith "Not Implemented"
+    member this.TypeHierarchySupertypes(arg1: TypeHierarchySupertypesParams): AsyncLspResult<TypeHierarchyItem array option> =
+        failwith "Not Implemented"
 
 module AdaptiveFSharpLspServer =
 

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -2002,10 +2002,12 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
             rootPath.Value <- actualRootPath
             clientCapabilities.Value <- p.Capabilities
             lspClient.ClientCapabilities <- p.Capabilities
+
             diagnosticCollections.ClientSupportsDiagnostics <-
               match p.Capabilities with
               | Some { TextDocument = Some { PublishDiagnostics = Some _ } } -> true
               | _ -> false
+
             updateConfig c
             workspacePaths.Value <- projs)
 
@@ -4657,18 +4659,36 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
 
         return ()
       }
-    member this.CallHierarchyIncomingCalls(arg1: CallHierarchyIncomingCallsParams): AsyncLspResult<CallHierarchyIncomingCall array option> =
-        failwith "Not Implemented"
-    member this.CallHierarchyOutgoingCalls(arg1: CallHierarchyOutgoingCallsParams): AsyncLspResult<CallHierarchyOutgoingCall array option> =
-        failwith "Not Implemented"
-    member this.TextDocumentPrepareCallHierarchy(arg1: CallHierarchyPrepareParams): AsyncLspResult<CallHierarchyItem array option> =
-        failwith "Not Implemented"
-    member this.TextDocumentPrepareTypeHierarchy(arg1: TypeHierarchyPrepareParams): AsyncLspResult<TypeHierarchyItem array option> =
-        failwith "Not Implemented"
-    member this.TypeHierarchySubtypes(arg1: TypeHierarchySubtypesParams): AsyncLspResult<TypeHierarchyItem array option> =
-        failwith "Not Implemented"
-    member this.TypeHierarchySupertypes(arg1: TypeHierarchySupertypesParams): AsyncLspResult<TypeHierarchyItem array option> =
-        failwith "Not Implemented"
+
+    member this.CallHierarchyIncomingCalls
+      (arg1: CallHierarchyIncomingCallsParams)
+      : AsyncLspResult<CallHierarchyIncomingCall array option> =
+      failwith "Not Implemented"
+
+    member this.CallHierarchyOutgoingCalls
+      (arg1: CallHierarchyOutgoingCallsParams)
+      : AsyncLspResult<CallHierarchyOutgoingCall array option> =
+      failwith "Not Implemented"
+
+    member this.TextDocumentPrepareCallHierarchy
+      (arg1: CallHierarchyPrepareParams)
+      : AsyncLspResult<CallHierarchyItem array option> =
+      failwith "Not Implemented"
+
+    member this.TextDocumentPrepareTypeHierarchy
+      (arg1: TypeHierarchyPrepareParams)
+      : AsyncLspResult<TypeHierarchyItem array option> =
+      failwith "Not Implemented"
+
+    member this.TypeHierarchySubtypes
+      (arg1: TypeHierarchySubtypesParams)
+      : AsyncLspResult<TypeHierarchyItem array option> =
+      failwith "Not Implemented"
+
+    member this.TypeHierarchySupertypes
+      (arg1: TypeHierarchySupertypesParams)
+      : AsyncLspResult<TypeHierarchyItem array option> =
+      failwith "Not Implemented"
 
 module AdaptiveFSharpLspServer =
 

--- a/src/FsAutoComplete/LspServers/Common.fs
+++ b/src/FsAutoComplete/LspServers/Common.fs
@@ -118,8 +118,7 @@ type DiagnosticCollection(sendDiagnostics: DocumentUri -> Diagnostic[] -> Async<
   member val ClientSupportsDiagnostics = true with get, set
 
   member x.SetFor(fileUri: DocumentUri, kind: string, values: Diagnostic[]) =
-    if x.ClientSupportsDiagnostics
-    then
+    if x.ClientSupportsDiagnostics then
       let mailbox = getOrAddAgent fileUri
 
       match values with
@@ -127,14 +126,12 @@ type DiagnosticCollection(sendDiagnostics: DocumentUri -> Diagnostic[] -> Async<
       | values -> mailbox.Post(Add(kind, values))
 
   member x.ClearFor(fileUri: DocumentUri) =
-    if x.ClientSupportsDiagnostics
-    then
+    if x.ClientSupportsDiagnostics then
       removeAgent fileUri
       sendDiagnostics fileUri [||] |> Async.Start
 
   member x.ClearFor(fileUri: DocumentUri, kind: string) =
-    if x.ClientSupportsDiagnostics
-    then
+    if x.ClientSupportsDiagnostics then
       let mailbox = getOrAddAgent fileUri
       mailbox.Post(Clear kind)
 

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -1080,6 +1080,10 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
 
         clientCapabilities <- p.Capabilities
         lspClient.ClientCapabilities <- clientCapabilities
+        diagnosticCollections.ClientSupportsDiagnostics <-
+          match p.Capabilities with
+          | Some { TextDocument = Some { PublishDiagnostics = Some _ } } -> true
+          | _ -> false
         glyphToCompletionKind <- glyphToCompletionKindGenerator clientCapabilities
         glyphToSymbolKind <- glyphToSymbolKindGenerator clientCapabilities
 
@@ -2893,6 +2897,18 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
       (x :> ILspServer).Shutdown() |> Async.Start
 
     member this.WorkDoneProgessCancel(arg1: ProgressToken) : Async<unit> = failwith "Not Implemented"
+    member this.CallHierarchyIncomingCalls(arg1: CallHierarchyIncomingCallsParams): AsyncLspResult<CallHierarchyIncomingCall array option> =
+        failwith "Not Implemented"
+    member this.CallHierarchyOutgoingCalls(arg1: CallHierarchyOutgoingCallsParams): AsyncLspResult<CallHierarchyOutgoingCall array option> =
+        failwith "Not Implemented"
+    member this.TextDocumentPrepareCallHierarchy(arg1: CallHierarchyPrepareParams): AsyncLspResult<CallHierarchyItem array option> =
+        failwith "Not Implemented"
+    member this.TextDocumentPrepareTypeHierarchy(arg1: TypeHierarchyPrepareParams): AsyncLspResult<TypeHierarchyItem array option> =
+        failwith "Not Implemented"
+    member this.TypeHierarchySubtypes(arg1: TypeHierarchySubtypesParams): AsyncLspResult<TypeHierarchyItem array option> =
+        failwith "Not Implemented"
+    member this.TypeHierarchySupertypes(arg1: TypeHierarchySupertypesParams): AsyncLspResult<TypeHierarchyItem array option> =
+        failwith "Not Implemented"
 
 module FSharpLspServer =
 

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -1080,10 +1080,12 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
 
         clientCapabilities <- p.Capabilities
         lspClient.ClientCapabilities <- clientCapabilities
+
         diagnosticCollections.ClientSupportsDiagnostics <-
           match p.Capabilities with
           | Some { TextDocument = Some { PublishDiagnostics = Some _ } } -> true
           | _ -> false
+
         glyphToCompletionKind <- glyphToCompletionKindGenerator clientCapabilities
         glyphToSymbolKind <- glyphToSymbolKindGenerator clientCapabilities
 
@@ -2897,18 +2899,36 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
       (x :> ILspServer).Shutdown() |> Async.Start
 
     member this.WorkDoneProgessCancel(arg1: ProgressToken) : Async<unit> = failwith "Not Implemented"
-    member this.CallHierarchyIncomingCalls(arg1: CallHierarchyIncomingCallsParams): AsyncLspResult<CallHierarchyIncomingCall array option> =
-        failwith "Not Implemented"
-    member this.CallHierarchyOutgoingCalls(arg1: CallHierarchyOutgoingCallsParams): AsyncLspResult<CallHierarchyOutgoingCall array option> =
-        failwith "Not Implemented"
-    member this.TextDocumentPrepareCallHierarchy(arg1: CallHierarchyPrepareParams): AsyncLspResult<CallHierarchyItem array option> =
-        failwith "Not Implemented"
-    member this.TextDocumentPrepareTypeHierarchy(arg1: TypeHierarchyPrepareParams): AsyncLspResult<TypeHierarchyItem array option> =
-        failwith "Not Implemented"
-    member this.TypeHierarchySubtypes(arg1: TypeHierarchySubtypesParams): AsyncLspResult<TypeHierarchyItem array option> =
-        failwith "Not Implemented"
-    member this.TypeHierarchySupertypes(arg1: TypeHierarchySupertypesParams): AsyncLspResult<TypeHierarchyItem array option> =
-        failwith "Not Implemented"
+
+    member this.CallHierarchyIncomingCalls
+      (arg1: CallHierarchyIncomingCallsParams)
+      : AsyncLspResult<CallHierarchyIncomingCall array option> =
+      failwith "Not Implemented"
+
+    member this.CallHierarchyOutgoingCalls
+      (arg1: CallHierarchyOutgoingCallsParams)
+      : AsyncLspResult<CallHierarchyOutgoingCall array option> =
+      failwith "Not Implemented"
+
+    member this.TextDocumentPrepareCallHierarchy
+      (arg1: CallHierarchyPrepareParams)
+      : AsyncLspResult<CallHierarchyItem array option> =
+      failwith "Not Implemented"
+
+    member this.TextDocumentPrepareTypeHierarchy
+      (arg1: TypeHierarchyPrepareParams)
+      : AsyncLspResult<TypeHierarchyItem array option> =
+      failwith "Not Implemented"
+
+    member this.TypeHierarchySubtypes
+      (arg1: TypeHierarchySubtypesParams)
+      : AsyncLspResult<TypeHierarchyItem array option> =
+      failwith "Not Implemented"
+
+    member this.TypeHierarchySupertypes
+      (arg1: TypeHierarchySupertypesParams)
+      : AsyncLspResult<TypeHierarchyItem array option> =
+      failwith "Not Implemented"
 
 module FSharpLspServer =
 

--- a/src/FsAutoComplete/Parser.fs
+++ b/src/FsAutoComplete/Parser.fs
@@ -188,12 +188,17 @@ module Parser =
 
   let warnOnUnknownOptions =
     Invocation.InvocationMiddleware(fun ctx next ->
-      if ctx.ParseResult.UnmatchedTokens = null || ctx.ParseResult.UnmatchedTokens.Count = 0
-      then next.Invoke(ctx)
-      else
-        ctx.Console.Error.Write($"""The following options were not recognized - please consider removing them: {String.Join(", ", ctx.ParseResult.UnmatchedTokens)}""")
+      if
+        ctx.ParseResult.UnmatchedTokens = null
+        || ctx.ParseResult.UnmatchedTokens.Count = 0
+      then
         next.Invoke(ctx)
-    )
+      else
+        ctx.Console.Error.Write(
+          $"""The following options were not recognized - please consider removing them: {String.Join(", ", ctx.ParseResult.UnmatchedTokens)}"""
+        )
+
+        next.Invoke(ctx))
 
   let configureOTel =
     Invocation.InvocationMiddleware(fun ctx next ->

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -394,7 +394,7 @@ let clientCaps: ClientCapabilities =
         PrepareSupport = Some false }
 
     { Synchronization = Some syncCaps
-      PublishDiagnostics = diagCaps
+      PublishDiagnostics = Some diagCaps
       Completion = Some compCaps
       Hover = Some hoverCaps
       SignatureHelp = Some sigCaps
@@ -412,7 +412,9 @@ let clientCaps: ClientCapabilities =
       FoldingRange = Some foldingRangeCaps
       SelectionRange = Some dynCaps
       SemanticTokens = Some semanticTokensCaps
-      InlayHint = Some inlayHintCaps }
+      InlayHint = Some inlayHintCaps
+      CallHierarchy = None
+      TypeHierarchy = None }
       // InlineValue = Some inlineValueCaps }
 
 


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 532910f</samp>

This pull request improves the compatibility and functionality of the F# language server by respecting the client capabilities for diagnostics and adding placeholders for new features. It also fixes a bug in the command-line parser and updates the test code. The changes affect the `AdaptiveFSharpLspServer`, `FSharpLspServer`, `DiagnosticCollection`, `Parser`, and `Helpers` types and modules in the `src` and `test` directories.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 532910f</samp>

> _This pull request is quite a mix_
> _It adds features and also fixes_
> _`Diagnostics` are smart_
> _`CallHierarchy` can start_
> _And `TypeHierarchy` joins the tricks_

<!--
copilot:emoji
-->

🛠️🌟🐛

<!--
1.  🛠️ - This emoji represents the addition of the `ClientSupportsDiagnostics` property and the improvement of the diagnostics handling, as they are both related to fixing or enhancing the functionality of the server.
2.  🌟 - This emoji represents the placeholders for the call hierarchy and type hierarchy features, as they are both related to adding new features or capabilities to the server.
3.  🐛 - This emoji represents the bug fix and the middleware function for unknown options, as they are both related to resolving errors or issues with the server.
-->

### WHY
We want to stop breaking some clients, so we need to conditionally send diagnostics to the client, as well as have some kind of way to handle older CLI args that have been removed.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 532910f</samp>

*  Add `ClientSupportsDiagnostics` property to `DiagnosticCollection` type to control whether to collect and send diagnostics to the client ([link](https://github.com/fsharp/FsAutoComplete/pull/1096/files?diff=unified&w=0#diff-444833594f5cf1c53d97749a712d8a6dd25b635ecea7891390e37746a66a7f6fL117-R139))
*  Set `ClientSupportsDiagnostics` property of `diagnosticCollections` field based on client capabilities in `AdaptiveFSharpLspServer` and `FSharpLspServer` types ([link](https://github.com/fsharp/FsAutoComplete/pull/1096/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0R2005-R2008), [link](https://github.com/fsharp/FsAutoComplete/pull/1096/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01R1083-R1086))
*  Add stubs for call hierarchy and type hierarchy methods to `AdaptiveFSharpLspServer` and `FSharpLspServer` types to comply with protocol specification ([link](https://github.com/fsharp/FsAutoComplete/pull/1096/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0R4660-R4671), [link](https://github.com/fsharp/FsAutoComplete/pull/1096/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01R2900-R2911))
*  Set `TreatUnmatchedTokensAsErrors` property of `rootCommand` value to false in `Parser` module to fix a bug that caused some clients to fail to start the server ([link](https://github.com/fsharp/FsAutoComplete/pull/1096/files?diff=unified&w=0#diff-83138e39ec2a1b48ab9298036c49a450021f15bbebf1085f9b1d58c2fd5ae08aL128-R130))
*  Add `warnOnUnknownOptions` middleware function to `Parser` module to write a warning message when unknown options are encountered ([link](https://github.com/fsharp/FsAutoComplete/pull/1096/files?diff=unified&w=0#diff-83138e39ec2a1b48ab9298036c49a450021f15bbebf1085f9b1d58c2fd5ae08aR189-R197), [link](https://github.com/fsharp/FsAutoComplete/pull/1096/files?diff=unified&w=0#diff-83138e39ec2a1b48ab9298036c49a450021f15bbebf1085f9b1d58c2fd5ae08aR325))
*  Fix typo and add call hierarchy and type hierarchy properties to `textDocumentCapabilities` value in `Range` module in test code ([link](https://github.com/fsharp/FsAutoComplete/pull/1096/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fL397-R397), [link](https://github.com/fsharp/FsAutoComplete/pull/1096/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fL415-R417))
