### PR TITLE
Fix range handling for code completion in interpolated strings

### DIFF
--- a/src/FsAutoComplete.Core/UntypedAstUtils.fs
+++ b/src/FsAutoComplete.Core/UntypedAstUtils.fs
@@ -684,11 +684,25 @@ module Completion =
               | SynExpr.Const(SynConst.String _, _) -> Some Context.StringLiteral
               | SynExpr.InterpolatedString(parts, _, _) ->
                 parts
-                |> List.tryPick (function
-                  | SynInterpolatedStringPart.String(s, m) when Range.rangeContainsPos m pos ->
+                |> List.indexed
+                |> List.tryPick (fun (i, part) ->
+                  let inRangeOfPrevious =
+                    if i = 0 then
+                      false
+                    else
+                      // With no space between FillExpr and }..." of interpolated string,
+                      // there will be a range clash.
+                      match List.item (i - 1) parts with
+                      | SynInterpolatedStringPart.String(_, m) -> Range.rangeContainsPos m pos
+                      | SynInterpolatedStringPart.FillExpr(e, _) -> Range.rangeContainsPos e.Range pos
+
+                  match part with
+                  | SynInterpolatedStringPart.String(s, m) when Range.rangeContainsPos m pos && not inRangeOfPrevious ->
                     Some Context.StringLiteral
                   | SynInterpolatedStringPart.String _ -> None
-                  | SynInterpolatedStringPart.FillExpr(e, _) when Range.rangeContainsPos e.Range pos ->
+                  | SynInterpolatedStringPart.FillExpr(e, _) when
+                    Range.rangeContainsPos e.Range pos && not inRangeOfPrevious
+                    ->
                     defaultTraverse e // gotta dive into the expr to see if we're in a literal inside the expr
                   | SynInterpolatedStringPart.FillExpr _ -> None)
               | _ -> defaultTraverse expr

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -473,7 +473,7 @@ let tests state =
       } |> AsyncResult.bimap id (fun e -> failwithf "%O" e))
 
       testCaseAsync
-        "completion in interpolated string at start of line"
+        "completion in interpolated string"
         (async {
           let! server, path = server
 
@@ -501,7 +501,7 @@ let tests state =
         })
 
       testCaseAsync
-        "completion in interpolated string at start of line 2"
+        "completion in interpolated string with whitespace"
         (async {
           let! server, path = server
 

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -470,7 +470,63 @@ let tests state =
         Expect.equal resolved.Label "CancellationToken" "Just making sure we're on the right member, one that should have backticks"
         Expect.equal resolved.Detail (Some "property Async.CancellationToken: Async<System.Threading.CancellationToken> with get") "Signature shouldn't have backticks"
 
-      } |> AsyncResult.bimap id (fun e -> failwithf "%O" e))]
+      } |> AsyncResult.bimap id (fun e -> failwithf "%O" e))
+
+      testCaseAsync
+        "completion in interpolated string at start of line"
+        (async {
+          let! server, path = server
+
+          let completionParams: CompletionParams =
+            { TextDocument = { Uri = Path.FilePathToUri path }
+              Position = { Line = 23; Character = 8 } // the '.' in 'List.'
+              Context =
+                Some
+                  { triggerKind = CompletionTriggerKind.TriggerCharacter
+                    triggerCharacter = Some '.' } }
+
+          let! response = server.TextDocumentCompletion completionParams
+
+          match response with
+          | Ok (Some completions) ->
+            Expect.equal completions.Items.Length 106 "at time of writing the List module has 106 exposed members"
+            let firstItem = completions.Items.[0]
+
+            Expect.equal
+              firstItem.Label
+              "Empty"
+              "first member should be List.Empty, since properties are preferred over functions"
+          | Ok None -> failtest "Should have gotten some completion items"
+          | Error e -> failtestf "Got an error while retrieving completions: %A" e
+        })
+
+      testCaseAsync
+        "completion in interpolated string at start of line 2"
+        (async {
+          let! server, path = server
+
+          let completionParams: CompletionParams =
+            { TextDocument = { Uri = Path.FilePathToUri path }
+              Position = { Line = 24; Character = 9 } // the '.' in 'List.'
+              Context =
+                Some
+                  { triggerKind = CompletionTriggerKind.TriggerCharacter
+                    triggerCharacter = Some '.' } }
+
+          let! response = server.TextDocumentCompletion completionParams
+
+          match response with
+          | Ok (Some completions) ->
+            Expect.equal completions.Items.Length 106 "at time of writing the List module has 106 exposed members"
+            let firstItem = completions.Items.[0]
+
+            Expect.equal
+              firstItem.Label
+              "Empty"
+              "first member should be List.Empty, since properties are preferred over functions"
+          | Ok None -> failtest "Should have gotten some completion items"
+          | Error e -> failtestf "Got an error while retrieving completions: %A" e
+        })]
 
 ///Tests for getting autocomplete
 let autocompleteTest state =

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Completion/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Completion/Script.fsx
@@ -20,3 +20,6 @@ Path.GetDirectoryName("foo")
 
 [1;2;3].
 [1;2;3]
+
+$"{List.}"
+$"{ List. }"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a165188</samp>

This pull request fixes a bug in the completion logic for interpolated strings and adds tests to verify the fix. It modifies the `UntypedAstUtils.fs` file to handle overlapping ranges of interpolated string parts, and the `CompletionTests.fs` and `Script.fsx` files to add two test cases using the `List` module.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a165188</samp>

> _Fix `interpolated`_
> _Completion logic bug in_
> _Autumn of F Sharp_

<!--
copilot:emoji
-->

🐛🧪📝

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the first change.
2.  🧪 - This emoji represents a test, which is what the second change adds to the project.
3.  📝 - This emoji represents a documentation or comment, which is what the third change modifies in the sample script file.
-->

### WHY
The range for the `DiscardAfterMissingQualificationAfterDot` overlaps with the rest of the string in `$"{List.}"`, but doesn't in `$"{ 
List. }"`. Potentially the real fix should be a change to that range instead, but I don't know enough about the AST to know whether that is the right call.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a165188</samp>

* Fix bug in completion logic for interpolated strings by adding index to parts list and checking previous part range ([link](https://github.com/fsharp/FsAutoComplete/pull/1133/files?diff=unified&w=0#diff-2e5ef02a47ec733c8f436600c4c3f8f08eebf8cd87fff68fec8545b9c6321777L687-R705))
* Add test cases for completion in interpolated strings using `testCaseAsync` and `Script.fsx` ([link](https://github.com/fsharp/FsAutoComplete/pull/1133/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL473-R530), [link](https://github.com/fsharp/FsAutoComplete/pull/1133/files?diff=unified&w=0#diff-3a55b10157397e040e1017cfd3f30b7846978f4ee1ba966859eafa3b513d7a7aR23-R25))

Related to #962, but doesn't completely fix it.
