### PR TITLE
FSAC Not exiting on macos/linux

### DIFF
--- a/src/FsAutoComplete/Program.fs
+++ b/src/FsAutoComplete/Program.fs
@@ -5,4 +5,6 @@ open System.CommandLine.Parsing
 [<EntryPoint>]
 let entry args =
   let results = Parser.parser.Invoke args
-  results
+  // macos seems to stall if we don't actually call exit
+  // https://github.com/fsharp/FsAutoComplete/issues/1117
+  exit results


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aefe387</samp>

Fixed a macOS bug that caused FsAutoComplete to hang by calling `exit` explicitly in `Program.fs`. The bug was related to the argument parser.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aefe387</samp>

> _`entry` function_
> _calls `exit` to avoid stall_
> _autumn bug is fixed_

<!--
copilot:emoji
-->

🐛🍎🚪

<!--
1.  🐛 - This emoji represents a bug fix, since the change was made to resolve a bug that affected the program's functionality.
2.  🍎 - This emoji represents macOS, since the bug was specific to that operating system and the change was tested on it.
3.  🚪 - This emoji represents exit, since the change involved calling the `exit` function to terminate the program.
-->

### WHY

Fixes #1117 

Why do we need to do this specifically for macos? I have no idea. 

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aefe387</samp>

* Fix bug where program stalls on macOS by explicitly calling `exit` with argument parser results ([link](https://github.com/fsharp/FsAutoComplete/pull/1141/files?diff=unified&w=0#diff-25b7c86f87865063a5a479365d13960e36783ac5ec67cb5ab408d73ce6a655cfL8-R10))
