### PR TITLE
Fix abstract class insert location when first good member has attributes

### DIFF
--- a/src/FsAutoComplete.Core/AbstractClassStubGenerator.fs
+++ b/src/FsAutoComplete.Core/AbstractClassStubGenerator.fs
@@ -10,18 +10,28 @@ open FsToolkit.ErrorHandling
 
 
 type AbstractClassData =
-  | ObjExpr of baseTy: SynType * bindings: SynBinding list * overallRange: Range
-  | ExplicitImpl of baseTy: SynType * members: SynMemberDefn list * safeInsertPosition: Position
+  | ObjExpr of
+    baseTy: SynType *
+    bindings: SynBinding list *
+    newExpression: Range *
+    withKeyword: Range option
+
+  | ExplicitImpl of
+      baseTy: SynType *
+      members: SynMemberDefn list *
+      /// the place where the inherit expression is declared - the codefix should insert
+      /// at an indent of .Start.Column, but insert a newline after .End
+      inheritExpressionRange: Range
 
   member x.AbstractTypeIdentRange =
     match x with
-    | ObjExpr(baseTy, _, _)
-    | ExplicitImpl(baseTy, _, _) -> baseTy.Range
+    | ObjExpr(baseTy = baseTy)
+    | ExplicitImpl(baseTy = baseTy) -> baseTy.Range
 
   member x.TypeParameters =
     match x with
-    | ObjExpr(t, _, _)
-    | ExplicitImpl(t, _, _) -> expandTypeParameters t
+    | ObjExpr(baseTy = t)
+    | ExplicitImpl(baseTy = t) -> expandTypeParameters t
 
 let private (|ExplicitCtor|_|) =
   function
