### PR TITLE
#1115 autocompletions

### DIFF
--- a/src/FsAutoComplete.Core/AdaptiveExtensions.fs
+++ b/src/FsAutoComplete.Core/AdaptiveExtensions.fs
@@ -295,7 +295,7 @@ module AMap =
     // else
     AMap.ofReader (fun () -> BatchRecalculateDirty(map, mapping))
 
-  let mapWithAdditionalDependenies
+  let mapWithAdditionalDependencies
     (mapping: HashMap<'K, 'T1> -> HashMap<'K, 'T2 * #seq<#IAdaptiveValue>>)
     (map: amap<'K, 'T1>)
     =

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -690,7 +690,7 @@ type ParseAndCheckResults
               && not results.IsForType
               && not results.IsError
               && List.isEmpty longName.QualifyingIdents
-            // Debug.waitForDebuggerAttachedAndBreak "--> TryGetCompletions"
+
             return Some(sortedDecls, residue, shouldKeywords)
         with :? TimeoutException ->
           return None

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -18,6 +18,10 @@ module FcsRange = FSharp.Compiler.Text.Range
 type FcsPos = FSharp.Compiler.Text.Position
 module FcsPos = FSharp.Compiler.Text.Position
 
+module FcsPos =
+  let subtractColumn (pos: FcsPos) (column: int) =
+    FcsPos.mkPos pos.Line (pos.Column - column)
+
 [<AutoOpen>]
 module Conversions =
   module Lsp = Ionide.LanguageServerProtocol.Types

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -2354,13 +2354,13 @@ type AdaptiveFSharpLspServer
                   | _ -> true
                   |> Result.requireTrue $"TextDocumentCompletion was sent before TextDocumentDidChange"
 
-                // Set of characters that should do a full typecheck
-                let requiresFullTypeCheck = [ Some ']'; Some ')'; Some '}'; Some '>' ]
+                // Special characters like parentheses, brackets, etc. require a full type check
+                let isSpecialChar = Option.exists (Char.IsLetterOrDigit >> not)
 
                 let previousCharacter = volatileFile.Source.TryGetChar(FcsPos.subtractColumn pos 1)
 
                 let! typeCheckResults =
-                  if requiresFullTypeCheck |> Seq.contains (previousCharacter) then
+                  if isSpecialChar previousCharacter then
                     forceGetTypeCheckResults filePath
                   else
                     forceGetTypeCheckResultsStale filePath

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -2315,9 +2315,9 @@ type AdaptiveFSharpLspServer
 
           let! volatileFile = forceFindOpenFileOrRead filePath |> AsyncResult.ofStringErr
 
-          let! lineStr2 = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
+          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
 
-          if lineStr2.StartsWith "#" then
+          if lineStr.StartsWith "#" then
             let completionList =
               { IsIncomplete = false
                 Items = KeywordList.hashSymbolCompletionItems }
@@ -2327,28 +2327,23 @@ type AdaptiveFSharpLspServer
           else
             let config = AVal.force config
 
-            let rec retryAsyncOption (delay: TimeSpan) timesLeft action =
+            let rec retryAsyncOption (delay: TimeSpan) timesLeft handleError action =
               async {
                 match! action with
                 | Ok x -> return Ok x
-                | Error _ when timesLeft >= 0 ->
+                | Error e when timesLeft >= 0 ->
+                  let nextAction = handleError e
                   do! Async.Sleep(delay)
-                  return! retryAsyncOption delay (timesLeft - 1) action
+                  return! retryAsyncOption delay (timesLeft - 1) handleError nextAction
                 | Error e -> return Error e
               }
 
-            let getCompletions =
+            let getCompletions forceGetTypeCheckResultsStale =
               asyncResult {
 
                 let! volatileFile = forceFindOpenFileOrRead filePath
                 let! lineStr = volatileFile.Source |> tryGetLineStr pos
-                and! typeCheckResults = forceGetTypeCheckResultsStale filePath
 
-                let getAllSymbols () =
-                  if config.ExternalAutocomplete then
-                    typeCheckResults.GetAllEntities true
-                  else
-                    []
                 // TextDocumentCompletion will sometimes come in before TextDocumentDidChange
                 // This will require the trigger character to be at the place VSCode says it is
                 // Otherwise we'll fail here and our retry logic will come into place
@@ -2359,17 +2354,46 @@ type AdaptiveFSharpLspServer
                   | _ -> true
                   |> Result.requireTrue $"TextDocumentCompletion was sent before TextDocumentDidChange"
 
+                // Set of characters that should do a full typecheck
+                let requiresFullTypeCheck = [ Some ']'; Some ')'; Some '}'; Some '>' ]
+
+                let previousCharacter = volatileFile.Source.TryGetChar(FcsPos.subtractColumn pos 1)
+
+                let! typeCheckResults =
+                  if requiresFullTypeCheck |> Seq.contains (previousCharacter) then
+                    forceGetTypeCheckResults filePath
+                  else
+                    forceGetTypeCheckResultsStale filePath
+
+                let getAllSymbols () =
+                  if config.ExternalAutocomplete then
+                    typeCheckResults.GetAllEntities true
+                  else
+                    []
 
                 let! (decls, residue, shouldKeywords) =
                   Debug.measure "TextDocumentCompletion.TryGetCompletions" (fun () ->
                     typeCheckResults.TryGetCompletions pos lineStr None getAllSymbols
                     |> AsyncResult.ofOption (fun () -> "No TryGetCompletions results"))
 
+                do! Result.requireNotEmpty "Should not have empty completions" decls
+
                 return Some(decls, residue, shouldKeywords, typeCheckResults, getAllSymbols, volatileFile)
               }
 
+            let handleError e =
+              match e with
+              | "Should not have empty completions" ->
+                // If we don't get any completions, assume we need to wait for a full typecheck
+                getCompletions forceGetTypeCheckResults
+              | _ -> getCompletions forceGetTypeCheckResultsStale
+
             match!
-              retryAsyncOption (TimeSpan.FromMilliseconds(10.)) 100 getCompletions
+              retryAsyncOption
+                (TimeSpan.FromMilliseconds(15.))
+                100
+                handleError
+                (getCompletions forceGetTypeCheckResultsStale)
               |> AsyncResult.ofStringErr
             with
             | None -> return! success (None)

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -700,7 +700,7 @@ type AdaptiveFSharpLspServer
 
         let! projectOptions =
           projects
-          |> AMap.mapWithAdditionalDependenies (fun projects ->
+          |> AMap.mapWithAdditionalDependencies (fun projects ->
 
             projects
             |> Seq.iter (fun (proj: string<LocalPath>, _) ->

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -63,17 +63,22 @@ let tests state =
           | Error e -> failtestf "Got an error while retrieving completions: %A" e
         })
 
+
       testCaseAsync
         "simple completion for ending of a function call after text change"
         (async {
           let! server, path = server
+
+          let lineUnderTest = """Path.GetDirectoryName("foo")"""
+          let line = 15
+          let character = lineUnderTest.Length
 
           let textChange : DidChangeTextDocumentParams =
             {
               TextDocument = { Uri = Path.FilePathToUri path ; Version = Some 1}
               ContentChanges =  [|
                 {
-                  Range = Some { Start = { Line = 15; Character = 28 }; End = { Line = 15; Character = 28 } }
+                  Range = Some { Start = { Line = line; Character = character }; End = { Line = line; Character = character } }
                   RangeLength = Some 0
                   Text = "."
                 }
@@ -84,7 +89,7 @@ let tests state =
 
           let completionParams: CompletionParams =
             { TextDocument = { Uri = Path.FilePathToUri path }
-              Position = { Line = 15; Character = 29 } // the '.' in 'GetDirectoryName().'
+              Position = { Line = line; Character = character + 1 }
               Context =
                 Some
                   { triggerKind = CompletionTriggerKind.TriggerCharacter
@@ -115,9 +120,13 @@ let tests state =
         (async {
           let! server, path = server
 
+          let lineUnderTest = """Path.GetDirectoryName("foo")."""
+          let line = 14
+          let character = lineUnderTest.Length
+
           let completionParams: CompletionParams =
             { TextDocument = { Uri = Path.FilePathToUri path }
-              Position = { Line = 14; Character = 29 } // the '.' in 'GetDirectoryName().'
+              Position = { Line = line; Character = character } // the '.' in 'GetDirectoryName().'
               Context =
                 Some
                   { triggerKind = CompletionTriggerKind.TriggerCharacter
@@ -138,6 +147,180 @@ let tests state =
               firstItem.Label
               "Chars"
               "first member should be Chars, since properties are preferred over functions"
+          | Ok None -> failtest "Should have gotten some completion items"
+          | Error e -> failtestf "Got an error while retrieving completions: %A" e
+        })
+
+      testCaseAsync
+        "simple completion for ending of a string after text change"
+        (async {
+          let! server, path = server
+
+          let line = 18
+          let lineUnderTest = "\"bareString\""
+          let character = lineUnderTest.Length
+
+          let textChange : DidChangeTextDocumentParams =
+            {
+              TextDocument = { Uri = Path.FilePathToUri path ; Version = Some 1}
+              ContentChanges =  [|
+                {
+                  Range = Some { Start = { Line = line; Character = character }; End = { Line = line; Character = character } }
+                  RangeLength = Some 0
+                  Text = "."
+                }
+              |]
+            }
+
+          let! c = server.TextDocumentDidChange textChange |> Async.StartChild
+
+          let completionParams: CompletionParams =
+            { TextDocument = { Uri = Path.FilePathToUri path }
+              Position = { Line = line; Character = character + 1 }
+              Context =
+                Some
+                  { triggerKind = CompletionTriggerKind.TriggerCharacter
+                    triggerCharacter = Some '.' } }
+
+          let! response = server.TextDocumentCompletion completionParams
+          do! c
+
+          match response with
+          | Ok (Some completions) ->
+            Expect.isLessThan
+              completions.Items.Length
+              100
+              "shouldn't have an incredibly huge completion list for a simple module completion"
+
+            let firstItem = completions.Items.[0]
+
+            Expect.equal
+              firstItem.Label
+              "Chars"
+              "first member should be Chars, since properties are preferred over functions"
+          | Ok None -> failtest "Should have gotten some completion items"
+          | Error e -> failtestf "Got an error while retrieving completions: %A" e
+        })
+
+      testCaseAsync
+        "simple completion for ending of a string"
+        (async {
+          let! server, path = server
+
+          let line = 17
+          let lineUnderTest = """"bareString"."""
+          let character = lineUnderTest.Length
+
+          let completionParams: CompletionParams =
+            { TextDocument = { Uri = Path.FilePathToUri path }
+              Position = { Line = line; Character = character }
+              Context =
+                Some
+                  { triggerKind = CompletionTriggerKind.TriggerCharacter
+                    triggerCharacter = Some '.' } }
+
+          let! response = server.TextDocumentCompletion completionParams
+
+          match response with
+          | Ok (Some completions) ->
+            Expect.isLessThan
+              completions.Items.Length
+              100
+              "shouldn't have an incredibly huge completion list for a simple module completion"
+
+            let firstItem = completions.Items.[0]
+
+            Expect.equal
+              firstItem.Label
+              "Chars"
+              "first member should be Chars, since properties are preferred over functions"
+          | Ok None -> failtest "Should have gotten some completion items"
+          | Error e -> failtestf "Got an error while retrieving completions: %A" e
+        })
+
+      testCaseAsync
+        "simple completion for ending of a list after text change"
+        (async {
+          let! server, path = server
+
+          let line = 21
+          let lineUnderTest = "[1;2;3]"
+          let character = lineUnderTest.Length
+
+          let textChange : DidChangeTextDocumentParams =
+            {
+              TextDocument = { Uri = Path.FilePathToUri path ; Version = Some 1}
+              ContentChanges =  [|
+                {
+                  Range = Some { Start = { Line = line; Character = character }; End = { Line = line; Character = character } }
+                  RangeLength = Some 0
+                  Text = "."
+                }
+              |]
+            }
+
+          let! c = server.TextDocumentDidChange textChange |> Async.StartChild
+
+          let completionParams: CompletionParams =
+            { TextDocument = { Uri = Path.FilePathToUri path }
+              Position = { Line = line; Character = character + 1 }
+              Context =
+                Some
+                  { triggerKind = CompletionTriggerKind.TriggerCharacter
+                    triggerCharacter = Some '.' } }
+
+          let! response = server.TextDocumentCompletion completionParams
+          do! c
+
+          match response with
+          | Ok (Some completions) ->
+            Expect.isLessThan
+              completions.Items.Length
+              100
+              "shouldn't have an incredibly huge completion list for a simple module completion"
+
+            let firstItem = completions.Items.[0]
+
+            Expect.equal
+              firstItem.Label
+              "Head"
+              "first member should be Head, since properties are preferred over functions"
+          | Ok None -> failtest "Should have gotten some completion items"
+          | Error e -> failtestf "Got an error while retrieving completions: %A" e
+        })
+
+      testCaseAsync
+        "simple completion for ending of a list"
+        (async {
+          let! server, path = server
+
+          let line = 20
+          let lineUnderTest = "[1;2;3]."
+          let character = lineUnderTest.Length
+
+          let completionParams: CompletionParams =
+            { TextDocument = { Uri = Path.FilePathToUri path }
+              Position = { Line = line; Character = character }
+              Context =
+                Some
+                  { triggerKind = CompletionTriggerKind.TriggerCharacter
+                    triggerCharacter = Some '.' } }
+
+          let! response = server.TextDocumentCompletion completionParams
+
+          match response with
+          | Ok (Some completions) ->
+            Expect.isLessThan
+              completions.Items.Length
+              100
+              "shouldn't have an incredibly huge completion list for a simple module completion"
+
+            let firstItem = completions.Items.[0]
+
+            Expect.equal
+              firstItem.Label
+              "Head"
+              "first member should be Head, since properties are preferred over functions"
           | Ok None -> failtest "Should have gotten some completion items"
           | Error e -> failtestf "Got an error while retrieving completions: %A" e
         })

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Completion/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Completion/Script.fsx
@@ -11,3 +11,6 @@ let tail = List.
 type A = {
   Id : Lis
 }
+open System.IO
+Path.GetDirectoryName("foo").
+Path.GetDirectoryName("foo")

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Completion/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Completion/Script.fsx
@@ -14,3 +14,9 @@ type A = {
 open System.IO
 Path.GetDirectoryName("foo").
 Path.GetDirectoryName("foo")
+
+"bareString".
+"bareString"
+
+[1;2;3].
+[1;2;3]


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ca1b7e</samp>

This pull request enhances the completion feature of the F# language server by improving the logic, performance, and testing of the `AdaptiveFSharpLspServer` type and its dependencies. It also fixes a typo in the `mapWithAdditionalDependencies` function and removes a redundant line of code. It adds a new function `subtractColumn` to manipulate positions, and a new test case to cover a text change scenario.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0ca1b7e</samp>

> _`FcsPos` subtracts_
> _Completion logic adapts_
> _Autumn of typos_

<!--
copilot:emoji
-->

🐛🧹➕

<!--
1.  🐛 for fixing a typo in the function name, which is a bug fix.
2.  🧹 for removing a commented out line of code, which is a cleanup or refactoring.
3.  ➕ for adding a new function, a new test case, and some code to improve the completion logic, which are enhancements or new features.
-->

### WHY

Addresses #1115 although I'm not entirely happy with this solution.

I stated in that issue the reason I went with "stale" type checks is it seemed to work really well for large files, keeping the autocomplete very snappy, for examples described below. However as the issue points out, this doesn't seem to work for certain cases, also described below.

Things it works for:

Tokens ending with ascii type characters.

`Async.`
`FSharp.Collections.Map.`.

Things it didn't work for.

`Path.GetExtension("foo").`
`[1;2;3].[0].`

Although the `TryGetCompletion` logs out the same exact thing whenever you trigger an autocomplete action through `.` or `ctrl+space` after typing a `.`, it seems to be based on the last parse or typecheck. It'll be a debugging effort to see what's going on in the F# Compiler to see why it works in some cases and doesn't in others.

With all that being said, this implementation does:

- Looks for the previous trigger character, and if it matches some type of brace character, require a full typecheck outright. Keeps it fast for items it can work for, and works when we can't fallback to that.
- Also sees if we found no items in autocomplete based off the stale typecheck, it will then retry with the full typecheck.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0ca1b7e</samp>

*  Fix a typo in the function name `mapWithAdditionalDependencies` in the `AMap` module ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-121aac933e527f4000be0ea4fd53e774e1c959dc4bba97637d768c42b8f074eeL290-R290))
*  Remove a commented out line of code in the `TryGetCompletions` method of the `ParseAndCheckResults` type ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-9fb9b45b77d929cc7b14a843f350fd52e6cd8734fc397572828c14098c31cef0L693))
*  Add a new function `subtractColumn` to the `FcsPos` module to manipulate F# compiler service positions ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-a0cc27b1398830cb3ce332015ecbd44c9649503474a0bfe34a6330dc04e99c55R19-R22))
*  Update the call to the `mapWithAdditionalDependencies` function in the `AdaptiveFSharpLspServer` type to reflect the name change ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L679-R679))
*  Rename some local variables in the `TextDocumentCompletion` method of the `AdaptiveFSharpLspServer` type to avoid confusion ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2286-R2290))
*  Modify the logic of the `TextDocumentCompletion` method of the `AdaptiveFSharpLspServer` type to handle completion requests from the client more robustly and efficiently ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2300-R2315), [link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2332-R2364))
   *  Introduce a new parameter `forceGetTypeCheckResultsStale` to the `getCompletions` function to get the type check results without waiting for a full type check ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2300-R2315))
   *  Add a new function `handleError` to the `getCompletions` function to retry the completion request with a different function to get the type check results, depending on the error message ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2300-R2315))
   *  Modify the call to the `retryAsyncOption` function to take the `handleError` function as an argument, and change the initial delay and number of retries ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2300-R2315))
   *  Move the logic of getting the `getAllSymbols` function inside the `getCompletions` function, and add a condition to check if the previous character requires a full type check ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2300-R2315))
   *  Add a check to ensure that the completion results are not empty, and return an error message if they are ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2300-R2315))
   *  Move the logic of getting the `decls`, `residue`, and `shouldKeywords` values from the `retryAsyncOption` function to the `getCompletions` function ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2332-R2364))
   *  Add a call to the `Debug.measure` function around the call to the `TryGetCompletions` method of the `typeCheckResults` value to measure the time taken ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2332-R2364))
   *  Add a call to the `Result.requireNotEmpty` function around the `decls` value, and return an error message if it is empty ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2332-R2364))
*  Replace the `testList` function with the `ftestList` function in the `tests` function of the `CompletionTests` module to filter the tests based on a predicate ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL32-R32))
*  Add a new test case to the `tests` function of the `CompletionTests` module to test the completion for the ending of a function call after a text change ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eR67-R145))
   *  Simulate the text change by sending a `TextDocumentDidChange` notification to the server with the appropriate parameters ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eR67-R145))
   *  Send a `TextDocumentCompletion` request to the server with the appropriate parameters ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eR67-R145))
   *  Expect to receive some completion suggestions from the server, and check that the first suggestion is "Chars" ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eR67-R145))
*  Add some code to the `Script.fsx` file to use the `System.IO.Path` type and its `GetDirectoryName` method, and add a dot character after the method call ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-3a55b10157397e040e1017cfd3f30b7846978f4ee1ba966859eafa3b513d7a7aR14-R16))
   *  The code is used to test the completion for the ending of a function call after a text change, as in the test case added in [link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eR67-R145) ([link](https://github.com/fsharp/FsAutoComplete/pull/1119/files?diff=unified&w=0#diff-3a55b10157397e040e1017cfd3f30b7846978f4ee1ba966859eafa3b513d7a7aR14-R16))
