### PR TITLE
Add type annotations to entire function

### DIFF
--- a/src/FsAutoComplete/CodeFixes/AddExplicitTypeAnnotation.fs
+++ b/src/FsAutoComplete/CodeFixes/AddExplicitTypeAnnotation.fs
@@ -1,80 +1,21 @@
 module FsAutoComplete.CodeFix.AddExplicitTypeAnnotation
 
-open System
 open FsToolkit.ErrorHandling
 open FsAutoComplete.CodeFix.Types
 open Ionide.LanguageServerProtocol.Types
 open FsAutoComplete
 open FsAutoComplete.LspHelpers
-open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text.Range
 open FsAutoComplete.Core.InlayHints
 open FsAutoComplete.Core
 
-
 let toLspEdit ({ Pos = insertAt; Text = text }: HintInsertion) =
   { Range = fcsPosToProtocolRange insertAt
     NewText = text }
 
 let toLspEdits (edits: HintInsertion[]) = edits |> Array.map toLspEdit
-
-[<Obsolete>] //TODO: correct?
-let private isPositionContainedInUntypedImplicitCtorParameter input pos =
-  let result =
-    SyntaxTraversal.Traverse(
-      pos,
-      input,
-      { new SyntaxVisitorBase<_>() with
-          member _.VisitModuleDecl(_, defaultTraverse, decl) =
-            match decl with
-            | SynModuleDecl.Types(typeDefns = typeDefns) ->
-              option {
-                let! ctorArgs =
-                  typeDefns
-                  |> List.tryPick (function
-                    | SynTypeDefn(implicitConstructor = Some(SynMemberDefn.ImplicitCtor(ctorArgs = args))) when
-                      rangeContainsPos args.Range pos
-                      ->
-                      Some args
-                    | _ -> None)
-
-                match ctorArgs with
-                | SynSimplePats.SimplePats(pats = pats) ->
-                  let! pat = pats |> List.tryFind (fun pat -> rangeContainsPos pat.Range pos)
-
-                  let rec tryGetUntypedIdent =
-                    function
-                    | SynSimplePat.Id(ident = ident) when rangeContainsPos ident.idRange pos -> Some ident
-                    | SynSimplePat.Attrib(pat = pat) when rangeContainsPos pat.Range pos -> tryGetUntypedIdent pat
-                    | SynSimplePat.Typed _
-                    | _ -> None
-
-                  return! tryGetUntypedIdent pat
-                | _ -> return! None
-              }
-              |> Option.orElseWith (fun _ -> defaultTraverse decl)
-            | _ -> defaultTraverse decl }
-    )
-
-  result.IsSome
-
-[<Obsolete>] //TODO: correct
-let private isSymbolToTriggerTypeAnnotation
-  (funcOrValue: FSharpMemberOrFunctionOrValue)
-  (symbolUse: FSharpSymbolUse)
-  (parseFileResults: FSharpParseFileResults)
-  =
-  (funcOrValue.IsValue
-   || (funcOrValue.IsFunction
-       && parseFileResults.IsBindingALambdaAtPosition symbolUse.Range.Start))
-  //TODO: check here for curried parameter? necessary? Or handled by `tryGetExplicitTypeInfo`?
-  && not funcOrValue.IsMember
-  && not funcOrValue.IsMemberThisValue
-  && not funcOrValue.IsConstructorThisValue
-  && not (PrettyNaming.IsOperatorDisplayName funcOrValue.DisplayName)
-
 
 let title = "Add explicit type annotation"
 
@@ -113,7 +54,7 @@ let (|FunctionBindingWithMissingTypes|_|) =
 /// <param name="textDocument"></param>
 /// <param name="sourceText"></param>
 /// <param name="lineStr"></param>