@@ -34,10 +44,10 @@ let private walkTypeDefn (SynTypeDefn(info, repr, members, implicitCtor, range, 
   option {
     let reprMembers =
       match repr with
-      | SynTypeDefnRepr.ObjectModel(_, members, _) -> members
-      | _ -> []
+      | SynTypeDefnRepr.ObjectModel(_, members, _) -> members // repr members already includes the implicit ctor if present
+      | _ -> Option.toList implicitCtor
 
-    let allMembers = reprMembers @ (Option.toList implicitCtor) @ members
+    let allMembers = reprMembers @ members
 
     let! inheritType, inheritMemberRange = // this must exist for abstract types
       allMembers
@@ -57,18 +67,14 @@ let private walkTypeDefn (SynTypeDefn(info, repr, members, implicitCtor, range, 
           let c = Range.rangeOrder.Compare(m, possible.Range)
 
           let m' =
-            if c < 0 then m
-            else if c = 0 then m
-            else possible.Range
+            if c < 0 then possible.Range
+            else m
 
           m', otherMembers
         | otherMember -> m, otherMember :: otherMembers)
 
-    let safeInsertPosition =
-      Position.mkPos (furthestMemberToSkip.EndLine + 1) (inheritMemberRange.StartColumn + 2)
-
     let otherMembersInDeclarationOrder = otherMembers |> List.rev
-    return AbstractClassData.ExplicitImpl(inheritType, otherMembersInDeclarationOrder, safeInsertPosition)
+    return AbstractClassData.ExplicitImpl(inheritType, otherMembersInDeclarationOrder, furthestMemberToSkip)
 
   }
 
@@ -84,7 +90,7 @@ let private tryFindAbstractClassExprInParsedInput
         member _.VisitExpr(path, traverseExpr, defaultTraverse, expr) =
           match expr with
           | SynExpr.ObjExpr(baseTy, constructorArgs, withKeyword, bindings, members, extraImpls, newExprRange, range) ->
-            Some(AbstractClassData.ObjExpr(baseTy, bindings, range))
+            Some(AbstractClassData.ObjExpr(baseTy, bindings, newExprRange, withKeyword))
           | _ -> defaultTraverse expr
 
         override _.VisitModuleDecl(_, defaultTraverse, decl) =
@@ -98,68 +104,55 @@ let private tryFindAbstractClassExprInParsedInput
 let tryFindAbstractClassExprInBufferAtPos
   (codeGenService: ICodeGenerationService)
   (pos: Position)
-  (document: Document)
+  (document: NamedText)
   =
   asyncMaybe {
-    let! parseResults = codeGenService.ParseFileInProject(document.FullName)
+    let! parseResults = codeGenService.ParseFileInProject document.FileName
     return! tryFindAbstractClassExprInParsedInput pos parseResults.ParseTree
   }
 
-let getAbstractClassIdentifier (abstractClassData: AbstractClassData) tokens =
-  let newKeywordIndex =
-    match abstractClassData with
-    | AbstractClassData.ObjExpr _ ->
-      tokens
-      // Find the `new` keyword
-      |> List.findIndex (fun token -> token.CharClass = FSharpTokenCharKind.Keyword && token.TokenName = "NEW")
-    | _ -> failwith "don't call me with this bro"
-
-  findLastIdentifier tokens.[newKeywordIndex + 2 ..] tokens.[newKeywordIndex + 2]
-
 let getMemberNameAndRanges (abstractClassData) =
   match abstractClassData with
-  | AbstractClassData.ExplicitImpl(ty, members, _) ->
+  | AbstractClassData.ExplicitImpl(members = members) ->
     members
     |> Seq.choose (function
       | (SynMemberDefn.Member(binding, _)) -> Some binding
       | _ -> None)
-    |> Seq.choose (|MemberNameAndRange|_|)
+    |> Seq.choose (|MemberNamePlusRangeAndKeywordRange|_|)
     |> Seq.toList
-  | AbstractClassData.ObjExpr(_, bindings, _) -> List.choose (|MemberNameAndRange|_|) bindings
+  | AbstractClassData.ObjExpr(bindings = bindings) -> List.choose (|MemberNamePlusRangeAndKeywordRange|_|) bindings
 
 /// Try to find the start column, so we know what the base indentation should be
 let inferStartColumn
-  (codeGenServer: ICodeGenerationService)
-  (pos: Position)
-  (doc: Document)
-  (lines: ISourceText)
-  (lineStr: string)
   (abstractClassData: AbstractClassData)
+  (memberNamesAndRanges: (_ * _ * Range) list)
   (indentSize: int)
   =
-  async {
-    match getMemberNameAndRanges abstractClassData with
-    | (_, range) :: _ -> return getLineIdent (lines.GetLineString(range.StartLine - 1))
-    | [] ->
-      match abstractClassData with
-      | AbstractClassData.ExplicitImpl _ ->
-        // 'interface ISomething with' is often in a new line, we use the indentation of that line
-        return getLineIdent lineStr + indentSize
-      | AbstractClassData.ObjExpr(_, _, newExprRange) ->
-        match! codeGenServer.TokenizeLine(doc.FullName, pos.Line) with
-        | Some tokens ->
-          return
-            tokens
-            |> List.tryPick (fun (t: FSharpTokenInfo) ->
-              if t.CharClass = FSharpTokenCharKind.Keyword && t.TokenName = "NEW" then
-                // We round to nearest so the generated code will align on the indentation guides
-                findGreaterMultiple (t.LeftColumn + indentSize) indentSize |> Some
-              else
-                None)
-            // There is no reference point, we indent the content at the start column of the interface
-            |> Option.defaultValue newExprRange.StartColumn
-        | None -> return newExprRange.StartColumn
-  }
+  match memberNamesAndRanges with
+  | (_, _, leadingKeywordRange) :: _ ->
+    // if we have any members, then we can use the start of the leading keyword to give us the indent correctly
+    leadingKeywordRange.StartColumn
+  | [] ->
+    match abstractClassData with
+    | AbstractClassData.ExplicitImpl (inheritExpressionRange = inheritRange) ->
+      // 'interface ISomething with' is often in a new line, we use the indentation of that line
+      inheritRange.StartColumn
+    | AbstractClassData.ObjExpr(newExpression = newExpr; withKeyword = withKeyword; bindings = bindings) ->
+      // two cases here to consider:
+      // * has a with keyword on same line as newExpr
+      match withKeyword with
+      | None ->
+        // if no withKeyword, then we add an indent to the start of the new Expression to get our final indent
+        newExpr.StartColumn + indentSize
+      | Some keyword ->
+        // if we have a keyword, if it's on the same line then we can do the same
+        if keyword.StartLine = newExpr.StartLine
+        then
+          newExpr.StartColumn + indentSize
+        else
+          if keyword.StartColumn = newExpr.StartColumn
+          then keyword.StartColumn + indentSize
+          else keyword.StartColumn
 
 /// Try to write any missing members of the given abstract type at the given location.
 /// If the destination type isn't an abstract class, or if there are no missing members to implement,
@@ -167,8 +160,7 @@ let inferStartColumn
 let writeAbstractClassStub
   (codeGenServer: ICodeGenerationService)
   (checkResultForFile: ParseAndCheckResults)
-  (doc: Document)
-  (lines: ISourceText)
+  (doc: NamedText)
   (lineStr: string)
   (abstractClassData: AbstractClassData)
   =
@@ -178,7 +170,7 @@ let writeAbstractClassStub
         abstractClassData.AbstractTypeIdentRange.Start.Line
         (abstractClassData.AbstractTypeIdentRange.End.Column)
 
-    let! (_lexerSym, usages) = codeGenServer.GetSymbolAndUseAtPositionOfKind(doc.FullName, pos, SymbolKind.Ident)
+    let! (_lexerSym, usages) = codeGenServer.GetSymbolAndUseAtPositionOfKind(doc.FileName, pos, SymbolKind.Ident)
     let! usage = usages
 
     let! (displayContext, entity) =
@@ -194,67 +186,56 @@ let writeAbstractClassStub
         | _ -> return! None
       }
 
-    let getMemberByLocation (name, range: Range) =
-      asyncOption {
-        let pos = Position.fromZ (range.StartLine - 1) (range.StartColumn + 1)
-        return! checkResultForFile.GetCheckResults.GetSymbolUseAtLocation(pos.Line, pos.Column, lineStr, [])
-      }
-
-    let insertInfo =
-      asyncOption {
-        let! tokens = codeGenServer.TokenizeLine(doc.FullName, pos.Line)
-
-        return
-          match abstractClassData with
-          | AbstractClassData.ObjExpr _ ->
-            findLastPositionOfWithKeyword tokens entity pos (getAbstractClassIdentifier abstractClassData)
-          | AbstractClassData.ExplicitImpl(_, _, safeInsertPosition) -> Some(false, safeInsertPosition)
-
-      }
+    let getMemberByLocation (name: string, range: Range, keywordRange: Range) =
+      match doc.GetLine range.Start with
+      | Some lineText ->
+        match
+          Lexer.getSymbol
+              range.Start.Line
+              range.Start.Column
+              lineText
+              SymbolLookupKind.ByLongIdent
+              [||] with
+        | Some sym ->
+          checkResultForFile.GetCheckResults.GetSymbolUseAtLocation(range.StartLine, range.EndColumn, lineText, sym.Text.Split('.') |> List.ofArray)
+        | None -> None
+      | None ->
+        None
 
     let desiredMemberNamesWithRanges = getMemberNameAndRanges abstractClassData
 
-    let! implementedSignatures =
+    let implementedSignatures =
       getImplementedMemberSignatures getMemberByLocation displayContext desiredMemberNamesWithRanges
-      |> Async.map Some
 
-    let! generatedString =
-      async {
-        let! start = (inferStartColumn codeGenServer pos doc lines lineStr abstractClassData 4) // 4 here correspond to the indent size
+    let start = inferStartColumn abstractClassData desiredMemberNamesWithRanges 4 // 4 here correspond to the indent size
+    let formattedString =
+      formatMembersAt
+        start
+        4 // Should we make it a setting from the IDE ?
+        abstractClassData.TypeParameters
+        "$objectIdent"
+        "$methodBody"
+        displayContext
+        implementedSignatures
+        entity
+        getAbstractNonVirtualMembers
+        true // Always generate the verbose version of the code
 
-        let formattedString =
-          formatMembersAt
-            start
-            4 // Should we make it a setting from the IDE ?
-            abstractClassData.TypeParameters
-            "$objectIdent"
-            "$methodBody"
-            displayContext
-            implementedSignatures
-            entity
-            getAbstractNonVirtualMembers
-            true // Always generate the verbose version of the code
-
-        // If we are in a object expression, we remove the last new line, so the `}` stay on the same line
-        match abstractClassData with
-        | AbstractClassData.ExplicitImpl _ -> return formattedString
-        | AbstractClassData.ObjExpr _ -> return formattedString.TrimEnd('\n')
-      }
+    let generatedString = formattedString.TrimEnd('\n')
 
     // If generatedString is empty it means nothing is missing to the abstract class
     // So we return None, in order to not show a "Falsy Hint"
     if System.String.IsNullOrEmpty generatedString then
       return! None
     else
-      match! insertInfo with
-      | Some(shouldAppendWith, insertPosition) ->
-        if shouldAppendWith then
-          return! Some(insertPosition, " with" + generatedString)
-        else
-          return! Some(insertPosition, generatedString)
-      | None ->
-        // Unable to find an optimal insert position so return the position under the cursor
-        // By doing that we allow the user to copy/paste the code if the insertion break the code
-        // If we return None, then user would not benefit from abstract stub generation at all
-        return! Some(pos, generatedString)
+      match abstractClassData with
+      | AbstractClassData.ObjExpr( newExpression = newExpr; withKeyword = keyword) ->
+        match keyword with
+        | None ->
+          return newExpr.End, " with\n" + generatedString
+        | Some k ->
+          return k.End, "\n" + generatedString
+
+      | AbstractClassData.ExplicitImpl(_, _, inheritExpressionRange) ->
+        return inheritExpressionRange.End, "\n" + generatedString
   }

--- a/src/FsAutoComplete.Core/AbstractClassStubGenerator.fs
+++ b/src/FsAutoComplete.Core/AbstractClassStubGenerator.fs
@@ -4,8 +4,6 @@ open FsAutoComplete.CodeGenerationUtils
 open FSharp.Compiler.Text
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Symbols
-open FSharp.Compiler.Tokenization
-open FsAutoComplete.Logging
 open FsToolkit.ErrorHandling
 
 
@@ -200,6 +198,10 @@ let writeAbstractClassStub
 
     let start = inferStartColumn abstractClassData desiredMemberNamesWithRanges 4 // 4 here correspond to the indent size
 
+    // this entire file could potentially be replaced by something very much like
+    // FSharp.Compiler.EditorServices.InterfaceStubGenerator.FormatInterface, if the
+    // function to 'get the members we want to implement' was exposed somehow instead of being hard-coded
+    // to just interface lookups
     let formattedString =
       formatMembersAt
         start

--- a/src/FsAutoComplete.Core/CodeGeneration.fs
+++ b/src/FsAutoComplete.Core/CodeGeneration.fs
@@ -676,7 +676,8 @@ module CodeGenerationUtils =
         Some(name, range, trivia.LeadingKeyword.Range)
       else
         Some("set_" + name, range, trivia.LeadingKeyword.Range)
-    | SynBinding(headPat = LongIdentPattern(name, range); trivia = trivia) -> Some(name, range, trivia.LeadingKeyword.Range)
+    | SynBinding(headPat = LongIdentPattern(name, range); trivia = trivia) ->
+      Some(name, range, trivia.LeadingKeyword.Range)
     | _ -> None
 
   let normalizeEventName (m: FSharpMemberOrFunctionOrValue) =

--- a/src/FsAutoComplete.Core/CodeGeneration.fs
+++ b/src/FsAutoComplete.Core/CodeGeneration.fs
@@ -430,7 +430,7 @@ module CodeGenerationUtils =
       if verboseMode then
         writer.Write(": {0}", returnType)
 
-      writer.Write(" = ", returnType)
+      writer.Write(" =")
 
       if verboseMode then
         writer.WriteLine("")
@@ -480,16 +480,16 @@ module CodeGenerationUtils =
       | "", _
       | "()", _ ->
         if verboseMode then
-          writer.WriteLine("and set (v: {0}): unit = ", retType)
+          writer.WriteLine("and set (v: {0}): unit =", retType)
         else
-          writer.Write("and set v = ")
+          writer.Write("and set v =")
       | args, namesWithIndices ->
         let valueArgName, _ = normalizeArgName namesWithIndices "v"
 
         if verboseMode then
-          writer.WriteLine("and set {0} ({1}: {2}): unit = ", args, valueArgName, retType)
+          writer.WriteLine("and set {0} ({1}: {2}): unit =", args, valueArgName, retType)
         else
-          writer.Write("and set {0} {1} = ", args, valueArgName)
+          writer.Write("and set {0} {1} =", args, valueArgName)
 
       writer |> writeImplementation
       writer.Unindent ctx.Indentation
@@ -520,7 +520,7 @@ module CodeGenerationUtils =
 
         match getParamArgs argInfos ctx v with
         | "", _
-        | "()", _ -> writer.WriteLine("with set (v: {0}): unit = ", retType)
+        | "()", _ -> writer.WriteLine("with set (v: {0}): unit =", retType)
         | args, namesWithIndices ->
           let valueArgName, _ = normalizeArgName namesWithIndices "v"
           writer.Write("with set {0} ({1}", args, valueArgName)
@@ -530,7 +530,7 @@ module CodeGenerationUtils =
           else
             writer.Write(")")
 
-          writer.Write(" = ")
+          writer.Write(" =")
 
           if verboseMode then
             writer.WriteLine("")
@@ -656,26 +656,27 @@ module CodeGenerationUtils =
       Some(last.idText, last.idRange)
     | _ -> None
 
-  // Get name and associated range of a member
-  // On merged properties (consisting both getters and setters), they have the same range values,
-  // so we use 'get_' and 'set_' prefix to ensure corresponding symbols are retrieved correctly.
-  let (|MemberNameAndRange|_|) =
+  /// Get name and associated range of a member
+  /// On merged properties (consisting both getters and setters), they have the same range values,
+  /// so we use 'get_' and 'set_' prefix to ensure corresponding symbols are retrieved correctly.
+  /// We also get the range of the leading keyword to establish indent position
+  let (|MemberNamePlusRangeAndKeywordRange|_|) =
     function
-    | SynBinding(valData = SynValData(Some mf, _, _); headPat = LongIdentPattern(name, range)) when
+    | SynBinding(valData = SynValData(Some mf, _, _); headPat = LongIdentPattern(name, range); trivia = trivia) when
       mf.MemberKind = SynMemberKind.PropertyGet
       ->
       if name.StartsWith("get_") then
-        Some(name, range)
+        Some(name, range, trivia.LeadingKeyword.Range)
       else
-        Some("get_" + name, range)
-    | SynBinding(valData = SynValData(Some mf, _, _); headPat = LongIdentPattern(name, range)) when
+        Some("get_" + name, range, trivia.LeadingKeyword.Range)
+    | SynBinding(valData = SynValData(Some mf, _, _); headPat = LongIdentPattern(name, range); trivia = trivia) when
       mf.MemberKind = SynMemberKind.PropertySet
       ->
       if name.StartsWith("set_") then
-        Some(name, range)
+        Some(name, range, trivia.LeadingKeyword.Range)
       else
-        Some("set_" + name, range)
-    | SynBinding(headPat = LongIdentPattern(name, range)) -> Some(name, range)
+        Some("set_" + name, range, trivia.LeadingKeyword.Range)
+    | SynBinding(headPat = LongIdentPattern(name, range); trivia = trivia) -> Some(name, range, trivia.LeadingKeyword.Range)
     | _ -> None
 
   let normalizeEventName (m: FSharpMemberOrFunctionOrValue) =
@@ -691,7 +692,7 @@ module CodeGenerationUtils =
   ///  (2) Check symbols of those members based on ranges
   ///  (3) If any symbol found, capture its member signature
   let getImplementedMemberSignatures
-    (getMemberByLocation: string * range -> Async<FSharpSymbolUse option>)
+    (getMemberByLocation: string * range * _ -> FSharpSymbolUse option)
     displayContext
     memberNamesAndRanges
     =
@@ -713,14 +714,11 @@ module CodeGenerationUtils =
         fail "Should only accept symbol uses of members."
         None
 
-    async {
-      let! symbolUses = memberNamesAndRanges |> List.toArray |> Async.Array.map getMemberByLocation
+    let symbolUses = memberNamesAndRanges |> List.map getMemberByLocation
 
-      return
-        symbolUses
-        |> Array.choose (Option.bind formatMemberSignature >> Option.map String.Concat)
-        |> Set.ofArray
-    }
+    symbolUses
+    |> List.choose (Option.bind formatMemberSignature >> Option.map String.Concat)
+    |> Set.ofList
 
   /// Check whether an entity is an interface or type abbreviation of an interface
   let rec isInterface (e: FSharpEntity) =

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -239,17 +239,15 @@ module Commands =
     (lineStr: LineStr)
     =
     asyncResult {
-      let doc = docForText lines tyRes
-
       let! abstractClass =
-        tryFindAbstractClassExprInBufferAtPos objExprRange.Start doc
+        tryFindAbstractClassExprInBufferAtPos objExprRange.Start lines
         |> Async.map (Result.ofOption (fun _ -> CoreResponse.InfoRes "Abstract class at position not found"))
 
-      let! (insertPosition, generatedCode) =
-        writeAbstractClassStub tyRes doc lines lineStr abstractClass
-        |> Async.map (Result.ofOption (fun _ -> CoreResponse.InfoRes "Didn't need to write an abstract class"))
+      let! inserts =
+        writeAbstractClassStub tyRes lines lineStr abstractClass
+        |> AsyncResult.ofOption (fun _ -> CoreResponse.InfoRes "Didn't need to write an abstract class")
 
-      return CoreResponse.Res(generatedCode, insertPosition)
+      return CoreResponse.Res inserts
     }
 
   let getRecordStub

--- a/src/FsAutoComplete/CodeFixes/GenerateAbstractClassStub.fs
+++ b/src/FsAutoComplete/CodeFixes/GenerateAbstractClassStub.fs
@@ -13,7 +13,7 @@ let title = "Generate abstract class members"
 /// a codefix that generates stubs for required override members in abstract types
 let fix
   (getParseResultsForFile: GetParseResultsForFile)
-  (genAbstractClassStub: _ -> _ -> _ -> _ -> Async<CoreResponse<string * FcsPos>>)
+  (genAbstractClassStub: _ -> _ -> _ -> _ -> Async<CoreResponse<FcsPos * string>>)
   (getTextReplacements: unit -> Map<string, string>)
   : CodeFix =
   Run.ifDiagnosticByCode (Set.ofList [ "365" ]) (fun diagnostic codeActionParams ->
@@ -28,7 +28,7 @@ let fix
       let! (tyRes, line, lines) = getParseResultsForFile fileName fcsRange.Start
 
       match! genAbstractClassStub tyRes fcsRange lines line with
-      | CoreResponse.Res(text, position) ->
+      | CoreResponse.Res(position, text) ->
         let replacements = getTextReplacements ()
 
         let replaced =

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -790,7 +790,7 @@ type FSharpConfig =
       Linter = false
       LinterConfig = None
       UnionCaseStubGeneration = false
-      UnionCaseStubGenerationBody = """failwith "Not Implemented" """
+      UnionCaseStubGenerationBody = "failwith \"Not Implemented\""
       RecordStubGeneration = false
       RecordStubGenerationBody = "failwith \"Not Implemented\""
       AbstractClassStubGeneration = true
@@ -863,7 +863,7 @@ type FSharpConfig =
       AbstractClassStubGeneration = defaultArg dto.AbstractClassStubGeneration false
       AbstractClassStubGenerationObjectIdentifier = defaultArg dto.AbstractClassStubGenerationObjectIdentifier "this"
       AbstractClassStubGenerationMethodBody =
-        defaultArg dto.AbstractClassStubGenerationMethodBody "failwith \Not Implemented\""
+        defaultArg dto.AbstractClassStubGenerationMethodBody "failwith \"Not Implemented\""
       CodeLenses =
         match dto.CodeLenses with
         | None -> CodeLensConfig.Default

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1598,7 +1598,6 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
     let writeAbstractClassStub =
       AbstractClassStubGenerator.writeAbstractClassStub codeGenServer
 
-
     let getAbstractClassStub tyRes objExprRange lines lineStr =
       Commands.getAbstractClassStub
         tryFindAbstractClassExprInBufferAtPos

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/GenerateAbstractClassStubTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/GenerateAbstractClassStubTests.fs
@@ -1,0 +1,193 @@
+module private FsAutoComplete.Tests.CodeFixTests.GenerateAbstractClassStubTests
+
+open Expecto
+open Helpers
+open Utils.ServerTests
+open Utils.CursorbasedTests
+open FsAutoComplete.CodeFix
+
+let tests state =
+  let config = { defaultConfigDto with AbstractClassStubGeneration = Some true }
+  serverTestList (nameof GenerateAbstractClassStub) state config None (fun server -> [
+    let selectCodeFix = CodeFix.withTitle GenerateAbstractClassStub.title
+    testCaseAsync "can generate a derivative of a long ident - System.IO.Stream" <|
+      CodeFix.checkApplicable server
+        """
+        type My$0Stream() =
+          inherit System.IO.Stream()
+        """
+        (Diagnostics.expectCode "365")
+        selectCodeFix
+    testCaseAsync "can generate a derivative for a simple ident - Stream" <|
+      CodeFix.checkApplicable server
+        """
+        open System.IO
+        type My$0Stream2() =
+          inherit Stream()
+        """
+        (Diagnostics.expectCode "365")
+        selectCodeFix
+    testCaseAsync "can generate abstract class stub" <|
+      // issue: Wants to insert text in line 13, column 12.
+      //        But Line 13 (line with `"""`) is empty -> no column 12
+      CodeFix.check server
+        """
+        [<AbstractClass>]
+        type Shape(x0: float, y0: float) =
+          let mutable x, y = x0, y0
+
+          abstract Name : string with get
+          abstract Area : float with get
+
+          member _.Move dx dy =
+            x <- x + dx
+            y <- y + dy
+
+        type $0Square(x,y, sideLength) =
+          inherit Shape(x,y)
+        ()"""
+        (Diagnostics.expectCode "365")
+        selectCodeFix
+        """
+        [<AbstractClass>]
+        type Shape(x0: float, y0: float) =
+          let mutable x, y = x0, y0
+
+          abstract Name : string with get
+          abstract Area : float with get
+
+          member _.Move dx dy =
+            x <- x + dx
+            y <- y + dy
+
+        type Square(x,y, sideLength) =
+          inherit Shape(x,y)
+
+          override this.Area: float =
+              failwith "Not Implemented"
+          override this.Name: string =
+              failwith "Not Implemented"
+        ()"""
+    testCaseAsync "can generate abstract class stub without trailing nl" <|
+      // issue: Wants to insert text in line 13, column 12.
+      //        But there's no line 13 (last line is line 12)
+      CodeFix.check server
+        """
+        [<AbstractClass>]
+        type Shape(x0: float, y0: float) =
+          let mutable x, y = x0, y0
+
+          abstract Name : string with get
+          abstract Area : float with get
+
+          member _.Move dx dy =
+            x <- x + dx
+            y <- y + dy
+
+        type $0Square(x,y, sideLength) =
+          inherit Shape(x,y)
+        ()"""
+        (Diagnostics.expectCode "365")
+        selectCodeFix
+        """
+        [<AbstractClass>]
+        type Shape(x0: float, y0: float) =
+          let mutable x, y = x0, y0
+
+          abstract Name : string with get
+          abstract Area : float with get
+
+          member _.Move dx dy =
+            x <- x + dx
+            y <- y + dy
+
+        type Square(x,y, sideLength) =
+          inherit Shape(x,y)
+
+          override this.Area: float =
+              failwith "Not Implemented"
+          override this.Name: string =
+              failwith "Not Implemented"
+        ()"""
+    testCaseAsync "inserts override in correct place" <|
+      // issue: inserts overrides after `let a = ...`, not before
+      CodeFix.check server
+        """
+        [<AbstractClass>]
+        type Shape(x0: float, y0: float) =
+          let mutable x, y = x0, y0
+
+          abstract Name : string with get
+          abstract Area : float with get
+
+          member _.Move dx dy =
+            x <- x + dx
+            y <- y + dy
+
+        type $0Square(x,y, sideLength) =
+          inherit Shape(x,y)
+        let a = 0"""
+        (Diagnostics.expectCode "365")
+        selectCodeFix
+        """
+        [<AbstractClass>]
+        type Shape(x0: float, y0: float) =
+          let mutable x, y = x0, y0
+
+          abstract Name : string with get
+          abstract Area : float with get
+
+          member _.Move dx dy =
+            x <- x + dx
+            y <- y + dy
+
+        type Square(x,y, sideLength) =
+          inherit Shape(x,y)
+
+          override this.Area: float =
+              failwith "Not Implemented"
+          override this.Name: string =
+              failwith "Not Implemented"
+        let a = 0"""
+    testCaseAsync "can generate abstract class stub with existing override" <|
+      CodeFix.check server
+        """
+        [<AbstractClass>]
+        type Shape(x0: float, y0: float) =
+          let mutable x, y = x0, y0
+
+          abstract Name : string with get
+          abstract Area : float with get
+
+          member _.Move dx dy =
+            x <- x + dx
+            y <- y + dy
+
+        type $0Square(x,y, sideLength) =
+          inherit Shape(x,y)
+
+          override this.Name = "Circle"
+        ()"""
+        (Diagnostics.expectCode "365")
+        selectCodeFix
+        """
+        [<AbstractClass>]
+        type Shape(x0: float, y0: float) =
+          let mutable x, y = x0, y0
+
+          abstract Name : string with get
+          abstract Area : float with get
+
+          member _.Move dx dy =
+            x <- x + dx
+            y <- y + dy
+
+        type Square(x,y, sideLength) =
+          inherit Shape(x,y)
+
+          override this.Area: float =
+              failwith "Not Implemented"
+
+          override this.Name = "Circle"
+        ()"""
+  ])

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -670,7 +670,7 @@ let private convertPositionalDUToNamedTests state =
             | Case1(field1 = 3; field2 = 4;) -> ()
             | _ -> ()
         """
-      
+
     testCaseAsync "when surrounding function takes union parameter" <|
       CodeFix.check server
         """
@@ -711,7 +711,7 @@ let private addPrivateAccessModifierTests state =
         """
         let private f x = x * x
         """
-      
+
       testCaseAsync "add private works for simple identifier"
       <| CodeFix.check
         server
@@ -779,7 +779,7 @@ let private addPrivateAccessModifierTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
-      
+
       testCaseAsync "add private works for class type definition"
       <| CodeFix.check
         server
@@ -793,7 +793,7 @@ let private addPrivateAccessModifierTests state =
         type [<System.Obsolete>] private MyClass() =
           member _.X = 10
         """
-      
+
       testCaseAsync "add private is not offered for class type definition with reference"
       <| CodeFix.checkNotApplicable
         server
@@ -805,7 +805,7 @@ let private addPrivateAccessModifierTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
-      
+
       testCaseAsync "add private is not offered for explicit ctor" // ref finding might not show us usages
       <| CodeFix.checkNotApplicable
         server
@@ -829,7 +829,7 @@ let private addPrivateAccessModifierTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
-      
+
       testCaseAsync "add private is not offered for member with reference outside its declaring class when caret is on thisValue"
       <| CodeFix.checkNotApplicable
         server
@@ -872,7 +872,7 @@ let private addPrivateAccessModifierTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
-      
+
       testCaseAsync "add private works for class member"
       <| CodeFix.check
         server
@@ -907,7 +907,7 @@ let private addPrivateAccessModifierTests state =
         """
         type MyClass() =
           member val Name$0 = "" with get, set
-        
+
         let myInst = MyClass()
         myInst.Name |> ignore
         """
@@ -924,7 +924,7 @@ let private addPrivateAccessModifierTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
-        
+
       testCaseAsync "add private is not offered for member with reference outside its declaring DU"
       <| CodeFix.checkNotApplicable
         server
@@ -940,7 +940,7 @@ let private addPrivateAccessModifierTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
-      
+
       testCaseAsync "add private is not offered for member with reference outside its declaring DU when caret is on thisValue"
       <| CodeFix.checkNotApplicable
         server
@@ -1000,7 +1000,7 @@ let private addPrivateAccessModifierTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
-      
+
       testCaseAsync "add private is not offered for member with reference outside its declaring Record"
       <| CodeFix.checkNotApplicable
         server
@@ -1016,7 +1016,7 @@ let private addPrivateAccessModifierTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
-      
+
       testCaseAsync "add private is not offered for member with reference outside its declaring Record when caret is on thisValue"
       <| CodeFix.checkNotApplicable
         server
@@ -1065,7 +1065,7 @@ let private addPrivateAccessModifierTests state =
         with
           member private _.Foo x = x
         """
-      
+
       testCaseAsync "add private works for top level module"
       <| CodeFix.check
         server
@@ -1081,7 +1081,7 @@ let private addPrivateAccessModifierTests state =
 
           module Sub = ()
         """
-      
+
       testCaseAsync "add private works for module"
       <| CodeFix.check
         server
@@ -1103,7 +1103,7 @@ let private addPrivateAccessModifierTests state =
         module M =
           module N$0 =
               let foofoo = 10
-    
+
         M.N.foofoo |> ignore
         """
         Diagnostics.acceptAll
@@ -1127,7 +1127,7 @@ let private addPrivateAccessModifierTests state =
         """
         module M =
           type My$0Int = int
-        
+
         let x: M.MyInt = 23
         """
         Diagnostics.acceptAll
@@ -1213,7 +1213,7 @@ let private convertTripleSlashCommentToXmlTaggedDocTests state =
         let f a b _ =
             /// line on use$0
             use r = new System.IO.BinaryReader(null)
-            
+
             a + b
         """
         Diagnostics.acceptAll
@@ -1222,7 +1222,7 @@ let private convertTripleSlashCommentToXmlTaggedDocTests state =
         let f a b _ =
             /// <summary>line on use</summary>
             use r = new System.IO.BinaryReader(null)
-            
+
             a + b
         """
 
@@ -1397,7 +1397,7 @@ let private convertTripleSlashCommentToXmlTaggedDocTests state =
           /// </summary>
           member val Name = "" with get, set
         """
-      
+
       testCaseAsync "multiline comment over named module"
       <| CodeFix.check
         server
@@ -1417,7 +1417,7 @@ let private convertTripleSlashCommentToXmlTaggedDocTests state =
         module M
           let f x = x
         """
-      
+
       testCaseAsync "multiline comment over nested module"
       <| CodeFix.check
         server
@@ -1479,7 +1479,7 @@ let private generateXmlDocumentationTests state =
         """
         let f a b _ =
           use $0r = new System.IO.BinaryReader(null)
-          
+
           a + b
         """
         Diagnostics.acceptAll
@@ -1489,7 +1489,7 @@ let private generateXmlDocumentationTests state =
           /// <summary></summary>
           /// <returns></returns>
           use r = new System.IO.BinaryReader(null)
-          
+
           a + b
         """
 
@@ -1604,7 +1604,7 @@ let private generateXmlDocumentationTests state =
           /// <returns></returns>
           member val Name = "" with get, set
         """
-      
+
       testCaseAsync "documentation for named module"
       <| CodeFix.check
         server
@@ -1619,7 +1619,7 @@ let private generateXmlDocumentationTests state =
         module M
           let f x = x
         """
-        
+
       testCaseAsync "documentation for nested module"
       <| CodeFix.check
         server
@@ -1636,192 +1636,6 @@ let private generateXmlDocumentationTests state =
           module MyNestedModule =
             let x = 3
         """ ])
