### PR TITLE
Various improvement around TipFormatter and Documentation

### DIFF
--- a/src/FsAutoComplete.Core/DocumentationFormatter.fs
+++ b/src/FsAutoComplete.Core/DocumentationFormatter.fs
@@ -16,7 +16,22 @@ module DocumentationFormatter =
 
   let mutable lastDisplayContext: FSharpDisplayContext = FSharpDisplayContext.Empty
 
-  let emptyTypeTip = [||], [||], [||], [||], [||], [||]
+  type EntityInfo =
+    { Constructors: string array
+      Fields: string array
+      Functions: string array
+      Interfaces: string array
+      Attributes: string array
+      DeclaredTypes: string array }
+
+    static member Empty =
+
+      { Constructors = [||]
+        Fields = [||]
+        Functions = [||]
+        Interfaces = [||]
+        Attributes = [||]
+        DeclaredTypes = [||] }
 
   /// Concat two strings with a space between if both a and b are not IsNullOrWhiteSpace
   let internal (++) (a: string) (b: string) =
@@ -719,8 +734,12 @@ module DocumentationFormatter =
           ++ fst (formatShowDocumentationLink ne.DisplayName ne.XmlDocSig ne.Assembly.SimpleName))
         |> Seq.toArray
 
-
-      constrc, fields, funcs, interfaces, attrs, types
+      { Constructors = constrc
+        Fields = fields
+        Functions = funcs
+        Interfaces = interfaces
+        Attributes = attrs
+        DeclaredTypes = types }
 
     let typeDisplay =
       let name =
@@ -756,9 +775,9 @@ module DocumentationFormatter =
     if fse.IsFSharpUnion then
       (typeDisplay + uniontip ()), typeTip ()
     elif fse.IsEnum then
-      (typeDisplay + enumtip ()), emptyTypeTip
+      (typeDisplay + enumtip ()), EntityInfo.Empty
     elif fse.IsDelegate then
-      (typeDisplay + delegateTip ()), emptyTypeTip
+      (typeDisplay + delegateTip ()), EntityInfo.Empty
     else
       typeDisplay, typeTip ()
 
@@ -867,60 +886,60 @@ module DocumentationFormatter =
       | Some ent when ent.IsValueType || ent.IsEnum ->
         //ValueTypes
         let signature = getFuncSignature symbol.DisplayContext func
-        Some((signature, emptyTypeTip), footerForType symbol, cn)
+        Some((signature, EntityInfo.Empty), footerForType symbol, cn)
       | _ ->
         //ReferenceType constructor
         let signature = getFuncSignature symbol.DisplayContext func
-        Some((signature, emptyTypeTip), footerForType symbol, cn)
+        Some((signature, EntityInfo.Empty), footerForType symbol, cn)
 
     | SymbolUse.Operator func ->
       let signature = getFuncSignature symbol.DisplayContext func
-      Some((signature, emptyTypeTip), footerForType symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType symbol, cn)
 
     | SymbolUse.Pattern func ->
       //Active pattern or operator
       let signature = getFuncSignature symbol.DisplayContext func
-      Some((signature, emptyTypeTip), footerForType symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType symbol, cn)
 
     | SymbolUse.Property prop ->
       let signature = getFuncSignature symbol.DisplayContext prop
-      Some((signature, emptyTypeTip), footerForType symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType symbol, cn)
 
     | SymbolUse.ClosureOrNestedFunction func ->
       //represents a closure or nested function
       let signature = getFuncSignature symbol.DisplayContext func
-      Some((signature, emptyTypeTip), footerForType symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType symbol, cn)
 
     | SymbolUse.Function func ->
       let signature = getFuncSignature symbol.DisplayContext func
-      Some((signature, emptyTypeTip), footerForType symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType symbol, cn)
 
     | SymbolUse.Val func ->
       //val name : Type
       let signature = getValSignature symbol.DisplayContext func
-      Some((signature, emptyTypeTip), footerForType symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType symbol, cn)
 
     | SymbolUse.Field fsf ->
       let signature = getFieldSignature symbol.DisplayContext fsf
-      Some((signature, emptyTypeTip), footerForType symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType symbol, cn)
 
     | SymbolUse.UnionCase uc ->
       let signature = getUnioncaseSignature symbol.DisplayContext uc
-      Some((signature, emptyTypeTip), footerForType symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType symbol, cn)
 
     | SymbolUse.ActivePatternCase apc ->
       let signature = getAPCaseSignature symbol.DisplayContext apc
-      Some((signature, emptyTypeTip), footerForType symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType symbol, cn)
 
     | SymbolUse.ActivePattern ap ->
       let signature = getFuncSignature symbol.DisplayContext ap
-      Some((signature, emptyTypeTip), footerForType symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType symbol, cn)
 
     | SymbolUse.GenericParameter gp ->
       let signature =
         $"'%s{gp.Name} (requires %s{formatGenericParameter false symbol.DisplayContext gp})"
 
-      Some((signature, emptyTypeTip), footerForType symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType symbol, cn)
 
     | _ -> None
 
@@ -942,51 +961,51 @@ module DocumentationFormatter =
       | Some ent when ent.IsValueType || ent.IsEnum ->
         //ValueTypes
         let signature = getFuncSignature lastDisplayContext func
