### PR TITLE
Swap maybe for option CEs

### DIFF
--- a/src/FsAutoComplete.Core/AbstractClassStubGenerator.fs
+++ b/src/FsAutoComplete.Core/AbstractClassStubGenerator.fs
@@ -98,7 +98,7 @@ let tryFindAbstractClassExprInBufferAtPos
   (pos: Position)
   (document: IFSACSourceText)
   =
-  asyncMaybe {
+  asyncOption {
     let! parseResults = codeGenService.ParseFileInProject document.FileName
     return! tryFindAbstractClassExprInParsedInput pos parseResults.ParseTree
   }

--- a/src/FsAutoComplete.Core/CodeGeneration.fs
+++ b/src/FsAutoComplete.Core/CodeGeneration.fs
@@ -53,7 +53,7 @@ type CodeGenerationService(checker: FSharpCompilerServiceChecker, state: State) 
       }
 
     override x.GetSymbolAndUseAtPositionOfKind(fileName, pos: Position, kind) =
-      asyncMaybe {
+      asyncOption {
         let! symbol = (x :> ICodeGenerationService).GetSymbolAtPosition(fileName, pos)
 
         if symbol.Kind = kind then

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -523,6 +523,8 @@ module RoslynSourceText =
         new Object() with
           override _.ToString() = sourceText.ToString()
 
+          override _.Equals(x) = sourceText.Equals(x)
+
           override _.GetHashCode() =
             let checksum = sourceText.GetChecksum()
 

--- a/src/FsAutoComplete.Core/InlayHints.fs
+++ b/src/FsAutoComplete.Core/InlayHints.fs
@@ -556,7 +556,7 @@ let private rangeOfNamedPat (text: IFSACSourceText) (pat: SynPat) =
   match pat with
   | SynPat.Named(accessibility = None) -> pat.Range
   | SynPat.Named(ident = SynIdent(ident = ident); accessibility = Some(access)) ->
-    maybe {
+    option {
       let start = ident.idRange.Start
       let! line = text.GetLine start
 
@@ -706,7 +706,7 @@ let tryGetExplicitTypeInfo (text: IFSACSourceText, ast: ParsedInput) (pos: Posit
           //      * `let f2 = fun (Value v) -> v + 1`
           //        -> compiler generated `_arg1` in `args`,
           //           and `v` is inside match expression in `body` & `parsedData` (-> `SynPat` )
-          maybe {
+          option {
             let! pat = pats |> List.tryFind (fun p -> rangeContainsPos p.Range pos)
 
             let rec tryGetIdent pat =
@@ -861,7 +861,7 @@ let tryGetDetailedExplicitTypeInfo
   (text: IFSACSourceText, parseAndCheck: ParseAndCheckResults)
   (pos: Position)
   =
-  maybe {
+  option {
     let! line = text.GetLine pos
     let! symbolUse = parseAndCheck.TryGetSymbolUse pos line
 

--- a/src/FsAutoComplete.Core/RecordStubGenerator.fs
+++ b/src/FsAutoComplete.Core/RecordStubGenerator.fs
@@ -72,7 +72,7 @@ type RecordStubsInsertionParams =
             Some(fieldInfo, indentColumn, fieldLine)
           | _ -> None)
 
-      maybe {
+      option {
         let! maxLineIdx =
           fieldAndStartColumnAndLineIdxList
           |> List.unzip3
@@ -212,7 +212,7 @@ let walkAndFindRecordBinding (pos, input) =
   SyntaxTraversal.Traverse(pos, input, walker)
 
 let tryFindRecordExprInBufferAtPos (codeGenService: ICodeGenerationService) (pos: Position) (document: Document) =
-  asyncMaybe {
+  asyncOption {
     let! parseResults = codeGenService.ParseFileInProject(document.FullName)
 
     let! found = walkAndFindRecordBinding (pos, parseResults.ParseTree)
@@ -270,7 +270,7 @@ let shouldGenerateRecordStub (recordExpr: RecordExpr) (entity: FSharpEntity) =
   fieldCount > 0 && writtenFieldCount < fieldCount
 
 let tryFindRecordDefinitionFromPos (codeGenService: ICodeGenerationService) (pos: Position) (document: Document) =
-  asyncMaybe {
+  asyncOption {
     let! recordExpression, insertionPos = tryFindStubInsertionParamsAtPos codeGenService pos document
 
     let! symbol, symbolUse =

--- a/src/FsAutoComplete.Core/SignatureHelp.fs
+++ b/src/FsAutoComplete.Core/SignatureHelp.fs
@@ -33,11 +33,11 @@ let private getSignatureHelpForFunctionApplication
     endOfPreviousIdentPos: Position,
     lines: IFSACSourceText
   ) : Async<SignatureHelpInfo option> =
-  asyncMaybe {
+  asyncOption {
     let! lineStr = lines.GetLine endOfPreviousIdentPos
 
     let! possibleApplicationSymbolEnd =
-      maybe {
+      option {
         if tyRes.GetParseResults.IsPosContainedInApplicationPatched endOfPreviousIdentPos then
           let! funcRange = tyRes.GetParseResults.TryRangeOfFunctionOrMethodBeingAppliedPatched endOfPreviousIdentPos
           return funcRange.End
@@ -130,7 +130,7 @@ let private getSignatureHelpForMethod
     lines: IFSACSourceText,
     triggerChar
   ) =
-  asyncMaybe {
+  asyncOption {
     let! paramLocations = tyRes.GetParseResults.FindParameterLocations caretPos
     let names = paramLocations.LongId
     let lidEnd = paramLocations.LongIdEndLocation

--- a/src/FsAutoComplete.Core/UnionPatternMatchCaseGenerator.fs
+++ b/src/FsAutoComplete.Core/UnionPatternMatchCaseGenerator.fs
@@ -8,6 +8,7 @@ open FSharp.Compiler.Text
 open FSharp.Compiler.Syntax
 open FsAutoComplete.CodeGenerationUtils
 open FSharp.Compiler.Symbols
+open FsToolkit.ErrorHandling
 
 [<NoEquality; NoComparison>]
 type PatternMatchExpr =
@@ -375,7 +376,7 @@ let shouldGenerateUnionPatternMatchCases (patMatchExpr: PatternMatchExpr) (entit
   caseCount > 0 && writtenCaseCount < caseCount
 
 let tryFindPatternMatchExprInBufferAtPos (codeGenService: ICodeGenerationService) (pos: Position) (document: Document) =
-  asyncMaybe {
+  asyncOption {
     let! parseResults = codeGenService.ParseFileInProject(document.FullName)
     let input = parseResults.ParseTree
     return! tryFindPatternMatchExprInParsedInput pos input
@@ -494,7 +495,7 @@ let checkThatPatternMatchExprEndsWithCompleteClause (expr: PatternMatchExpr) =
 
 
 let tryFindCaseInsertionParamsAtPos (codeGenService: ICodeGenerationService) pos document =
-  asyncMaybe {
+  asyncOption {
     let! patMatchExpr = tryFindPatternMatchExprInBufferAtPos codeGenService pos document
 
     if checkThatPatternMatchExprEndsWithCompleteClause patMatchExpr then
@@ -505,13 +506,13 @@ let tryFindCaseInsertionParamsAtPos (codeGenService: ICodeGenerationService) pos
   }
 
 let tryFindUnionDefinitionFromPos (codeGenService: ICodeGenerationService) pos document =
-  asyncMaybe {
+  asyncOption {
     let! patMatchExpr, insertionParams = tryFindCaseInsertionParamsAtPos codeGenService pos document
     let! symbol, symbolUse = codeGenService.GetSymbolAndUseAtPositionOfKind(document.FullName, pos, SymbolKind.Ident)
 
 
     let! superficialTypeDefinition =
-      asyncMaybe {
+      asyncOption {
         let! symbolUse = symbolUse
 
         match symbolUse.Symbol with

--- a/src/FsAutoComplete/CodeFixes/AddExplicitTypeAnnotation.fs
+++ b/src/FsAutoComplete/CodeFixes/AddExplicitTypeAnnotation.fs
@@ -30,7 +30,7 @@ let private isPositionContainedInUntypedImplicitCtorParameter input pos =
           member _.VisitModuleDecl(_, defaultTraverse, decl) =
             match decl with
             | SynModuleDecl.Types(typeDefns = typeDefns) ->
-              maybe {
+              option {
                 let! ctorArgs =
                   typeDefns
                   |> List.tryPick (function


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44a49a8</samp>

This pull request refactors several modules in the FsAutoComplete.Core project to use the `FSharpSymbolUse` type and the `FsToolkit.ErrorHandling` library, which simplify the code and improve the error handling logic. It also removes some unused or redundant code, and adds an equality override for the `Hash` type.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 44a49a8</samp>

> _Sing, O Muse, of the valiant deeds of the F# coders,_
> _Who refactored their code with skill and wisdom divine,_
> _Replacing `asyncMaybe` with `asyncOption`, the solver_
> _Of optional woes, and `FSharpSymbolUse`, the sublime._

<!--
copilot:emoji
-->

🔄🧹🛠️

<!--
1.  🔄 - This emoji indicates a refactoring or restructuring of the code, without changing its functionality or behavior.
2.  🧹 - This emoji indicates a cleanup or removal of unused or redundant code, or a simplification of the code.
3.  🛠️ - This emoji indicates a fix or improvement of the code, or a addition of a new feature or functionality.
-->

### WHY

Just delegating to FsToolkit for this stuff now

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 44a49a8</samp>

*  Replaced `asyncMaybe` computation expression with `asyncOption` from `FsToolkit.ErrorHandling` library for more consistent and convenient handling of optional values in async workflows ([link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-4062aa4dad0c4680ba9c353064ecfdf500e884b5d5838792009ec670c289633aL101-R101), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-542241253f952a50c96405c20d8c10c40f23bf3d330bc8ea0310e0dc80179fe2L56-R56), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-b6395f63a994db1807e01fe8b1bb75322e6f998630ff9db0539d5a0c7c486604L559-R559), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-b6395f63a994db1807e01fe8b1bb75322e6f998630ff9db0539d5a0c7c486604L709-R709), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-b6395f63a994db1807e01fe8b1bb75322e6f998630ff9db0539d5a0c7c486604L864-R864), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-f746a118999735f5f43f7a0f9f6ba23aad83278ebf69b9acb16720176ebc6e84L75-R75), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-f746a118999735f5f43f7a0f9f6ba23aad83278ebf69b9acb16720176ebc6e84L215-R215), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-f746a118999735f5f43f7a0f9f6ba23aad83278ebf69b9acb16720176ebc6e84L273-R273), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-eba3b23ba360ad506d15e56d3bf96a0f2e88a1686c7d64e7416535eccc7481b8L36-R40), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-eba3b23ba360ad506d15e56d3bf96a0f2e88a1686c7d64e7416535eccc7481b8L133-R133), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-b40fcb605a7f8cfbeaf74740eaf5c838b718d870f432e30f66aedaa9fda4f9ccL378-R379), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-b40fcb605a7f8cfbeaf74740eaf5c838b718d870f432e30f66aedaa9fda4f9ccL497-R498), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-b40fcb605a7f8cfbeaf74740eaf5c838b718d870f432e30f66aedaa9fda4f9ccL508-R509), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-b40fcb605a7f8cfbeaf74740eaf5c838b718d870f432e30f66aedaa9fda4f9ccL514-R515))
* Added an override for the `Equals` method to the `Hash` type in `FileSystem.fs` to implement equality comparison for `IFSACSourceText` values ([link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-7c1d3328baa270a7e1450113731e5f1fe55cce453db26186a346965e4b66e981R526-R527))
* Added an open statement for `FsToolkit.ErrorHandling` library in `UnionPatternMatchCaseGenerator.fs` to use the `asyncOption` computation expression and other utilities for error handling in F# ([link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-b40fcb605a7f8cfbeaf74740eaf5c838b718d870f432e30f66aedaa9fda4f9ccR11))
* Removed the `MaybeBuilder` and `AsyncMaybeBuilder` types and the `maybe` and `asyncMaybe` values from the `Utils` module, and removed the `asyncMaybe` and `maybe` values from the `String` module, as they were replaced by the `option` and `asyncOption` values from the `FsToolkit.ErrorHandling` library ([link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-9af59b386f0d6d11954514dbf9d61c88cb09fbed23c39b4412f5e7c5a63b32a6L254-R252), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-9af59b386f0d6d11954514dbf9d61c88cb09fbed23c39b4412f5e7c5a63b32a6L734-L735))
* Removed some empty lines from the `ProcessHelper` module in `Utils.fs` and the `List` module in `Utils.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-9af59b386f0d6d11954514dbf9d61c88cb09fbed23c39b4412f5e7c5a63b32a6L79-L80), [link](https://github.com/fsharp/FsAutoComplete/pull/1131/files?diff=unified&w=0#diff-9af59b386f0d6d11954514dbf9d61c88cb09fbed23c39b4412f5e7c5a63b32a6L536-L538))