-
-let private generateAbstractClassStubTests state =
-  let config = { defaultConfigDto with AbstractClassStubGeneration = Some true }
-  serverTestList (nameof GenerateAbstractClassStub) state config None (fun server -> [
-    let selectCodeFix = CodeFix.withTitle GenerateAbstractClassStub.title
-    testCaseAsync "can generate a derivative of a long ident - System.IO.Stream" <|
-      CodeFix.checkApplicable server
-        """
-        type My$0Stream() =
-          inherit System.IO.Stream()
-        """
-        (Diagnostics.expectCode "365")
-        selectCodeFix
-    testCaseAsync "can generate a derivative for a simple ident - Stream" <|
-      CodeFix.checkApplicable server
-        """
-        open System.IO
-        type My$0Stream2() =
-          inherit Stream()
-        """
-        (Diagnostics.expectCode "365")
-        selectCodeFix
-    ptestCaseAsync "can generate abstract class stub" <|
-      // issue: Wants to insert text in line 13, column 12.
-      //        But Line 13 (line with `"""`) is empty -> no column 12
-      CodeFix.check server
-        """
-        [<AbstractClass>]
-        type Shape(x0: float, y0: float) =
-          let mutable x, y = x0, y0
-
-          abstract Name : string with get
-          abstract Area : float with get
-
-          member _.Move dx dy =
-            x <- x + dx
-            y <- y + dy
-
-        type $0Square(x,y, sideLength) =
-          inherit Shape(x,y)
-        """
-        (Diagnostics.expectCode "365")
-        selectCodeFix
-        """
-        [<AbstractClass>]
-        type Shape(x0: float, y0: float) =
-          let mutable x, y = x0, y0
-
-          abstract Name : string with get
-          abstract Area : float with get
-
-          member _.Move dx dy =
-            x <- x + dx
-            y <- y + dy
-
-        type Square(x,y, sideLength) =
-          inherit Shape(x,y)
-
-          override this.Area: float =
-              failwith "Not Implemented"
-          override this.Name: string =
-              failwith "Not Implemented"
-        """
-    ptestCaseAsync "can generate abstract class stub without trailing nl" <|
-      // issue: Wants to insert text in line 13, column 12.
-      //        But there's no line 13 (last line is line 12)
-      CodeFix.check server
-        """
-        [<AbstractClass>]
-        type Shape(x0: float, y0: float) =
-          let mutable x, y = x0, y0
-
-          abstract Name : string with get
-          abstract Area : float with get
-
-          member _.Move dx dy =
-            x <- x + dx
-            y <- y + dy
-
-        type $0Square(x,y, sideLength) =
-          inherit Shape(x,y)"""
-        (Diagnostics.expectCode "365")
-        selectCodeFix
-        """
-        [<AbstractClass>]
-        type Shape(x0: float, y0: float) =
-          let mutable x, y = x0, y0
-
-          abstract Name : string with get
-          abstract Area : float with get
-
-          member _.Move dx dy =
-            x <- x + dx
-            y <- y + dy
-
-        type Square(x,y, sideLength) =
-          inherit Shape(x,y)
-
-          override this.Area: float =
-              failwith "Not Implemented"
-          override this.Name: string =
-              failwith "Not Implemented"
-        """
-    ptestCaseAsync "inserts override in correct place" <|
-      // issue: inserts overrides after `let a = ...`, not before
-      CodeFix.check server
-        """
-        [<AbstractClass>]
-        type Shape(x0: float, y0: float) =
-          let mutable x, y = x0, y0
-
-          abstract Name : string with get
-          abstract Area : float with get
-
-          member _.Move dx dy =
-            x <- x + dx
-            y <- y + dy
-
-        type $0Square(x,y, sideLength) =
-          inherit Shape(x,y)
-        let a = 0
-        """
-        (Diagnostics.expectCode "365")
-        selectCodeFix
-        """
-        [<AbstractClass>]
-        type Shape(x0: float, y0: float) =
-          let mutable x, y = x0, y0
-
-          abstract Name : string with get
-          abstract Area : float with get
-
-          member _.Move dx dy =
-            x <- x + dx
-            y <- y + dy
-
-        type Square(x,y, sideLength) =
-          inherit Shape(x,y)
-
-          override this.Area: float =
-              failwith "Not Implemented"
-          override this.Name: string =
-              failwith "Not Implemented"
-        let a = 0
-        """
-    ptestCaseAsync "can generate abstract class stub with existing override" <|
-      // issue: Generates override for already existing member
-      CodeFix.check server
-        """
-        [<AbstractClass>]
-        type Shape(x0: float, y0: float) =
-          let mutable x, y = x0, y0
-
-          abstract Name : string with get
-          abstract Area : float with get
-
-          member _.Move dx dy =
-            x <- x + dx
-            y <- y + dy
-
-        type $0Square(x,y, sideLength) =
-          inherit Shape(x,y)
-        """
-        (Diagnostics.expectCode "365")
-        selectCodeFix
-        """
-        [<AbstractClass>]
-        type Shape(x0: float, y0: float) =
-          let mutable x, y = x0, y0
-
-          abstract Name : string with get
-          abstract Area : float with get
-
-          member _.Move dx dy =
-            x <- x + dx
-            y <- y + dy
-
-        type Square(x,y, sideLength) =
-          inherit Shape(x,y)
-
-          override this.Name = "Circle"
-
-          override this.Area: float =
-              failwith "Not Implemented"
-        """
-  ])
 
 let private generateRecordStubTests state =
   let config =