-        Some((signature, emptyTypeTip), footerForType' symbol, cn)
+        Some((signature, EntityInfo.Empty), footerForType' symbol, cn)
       | _ ->
         //ReferenceType constructor
         let signature = getFuncSignature lastDisplayContext func
-        Some((signature, emptyTypeTip), footerForType' symbol, cn)
+        Some((signature, EntityInfo.Empty), footerForType' symbol, cn)
 
     | SymbolPatterns.Operator func ->
       let signature = getFuncSignature lastDisplayContext func
-      Some((signature, emptyTypeTip), footerForType' symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType' symbol, cn)
 
     | Property prop ->
       let signature = getFuncSignature lastDisplayContext prop
-      Some((signature, emptyTypeTip), footerForType' symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType' symbol, cn)
 
     | ClosureOrNestedFunction func ->
       //represents a closure or nested function
       let signature = getFuncSignature lastDisplayContext func
-      Some((signature, emptyTypeTip), footerForType' symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType' symbol, cn)
 
     | Function func ->
       let signature = getFuncSignature lastDisplayContext func
-      Some((signature, emptyTypeTip), footerForType' symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType' symbol, cn)
 
     | Val func ->
       //val name : Type
       let signature = getValSignature lastDisplayContext func
-      Some((signature, emptyTypeTip), footerForType' symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType' symbol, cn)
 
     | Field(fsf, _) ->
       let signature = getFieldSignature lastDisplayContext fsf
-      Some((signature, emptyTypeTip), footerForType' symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType' symbol, cn)
 
     | UnionCase uc ->
       let signature = getUnioncaseSignature lastDisplayContext uc
-      Some((signature, emptyTypeTip), footerForType' symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType' symbol, cn)
 
     | ActivePatternCase apc ->
       let signature = getAPCaseSignature lastDisplayContext apc
-      Some((signature, emptyTypeTip), footerForType' symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType' symbol, cn)
 
 
     | GenericParameter gp ->
       let signature =
         $"'%s{gp.Name} (requires %s{formatGenericParameter false lastDisplayContext gp})"
 
-      Some((signature, emptyTypeTip), footerForType' symbol, cn)
+      Some((signature, EntityInfo.Empty), footerForType' symbol, cn)
 
     | _ -> None

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -1134,7 +1134,7 @@ let private tryComputeTooltipInfo (ToolTipText tips) (formatCommentStyle: Format
   let computeGenericParametersText (tooltipData: ToolTipElementData) =
     // If there are no generic parameters, don't display the section
     if tooltipData.TypeMapping.IsEmpty then
-      ""
+      None
     // If there are generic parameters, display the section
     else
       nl
@@ -1143,6 +1143,7 @@ let private tryComputeTooltipInfo (ToolTipText tips) (formatCommentStyle: Format
       + nl
       + nl
       + formatGenericParameters tooltipData.TypeMapping
+      |> Some
 
   tips
   // Render the first valid tooltip and return it
@@ -1156,13 +1157,20 @@ let private tryComputeTooltipInfo (ToolTipText tips) (formatCommentStyle: Format
 
           // Concatenate the doc comment and the generic parameters section
           let consolidatedDocCommentText =
-            docCommentText + nl + nl + computeGenericParametersText tooltipData
+            match computeGenericParametersText tooltipData with
+            | Some genericParametersText -> docCommentText + nl + nl + genericParametersText
+            | None -> docCommentText
 
           consolidatedDocCommentText, xmlDoc.HasTruncatedExamples
 
         | TryGetXmlDocMemberResult.None ->
           // Even if a symbol doesn't have a doc comment, it can still have generic parameters
-          computeGenericParametersText tooltipData, false
+          let docComment =
+            match computeGenericParametersText tooltipData with
+            | Some genericParametersText -> genericParametersText
+            | None -> ""
+
+          docComment, false
         | TryGetXmlDocMemberResult.Error -> ERROR_WHILE_PARSING_DOC_COMMENT, false
 
       {| DocComment = docComment

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -201,7 +201,12 @@ module private Format =
 
         | NonVoidElement(innerText, _) ->
           let formattedText =
-            Section.addSection "Example" innerText
+            nl + nl
+            // This try to keep a visual consistency and indicate that this
+            // "Example section" is part of it parent section (summary, remarks, etc.)
+            + """Example:"""
+            + nl + nl
+            + innerText
 
           Some formattedText
 

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -1137,9 +1137,7 @@ let private tryComputeTooltipInfo (ToolTipText tips) (formatCommentStyle: Format
       None
     // If there are generic parameters, display the section
     else
-      nl
-      + nl
-      + "**Generic Parameters**"
+      "**Generic Parameters**"
       + nl
       + nl
       + formatGenericParameters tooltipData.TypeMapping

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -1011,7 +1011,7 @@ let private tryGetXmlDocMember (xmlDoc: FSharpXmlDoc) =
 
 [<Literal>]
 let private ERROR_WHILE_PARSING_DOC_COMMENT =
-  "An error occured when parsing the doc comment, please check that your doc comment is valid.\n\nMore info can be found LSP output"
+  "An error occurred when parsing the doc comment, please check that your doc comment is valid.\n\nMore info can be found in the LSP output"
 
 let private formatTaggedText (t: TaggedText) : string =
   match t.Tag with

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -12,6 +12,7 @@ open FSharp.Compiler.EditorServices
 open FSharp.Compiler.Symbols
 open FsAutoComplete.Logging
 open FSharp.Compiler.Text
+open Ionide.LanguageServerProtocol.Types
 
 let inline nl<'T> = Environment.NewLine
 
@@ -179,14 +180,10 @@ module private Format =
           // by avoid empty lines at the beginning or the end
           let formattedText =
             match innerText.StartsWith("\n"), innerText.EndsWith("\n") with
-            | true, true ->
-              sprintf "```%s%s```" lang innerText
-            | true, false ->
-              sprintf "```%s%s\n```" lang innerText
-            | false, true ->
-              sprintf "```%s\n%s```" lang innerText
-            | false, false ->
-              sprintf "```%s\n%s\n```" lang innerText
+            | true, true -> sprintf "```%s%s```" lang innerText
+            | true, false -> sprintf "```%s%s\n```" lang innerText
+            | false, true -> sprintf "```%s\n%s```" lang innerText
+            | false, false -> sprintf "```%s\n%s\n```" lang innerText
 
           Some formattedText
 
@@ -201,11 +198,13 @@ module private Format =
 
         | NonVoidElement(innerText, _) ->
           let formattedText =
-            nl + nl
+            nl
+            + nl
             // This try to keep a visual consistency and indicate that this
             // "Example section" is part of it parent section (summary, remarks, etc.)
             + """Example:"""
-            + nl + nl
+            + nl
+            + nl
             + innerText
 
           Some formattedText
@@ -715,6 +714,13 @@ module private Format =
     |> handleMicrosoftOrList
     |> unescapeSpecialCharacters
 
+[<RequireQualifiedAccess>]
+type FormatCommentStyle =
+  | Legacy
+  | FullEnhanced
+  | SummaryOnly
+  | Documentation
+
 // TODO: Improve this parser. Is there any other XmlDoc parser available?
 type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: int) =
   /// References used to detect if we should remove meaningless spaces
@@ -758,7 +764,17 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
     |> Seq.tryHead
 
   let rawExamples =
-    doc.DocumentElement.GetElementsByTagName "example" |> Seq.cast<XmlNode>
+    doc.DocumentElement.GetElementsByTagName "example"
+    |> Seq.cast<XmlNode>
+    // We need to filter out the examples node that are children
+    // of another "main" node
+    // This is because if the example node is inside a "main" node
+    // then we render it in place.
+    // So we don't need to render it independently in the Examples section
+    |> Seq.filter (fun node ->
+      [ "summary"; "param"; "returns"; "exception"; "remarks"; "typeparam" ]
+      |> List.contains node.ParentNode.Name
+      |> not)
 
   let readNamedContentAsKvPair (key, content) =
     KeyValuePair(key, readContentForTooltip content)
@@ -803,6 +819,8 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
     else
       "**Description**" + nl + nl + summary
 
+  member __.HasTruncatedExamples = examples |> Seq.isEmpty |> not
+
   member __.ToFullEnhancedString() =
     let content =
       summary
@@ -811,7 +829,6 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
       + Section.fromKeyValueList "Parameters" parameters
       + Section.fromOption "Returns" returns
       + Section.fromKeyValueList "Exceptions" exceptions
-      + Section.fromList "Examples" examples
       + Section.fromList "See also" seeAlso
 
     // If we where unable to process the doc comment, then just output it as it is
@@ -833,6 +850,14 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
     + Section.fromKeyValueList "Exceptions" exceptions
     + Section.fromList "Examples" examples
     + Section.fromList "See also" seeAlso
+
+  member this.FormatComment(formatStyle: FormatCommentStyle) =
+    match formatStyle with
+    | FormatCommentStyle.Legacy -> this.ToString()
+    | FormatCommentStyle.SummaryOnly -> this.ToSummaryOnlyString()
+    | FormatCommentStyle.FullEnhanced -> this.ToFullEnhancedString()
+    | FormatCommentStyle.Documentation -> this.ToDocumentationString()
+
 
 let rec private readXmlDoc (reader: XmlReader) (indentationSize: int) (acc: Map<string, XmlDocMember>) =
   let acc' =
@@ -920,23 +945,30 @@ let private getXmlDoc dllFile =
         xmlDocCache.AddOrUpdate(xmlFile, xmlDoc, (fun _ _ -> xmlDoc)) |> ignore
 
         Some xmlDoc
-      with ex ->
+      with _ ->
         None // TODO: Remove the empty map from cache to try again in the next request?
-
-[<RequireQualifiedAccess>]
-type FormatCommentStyle =
-  | Legacy
-  | FullEnhanced
-  | SummaryOnly
-  | Documentation
 
 // --------------------------------------------------------------------------------------
 // Formatting of tool-tip information displayed in F# IntelliSense
 // --------------------------------------------------------------------------------------
-let private buildFormatComment cmt (formatStyle: FormatCommentStyle) (typeDoc: string option) =
-  match cmt with
-  | FSharpXmlDoc.FromXmlText xmldoc ->
-    try
+
+[<RequireQualifiedAccess>]
+type private TryGetXmlDocMemberResult =
+  | Some of XmlDocMember
+  | None
+  | Error
+
+[<RequireQualifiedAccess>]
+type TipFormatterResult<'T> =
+  | Success of 'T
+  | Error of string
+  | None
+
+let private tryGetXmlDocMember (xmlDoc: FSharpXmlDoc) =
+  try
+    match xmlDoc with
+    | FSharpXmlDoc.FromXmlText xmldoc ->
+
       let document = xmldoc.GetXmlText()
       // We create a "fake" XML document in order to use the same parser for both libraries and user code
       let xml = sprintf "<fake>%s</fake>" document
@@ -960,49 +992,28 @@ let private buildFormatComment cmt (formatStyle: FormatCommentStyle) (typeDoc: s
 
       let xmlDoc = XmlDocMember(doc, indentationSize, 0)
 
-      match formatStyle with
-      | FormatCommentStyle.Legacy -> xmlDoc.ToString()
-      | FormatCommentStyle.SummaryOnly -> xmlDoc.ToSummaryOnlyString()
-      | FormatCommentStyle.FullEnhanced -> xmlDoc.ToFullEnhancedString()
-      | FormatCommentStyle.Documentation -> xmlDoc.ToDocumentationString()
+      TryGetXmlDocMemberResult.Some xmlDoc
 
-    with ex ->
-      logger.warn (
-        Log.setMessage "TipFormatter - Error while parsing the doc comment"
-        >> Log.addExn ex
-      )
+    | FSharpXmlDoc.FromXmlFile(dllFile, memberName) ->
+      match getXmlDoc dllFile with
+      | Some doc when doc.ContainsKey memberName -> TryGetXmlDocMemberResult.Some doc.[memberName]
 
-      sprintf
-        "An error occured when parsing the doc comment, please check that your doc comment is valid.\n\nMore info can be found LSP output"
+      | _ -> TryGetXmlDocMemberResult.None
 
-  | FSharpXmlDoc.FromXmlFile(dllFile, memberName) ->
-    match getXmlDoc dllFile with
-    | Some doc when doc.ContainsKey memberName ->
-      let typeDoc =
-        match typeDoc with
-        | Some s when doc.ContainsKey s ->
-          match formatStyle with
-          | FormatCommentStyle.Legacy -> doc.[s].ToString()
-          | FormatCommentStyle.SummaryOnly -> doc.[s].ToSummaryOnlyString()
-          | FormatCommentStyle.FullEnhanced -> doc.[s].ToFullEnhancedString()
-          | FormatCommentStyle.Documentation -> doc.[s].ToDocumentationString()
-        | _ -> ""
+    | FSharpXmlDoc.None -> TryGetXmlDocMemberResult.None
+  with ex ->
+    logger.warn (
+      Log.setMessage "TipFormatter - Error while parsing the doc comment"
+      >> Log.addExn ex
+    )
 
-      match formatStyle with
-      | FormatCommentStyle.Legacy -> doc.[memberName].ToString() + (if typeDoc <> "" then "\n\n" + typeDoc else "")
-      | FormatCommentStyle.SummaryOnly ->
-        doc.[memberName].ToSummaryOnlyString()
-        + (if typeDoc <> "" then "\n\n" + typeDoc else "")
-      | FormatCommentStyle.FullEnhanced ->
-        doc.[memberName].ToFullEnhancedString()
-        + (if typeDoc <> "" then "\n\n" + typeDoc else "")
-      | FormatCommentStyle.Documentation ->
-        doc.[memberName].ToDocumentationString()
-        + (if typeDoc <> "" then "\n\n" + typeDoc else "")
-    | _ -> ""
-  | _ -> ""
+    TryGetXmlDocMemberResult.Error
 
-let formatTaggedText (t: TaggedText) : string =
+[<Literal>]
+let private ERROR_WHILE_PARSING_DOC_COMMENT =
+  "An error occured when parsing the doc comment, please check that your doc comment is valid.\n\nMore info can be found LSP output"
+
+let private formatTaggedText (t: TaggedText) : string =
   match t.Tag with
   | TextTag.ActivePatternResult
   | TextTag.UnionCase
@@ -1039,13 +1050,13 @@ let formatTaggedText (t: TaggedText) : string =
   | TextTag.Record
   | TextTag.TypeParameter -> $"`{t.Text}`"
 
-let formatUntaggedText (t: TaggedText) = t.Text
+let private formatUntaggedText (t: TaggedText) = t.Text
 
-let formatUntaggedTexts = Array.map formatUntaggedText >> String.concat ""
+let private formatUntaggedTexts = Array.map formatUntaggedText >> String.concat ""
 
-let formatTaggedTexts = Array.map formatTaggedText >> String.concat ""
+let private formatTaggedTexts = Array.map formatTaggedText >> String.concat ""
 
-let formatGenericParameters (typeMappings: TaggedText[] list) =
+let private formatGenericParameters (typeMappings: TaggedText[] list) =
   typeMappings
   |> List.map (fun typeMap -> $"* {formatTaggedTexts typeMap}")
   |> String.concat nl
@@ -1059,7 +1070,12 @@ let formatCompletionItemTip (ToolTipText tips) : (string * string) =
       let makeTooltip (tipElement: ToolTipElementData) =
         let header = formatUntaggedTexts tipElement.MainDescription
 
-        let body = buildFormatComment tipElement.XmlDoc FormatCommentStyle.Legacy None
+        let body =
+          match tryGetXmlDocMember tipElement.XmlDoc with
+          | TryGetXmlDocMemberResult.Some xmlDoc -> xmlDoc.FormatComment(FormatCommentStyle.Legacy)
+          | TryGetXmlDocMemberResult.None -> ""
+          | TryGetXmlDocMemberResult.Error -> ERROR_WHILE_PARSING_DOC_COMMENT
+
         header, body
 
       items |> List.tryHead |> Option.map makeTooltip
@@ -1075,82 +1091,191 @@ let formatPlainTip (ToolTipText tips) : (string * string) =
     | ToolTipElement.Group items ->
       let t = items |> Seq.head
       let signature = formatUntaggedTexts t.MainDescription
-      let description = buildFormatComment t.XmlDoc FormatCommentStyle.Legacy None
+
+      let description =
+        match tryGetXmlDocMember t.XmlDoc with
+        | TryGetXmlDocMemberResult.Some xmlDoc -> xmlDoc.FormatComment(FormatCommentStyle.Legacy)
+        | TryGetXmlDocMemberResult.None -> ""
+        | TryGetXmlDocMemberResult.Error -> ERROR_WHILE_PARSING_DOC_COMMENT
+
       Some(signature, description)
     | ToolTipElement.CompositionError(error) -> Some("<Note>", error)
     | _ -> Some("<Note>", "No signature data"))
 
-let formatTipEnhanced
-  (ToolTipText tips)
-  (signature: string)
-  (footer: string)
-  (typeDoc: string option)
-  (formatCommentStyle: FormatCommentStyle)
-  : (string * string * string) list list =
+let prepareSignature (signatureText: string) =
+  signatureText.Split Environment.NewLine
+  // Remove empty lines
+  |> Array.filter (not << String.IsNullOrWhiteSpace)
+  |> String.concat nl
+
+let prepareFooterLines (footerText: string) =
+  footerText.Split Environment.NewLine
+  // Remove empty lines
+  |> Array.filter (not << String.IsNullOrWhiteSpace)
+  // Mark each line as an individual string in italics
+  |> Array.map (fun n -> "*" + n + "*")
+
+
+let private tryComputeTooltipInfo (ToolTipText tips) (formatCommentStyle: FormatCommentStyle) =
+
+  // Note: In the previous code, we were returning a `(string * string * string) list list`
+  // but always discarding the tooltip later if the list had more than one element
+  // and only using the first element of the inner list.
+  // More over, I don't know in which case we can have several elements in the
+  // `(ToolTipText tips)` parameter.
+  // So I can't test why we have list of list stuff, but like I said, we were
+  // discarding the tooltip if it had more than one element.
+  //
+  // The new code should do the same thing, as before but instead of
+  // computing the rendered tooltip, and discarding some of them afterwards,
+  // we are discarding the things we don't want earlier and only compute the
+  // tooltip we want to display if we have the right data.
+
   tips
-  |> List.choose (function
-    | ToolTipElement.Group items ->
-      Some(
-        items
-        |> List.map (fun i ->
-          let comment =
-            if i.TypeMapping.IsEmpty then
-              buildFormatComment i.XmlDoc formatCommentStyle typeDoc
+  // Render the first valid tooltip and return it
+  |> List.tryPick (function
+    | ToolTipElement.Group(head :: _) ->
+      let docComment, hasTruncatedExamples =
+        match tryGetXmlDocMember head.XmlDoc with
+        | TryGetXmlDocMemberResult.Some xmlDoc ->
+          // Format the doc comment
+          let docCommentText = xmlDoc.FormatComment formatCommentStyle
+
+          // Handle generic parameters section
+          let genericParametersText =
+            // If there are no generic parameters, don't display the section
+            if head.TypeMapping.IsEmpty then
+              ""
+            // If there are generic parameters, display the section
             else
-              buildFormatComment i.XmlDoc formatCommentStyle typeDoc
-              + nl
+              nl
               + nl
               + "**Generic Parameters**"
               + nl
               + nl
-              + formatGenericParameters i.TypeMapping
+              + formatGenericParameters head.TypeMapping
 
-          (signature, comment, footer))
-      )
-    | ToolTipElement.CompositionError(error) -> Some [ ("<Note>", error, "") ]
-    | _ -> None)
+          // Concatenate the doc comment and the generic parameters section
+          let consolidatedDocCommentText = docCommentText + nl + nl + genericParametersText
 
-let formatDocumentation
-  (ToolTipText tips)
-  ((signature, (constructors, fields, functions, interfaces, attrs, ts)):
-    string * (string[] * string[] * string[] * string[] * string[] * string[]))
-  (footer: string)
-  (cn: string)
-  =
-  tips
-  |> List.choose (function
-    | ToolTipElement.Group items ->
-      Some(
-        items
-        |> List.map (fun i ->
-          let comment =
-            if i.TypeMapping.IsEmpty then
-              buildFormatComment i.XmlDoc FormatCommentStyle.Documentation None
-            else
-              buildFormatComment i.XmlDoc FormatCommentStyle.Documentation None
-              + nl
-              + nl
-              + "**Generic Parameters**"
-              + nl
-              + nl
-              + formatGenericParameters i.TypeMapping
+          consolidatedDocCommentText, xmlDoc.HasTruncatedExamples
 
-          (signature, constructors, fields, functions, interfaces, attrs, ts, comment, footer, cn))
-      )
-    | ToolTipElement.CompositionError(error) -> Some [ ("<Note>", [||], [||], [||], [||], [||], [||], error, "", "") ]
-    | _ -> None)
+        | TryGetXmlDocMemberResult.None -> "", false
+        | TryGetXmlDocMemberResult.Error -> ERROR_WHILE_PARSING_DOC_COMMENT, false
 
-let formatDocumentationFromXmlSig
-  (xmlSig: string)
-  (assembly: string)
-  ((signature, (constructors, fields, functions, interfaces, attrs, ts)):
-    string * (string[] * string[] * string[] * string[] * string[] * string[]))
-  (footer: string)
-  (cn: string)
-  =
+      {| DocComment = docComment
+         HasTruncatedExamples = hasTruncatedExamples |}
+      |> Ok
+      |> Some
+
+    | ToolTipElement.CompositionError error -> error |> Error |> Some
+
+    | ToolTipElement.Group []
+    | ToolTipElement.None -> None)
+
+/// <summary>
+/// Try format the given tooltip with the requested style.
+/// </summary>
+/// <param name="toolTipText">Tooltip documentation to render in the middle</param>
+/// <param name="formatCommentStyle">Style of tooltip</param>
+/// <returns>
+/// - <c>TipFormatterResult.Success {| DocComment; HasTruncatedExamples |}</c> if the doc comment has been formatted
+///
+///   Where DocComment is the format tooltip and HasTruncatedExamples is true if examples have been truncated
+///
+/// - <c>TipFormatterResult.None</c> if the doc comment has not been found
+/// - <c>TipFormatterResult.Error string</c> if an error occurred while parsing the doc comment
+/// </returns>
+let tryFormatTipEnhanced toolTipText (formatCommentStyle: FormatCommentStyle) =
+
+  match tryComputeTooltipInfo toolTipText formatCommentStyle with
+  | Some(Ok tooltipResult) -> TipFormatterResult.Success tooltipResult
+
+  | Some(Error error) -> TipFormatterResult.Error error
+
+  | None -> TipFormatterResult.None
+
+/// <summary>
+/// Generate the 'Show documentation' link for the tooltip.
+///
+/// The link is rendered differently depending on if examples
+/// have been truncated or not.
+/// </summary>
+/// <param name="hasTruncatedExamples"><c>true</c> if the examples have been truncated</param>
+/// <param name="xmlDocSig">XmlDocSignature in the format of <c>T:System.String.concat</c></param>
+/// <param name="assemblyName">Assembly name, example <c>FSharp.Core</c></param>
+/// <returns>Returns a string which represent the show documentation link</returns>
+let renderShowDocumentationLink (hasTruncatedExamples: bool) (xmlDocSig: string) (assemblyName: string) =
+
+  // TODO: Refactor this code, to avoid duplicate with DocumentationFormatter.fs
+  let content =
+    Uri.EscapeDataString(sprintf """[{ "XmlDocSig": "%s", "AssemblyName": "%s" }]""" xmlDocSig assemblyName)
+
+  let text =
+    if hasTruncatedExamples then
+      "Open the documentation to see the truncated examples"
+    else
+      "Open the documentation"
+
+  $"<a href='command:fsharp.showDocumentation?%s{content}'>%s{text}</a>"
+
+/// <summary>
+/// Try format the given tooltip as documentation.
+/// </summary>
+/// <param name="toolTipText">Tooltip to format</param>
+/// <returns>
+/// - <c>TipFormatterResult.Success string</c> if the doc comment has been formatted
+/// - <c>TipFormatterResult.None</c> if the doc comment has not been found
+/// - <c>TipFormatterResult.Error string</c> if an error occurred while parsing the doc comment
+/// </returns>
+let tryFormatDocumentationFromTooltip toolTipText =
+
+  match tryComputeTooltipInfo toolTipText FormatCommentStyle.Documentation with
+  | Some(Ok tooltipResult) -> TipFormatterResult.Success tooltipResult.DocComment
+
+  | Some(Error error) -> TipFormatterResult.Error error
+
+  | None -> TipFormatterResult.None
+
+/// <summary>
+/// Try format the doc comment based on the XmlSignature and the assembly name.
+/// </summary>
+/// <param name="xmlSig">
+/// XmlSignature used to identify the doc comment to format
+///
+/// Example: <c>T:System.String.concat</c>
+/// </param>
+/// <param name="assembly">
+/// Assembly name used to identify the doc comment to format
+///
+/// Example: <c>FSharp.Core</c>
+/// </param>
+/// <returns>
+/// - <c>TipFormatterResult.Success string</c> if the doc comment has been formatted
+/// - <c>TipFormatterResult.None</c> if the doc comment has not been found
+/// - <c>TipFormatterResult.Error string</c> if an error occurred while parsing the doc comment
+/// </returns>
+let tryFormatDocumentationFromXmlSig (xmlSig: string) (assembly: string) =
   let xmlDoc = FSharpXmlDoc.FromXmlFile(assembly, xmlSig)
-  let comment = buildFormatComment xmlDoc FormatCommentStyle.Documentation None
-  [ [ (signature, constructors, fields, functions, interfaces, attrs, ts, comment, footer, cn) ] ]
+
+  match tryGetXmlDocMember xmlDoc with
+  | TryGetXmlDocMemberResult.Some xmlDoc ->
+    let formattedComment = xmlDoc.FormatComment(FormatCommentStyle.Documentation)
+
+    TipFormatterResult.Success formattedComment
+
+  | TryGetXmlDocMemberResult.None -> TipFormatterResult.None
+  | TryGetXmlDocMemberResult.Error -> TipFormatterResult.Error ERROR_WHILE_PARSING_DOC_COMMENT
+
+let formatDocumentationFromXmlDoc xmlDoc =
+  match tryGetXmlDocMember xmlDoc with
+  | TryGetXmlDocMemberResult.Some xmlDoc ->
+    let formattedComment = xmlDoc.FormatComment(FormatCommentStyle.Documentation)
+
+    TipFormatterResult.Success formattedComment
+
+  | TryGetXmlDocMemberResult.None -> TipFormatterResult.None
+  | TryGetXmlDocMemberResult.Error -> TipFormatterResult.Error ERROR_WHILE_PARSING_DOC_COMMENT
 
 let extractSignature (ToolTipText tips) =
   let getSignature (t: TaggedText[]) =

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -1563,7 +1563,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
         | CoreResponse.InfoRes msg -> async.Return(success None)
         | CoreResponse.ErrorRes msg -> LspResult.internalError msg |> async.Return
         | CoreResponse.Res None -> async.Return(success None)
-        | CoreResponse.Res(Some(tip, signature, footer, typeDoc)) ->
+        | CoreResponse.Res(Some tooltipResult) ->
           let formatCommentStyle =
             if config.TooltipMode = "full" then
               TipFormatter.FormatCommentStyle.FullEnhanced
@@ -1572,41 +1572,50 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
             else
               TipFormatter.FormatCommentStyle.Legacy
 
-          match TipFormatter.formatTipEnhanced tip signature footer typeDoc formatCommentStyle with
-          | (sigCommentFooter :: _) :: _ ->
-            let signature, comment, footer = sigCommentFooter
+          match TipFormatter.tryFormatTipEnhanced tooltipResult.ToolTipText formatCommentStyle with
+          | TipFormatter.TipFormatterResult.Success tooltipInfo ->
 
-            let markStr lang (value: string) =
-              MarkedString.WithLanguage { Language = lang; Value = value }
+            // Display the signature as a code block
+            let signature =
+              tooltipResult.Signature
+              |> TipFormatter.prepareSignature
+              |> (fun content -> MarkedString.WithLanguage { Language = "fsharp"; Value = content })
 
-            let fsharpBlock (lines: string[]) =
-              lines |> String.concat Environment.NewLine |> markStr "fsharp"
+            // Display each footer line as a separate line
+            let footerLines =
+              tooltipResult.Footer
+              |> TipFormatter.prepareFooterLines
+              |> Array.map MarkedString.String
 
-            let sigContent =
-              let lines =
-                signature.Split Environment.NewLine
-                |> Array.filter (not << String.IsNullOrWhiteSpace)
-
-              match lines |> Array.splitAt (lines.Length - 1) with
-              | (h, [| StartsWith "Full name:" fullName |]) ->
-                [| yield fsharpBlock h; yield MarkedString.String("*" + fullName + "*") |]
-              | _ -> [| fsharpBlock lines |]
-
-
-            let commentContent = comment |> MarkedString.String
-
-            let footerContent =
-              footer.Split Environment.NewLine
-              |> Array.filter (not << String.IsNullOrWhiteSpace)
-              |> Array.map (fun n -> MarkedString.String("*" + n + "*"))
-
+            let contents =
+              [| signature
+                 MarkedString.String tooltipInfo.DocComment
+                 match tooltipResult.SymbolInfo with
+                 | TryGetToolTipEnhancedResult.Keyword _ -> ()
+                 | TryGetToolTipEnhancedResult.Symbol symbolInfo ->
+                   TipFormatter.renderShowDocumentationLink
+                     tooltipInfo.HasTruncatedExamples
+                     symbolInfo.XmlDocSig
+                     symbolInfo.Assembly
+                   |> MarkedString.String
+                 yield! footerLines |]
 
             let response =
-              { Contents = MarkedStrings [| yield! sigContent; yield commentContent; yield! footerContent |]
+              { Contents = MarkedStrings contents
                 Range = None }
 
             async.Return(success (Some response))
-          | _ -> async.Return(success None))
+
+          | TipFormatter.TipFormatterResult.Error error ->
+            let contents = [| MarkedString.String "<Note>"; MarkedString.String error |]
+
+            let response =
+              { Contents = MarkedStrings contents
+                Range = None }
+
+            async.Return(success (Some response))
+
+          | TipFormatter.TipFormatterResult.None -> async.Return(success None))
 
     override x.TextDocumentPrepareRename p =
       logger.info (
@@ -2662,12 +2671,16 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
         (match Commands.FormattedDocumentation tyRes pos lineStr with
          | CoreResponse.InfoRes msg -> success None
          | CoreResponse.ErrorRes msg -> LspResult.internalError msg
-         | CoreResponse.Res(tip, xml, signature, footer, cm) ->
+         | CoreResponse.Res(tip, xml, signature, footer, xmlKey) ->
            let notification: PlainNotification =
              { Content =
                  CommandResponse.formattedDocumentation
-                   FsAutoComplete.JsonSerializer.writeJson
-                   (tip, xml, signature, footer, cm) }
+                   JsonSerializer.writeJson
+                   {| Tip = tip
+                      XmlSig = xml
+                      Signature = signature
+                      Footer = footer
+                      XmlKey = xmlKey |} }
 
            success (Some notification))
         |> async.Return)
@@ -2685,21 +2698,18 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
           match Commands.FormattedDocumentationForSymbol tyRes p.XmlSig p.Assembly with
           | (CoreResponse.InfoRes msg) -> return success None
           | (CoreResponse.ErrorRes msg) -> return! AsyncLspResult.internalError msg
-          | (CoreResponse.Res(xml, assembly, doc, signature, footer, cn)) ->
-            let xmldoc =
-              match doc with
-              | FSharpXmlDoc.None -> [||]
-              | FSharpXmlDoc.FromXmlFile _ -> [||]
-              | FSharpXmlDoc.FromXmlText d -> d.GetElaboratedXmlLines()
+          | (CoreResponse.Res(xml, assembly, xmlDoc, signature, footer, xmlKey)) ->
 
             return
               { Content =
                   CommandResponse.formattedDocumentationForSymbol
-                    FsAutoComplete.JsonSerializer.writeJson
-                    xml
-                    assembly
-                    xmldoc
-                    (signature, footer, cn) }
+                    JsonSerializer.writeJson
+                    {| Xml = xml
+                       Assembly = assembly
+                       XmlDoc = xmlDoc
+                       Signature = signature
+                       Footer = footer
+                       XmlKey = xmlKey |} }
               |> Some
               |> success
       }

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -303,7 +303,9 @@ let tooltipTests state =
               ""
               "**Generic Parameters**"
               ""
-              "* `'T` is `string`" ] // verify fancy descriptions for external library functions
+              "* `'T` is `string`"
+              ""
+              "" ] // verify fancy descriptions for external library functions
           verifyDescription
             13
             11

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -297,15 +297,9 @@ let tooltipTests state =
               ""
               "The formatted result."
               ""
-              "**Examples**"
-              ""
-              "See `Printf.sprintf` (link: ``Microsoft.FSharp.Core.PrintfModule.PrintFormatToStringThen``1``) for examples."
-              ""
               "**Generic Parameters**"
               ""
-              "* `'T` is `string`"
-              ""
-              "" ] // verify fancy descriptions for external library functions
+              "* `'T` is `string`" ] // verify fancy descriptions for external library functions
           verifyDescription
             13
             11
@@ -364,9 +358,7 @@ let tooltipTests state =
           verifyDescription
             45
             15
-            [ ""
-              ""
-              "**Generic Parameters**"
+            [ "**Generic Parameters**"
               ""
               "* `'a` is `int`"
               "* `'b` is `int`"

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -176,7 +176,12 @@ let tooltipTests state =
   let (|Signature|_|) (hover: Hover) =
     match hover with
     | { Contents = MarkedStrings [| MarkedString.WithLanguage { Language = "fsharp"; Value = tooltip }
-                                    MarkedString.String newline
+                                    MarkedString.String docComment
+                                    MarkedString.String fullname
+                                    MarkedString.String assembly |] } -> Some tooltip
+    | { Contents = MarkedStrings [| MarkedString.WithLanguage { Language = "fsharp"; Value = tooltip }
+                                    MarkedString.String docComment
+                                    MarkedString.String showDocumentationLink
                                     MarkedString.String fullname
                                     MarkedString.String assembly |] } -> Some tooltip
     | _ -> None
@@ -187,6 +192,11 @@ let tooltipTests state =
                                     MarkedString.String description |] } -> Some description
     | { Contents = MarkedStrings [| MarkedString.WithLanguage { Language = "fsharp"; Value = tooltip }
                                     MarkedString.String description
+                                    MarkedString.String fullname
+                                    MarkedString.String assembly |] } -> Some description
+    | { Contents = MarkedStrings [| MarkedString.WithLanguage { Language = "fsharp"; Value = tooltip }
+                                    MarkedString.String description
+                                    MarkedString.String showDocumentationLink
                                     MarkedString.String fullname
                                     MarkedString.String assembly |] } -> Some description
     | _ -> None

--- a/test/FsAutoComplete.Tests.Lsp/InfoPanelTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InfoPanelTests.fs
@@ -40,7 +40,7 @@ let docFormattingTest state =
 
           match doc with
           | Result.Error err -> failtest $"Doc error: {err.Message}"
-          | Result.Ok (Some(As ([ [ model: FsAutoComplete.CommandResponse.DocumentationDescription ] ]))) ->
+          | Result.Ok (Some(As (model: FsAutoComplete.CommandResponse.DocumentationDescription ))) ->
             Expect.stringContains model.Signature "'Key, 'U" "Formatted doc contains both params separated by (, )"
           | Result.Ok _ -> failtest "couldn't parse doc as the json type we expected"
         })