-/// <param name="cursorPos">Expected to be between the start of the binding (from the keyword) and the end of the function name.</param>
+/// <param name="cursorPos">Expected to be between the start of the leading keyword and the end of the function name.</param>
 let tryFunctionIdentifier (parseAndCheck: ParseAndCheckResults) textDocument sourceText lineStr cursorPos =
   let bindingInfo =
     SyntaxTraversal.Traverse(
@@ -209,7 +150,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
       let filePath = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
 
       let fcsStartPos = protocolPosToPos codeActionParams.Range.Start
-      let! (parseAndCheck, lineStr, sourceText) = getParseResultsForFile filePath fcsStartPos
+      let! parseAndCheck, lineStr, sourceText = getParseResultsForFile filePath fcsStartPos
 
       let res =
         InlayHints.tryGetDetailedExplicitTypeInfo

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/AddExplicitTypeAnnotationTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/AddExplicitTypeAnnotationTests.fs
@@ -549,7 +549,7 @@ let tests state =
           Diagnostics.acceptAll
           selectCodeFix
           """
-          let f2$0 (a: int) : int -> int =
+          let f2 (a: int) : int -> int =
               ()
               fun b -> a + b
           """
@@ -574,6 +574,56 @@ let tests state =
           selectCodeFix
           """
           let f1: 'a option -> int = function | None -> 1 | Some _ -> 2
+          """
+
+      testCaseAsync "add return type annotation when cursor is on let keyword" <|
+        CodeFix.check server
+          """
+          let$0 f g h = ignore<int> g ; ignore<string> h ; - 9.0
+          """
+          Diagnostics.acceptAll
+          selectCodeFix
+          """
+          let f (g: int) (h: string) : float = ignore<int> g ; ignore<string> h ; - 9.0
+          """
+
+      testCaseAsync "add type annotation for parameter when cursor is on function name" <|
+        CodeFix.check server
+          """
+          let f$0 (a:int) b : int = a + b
+          """
+          Diagnostics.acceptAll
+          selectCodeFix
+          """
+          let f (a:int) (b: int) : int = a + b
+          """
+
+      testCaseAsync "add type annotation for local function" <|
+        CodeFix.check server
+          """
+          do
+              let f$0 a b = a + b
+              ()
+          """
+          Diagnostics.acceptAll
+          selectCodeFix
+          """
+          do
+              let f (a: int) (b: int) : int = a + b
+              ()
+          """
+
+      testCaseAsync "add type annotation for recursive function" <|
+        CodeFix.check server
+          """
+          let rec a b = b - 1
+          and c$0 d e = d - e
+          """
+          Diagnostics.acceptAll
+          selectCodeFix
+          """
+          let rec a b = b - 1
+          and c (d: int) (e: int) : int = d - e
           """
     ]
   ])

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/AddExplicitTypeAnnotationTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/AddExplicitTypeAnnotationTests.fs
@@ -510,5 +510,22 @@ let tests state =
           """
           (Diagnostics.acceptAll)
           selectCodeFix
+
+      ftestCaseAsync "add type annotations to entire function" <|
+        CodeFix.check server
+          """
+          let x$0 y z =
+              ignore<int> y
+              ignore<char> z
+              0
+          """
+          (Diagnostics.acceptAll)
+          selectCodeFix
+          """
+          let x (y: int) (z: char) : int =
+              ignore<int> y
+              ignore<char> z
+              0
+          """
     ]
   ])

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/AddExplicitTypeAnnotationTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/AddExplicitTypeAnnotationTests.fs
@@ -528,7 +528,7 @@ let tests state =
               0
           """
 
-      testCaseAsync "add type annotations to function with function return type" <|
+      testCaseAsync "add type annotations to function with lambda function body" <|
         CodeFix.check server
           """
           let f1$0 a = fun b -> a + b
@@ -539,7 +539,7 @@ let tests state =
           let f1 (a: int) : int -> int = fun b -> a + b
           """
 
-      testCaseAsync "add type annotations to function with function return type" <|
+      testCaseAsync "add type annotations to function with sequential lambda function body" <|
         CodeFix.check server
           """
           let f2$0 a =

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/AddExplicitTypeAnnotationTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/AddExplicitTypeAnnotationTests.fs
@@ -511,7 +511,7 @@ let tests state =
           (Diagnostics.acceptAll)
           selectCodeFix
 
-      ftestCaseAsync "add type annotations to entire function" <|
+      testCaseAsync "add type annotations to entire function" <|
         CodeFix.check server
           """
           let x$0 y z =
@@ -519,13 +519,61 @@ let tests state =
               ignore<char> z
               0
           """
-          (Diagnostics.acceptAll)
+          Diagnostics.acceptAll
           selectCodeFix
           """
           let x (y: int) (z: char) : int =
               ignore<int> y
               ignore<char> z
               0
+          """
+
+      testCaseAsync "add type annotations to function with function return type" <|
+        CodeFix.check server
+          """
+          let f1$0 a = fun b -> a + b
+          """
+          Diagnostics.acceptAll
+          selectCodeFix
+          """
+          let f1 (a: int) : int -> int = fun b -> a + b
+          """
+
+      testCaseAsync "add type annotations to function with function return type" <|
+        CodeFix.check server
+          """
+          let f2$0 a =
+              ()
+              fun b -> a + b
+          """
+          Diagnostics.acceptAll
+          selectCodeFix
+          """
+          let f2$0 (a: int) : int -> int =
+              ()
+              fun b -> a + b
+          """
+
+      testCaseAsync "add return type annotation when other parameters are typed" <|
+        CodeFix.check server
+          """
+          let f1$0 (a:int) = fun (b:char) -> System.TimeSpan.Zero
+          """
+          Diagnostics.acceptAll
+          selectCodeFix
+          """
+          let f1 (a:int) : char -> System.TimeSpan = fun (b:char) -> System.TimeSpan.Zero
+          """
+
+      testCaseAsync "add return type annotation for match lambda" <|
+        CodeFix.check server
+          """
+          let f1$0 = function | None -> 1 | Some _ -> 2
+          """
+          Diagnostics.acceptAll
+          selectCodeFix
+          """
+          let f1: 'a option -> int = function | None -> 1 | Some _ -> 2
           """
     ]
   ])


### PR DESCRIPTION
Hi @Booksbaum and @baronfel,

I noticed there is no code fix for an entire let binding:
![image](https://github.com/fsharp/FsAutoComplete/assets/2621499/628dacaa-6a17-44b4-8372-29b5326c086d)

In Rider, I'm used to annotating the entire function (all parameters without types + return type).
I'd like to take a stab at adding this for fsac.

I think this is good enough to take it:
![IonideAddTypesToFunction](https://github.com/fsharp/FsAutoComplete/assets/2621499/4cefb153-3eda-4104-9a9d-ceed5fc36366)