@@ -2684,7 +2498,7 @@ let tests state = testList "CodeFix-tests" [
   convertPositionalDUToNamedTests state
   convertTripleSlashCommentToXmlTaggedDocTests state
   addPrivateAccessModifierTests state
-  generateAbstractClassStubTests state
+  GenerateAbstractClassStubTests.tests state
   generateRecordStubTests state
   generateUnionCasesTests state
   generateXmlDocumentationTests state

--- a/test/FsAutoComplete.Tests.Lsp/Utils/CursorbasedTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/CursorbasedTests.fs
@@ -114,7 +114,7 @@ module CodeFix =
     (beforeWithCursor: string)
     (validateDiagnostics: Diagnostic[] -> unit)
     (chooseFix: ChooseFix)
-    (expected: ExpectedResult)
+    (expected: unit -> ExpectedResult)
     = async {
       let (range, text) =
         beforeWithCursor
@@ -124,7 +124,7 @@ module CodeFix =
       let! (doc, diags) = server |> Server.createUntitledDocument text
       use doc = doc // ensure doc gets closed (disposed) after test
 
-      do! checkFixAt (doc, diags) (text, range) validateDiagnostics chooseFix expected
+      do! checkFixAt (doc, diags) (text, range) validateDiagnostics chooseFix (expected())
     }
 
   /// Checks a CodeFix (CodeAction) for validity.
@@ -170,7 +170,7 @@ module CodeFix =
       beforeWithCursor
       validateDiagnostics
       chooseFix
-      (After (expected |> Text.trimTripleQuotation))
+      (fun () -> After (expected |> Text.trimTripleQuotation))
 
   /// Note: Doesn't apply Fix! Just checks its existence!
   let checkApplicable
@@ -184,7 +184,7 @@ module CodeFix =
       beforeWithCursor
       validateDiagnostics
       chooseFix
-      Applicable
+      (fun () -> Applicable)
 
   let checkNotApplicable
     server
@@ -197,7 +197,7 @@ module CodeFix =
       beforeWithCursor
       validateDiagnostics
       chooseFix
-      NotApplicable
+      (fun () -> NotApplicable)
 
   let matching cond (fixes: CodeAction array) =
     fixes
@@ -248,11 +248,11 @@ module CodeFix =
       (beforeWithCursors: string)
       (validateDiagnostics: Diagnostic[] -> unit)
       (chooseFix: ChooseFix)
-      (expected: ExpectedResult)
+      (expected: unit -> ExpectedResult)
       =
       let (beforeWithoutCursor, poss) = beforeWithCursors |> Text.trimTripleQuotation |> Cursors.extract
       let ranges = poss |> List.map (fun p -> { Start = p; End = p })
-      checkFixAll name server beforeWithoutCursor ranges validateDiagnostics chooseFix expected
+      checkFixAll name server beforeWithoutCursor ranges validateDiagnostics chooseFix (expected())
 
   let testAllPositions
     name
@@ -268,7 +268,8 @@ module CodeFix =
       beforeWithCursors
       validateDiagnostics
       chooseFix
-      (After (expected |> Text.trimTripleQuotation))
+      (fun () -> After (expected |> Text.trimTripleQuotation))
+
   let testApplicableAllPositions
     name
     server
@@ -282,7 +283,7 @@ module CodeFix =
       beforeWithCursors
       validateDiagnostics
       chooseFix
-      Applicable
+      (fun () -> Applicable)
   let testNotApplicableAllPositions
     name
     server
@@ -296,4 +297,4 @@ module CodeFix =
       beforeWithCursors
       validateDiagnostics
       chooseFix
-      NotApplicable
+      (fun () -> NotApplicable)


### PR DESCRIPTION
Previously when completing an abstract class we'd look for the first non-ctor/interface member and go back a line + indent. That doesn't work when attributes are in play. Instead, now we look for the _last_ invalid member - which are implicit ctors, explicit ctors, class-level let/do bindings, and inherit expressions - and insert the line after that + indent.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ae6b24</samp>

Refactor `walkTypeDefn` function in `AbstractClassStubGenerator.fs` to simplify logic and improve stub insertion position. This fixes a bug in the stub generator for abstract classes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8ae6b24</samp>

> _`walkTypeDefn` changed_
> _Option and active pattern_
> _Simplify the code_

<!--
copilot:emoji
-->

🐛🧹🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the main goal of the pull request. The original issue reported that the stub generator would sometimes insert stubs in the wrong place or not at all, which could cause compilation errors or incomplete code. The emoji conveys that the changes address this problem and improve the reliability of the feature.
2.  🧹 - This emoji represents a cleanup or refactoring, which is what the `walkTypeDefn` function underwent. The emoji suggests that the changes make the code cleaner, simpler, or more readable, without changing its functionality or behavior. The emoji also implies that the changes remove some unnecessary or redundant code, such as nested matches or duplicated logic.
3.  🚀 - This emoji represents a performance improvement or optimization, which is a possible side effect of the changes. The emoji indicates that the changes make the code faster, more efficient, or more scalable, which could benefit the users or developers of the feature. The emoji also conveys a sense of excitement or enthusiasm for the changes, as they could enhance the user experience or the development process.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8ae6b24</samp>

*  Simplify and fix the logic of finding the abstract class and its members for a type definition ([link](https://github.com/fsharp/FsAutoComplete/pull/1107/files?diff=unified&w=0#diff-4062aa4dad0c4680ba9c353064ecfdf500e884b5d5838792009ec670c289633aL26-R72))

### TODO

Test cases for the scenario reported by @lenscas on discord.
