### PR TITLE
Use of the now public Range propery of PreXmlDoc

### DIFF
--- a/src/FsAutoComplete/CodeFixes/AddMissingXmlDocumentation.fs
+++ b/src/FsAutoComplete/CodeFixes/AddMissingXmlDocumentation.fs
@@ -16,6 +16,7 @@ let private tryGetExistingXmlDoc (pos: FSharp.Compiler.Text.Position) (xmlDoc: P
   let tryGetSummaryIfContainsPos (xd: PreXmlDoc) =
     if rangeContainsPos xd.Range pos then
       let d = xd.ToXmlDoc(false, None)
+
       if Array.isEmpty d.UnprocessedLines then
         None
       elif d.UnprocessedLines |> Array.exists (fun s -> s.Contains("<summary>")) then

--- a/src/FsAutoComplete/CodeFixes/AddMissingXmlDocumentation.fs
+++ b/src/FsAutoComplete/CodeFixes/AddMissingXmlDocumentation.fs
@@ -14,13 +14,12 @@ let title = "Add missing XML documentation"
 
 let private tryGetExistingXmlDoc (pos: FSharp.Compiler.Text.Position) (xmlDoc: PreXmlDoc) =
   let tryGetSummaryIfContainsPos (xd: PreXmlDoc) =
-    let d = xd.ToXmlDoc(false, None)
-
-    if rangeContainsPos d.Range pos then
+    if rangeContainsPos xd.Range pos then
+      let d = xd.ToXmlDoc(false, None)
       if Array.isEmpty d.UnprocessedLines then
         None
       elif d.UnprocessedLines |> Array.exists (fun s -> s.Contains("<summary>")) then
-        Some(d.UnprocessedLines, d.Range)
+        Some(d.UnprocessedLines, xd.Range)
       else
         let lines =
           match d.UnprocessedLines with
@@ -28,7 +27,7 @@ let private tryGetExistingXmlDoc (pos: FSharp.Compiler.Text.Position) (xmlDoc: P
           | [| c |] -> [| $" <summary>%s{c.Trim()}</summary>" |]
           | cs -> [| yield " <summary>"; yield! cs; yield " </summary>" |]
 
-        Some(lines, d.Range)
+        Some(lines, xd.Range)
     else
       None
 

--- a/src/FsAutoComplete/CodeFixes/ConvertTripleSlashCommentToXmlTaggedDoc.fs
+++ b/src/FsAutoComplete/CodeFixes/ConvertTripleSlashCommentToXmlTaggedDoc.fs
@@ -16,6 +16,7 @@ let private containsPosAndNotEmptyAndNotElaborated (pos: FSharp.Compiler.Text.Po
   let containsPosAndNoSummaryPresent (xd: PreXmlDoc) =
     if rangeContainsPos xd.Range pos then
       let d = xd.ToXmlDoc(false, None)
+
       let summaryPresent =
         d.UnprocessedLines |> Array.exists (fun s -> s.Contains("<summary>"))
 

--- a/src/FsAutoComplete/CodeFixes/ConvertTripleSlashCommentToXmlTaggedDoc.fs
+++ b/src/FsAutoComplete/CodeFixes/ConvertTripleSlashCommentToXmlTaggedDoc.fs
@@ -14,9 +14,8 @@ let title = "Convert '///' comment to XML-tagged doc comment"
 
 let private containsPosAndNotEmptyAndNotElaborated (pos: FSharp.Compiler.Text.Position) (xmlDoc: PreXmlDoc) =
   let containsPosAndNoSummaryPresent (xd: PreXmlDoc) =
-    let d = xd.ToXmlDoc(false, None)
-
-    if rangeContainsPos d.Range pos then
+    if rangeContainsPos xd.Range pos then
+      let d = xd.ToXmlDoc(false, None)
       let summaryPresent =
         d.UnprocessedLines |> Array.exists (fun s -> s.Contains("<summary>"))
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e5b624e</samp>

The pull request optimizes the code that handles XML documentation for F# symbols in two files: `AddMissingXmlDocumentation.fs` and `ConvertTripleSlashCommentToXmlTaggedDoc.fs`. It avoids unnecessary computations and simplifies the access to the range of the `PreXmlDoc` nodes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e5b624e</samp>

> _Oh we are the coders of the F# sea_
> _And we write the docs in XML_
> _But we don't waste our time or memory_
> _We use `xd.Range` and `PreXmlDoc` well_

<!--
copilot:emoji
-->

🚀📝🧹

<!--
1.  🚀 - This emoji conveys the idea of improving performance or speed, which is one of the goals of this change.
2.  📝 - This emoji conveys the idea of writing or editing documentation, which is another aspect of this change.
3.  🧹 - This emoji conveys the idea of cleaning or simplifying code, which is also a result of this change.
-->

### WHY
Some time ago, the Range property of PreXmlDoc was made public. After updating fsc, we can now make use of it to save resources in some range checks.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e5b624e</samp>

* Optimize the computation of `XmlDoc` by moving it inside the `if` branch that checks the position range of the `PreXmlDoc` ([link](https://github.com/fsharp/FsAutoComplete/pull/1128/files?diff=unified&w=0#diff-844e93910ae20b60c4d58e328af924e7079638fb7296f2a6b42ff1902c1b69eaL17-R22), [link](https://github.com/fsharp/FsAutoComplete/pull/1128/files?diff=unified&w=0#diff-75db7c1b6de95a6957e56bb04bbbd3071099722cf5e26c56b0291b4cef2e3891L17-R18))
* Simplify the access to the position range by using `xd.Range` instead of `d.Range` in `AddMissingXmlDocumentation.fs` and `ConvertTripleSlashCommentToXmlTaggedDoc.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1128/files?diff=unified&w=0#diff-844e93910ae20b60c4d58e328af924e7079638fb7296f2a6b42ff1902c1b69eaL17-R22), [link](https://github.com/fsharp/FsAutoComplete/pull/1128/files?diff=unified&w=0#diff-844e93910ae20b60c4d58e328af924e7079638fb7296f2a6b42ff1902c1b69eaL31-R30), [link](https://github.com/fsharp/FsAutoComplete/pull/1128/files?diff=unified&w=0#diff-75db7c1b6de95a6957e56bb04bbbd3071099722cf5e26c56b0291b4cef2e3891L17-R18))
