### PR TITLE
Make ServerProgressReport threadsafe

### DIFF
--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -42,6 +42,7 @@ open System.Collections.Concurrent
 open System.Diagnostics
 open System.Text.RegularExpressions
 open IcedTasks
+open System.Threading.Tasks
 
 [<RequireQualifiedAccess>]
 type WorkspaceChosen =
@@ -712,8 +713,8 @@ type AdaptiveFSharpLspServer
 
             use progressReport = new ServerProgressReport(lspClient)
 
-            progressReport.Begin($"Loading {projects.Count} Projects")
-            |> Async.StartImmediate
+            progressReport.Begin ($"Loading {projects.Count} Projects") (CancellationToken.None)
+            |> ignore<Task<unit>>
 
             let projectOptions =
               loader.LoadProjects(projects |> Seq.map (fst >> UMX.untag) |> Seq.toList, [], binlogConfig)

--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fs
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fs
@@ -9,6 +9,8 @@ open FsAutoComplete.LspHelpers
 open System
 open System.Threading.Tasks
 open FsAutoComplete.Utils
+open System.Threading
+open IcedTasks
 
 
 type FSharpLspClient(sendServerNotification: ClientNotificationSender, sendServerRequest: ClientRequestSender) =
@@ -89,37 +91,77 @@ type FSharpLspClient(sendServerNotification: ClientNotificationSender, sendServe
 
 
 
+/// <summary>
+/// An awaitable wrapper around a task whose result is disposable. The wrapper is not disposable, so this prevents usage errors like "use _lock = myAsync()" when the appropriate usage should be "use! _lock = myAsync())".
+/// </summary>
+[<Struct>]
+type AwaitableDisposable<'T when 'T :> IDisposable>(t: Task<'T>) =
+  member x.GetAwaiter() = t.GetAwaiter()
+  member x.AsTask() = t
+  static member op_Implicit(source: AwaitableDisposable<'T>) = source.AsTask()
+
+[<AutoOpen>]
+module private SemaphoreSlimExtensions =
+  // Based on https://gist.github.com/StephenCleary/7dd1c0fc2a6594ba0ed7fb7ad6b590d6
+  // and https://gist.github.com/brendankowitz/5949970076952746a083054559377e56
+  type SemaphoreSlim with
+
+    member x.LockAsync(?ct: CancellationToken) =
+      AwaitableDisposable(
+        task {
+          let ct = defaultArg ct CancellationToken.None
+          let t = x.WaitAsync(ct)
+
+          do! t
+
+          return
+            { new IDisposable with
+                member _.Dispose() =
+                  // only release if the task completed successfully
+                  // otherwise, we could be releasing a semaphore that was never acquired
+                  if t.Status = TaskStatus.RanToCompletion then
+                    x.Release() |> ignore }
+        }
+      )
+
 type ServerProgressReport(lspClient: FSharpLspClient, ?token: ProgressToken) =
 
-  let mutable canReportProgress = true
+  let mutable canReportProgress = false
   let mutable endSent = false
+
+  let locker = new SemaphoreSlim(1, 1)
 
   member val Token = defaultArg token (ProgressToken.Second((Guid.NewGuid().ToString())))
 
   member x.Begin(title, ?cancellable, ?message, ?percentage) =
-    async {
-      let! result = lspClient.WorkDoneProgressCreate x.Token
+    cancellableTask {
+      use! __ = fun ct -> locker.LockAsync(ct)
 
-      match result with
-      | Ok() -> ()
-      | Error e -> canReportProgress <- false
+      if not endSent then
+        let! result = lspClient.WorkDoneProgressCreate x.Token
 
-      if canReportProgress then
-        do!
-          lspClient.Progress(
-            x.Token,
-            WorkDoneProgressBegin.Create(
-              title,
-              ?cancellable = cancellable,
-              ?message = message,
-              ?percentage = percentage
+        match result with
+        | Ok() -> canReportProgress <- true
+        | Error e -> canReportProgress <- false
+
+        if canReportProgress then
+          do!
+            lspClient.Progress(
+              x.Token,
+              WorkDoneProgressBegin.Create(
+                title,
+                ?cancellable = cancellable,
+                ?message = message,
+                ?percentage = percentage
+              )
             )
-          )
     }
 
   member x.Report(?cancellable, ?message, ?percentage) =
-    async {
-      if canReportProgress then
+    cancellableTask {
+      use! __ = fun ct -> locker.LockAsync(ct)
+
+      if canReportProgress && not endSent then
         do!
           lspClient.Progress(
             x.Token,
@@ -128,14 +170,18 @@ type ServerProgressReport(lspClient: FSharpLspClient, ?token: ProgressToken) =
     }
 
   member x.End(?message) =
-    async {
-      if canReportProgress && not endSent then
+    cancellableTask {
+      use! __ = fun ct -> locker.LockAsync(ct)
+      let stillNeedsToSend = canReportProgress && not endSent
+      endSent <- true
+
+      if stillNeedsToSend then
         do! lspClient.Progress(x.Token, WorkDoneProgressEnd.Create(?message = message))
-        endSent <- true
     }
 
   interface IAsyncDisposable with
-    member x.DisposeAsync() = task { do! x.End() } |> ValueTask
+    member x.DisposeAsync() =
+      task { do! x.End () (CancellationToken.None) } |> ValueTask
 
   interface IDisposable with
     member x.Dispose() =


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e12738</samp>

This pull request improves the cancellation and progress reporting of long-running tasks in the LSP servers. It introduces a new computation expression for `AdaptiveFSharpLspServer` and refactors the existing logic in `FSharpLspClient` to use async tasks and semaphores.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2e12738</samp>

> _We're refactoring code with a new computation_
> _To handle cancellation and progress of our mission_
> _We'll use async tasks and tokens and semaphores_
> _And send our LSP messages as we sail the shores_

<!--
copilot:emoji
-->

🔄🚀🛠️

<!--
1.  🔄 - This emoji represents the refactoring of existing code to use a different approach or structure. It can also imply improving the performance or readability of the code.
2.  🚀 - This emoji represents the improvement of the responsiveness and speed of the LSP server and client by using async tasks, cancellation tokens, and semaphores. It can also imply enhancing the user experience or functionality of the LSP features.
3.  🛠️ - This emoji represents the fixing of a missing or incorrect namespace import, which could cause compilation errors or unexpected behavior. It can also imply resolving a bug or issue in the code.
-->

### WHY

It's possible for the progress report to get out of sync with reality, it will show the progress dialogue box with no way to close it because it's possible to send Begin after End.  This resolves that.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e12738</samp>

*  Refactor progress reporting to use `cancellableTask` and `locker` semaphore for consistency and cancellation support ([link](https://github.com/fsharp/FsAutoComplete/pull/1130/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L715-R716), [link](https://github.com/fsharp/FsAutoComplete/pull/1130/files?diff=unified&w=0#diff-8ff27bd6886726bcfabce64ed8bac2ba936954fbf00e2c4d3e9c642a663c172aL97-R162), [link](https://github.com/fsharp/FsAutoComplete/pull/1130/files?diff=unified&w=0#diff-8ff27bd6886726bcfabce64ed8bac2ba936954fbf00e2c4d3e9c642a663c172aL131-R180))
* Add `AwaitableDisposable` type and `LockAsync` extension method for `SemaphoreSlim` to handle async disposables safely and conveniently ([link](https://github.com/fsharp/FsAutoComplete/pull/1130/files?diff=unified&w=0#diff-8ff27bd6886726bcfabce64ed8bac2ba936954fbf00e2c4d3e9c642a663c172aR94-R126))
* Add namespace imports for `System.Threading.Tasks`, `System.Threading`, and `IcedTasks` to use `Task`, `CancellationToken`, and `cancellableTask` types and methods ([link](https://github.com/fsharp/FsAutoComplete/pull/1130/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0R45), [link](https://github.com/fsharp/FsAutoComplete/pull/1130/files?diff=unified&w=0#diff-8ff27bd6886726bcfabce64ed8bac2ba936954fbf00e2c4d3e9c642a663c172aR12-R13))