@@ -57,7 +57,7 @@ let docFormattingTest state =
 
           match doc with
           | Result.Error err -> failtest $"Doc error: {err.Message}"
-          | Result.Ok (Some (As ([ [ model: FsAutoComplete.CommandResponse.DocumentationDescription ] ]))) ->
+          | Result.Ok (Some (As (model: FsAutoComplete.CommandResponse.DocumentationDescription))) ->
             Expect.stringContains model.Signature "'T1 * 'T2 * 'T3" "Formatted doc contains 3 params separated by ( * )"
           | Result.Ok _ -> failtest "couldn't parse doc as the json type we expected"
         }) ]


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f78450b</samp>

This pull request refactors the code for tooltip and documentation formatting across different modules and servers. It introduces new types and functions to improve the readability, consistency, and structure of the code and the data types. It also uses the `TipFormatter` module to centralize the formatting logic. It affects the files `DocumentationFormatter.fs`, `ParseAndCheckResults.fs`, `CommandResponse.fs`, `AdaptiveFSharpLspServer.fs`, and `FsAutoComplete.Lsp.fs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f78450b</samp>

> _The code for the tooltips was a mess_
> _With tuples and arrays to compress_
> _So they used `EntityInfo`_
> _And `TipFormatter` to simplify_
> _The logic and the data to express_

<!--
copilot:emoji
-->

📝🔧🧹

<!--
1.  📝 - This emoji represents the refactoring of the documentation formatter and the use of the `DocumentationDescription` type, which improves the readability and consistency of the code and the data types related to documentation.
2.  🔧 - This emoji represents the refactoring of the tooltip generation and the use of more descriptive and structured data types, which improves the clarity and structure of the code and the data types related to tooltips.
3.  🧹 - This emoji represents the refactoring of the LSP server code and the use of the `TipFormatter` module, which simplifies and unifies the formatting logic and removes some duplication and complexity from the code.
-->

### WHY
<!-- author to complete -->

This PR improves various area around TipFormatter and Documentation, I tried to list all the changes that I made in the list below.

- Support example tag inside of summary tag

**Before**
<img width="531" alt="CleanShot 2023-04-07 at 15 00 48@2x" src="https://user-images.githubusercontent.com/4760796/230613118-f0d73653-fb03-49a4-b630-85243fdf3834.png">

**After**
<img width="543" alt="CleanShot 2023-04-07 at 14 59 27@2x" src="https://user-images.githubusercontent.com/4760796/230612948-64c08d01-c446-4b3b-b7d3-0fb271e2bd9c.png">

---

- Display a link to open the documentation from the tooltip

https://user-images.githubusercontent.com/4760796/230612454-755dfdcb-1220-4fc5-9de7-e364d71d8b48.mp4

---

- Fix info panel rendering when navigating via symbol inside of the user code 

**Before**
![image](https://user-images.githubusercontent.com/4760796/230611857-137d8dbb-7419-440b-bd5e-37297169407d.png)

**After**
<img width="627" alt="CleanShot 2023-04-07 at 14 52 18@2x" src="https://user-images.githubusercontent.com/4760796/230611955-5582ed1c-c5fb-4e7a-a4ed-0d3b35265768.png">

---

- Reduce logic duplication by moving more into TipFormatter
- Use records instead of union for passing the data around
- Truncate global examples from the tooltip
- Change how returned type of `fsharp/documentation` instead of using a nested list it returns directly the data.

<img width="573" alt="CleanShot 2023-04-07 at 15 04 06@2x" src="https://user-images.githubusercontent.com/4760796/230613592-1a2a8cfc-1243-4b96-9c28-3e8420987dc9.png">

Note: According to the previous implementation in FsAutoComplete the first list was always having a single element otherwise it was being thrown away.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f78450b</samp>

*  Introduce new types `EntityInfo` and `TryGetToolTipEnhancedResult` to represent the information about the symbols and the tooltips in a more structured and descriptive way ([link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L19-R35), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-9fb9b45b77d929cc7b14a843f350fd52e6cd8734fc397572828c14098c31cef0R25-R39), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-f94dd4967b2b6d03ae945d3563f727b8e866040e70313aafed4470ed178fe1b9L173-R195))
* Refactor the `TryGetToolTipEnhanced` function and its callers to use the new types instead of tuples and options, and handle the cases where the formatting of the tooltip text fails or returns none ([link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-9fb9b45b77d929cc7b14a843f350fd52e6cd8734fc397572828c14098c31cef0L323-R341), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-9fb9b45b77d929cc7b14a843f350fd52e6cd8734fc397572828c14098c31cef0L350-R374), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-9fb9b45b77d929cc7b14a843f350fd52e6cd8734fc397572828c14098c31cef0L358-R400), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2517-R2520), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2533-R2577), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L1566-R1566), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L1575-R1619))
* Refactor the `getTooltipDetailsFromSymbolUse` function and its callers to use the `EntityInfo` type instead of a tuple of six arrays, and make the code more readable and consistent ([link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L722-R743), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L759-R780), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L870-R936), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L923-R942), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L945-R1002), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L990-R1009), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-9fb9b45b77d929cc7b14a843f350fd52e6cd8734fc397572828c14098c31cef0L383-R418))
* Refactor the `formattedDocumentation` and `formattedDocumentationForSymbol` functions and their callers to use the `DocumentationDescription` type instead of a tuple of lists and strings, and handle the cases where the formatting of the documentation comment fails or returns none ([link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-f94dd4967b2b6d03ae945d3563f727b8e866040e70313aafed4470ed178fe1b9L547-R609), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-f94dd4967b2b6d03ae945d3563f727b8e866040e70313aafed4470ed178fe1b9L586-R655), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4272-R4292), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4308-R4338), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L2665-R2683), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L2688-R2712))
* Replace the use of `emptyTypeTip`, which was a tuple of six empty arrays, with `EntityInfo.Empty`, which is a record of the same shape, in the `DocumentationFormatter` module ([link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L759-R780), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L870-R936), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L923-R942), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L945-R1002), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L990-R1009))
* Use the `TipFormatter` module to prepare the signature and the footer lines, and to render a link to show the documentation if the tooltip has truncated examples, in the `AdaptiveFSharpLspServer` and `FsAutoComplete.Lsp` modules ([link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2533-R2577), [link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L1575-R1619))
* Add an open statement for the `FSharp.Compiler.Symbols` namespace in the `CommandResponse` module, which is needed to use the `FSharpXmlDoc` type ([link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-f94dd4967b2b6d03ae945d3563f727b8e866040e70313aafed4470ed178fe1b9R11))
* Rename the `Types` field to `DeclaredTypes` and the `Footer` field to `FooterLines` in the `DocumentationDescription` type, to avoid confusion and indicate the data structure ([link](https://github.com/fsharp/FsAutoComplete/pull/1099/files?diff=unified&w=0#diff-f94dd4967b2b6d03ae945d3563f727b8e866040e70313aafed4470ed178fe1b9L173-R195))
