### PR TITLE
RemovePatternArgument quick fix

### DIFF
--- a/src/FsAutoComplete/CodeFixes/RemovePatternArgument.fs
+++ b/src/FsAutoComplete/CodeFixes/RemovePatternArgument.fs
@@ -1,0 +1,54 @@
+module FsAutoComplete.CodeFix.RemovePatternArgument
+
+open FsToolkit.ErrorHandling
+open FsAutoComplete.CodeFix.Types
+open Ionide.LanguageServerProtocol.Types
+open FsAutoComplete
+open FsAutoComplete.LspHelpers
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text.Range
+open FSharp.Compiler.Text
+
+let title = "Remove argument"
+
+let tryFindPattern pos input =
+  let visitor =
+    { new SyntaxVisitorBase<range>() with
+
+        member _.VisitExpr(path, traverseSynExpr, defaultTraverse, expr) = defaultTraverse expr
+
+        member this.VisitPat(path: SyntaxVisitorPath, defaultTraverse: SynPat -> range option, synPat: SynPat) =
+          match synPat with
+          | SynPat.LongIdent(longDotId = synLongIdent; argPats = SynArgPats.Pats(pats); range = m) when
+            rangeContainsPos synPat.Range pos && not pats.IsEmpty
+            ->
+            let mRemove = mkRange m.FileName synLongIdent.Range.End m.End
+            Some mRemove
+          | SynPat.Paren(pat = innerPat) ->
+            let nextPath = SyntaxNode.SynPat(synPat) :: path
+            this.VisitPat(nextPath, defaultTraverse, innerPat)
+          | _ -> None }
+
+  SyntaxTraversal.Traverse(pos, input, visitor)
+
+let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
+  Run.ifDiagnosticByCode (Set.ofList [ "725"; "3191" ]) (fun _ codeActionParams ->
+    asyncResult {
+      let filePath = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
+      let fcsPos = protocolPosToPos codeActionParams.Range.Start
+      let! parseAndCheck, _, _ = getParseResultsForFile filePath fcsPos
+
+      match tryFindPattern fcsPos parseAndCheck.GetAST with
+      | None -> return []
+      | Some removeRange ->
+        let e =
+          { Range = fcsRangeToLsp removeRange
+            NewText = "" }
+
+        return
+          [ { Edits = [| e |]
+              File = codeActionParams.TextDocument
+              Title = title
+              SourceDiagnostic = None
+              Kind = FixKind.Refactor } ]
+    })

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1691,7 +1691,8 @@ type AdaptiveFSharpLspServer
            (fun _ -> config.AddPrivateAccessModifier)
            (AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace)
          UseTripleQuotedInterpolation.fix tryGetParseResultsForFile getRangeText
