### PR TITLE
Light up method tupled parameters

### DIFF
--- a/src/FsAutoComplete.Core/InlayHints.fs
+++ b/src/FsAutoComplete.Core/InlayHints.fs
@@ -971,8 +971,9 @@ let provideHints
                 parameterHints.Add hint
 
       | :? FSharpMemberOrFunctionOrValue as methodOrConstructor when
-        hintConfig.ShowParameterHints && methodOrConstructor.IsConstructor
-        -> // TODO: support methods when this API comes into FCS
+        hintConfig.ShowParameterHints
+        && (methodOrConstructor.IsMethod || methodOrConstructor.IsConstructor)
+        ->
         let endPosForMethod = symbolUse.Range.End
         let line, _ = Position.toZ endPosForMethod
 
@@ -995,13 +996,17 @@ let provideHints
             methodOrConstructor.CurriedParameterGroups |> Seq.concat |> Array.ofSeq // TODO: need ArgumentLocations to be surfaced
 
           for idx = 0 to parameters.Length - 1 do
-            // let paramLocationInfo = tupledParamInfos.ArgumentLocations.[idx]
+            let paramLocationInfo = tupledParamInfos.ArgumentLocations.[idx]
             let param = parameters.[idx]
             let paramName = param.DisplayName
 
-            // if shouldCreateHint param && paramLocationInfo.IsNamedArgument then
-            //     let hint = { Text = paramName + " ="; Pos = paramLocationInfo.ArgumentRange.Start; Kind = Parameter }
-            //     parameterHints.Add(hint)
+            if
+              ShouldCreate.paramHint methodOrConstructor param paramName
+              && paramLocationInfo.IsNamedArgument
+            then
+              let hint = createParamHint paramLocationInfo.ArgumentRange paramName
+              parameterHints.Add(hint)
+
             ()
 
         // This will only happen for curried methods defined in F#.
@@ -1018,8 +1023,7 @@ let provideHints
                 Some(definitionArgs.[i], v)
               else
                 None)
-            |> Array.filter Option.isSome
-            |> Array.map Option.get
+            |> Array.choose id
 
           for (definitionArg, appliedArgRange) in parms do
             let! appliedArgText = text[appliedArgRange]


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4024f9c</samp>

Enhance inlay hints for F# code by adding support for methods and named arguments, and simplify hint creation code in `InlayHints.fs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4024f9c</samp>

> _The F# coder loves inlay hints_
> _They help to avoid syntax stints_
> _But methods and args_
> _Were missing some sparks_
> _This pull request adds them in sprints_

<!--
copilot:emoji
-->

🚀🔧🧹

<!--
1.  🚀 for adding support for methods and named arguments, which can improve the user experience and productivity of F# developers by providing more contextual information and reducing ambiguity.
2.  🔧 for simplifying the code for creating hints, which can make the feature more maintainable and easier to extend in the future.
3.  🧹 for cleaning up some unused code and imports, which can improve the code quality and readability.
-->

### WHY
Now that we're on a version of FCS that supports the `ArgumentLocations` member for supporting parameter hints in methods, we should light this up. This currently fails because the new parameter hint reports at the incorrect position, so I need to figure that part out.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4024f9c</samp>

*  Extend condition for showing parameter hints to methods as well as constructors ([link](https://github.com/fsharp/FsAutoComplete/pull/1140/files?diff=unified&w=0#diff-b6395f63a994db1807e01fe8b1bb75322e6f998630ff9db0539d5a0c7c486604L974-R975)). This is part of the inlay hints feature for F# code in `src/FsAutoComplete.Core/InlayHints.fs`.
