### PR TITLE
Add codefix for redundant attribute suffix.

### DIFF
--- a/src/FsAutoComplete/CodeFixes/RemoveRedundantAttributeSuffix.fs
+++ b/src/FsAutoComplete/CodeFixes/RemoveRedundantAttributeSuffix.fs
@@ -1,0 +1,53 @@
+﻿module FsAutoComplete.CodeFix.RemoveRedundantAttributeSuffix
+
+open FSharp.Compiler.Syntax
+open FsToolkit.ErrorHandling
+open FsAutoComplete.CodeFix.Types
+open Ionide.LanguageServerProtocol.Types
+open FsAutoComplete
+open FsAutoComplete.LspHelpers
+
+let title = "Remove redundant attribute suffix"
+
+let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
+  fun codeActionParams ->
+    asyncResult {
+      let filePath = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
+      let fcsPos = protocolPosToPos codeActionParams.Range.Start
+      let! parseAndCheck, _, _ = getParseResultsForFile filePath fcsPos
+
+      let isAttributeWithRedundantSuffix =
+        SyntaxTraversal.Traverse(
+          fcsPos,
+          parseAndCheck.GetParseResults.ParseTree,
+          { new SyntaxVisitorBase<_>() with
+              member _.VisitAttributeApplication(path, attributes) =
+                let attributesWithRedundantSuffix =
+                  attributes.Attributes
+                  |> List.choose (fun a ->
+                    match List.tryLast a.TypeName.LongIdent with
+                    | Some ident when ident.idText.EndsWith("Attribute") -> Some ident
+                    | _ -> None)
+
+                if List.isEmpty attributesWithRedundantSuffix then
+                  None
+                else
+                  Some attributesWithRedundantSuffix }
+        )
+
+      match isAttributeWithRedundantSuffix with
+      | None -> return []
+      | Some redundantSuffixIdents ->
+        return
+          redundantSuffixIdents
+          |> List.map (fun ident ->
+            let updateText = ident.idText.Replace("Attribute", "")
+
+            { Edits =
+                [| { Range = fcsRangeToLsp ident.idRange
+                     NewText = updateText } |]
+              File = codeActionParams.TextDocument
+              Title = title
+              SourceDiagnostic = None
+              Kind = FixKind.Refactor })
+    }

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1686,6 +1686,7 @@ type AdaptiveFSharpLspServer
          ConvertPositionalDUToNamed.fix tryGetParseResultsForFile getRangeText
          ConvertTripleSlashCommentToXmlTaggedDoc.fix tryGetParseResultsForFile getRangeText
          GenerateXmlDocumentation.fix tryGetParseResultsForFile
+         RemoveRedundantAttributeSuffix.fix tryGetParseResultsForFile
          Run.ifEnabled
            (fun _ -> config.AddPrivateAccessModifier)
            (AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace)

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -1223,6 +1223,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient, sourceTextFactory
              ConvertPositionalDUToNamed.fix tryGetParseResultsForFile getRangeText
              ConvertTripleSlashCommentToXmlTaggedDoc.fix tryGetParseResultsForFile getRangeText
              GenerateXmlDocumentation.fix tryGetParseResultsForFile
+             RemoveRedundantAttributeSuffix.fix tryGetParseResultsForFile
              Run.ifEnabled
                (fun _ -> config.AddPrivateAccessModifier)
                (AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace)


### PR DESCRIPTION

![RedundantAttributeSuffix](https://github.com/fsharp/FsAutoComplete/assets/2621499/d0cdce13-5c0a-4ea7-b70a-f71d2db50441)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e3f0fd7</samp>

This pull request adds a new code fix for removing redundant "Attribute" suffixes from F# attribute applications. The code fix is implemented in the `RemoveRedundantAttributeSuffix` module and registered with both the `AdaptiveFSharpLspServer` and the `FSharpLspServer` types. The code fix is also tested in the `test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e3f0fd7</samp>

> _`Attribute` suffix_
> _Trimmed by a code fixer_
> _Autumn leaves falling_

<!--
copilot:emoji
-->

🛠️📝🧪

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate the addition of a new code fix module and function.
2.  📝 - This emoji represents a document or a text, and can be used to indicate the modification of the language server protocol implementation and the code fix list.
3.  🧪 - This emoji represents a test or an experiment, and can be used to indicate the introduction of new tests for the code fix.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e3f0fd7</samp>

*  Add a new code fix for removing redundant attribute suffixes ([link](https://github.com/fsharp/FsAutoComplete/pull/1132/files?diff=unified&w=0#diff-fd6b9d9451b19ceb3508e84206446a254af0347d5ef42bb39ad6460daa8ed7aaR1-R53))
* Enable the code fix for both language server implementations ([link](https://github.com/fsharp/FsAutoComplete/pull/1132/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0R1689), [link](https://github.com/fsharp/FsAutoComplete/pull/1132/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01R1226))
* Add test cases for the code fix ([link](https://github.com/fsharp/FsAutoComplete/pull/1132/files?diff=unified&w=0#diff-76fc8863cc00a62068d47becebf42e1632f960d23fc5f85759060884583fe464R2780-R2875), [link](https://github.com/fsharp/FsAutoComplete/pull/1132/files?diff=unified&w=0#diff-76fc8863cc00a62068d47becebf42e1632f960d23fc5f85759060884583fe464R2918))
