### PR TITLE
Add "Add missing XML documentation" codefix

### DIFF
--- a/src/FsAutoComplete/CodeFixes/AddMissingXmlDocumentation.fs
+++ b/src/FsAutoComplete/CodeFixes/AddMissingXmlDocumentation.fs
@@ -1,0 +1,196 @@
+module FsAutoComplete.CodeFix.AddMissingXmlDocumentation
+
+open FsToolkit.ErrorHandling
+open FsAutoComplete.CodeFix.Types
+open Ionide.LanguageServerProtocol.Types
+open FsAutoComplete
+open FsAutoComplete.LspHelpers
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text.Range
+open FSharp.Compiler.Xml
+open System
+
+let title = "Add missing XML documentation"
+
+let private tryGetExistingXmlDoc (pos: FSharp.Compiler.Text.Position) (xmlDoc: PreXmlDoc) =
+  let containsPosAndSummaryPresent (xd: PreXmlDoc) =
+    let d = xd.ToXmlDoc(false, None)
+
+    if rangeContainsPos d.Range pos then
+      let summaryPresent =
+        d.UnprocessedLines |> Array.exists (fun s -> s.Contains("<summary>"))
+
+      if summaryPresent then Some d.UnprocessedLines else None
+    else
+      None
+
+  if not xmlDoc.IsEmpty then
+    containsPosAndSummaryPresent xmlDoc
+  else
+    None
+
+let private isLetWithSummary input pos =
+  SyntaxTraversal.Traverse(
+    pos,
+    input,
+    { new SyntaxVisitorBase<_>() with
+        member _.VisitBinding(_, defaultTraverse, synBinding) =
+          match synBinding with
+          | SynBinding(xmlDoc = xmlDoc; headPat = headPat) as s ->
+            let doc = tryGetExistingXmlDoc pos xmlDoc
+
+            match doc with
+            | Some d ->
+              let r =
+                match headPat with
+                | SynPat.LongIdent(longDotId = longDotId) -> longDotId.Range.End
+                | _ -> s.RangeOfHeadPattern.Start
+
+              Some(d, r)
+            | None -> defaultTraverse synBinding
+
+        member _.VisitLetOrUse(_, _, defaultTraverse, bindings, _) =
+          let isInLine b =
+            match b with
+            | SynBinding(xmlDoc = xmlDoc; headPat = headPat) as s ->
+              let doc = tryGetExistingXmlDoc pos xmlDoc
+
+              match doc with
+              | Some d ->
+                let r =
+                  match headPat with
+                  | SynPat.LongIdent(longDotId = longDotId) -> longDotId.Range.End
+                  | _ -> s.RangeOfHeadPattern.Start
+
+                Some(d, r)
+              | None -> defaultTraverse b
+
+          bindings |> List.tryPick isInLine
+
+        member _.VisitExpr(_, _, defaultTraverse, expr) = defaultTraverse expr } // needed for nested let bindings
+  )
+
+let private isAutoPropertyWithSummary input pos =
+  SyntaxTraversal.Traverse(
+    pos,
+    input,
+    { new SyntaxVisitorBase<_>() with
+
+        member _.VisitModuleOrNamespace(_, synModuleOrNamespace) =
+          match synModuleOrNamespace with
+          | SynModuleOrNamespace(decls = decls) ->
+
+            let rec findNested decls =
+              decls
+              |> List.tryPick (fun d ->
+                match d with
+                | SynModuleDecl.NestedModule(moduleInfo = moduleInfo; decls = decls) ->
+                  match moduleInfo with
+                  | _ -> findNested decls
+                | SynModuleDecl.Types(typeDefns = typeDefns) ->
+                  typeDefns
+                  |> List.tryPick (fun td ->
+                    match td with
+                    | SynTypeDefn(typeRepr = SynTypeDefnRepr.ObjectModel(_, members, _)) ->
+                      members
+                      |> List.tryPick (fun m ->
+                        match m with
+                        | SynMemberDefn.AutoProperty(xmlDoc = xmlDoc; ident = ident) ->
+                          let doc = tryGetExistingXmlDoc pos xmlDoc
+
+                          match doc with
+                          | Some d -> Some(d, ident.idRange.End)
+                          | _ -> None
+                        | _ -> None)
+                    | _ -> None)
+                | _ -> None)
+
+            findNested decls }
+  )
+
+let private tryGetCommentsAndSymbolPos input pos =
+  match isLetWithSummary input pos with
+  | Some x -> Some x
+  | _ -> isAutoPropertyWithSummary input pos
+
+let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
+  fun codeActionParams ->
+    asyncResult {
+      let filePath = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
+      let fcsPos = protocolPosToPos codeActionParams.Range.Start
+      let! (parseAndCheck, lineStr, _sourceText) = getParseResultsForFile filePath fcsPos
+
+      let parameterSection (name, _type) =
+        $"/// <param name=\"%s{name}\"></param>"
+
+      let genericArg name =
+        $"/// <typeparam name=\"'%s{name}\"></typeparam>"
+
+      let returnsSection = "/// <returns></returns>"
+
+      let commentsAndPos = tryGetCommentsAndSymbolPos parseAndCheck.GetAST fcsPos
+
+      match commentsAndPos with
+      | Some(comments, symbolPos) ->
+        let lineStrOfSymbol = _sourceText.GetLine symbolPos |> Option.defaultValue ""
+        let signatureData = parseAndCheck.TryGetSignatureData symbolPos lineStrOfSymbol
+
+        match signatureData with
+        | Ok(_, memberParameters, genericParameters) ->
+
+          let trimmed = lineStr.TrimStart(' ')
+          let indentLength = lineStr.Length - trimmed.Length
+          let indentString = String.replicate indentLength " "
+
+          let formattedXmlDoc =
+            seq {
+              match memberParameters with
+              | [] -> ()
+              | parameters ->
+                yield!
+                  parameters
+                  |> List.concat
+                  |> List.filter (fun (parameter, _) -> comments |> Array.exists (fun c -> c.Contains($"<param name=\"{parameter}\">")) |> not)
+                  |> List.mapi (fun _index parameter -> parameterSection parameter)
+
+              match genericParameters with
+              | [] -> ()
+              | generics ->
+                yield!
+                  generics
+                  |> List.filter (fun generic -> comments |> Array.exists (fun c -> c.Contains($"<typeparam name=\"'{generic}\">")) |> not)
+                  |> List.mapi (fun _index generic -> genericArg generic)
+
+              if comments |> Array.exists (fun s -> s.Contains("<returns>")) then
+                ()
+              else
+                yield returnsSection
+            }
+            |> fun lines ->
+              if Seq.isEmpty lines then
+                None
+              else
+                lines
+                |> Seq.map (fun s -> indentString + s)
+                |> String.concat Environment.NewLine
+                |> fun s -> Some (s + Environment.NewLine) // need a newline at the very end
+
+          match formattedXmlDoc with
+          | Some text ->
+            // always insert at the start of the line, because we've prepended the indent to the doc strings
+            let insertPosition = fcsPosToLsp (symbolPos.WithColumn 0)
+
+            let editRange =
+              { Start = insertPosition
+                End = insertPosition }
+
+            return
+              [ { Edits = [| { Range = editRange; NewText = text } |]
+                  File = codeActionParams.TextDocument
+                  Title = title
+                  SourceDiagnostic = None
+                  Kind = FixKind.Refactor } ]
+          | _ -> return []
+        | _ -> return []
+      | _ -> return []
+    }

