### PR TITLE
guard against explicit getters/setters in Commands.GenerateXmlDocumentation

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1989,10 +1989,14 @@ type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers:
           { new SyntaxVisitorBase<_>() with
               member _.VisitBinding(_, defaultTraverse, synBinding) =
                 match synBinding with
-                | SynBinding(xmlDoc = xmlDoc) as s when
+                | SynBinding(xmlDoc = xmlDoc; valData = valData) as s when
                   rangeContainsPos s.RangeOfBindingWithoutRhs pos && xmlDoc.IsEmpty
                   ->
-                  Some()
+                  match valData with
+                  | SynValData(memberFlags = Some({ MemberKind = SynMemberKind.PropertyGet }))
+                  | SynValData(memberFlags = Some({ MemberKind = SynMemberKind.PropertySet }))
+                  | SynValData(memberFlags = Some({ MemberKind = SynMemberKind.PropertyGetSet })) -> None
+                  | _ -> Some()
                 | _ -> defaultTraverse synBinding
 
               member _.VisitComponentInfo(_, synComponentInfo) =

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -1605,6 +1605,43 @@ let private generateXmlDocumentationTests state =
           member val Name = "" with get, set
         """
 
+      testCaseAsync "not applicable for explicit getter and setter"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyClass() =
+          let mutable someField = ""
+          member _.Name
+            with $0get () = "foo"
+            and set (x: string) = someField <- x
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+
+      testCaseAsync "not applicable for explicit getter"
+
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyClass() =
+          member _.Name
+            with $0get () = "foo"
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+
+      testCaseAsync "not applicable for explicit setter"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        type MyClass() =
+          let mutable someField = ""
+          member _.Name
+            with s$0et (x: string) = someField <- x
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+
       testCaseAsync "documentation for named module"
       <| CodeFix.check
         server

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/ExpectoTests/ExpectoTests.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/ExpectoTests/ExpectoTests.fsproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Expecto" Version="9.*" />
-    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
+    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.13.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
     <PackageReference Update="FSharp.Core" Version="4.*" />
   </ItemGroup>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 88ad3de</samp>

This pull request improves the `GenerateXmlDocumentation` code fix to avoid generating invalid comments for properties with explicit getters and setters. It also adds tests to verify this behavior in `CodeFixTests`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 88ad3de</samp>

> _`GenerateXmlDocumentation`_
> _Fixes missing comments - but not_
> _For `get` and `set`_

<!--
copilot:emoji
-->

🛠️📝🧪

<!--
1.  🛠️ - This emoji represents a tool or a fix, and it can be used to indicate the code fix that adds XML documentation comments.
2.  📝 - This emoji represents a document or a note, and it can be used to indicate the XML documentation comments that are generated by the code fix.
3.  🧪 - This emoji represents a test or an experiment, and it can be used to indicate the test cases that verify the code fix.
-->

### WHY
XML comments are invalid on explicit getters and setters.
So guard against that.

Currently, properties (I mean the members themselves, not their getters/setters) with explicit getters or setters don't trigger the codefix, I'll try to fix that in a separate PR

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 88ad3de</samp>

*  Exclude properties with explicit getters and setters from the code fix for adding XML documentation ([link](https://github.com/fsharp/FsAutoComplete/pull/1124/files?diff=unified&w=0#diff-f030ffbad83492980d57dd555322c7d8e9f26a1986413d60384e0730f8f54dd7L1992-R1999))
* Add test cases for the code fix for adding XML documentation ([link](https://github.com/fsharp/FsAutoComplete/pull/1124/files?diff=unified&w=0#diff-76fc8863cc00a62068d47becebf42e1632f960d23fc5f85759060884583fe464R1608-R1644))