-         RenameParamToMatchSignature.fix tryGetParseResultsForFile |])
+         RenameParamToMatchSignature.fix tryGetParseResultsForFile
+         RemovePatternArgument.fix tryGetParseResultsForFile |])
 
   let forgetDocument (uri: DocumentUri) =
     async {

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -1228,7 +1228,8 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient, sourceTextFactory
                (fun _ -> config.AddPrivateAccessModifier)
                (AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace)
              UseTripleQuotedInterpolation.fix tryGetParseResultsForFile getRangeText
-             RenameParamToMatchSignature.fix tryGetParseResultsForFile |]
+             RenameParamToMatchSignature.fix tryGetParseResultsForFile
+             RemovePatternArgument.fix tryGetParseResultsForFile |]
 
 
         match p.RootPath, c.AutomaticWorkspaceInit with

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -2873,6 +2873,222 @@ let private removeRedundantAttributeSuffixTests state =
             class end
         """ ])
 
+let private removePatternArgumentTests state =
+  fserverTestList (nameof RemovePatternArgument) state defaultConfigDto None (fun server -> [
+    let selectCodeFix = CodeFix.withTitle RemovePatternArgument.title
+    testCaseAsync "Literal pattern qualified single parameter" <|
+      CodeFix.check server
+        """
+        type E =
+            | A = 1
+            | B = 2
+
+        let (E.A x$0) = E.A
+        """
+        (Diagnostics.expectCode "3191")
+        selectCodeFix
+        """
+        type E =
+            | A = 1
+            | B = 2
+
+        let (E.A) = E.A
+        """
+
+    testCaseAsync "Local literal pattern qualified match parens parameter" <|
+      CodeFix.check server
+        """
+        type E =
+            | A = 1
+            | B = 2
+
+        match E.A with
+        | (E.A x$0) -> ()
+        """
+        (Diagnostics.expectCode "3191")
+        selectCodeFix
+        """
+        type E =
+            | A = 1
+            | B = 2
+
+        match E.A with
+        | (E.A) -> ()
+        """
+
+    testCaseAsync "Local literal pattern qualified single parameter" <|
+      CodeFix.check server
+        """
+        type E =
+          | A = 1
+          | B = 2
+
+        do
+	        let (E.A x$0) = E.A
+	        ()
+        """
+        (Diagnostics.expectCode "3191")
+        selectCodeFix
+        """
+        type E =
+          | A = 1
+          | B = 2
+
+        do
+	        let (E.A) = E.A
+	        ()
+        """
+
+    testCaseAsync "Local literal constant pattern qualified parameter" <|
+      CodeFix.check server
+        """
+        let [<Literal>] A = 1
+
+        match 1 with
+        | A x$0 -> ()
+        """
+        (Diagnostics.expectCode "3191")
+        selectCodeFix
+        """
+        let [<Literal>] A = 1
+
+        match 1 with
+        | A -> ()
+        """
+
+    testCaseAsync "Local literal constant pattern qualified parens parameter" <|
+      CodeFix.check server
+        """
+        let [<Literal>] A = 1
+
+        match 1 with
+        | (A x$0) -> ()
+        """
+        (Diagnostics.expectCode "3191")
+        selectCodeFix
+        """
+        let [<Literal>] A = 1
+
+        match 1 with
+        | (A) -> ()
+        """
+
+    testCaseAsync "Local match qualified single parameter" <|
+      CodeFix.check server
+        """
+        match None with
+        | Option.None x$0 -> ()
+        """
+        (Diagnostics.expectCode "725")
+        selectCodeFix
+        """
+        match None with
+        | Option.None -> ()
+        """
+
+    testCaseAsync "Local match qualified single parens parameter" <|
+      CodeFix.check server
+        """
+        match None with
+        | (Option.None x$0) -> ()
+        """
+        (Diagnostics.expectCode "725")
+        selectCodeFix
+        """
+        match None with
+        | (Option.None) -> ()
+        """
+
+    testCaseAsync "Qualified single parameter" <|
+      CodeFix.check server
+        """
+        let (Option.None x$0) = None
+        """
+        (Diagnostics.expectCode "725")
+        selectCodeFix
+        """
+        let (Option.None) = None
+        """
+
+    testCaseAsync "Local single parameter" <|
+      CodeFix.check server
+        """
+        do
+          let (Option.None x$0) = None
+          ()
+        """
+        (Diagnostics.expectCode "725")
+        selectCodeFix
+        """
+        do
+          let (Option.None) = None
+          ()
+        """
+
+    testCaseAsync "Local two match parameters" <|
+      CodeFix.check server
+        """
+        match None with
+        | None x$0 y -> ()
+        """
+        (Diagnostics.expectCode "725")
+        selectCodeFix
+        """
+        match None with
+        | None -> ()
+        """
+
+    testCaseAsync "Local two match parens parameters" <|
+      CodeFix.check server
+        """
+        match None with
+        | None (x$0 y) -> ()
+        """
+        (Diagnostics.expectCode "725")
+        selectCodeFix
+        """
+        match None with
+        | None -> ()
+        """
+
+    testCaseAsync "Local two parameter" <|
+      CodeFix.check server
+        """
+        do
+          let (Option.None x$0 y) = None
+          ()
+        """
+        (Diagnostics.expectCode "725")
+        selectCodeFix
+        """
+        do
+          let (Option.None) = None
+          ()
+        """
+
+    testCaseAsync "Single parameter" <|
+      CodeFix.check server
+        """
+        let (None x$0) = None
+        """
+        (Diagnostics.expectCode "725")
+        selectCodeFix
+        """
+        let (None) = None
+        """
+
+    testCaseAsync "Two parameters" <|
+      CodeFix.check server
+        """
+        let (None x$0 y) = None
+        """
+        (Diagnostics.expectCode "725")
+        selectCodeFix
+        """
+        let (None) = None
+        """
+  ])
+
 let tests state = testList "CodeFix-tests" [
   HelpersTests.tests
 
@@ -2916,4 +3132,5 @@ let tests state = testList "CodeFix-tests" [
   useTripleQuotedInterpolationTests state
   wrapExpressionInParenthesesTests state
   removeRedundantAttributeSuffixTests state
+  removePatternArgumentTests state
 ]


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cd11d4d</samp>

This pull request adds a new code fix for removing unnecessary arguments in pattern matching expressions. The code fix is implemented in the `RemovePatternArgument` module and is triggered by compiler diagnostics with codes 725 or 3191. The code fix is registered by both the `AdaptiveFSharpLspServer` and the `FSharpLspServer` types, so that it can be used by different language server protocol clients. The pull request also includes tests for the code fix in the `FsAutoComplete.Tests.Lsp` project.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cd11d4d</samp>

> _`RemovePatternArgument`_
> _Code fix for F# patterns_
> _Autumn leaves unused_

<!--
copilot:emoji
-->

🧹🔬🧩

<!--
1.  🧹 - This emoji represents the idea of cleaning up or removing unnecessary code, which is what the code fix does.
2.  🔬 - This emoji represents the idea of testing or verifying the code fix, which is what the new tests do.
3.  🧩 - This emoji represents the idea of adding a new piece or module to the existing code base, which is what the new `RemovePatternArgument` module does.
-->

### WHY
Closes https://github.com/fsharp/FsAutoComplete/issues/1034

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cd11d4d</samp>

*  Add a new code fix for removing unnecessary arguments in pattern matching expressions ([link](https://github.com/fsharp/FsAutoComplete/pull/1142/files?diff=unified&w=0#diff-b469ec8fc61f9cfb3ea424c46e584908168a9548e73642ad64eba8e426661a5eR1-R54))
* Register the new code fix with the two language server types that provide language server protocol features for F# ([link](https://github.com/fsharp/FsAutoComplete/pull/1142/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L1694-R1695), [link](https://github.com/fsharp/FsAutoComplete/pull/1142/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L1231-R1232))
* Add a new function with test cases for the new code fix in the test file `test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1142/files?diff=unified&w=0#diff-76fc8863cc00a62068d47becebf42e1632f960d23fc5f85759060884583fe464R2876-R3091), [link](https://github.com/fsharp/FsAutoComplete/pull/1142/files?diff=unified&w=0#diff-76fc8863cc00a62068d47becebf42e1632f960d23fc5f85759060884583fe464R3135))