--- a/src/FsAutoComplete/CodeFixes/AddMissingXmlDocumentation.fs
+++ b/src/FsAutoComplete/CodeFixes/AddMissingXmlDocumentation.fs
@@ -135,7 +135,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
                 |> List.concat
                 |> List.filter (fun (parameter, _) ->
                   docLines
-                  |> List.exists (fun c -> c.Contains($"<param name=\"{parameter}\">"))
+                  |> List.exists (fun c -> c.Contains($"<param name=\"%s{parameter}\">"))
                   |> not)
                 |> List.mapi (fun _index parameter -> parameterSection parameter)
 
@@ -156,7 +156,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
                 generics
                 |> List.filter (fun generic ->
                   docLines
-                  |> List.exists (fun c -> c.Contains($"<typeparam name=\"'{generic}\">"))
+                  |> List.exists (fun c -> c.Contains($"<typeparam name=\"'%s{generic}\">"))
                   |> not)
                 |> List.mapi (fun _index generic -> genericArg generic)
 
@@ -179,7 +179,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
 
           let formattedXmlDoc =
             withAdded
-            |> Seq.mapi (fun i s -> if i = 0 then $"///{s}" else $"{indentString}///{s}")
+            |> Seq.mapi (fun i s -> if i = 0 then $"///%s{s}" else $"%s{indentString}///%s{s}")
             |> String.concat Environment.NewLine
 
           if docLines.Length = withAdded.Length then

