### PR TITLE
Add module to SemanticTokenTypes

### DIFF
--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -465,6 +465,7 @@ module ClassificationUtils =
     /// computation expressions
     | Cexpr = 23
     | Text = 24
+    | Module = 25
 
   [<RequireQualifiedAccess; Flags>]
   type SemanticTokenModifier =
@@ -502,7 +503,7 @@ module ClassificationUtils =
     | SemanticClassificationType.Property -> SemanticTokenTypes.Property, []
     | SemanticClassificationType.MutableVar
     | SemanticClassificationType.MutableRecordField -> SemanticTokenTypes.Member, [ SemanticTokenModifier.Mutable ]
-    | SemanticClassificationType.Module
+    | SemanticClassificationType.Module -> SemanticTokenTypes.Module, []
     | SemanticClassificationType.Namespace -> SemanticTokenTypes.Namespace, []
     | SemanticClassificationType.Printf -> SemanticTokenTypes.Regexp, []
     | SemanticClassificationType.ComputationExpression -> SemanticTokenTypes.Cexpr, []

--- a/test/FsAutoComplete.Tests.Lsp/HighlightingTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/HighlightingTests.fs
@@ -148,4 +148,4 @@ let tests state =
           tokenIsOfType (3, 52) ClassificationUtils.SemanticTokenTypes.Type fullHighlights // the `string` type annotation in the PooPoo srtp member
           tokenIsOfType (6, 21) ClassificationUtils.SemanticTokenTypes.EnumMember fullHighlights // the `PeePee` AP application in the `yeet` function definition
           tokenIsOfType (9, 10) ClassificationUtils.SemanticTokenTypes.Type fullHighlights //the `SomeJson` type alias should be a type
-          tokenIsOfType (15, 2) ClassificationUtils.SemanticTokenTypes.Namespace fullHighlights ] ] // tests that module coloration isn't overwritten by function coloration when a module function is used, so Foo in Foo.x should be module-colored
+          tokenIsOfType (15, 2) ClassificationUtils.SemanticTokenTypes.Module fullHighlights ] ] // tests that module coloration isn't overwritten by function coloration when a module function is used, so Foo in Foo.x should be module-colored


### PR DESCRIPTION
Turns out https://github.com/fsharp/FsAutoComplete/issues/1129 was a bit of a mapping issue.

After this PR:
![image](https://github.com/fsharp/FsAutoComplete/assets/2621499/3af88e4f-e744-4812-9f6f-d38effe64182)

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7efae73</samp>

This pull request enhances semantic tokens support for F# in LSP clients by adding a new token type for modules and updating the classification logic. This affects the file `src/FsAutoComplete/LspHelpers.fs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7efae73</samp>

> _F# modules shine_
> _`SemanticTokenTypes` grow_
> _Autumn of code_

<!--
copilot:emoji
-->

🎨🔎🚀

<!--
1.  🎨 for improving syntax highlighting and visual appearance
2.  🔎 for enhancing code analysis and navigation
3.  🚀 for adding a new feature or functionality
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7efae73</samp>

*  Add a new semantic token type for modules ([link](https://github.com/fsharp/FsAutoComplete/pull/1137/files?diff=unified&w=0#diff-a0cc27b1398830cb3ce332015ecbd44c9649503474a0bfe34a6330dc04e99c55R468))
*  Map F# module classification to the new token type ([link](https://github.com/fsharp/FsAutoComplete/pull/1137/files?diff=unified&w=0#diff-a0cc27b1398830cb3ce332015ecbd44c9649503474a0bfe34a6330dc04e99c55L505-R506))
