### PR TITLE
offer "generate xml documentation" to properties with explicit getter/setter

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -2091,6 +2091,18 @@ type Commands(checker: FSharpCompilerServiceChecker, state: State, hasAnalyzers:
                                 rangeContainsPos ident.idRange pos && xmlDoc.IsEmpty
                                 ->
                                 Some()
+                              | SynMemberDefn.GetSetMember(
+                                  memberDefnForGet = Some(SynBinding(
+                                    xmlDoc = xmlDoc; headPat = SynPat.LongIdent(longDotId = longDotId)))) when
+                                rangeContainsPos longDotId.Range pos && xmlDoc.IsEmpty
+                                ->
+                                Some()
+                              | SynMemberDefn.GetSetMember(
+                                  memberDefnForSet = Some(SynBinding(
+                                    xmlDoc = xmlDoc; headPat = SynPat.LongIdent(longDotId = longDotId)))) when
+                                rangeContainsPos longDotId.Range pos && xmlDoc.IsEmpty
+                                ->
+                                Some()
                               | _ -> None)
                           | _ -> None)
                       | _ -> None)

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -1618,6 +1618,69 @@ let private generateXmlDocumentationTests state =
         Diagnostics.acceptAll
         selectCodeFix
 
+      testCaseAsync "documentation on property with explicit getter and setter"
+      <| CodeFix.check
+        server
+        """
+        type MyClass() =
+          let mutable someField = ""
+          member _.$0Name
+            with get () = "foo"
+            and set (x: string) = someField <- x
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        type MyClass() =
+          let mutable someField = ""
+          /// <summary></summary>
+          /// <returns></returns>
+          member _.Name
+            with get () = "foo"
+            and set (x: string) = someField <- x
+        """
+
+      testCaseAsync "documentation on property with explicit getter"
+      <| CodeFix.check
+        server
+        """
+        type MyClass() =
+          let mutable someField = ""
+          member _.$0Name
+            with get () = "foo"
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        type MyClass() =
+          let mutable someField = ""
+          /// <summary></summary>
+          /// <returns></returns>
+          member _.Name
+            with get () = "foo"
+        """
+
+      testCaseAsync "documentation on property with explicit setter"
+      <| CodeFix.check
+        server
+        """
+        type MyClass() =
+          let mutable someField = ""
+          member _.$0Name
+            with set (x: string) = someField <- x
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        type MyClass() =
+          let mutable someField = ""
+          /// <summary></summary>
+          /// <param name="x"></param>
+          /// <returns></returns>
+          member _.Name
+            with set (x: string) = someField <- x
+        """
+
       testCaseAsync "not applicable for explicit getter"
 
       <| CodeFix.checkNotApplicable


### PR DESCRIPTION
…/setter

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc258f7</samp>

This pull request enhances the code fix for adding documentation comments to properties with explicit getters or setters. It updates the `findNested` function in `src/FsAutoComplete.Core/Commands.fs` to handle long identifier patterns, and adds new test cases in `test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs` to verify the functionality.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cc258f7</samp>

> _`findNested` expands_
> _to handle long properties_
> _autumn of comments_

<!--
copilot:emoji
-->

📝🔧🧪

<!--
1.  📝 - This emoji represents documentation, writing, or editing, and can be used to indicate the change that adds a documentation comment to the property.
2.  🔧 - This emoji represents a tool, fixing, or adjusting, and can be used to indicate the change that implements a code fix for the empty documentation comment diagnostic.
3.  🧪 - This emoji represents a test, experiment, or science, and can be used to indicate the change that adds new test cases for the code fix functionality.
-->

### WHY
Greetings from the live session of Amplifying F# in Bingen :)
This fixes the "Generate XML Documentation" codefix/command to be also offered for type properties with explicit getter/setter

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc258f7</samp>

*  Add code fix for adding documentation comments to properties with explicit getters or setters ([link](https://github.com/fsharp/FsAutoComplete/pull/1126/files?diff=unified&w=0#diff-f030ffbad83492980d57dd555322c7d8e9f26a1986413d60384e0730f8f54dd7R2094-R2105))
*  Add test cases for the code fix in `test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1126/files?diff=unified&w=0#diff-76fc8863cc00a62068d47becebf42e1632f960d23fc5f85759060884583fe464R1621-R1683))