--- a/src/FsAutoComplete/CodeFixes/AddMissingXmlDocumentation.fs
+++ b/src/FsAutoComplete/CodeFixes/AddMissingXmlDocumentation.fs
@@ -25,7 +25,7 @@ let private tryGetExistingXmlDoc (pos: FSharp.Compiler.Text.Position) (xmlDoc: P
         let lines =
           match d.UnprocessedLines with
           | [||] -> [| " <summary></summary>" |]
-          | [| c |] -> [| $" <summary>%s{c}</summary>" |]
+          | [| c |] -> [| $" <summary>%s{c.Trim()}</summary>" |]
           | cs -> [| yield " <summary>"; yield! cs; yield " </summary>" |]
 
         Some(lines, d.Range)

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1661,6 +1661,7 @@ type AdaptiveFSharpLspServer(workspaceLoader: IWorkspaceLoader, lspClient: FShar
          AddTypeToIndeterminateValue.fix tryGetParseResultsForFile forceGetProjectOptions
          ChangeTypeOfNameToNameOf.fix tryGetParseResultsForFile
          AddMissingInstanceMember.fix
+         AddMissingXmlDocumentation.fix tryGetParseResultsForFile
          AddExplicitTypeAnnotation.fix tryGetParseResultsForFile
          ConvertPositionalDUToNamed.fix tryGetParseResultsForFile getRangeText
          ConvertTripleSlashCommentToXmlTaggedDoc.fix tryGetParseResultsForFile getRangeText

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -1217,6 +1217,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient) =
              AddTypeToIndeterminateValue.fix tryGetParseResultsForFile tryGetProjectOptions
              ChangeTypeOfNameToNameOf.fix tryGetParseResultsForFile
              AddMissingInstanceMember.fix
+             AddMissingXmlDocumentation.fix tryGetParseResultsForFile
              AddExplicitTypeAnnotation.fix tryGetParseResultsForFile
              ConvertPositionalDUToNamed.fix tryGetParseResultsForFile getRangeText
              ConvertTripleSlashCommentToXmlTaggedDoc.fix tryGetParseResultsForFile getRangeText

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -1658,6 +1658,29 @@ let private addMissingXmlDocumentationTests state =
         let f x y = x + y
         """
 
+      testCaseAsync "missing params and returns for nested function with two parameters"
+      <| CodeFix.check
+        server
+        """
+        let f x y =
+          /// <summary>some comment$0</summary>
+          let g a b =
+            a + b
+          x + y
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        let f x y =
+          /// <summary>some comment</summary>
+          /// <param name=""></param>
+          /// <param name=""></param>
+          /// <returns></returns>
+          let g a b =
+            a + b
+          x + y
+        """
+
       testCaseAsync "missing single parameter for function with two parameters"
       <| CodeFix.check
         server
@@ -1672,8 +1695,8 @@ let private addMissingXmlDocumentationTests state =
         """
         /// <summary>some comment</summary>
         /// <param name="x"></param>
-        /// <returns></returns>
         /// <param name="y"></param>
+        /// <returns></returns>
         let f x y = x + y
         """
 
@@ -1693,9 +1716,9 @@ let private addMissingXmlDocumentationTests state =
         /// <summary>some comment</summary>
         /// <param name="x"></param>
         /// <param name="y"></param>
-        /// <returns></returns>
         /// <param name=""></param>
         /// <typeparam name="'a"></typeparam>
+        /// <returns></returns>
         let f x y _ = x + y
         """
 

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -1732,7 +1732,7 @@ let private addMissingXmlDocumentationTests state =
         Diagnostics.acceptAll
         selectCodeFix
         """
-        /// <summary> some comment</summary>
+        /// <summary>some comment</summary>
         /// <param name="x"></param>
         /// <param name="y"></param>
         /// <returns></returns>

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -1722,8 +1722,8 @@ let private addMissingXmlDocumentationTests state =
         let f x y _ = x + y
         """
 
-      testCaseAsync "not applicable for function without summary"
-      <| CodeFix.checkNotApplicable
+      testCaseAsync "wraps single line non-xml comment"
+      <| CodeFix.check
         server
         """
         /// some comment$0
@@ -1731,6 +1731,34 @@ let private addMissingXmlDocumentationTests state =
         """
         Diagnostics.acceptAll
         selectCodeFix
+        """
+        /// <summary> some comment</summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        let f x y = x + y
+        """
+
+      testCaseAsync "wraps multi line non-xml comment"
+      <| CodeFix.check
+        server
+        """
+        /// some comment here
+        /// some comment there$0
+        let f x y = x + y
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        /// <summary>
+        /// some comment here
+        /// some comment there
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        let f x y = x + y
+        """
 
       testCaseAsync "missing returns for use"
       <| CodeFix.check
@@ -1739,7 +1767,7 @@ let private addMissingXmlDocumentationTests state =
         let f a b _ =
           /// <summary>$0</summary>
           use r = new System.IO.BinaryReader(null)
-          
+
           a + b
         """
         Diagnostics.acceptAll
@@ -1749,7 +1777,7 @@ let private addMissingXmlDocumentationTests state =
           /// <summary></summary>
           /// <returns></returns>
           use r = new System.IO.BinaryReader(null)
-          
+
           a + b
         """
 
@@ -1798,7 +1826,7 @@ let private addMissingXmlDocumentationTests state =
           /// <returns></returns>
           member val Name = "" with get, set
         """
-        
+
       testCaseAsync "not applicable for autoproperty with summary and returns"
       <| CodeFix.checkNotApplicable
         server


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c1d8742</samp>

This pull request adds a new code fix feature for adding missing XML documentation comments to F# code. It implements the logic for the code fix in a new module `AddMissingXmlDocumentation.fs` and adds tests for it in `Tests.fs`. It also registers the code fix function in the two language server types `AdaptiveFSharpLspServer` and `FSharpLspServer` so that it can be invoked by the code action request.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c1d8742</samp>

> _`AddMissingXmlDocumentation`_
> _A code fix for F# / kireji_
> _Autumn leaves no gaps / kigo_

<!--
copilot:emoji
-->

📝🛠️🧪

<!--
1.  📝 - This emoji represents the addition of documentation, which is the main purpose of the code fix.
2.  🛠️ - This emoji represents the implementation of a code fix, which is a tool that helps developers improve their code quality and style.
3.  🧪 - This emoji represents the addition of tests, which are experiments that verify the correctness and functionality of the code fix.
-->

### WHY

As discussed [here](https://github.com/fsharp/FsAutoComplete/pull/1068#pullrequestreview-1325268527), another code fix should handle the insertion of missing xml tags. It's applicable if the cursor is inside of an xml comment with a summary tag above an AST element for which the FCS gives a signature.

https://user-images.githubusercontent.com/3221269/233855199-57bc6e4b-fa61-4cec-9d0a-aa1fcb358c44.mp4

<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c1d8742</samp>

*  Add a new module `AddMissingXmlDocumentation` that implements a code fix for adding missing XML documentation to F# symbols ([link](https://github.com/fsharp/FsAutoComplete/pull/1108/files?diff=unified&w=0#diff-844e93910ae20b60c4d58e328af924e7079638fb7296f2a6b42ff1902c1b69eaR1-R200))
*  Register the `AddMissingXmlDocumentation.fix` function as a code fix for the `AdaptiveFSharpLspServer` and `FSharpLspServer` types, which handle code action requests from the language server protocol ([link](https://github.com/fsharp/FsAutoComplete/pull/1108/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0R1663), [link](https://github.com/fsharp/FsAutoComplete/pull/1108/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01R1220))
*  Define a list of test cases for the `AddMissingXmlDocumentation` code fix in the `CodeFixTests.Tests` module, using the `CodeFix.check` and `CodeFix.checkNotApplicable` functions to verify the expected behavior ([link](https://github.com/fsharp/FsAutoComplete/pull/1108/files?diff=unified&w=0#diff-76fc8863cc00a62068d47becebf42e1632f960d23fc5f85759060884583fe464R1640-R1813))
*  Run the `addMissingXmlDocumentationTests` function as part of the `tests` function, which is the main entry point for the code fix tests ([link](https://github.com/fsharp/FsAutoComplete/pull/1108/files?diff=unified&w=0#diff-76fc8863cc00a62068d47becebf42e1632f960d23fc5f85759060884583fe464R2660))
