### PR TITLE
handle content when it's an empty string

### DIFF
--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -1334,6 +1334,13 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
             match change.Range with
             | None -> // replace entire content
               NamedText(filePath, change.Text)
+            | Some rangeToReplace when
+              rangeToReplace.Start.Line = 0
+              && rangeToReplace.Start.Character = 0
+              && rangeToReplace.End.Line = 0
+              && rangeToReplace.End.Character = 0
+              ->
+              NamedText(filePath, change.Text)
             | Some rangeToReplace ->
               // replace just this slice
               let fcsRangeToReplace = protocolRangeToRange (UMX.untag filePath) rangeToReplace


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19c74a2</samp>

Fix text document change handling for whole first line replacements in `FsAutoComplete.Lsp.fs`. Use named text instead of text edit to avoid line ending and offset issues.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 19c74a2</samp>

> _`text document change`_
> _special case for first line_
> _autumn leaves falling_

<!--
copilot:emoji
-->

📝🐛🚀

<!--
1.  📝 - This emoji can be used to indicate a change related to documentation, comments, or text editing. In this case, the change affects how text document changes are handled and applied by the language server.
2.  🐛 - This emoji can be used to indicate a change that fixes a bug or a potential issue. In this case, the change avoids potential issues with line endings and offsets when applying the change to the file system.
3.  🚀 - This emoji can be used to indicate a change that improves the performance, speed, or efficiency of the code. In this case, the change simplifies the logic for applying the change to the file system and avoids unnecessary calculations.
-->


### WHY
FSAC currently crashes when the buffer is empty and we type something. I thought I saw the same behaviour on the F# Data Adaptive version, but I was wrong. Since the latter doesn't suffer from this edge case so no need for code change there.

Fixes https://github.com/fsharp/FsAutoComplete/issues/1091

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19c74a2</samp>

*  Add a special case for text document changes that replace the entire first line ([link](https://github.com/fsharp/FsAutoComplete/pull/1100/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01R1337-R1339)). This avoids potential issues with line endings and offsets when applying the change to the file system. This affects the `FsAutoComplete.Lsp.fs` file, which implements the F# language server protocol.
