### PR TITLE
initial goto impl for signature file

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -514,11 +514,15 @@ module Commands =
     =
 
     let filterSymbols symbols =
-      symbols
-      |> Array.where (fun (su: FSharpSymbolUse) ->
-        su.IsFromDispatchSlotImplementation
-        || (su.IsFromType
-            && not (tyRes.GetParseResults.IsTypeAnnotationGivenAtPosition(su.Range.Start))))
+      if Utils.isSignatureFile (UMX.untag tyRes.FileName) then
+        let implFile = Utils.toFSharpFile (UMX.untag tyRes.FileName)
+        symbols |> Array.filter (fun (su: FSharpSymbolUse) -> su.FileName = implFile)
+      else
+        symbols
+        |> Array.where (fun (su: FSharpSymbolUse) ->
+          su.IsFromDispatchSlotImplementation
+          || (su.IsFromType
+              && not (tyRes.GetParseResults.IsTypeAnnotationGivenAtPosition(su.Range.Start))))
 
     async {
       match tyRes.TryGetSymbolUseAndUsages pos lineStr with

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -124,6 +124,9 @@ let inline isAScript (fileName: ReadOnlySpan<char>) =
 /// </summary>
 let inline isSignatureFile (fileName: ReadOnlySpan<char>) = fileName.EndsWith ".fsi"
 
+let toSignatureFile fileName =
+  IO.Path.ChangeExtension(fileName, ".fsi")
+
 /// <summary>
 /// Checks if the file ends with `.fs`
 /// </summary>
@@ -131,6 +134,9 @@ let isFsharpFile (fileName: ReadOnlySpan<char>) = fileName.EndsWith ".fs"
 
 let inline internal isFileWithFSharpI fileName = isAScript fileName || isSignatureFile fileName || isFsharpFile fileName
 
+
+let toFSharpFile fileName =
+  IO.Path.ChangeExtension(fileName, ".fs")
 
 /// <summary>
 /// This is a combination of `isAScript`, `isSignatureFile`, and `isFsharpFile`


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cf01557</samp>

This pull request improves the support for signature files in FsAutoComplete by adding helper functions to convert file names and filtering out irrelevant symbols from code completion and tooltips. It affects the `ProcessHelper` and `Commands` modules in the `src/FsAutoComplete.Core` folder.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cf01557</samp>

> _To support signature files in F#_
> _We filter symbols with some zest_
> _We use `filterSymbols` and `ProcessHelper`_
> _To match the files with `.fsi` and `.fs`_
> _And avoid showing duplicates or incorrect stuff_

<!--
copilot:emoji
-->

📝🔎🛠️

<!--
1.  📝 - This emoji represents the signature files, which are text documents that specify the public interface of a module or type.
2.  🔎 - This emoji represents the filtering of symbols, which is a process of searching and narrowing down the relevant information for code completion and tooltips.
3.  🛠️ - This emoji represents the helper functions, which are tools that simplify and support the main functionality of the feature.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cf01557</samp>

*  Add support for signature files in code completion and tooltips by filtering out irrelevant symbols ([link](https://github.com/fsharp/FsAutoComplete/pull/1111/files?diff=unified&w=0#diff-f030ffbad83492980d57dd555322c7d8e9f26a1986413d60384e0730f8f54dd7L519-R528), [link](https://github.com/fsharp/FsAutoComplete/pull/1111/files?diff=unified&w=0#diff-9af59b386f0d6d11954514dbf9d61c88cb09fbed23c39b4412f5e7c5a63b32a6R123), [link](https://github.com/fsharp/FsAutoComplete/pull/1111/files?diff=unified&w=0#diff-9af59b386f0d6d11954514dbf9d61c88cb09fbed23c39b4412f5e7c5a63b32a6R130-R131))
  - In `src/FsAutoComplete.Core/Commands.fs`, modify `filterSymbols` to check if the file is a signature file (`.fsi`) and only keep the symbols that match the implementation file (`.fs`) ([link](https://github.com/fsharp/FsAutoComplete/pull/1111/files?diff=unified&w=0#diff-f030ffbad83492980d57dd555322c7d8e9f26a1986413d60384e0730f8f54dd7L519-R528))
  - In `src/FsAutoComplete.Core/Utils.fs`, add helper functions `toSignatureFile` and `toFSharpFile` to convert file names between signature and implementation files ([link](https://github.com/fsharp/FsAutoComplete/pull/1111/files?diff=unified&w=0#diff-9af59b386f0d6d11954514dbf9d61c88cb09fbed23c39b4412f5e7c5a63b32a6R123), [link](https://github.com/fsharp/FsAutoComplete/pull/1111/files?diff=unified&w=0#diff-9af59b386f0d6d11954514dbf9d61c88cb09fbed23c39b4412f5e7c5a63b32a6R130-R131))
