### PR TITLE
To interpolated string

### DIFF
--- a/src/FsAutoComplete.Core/FCSPatches.fs
+++ b/src/FsAutoComplete.Core/FCSPatches.fs
@@ -495,3 +495,114 @@ module SyntaxTreeOps =
 
 
     walkExpr inpExpr
+
+open System
+open System.Reflection
+open Microsoft.FSharp.Reflection
+
+module ReflectionDelegates =
+
+  let public BindingFlagsToSeeAll: BindingFlags =
+    BindingFlags.Static
+    ||| BindingFlags.FlattenHierarchy
+    ||| BindingFlags.Instance
+    ||| BindingFlags.NonPublic
+    ||| BindingFlags.Public
+
+  let createFuncArity1<'returnType> (instanceType: Type) (arg1: Type) (getterName: string) =
+    let method = instanceType.GetMethod(getterName, BindingFlagsToSeeAll)
+
+    let getFunc =
+      typedefof<Func<_, _, _>>
+        .MakeGenericType(instanceType, arg1, typeof<'returnType>)
+
+    let delegate2 = method.CreateDelegate(getFunc)
+    // TODO: Emit IL for performance
+    fun (instance, arg1) -> delegate2.DynamicInvoke [| instance; arg1 |] |> unbox<bool>
+
+  let createGetter<'returnType> (instanceType: System.Type) (getterName: string) =
+    let method =
+      instanceType.GetProperty(getterName, BindingFlagsToSeeAll).GetGetMethod(true)
+
+    let getFunc =
+      typedefof<Func<_, _>>.MakeGenericType(instanceType, typeof<'returnType>)
+
+    let delegate2 = method.CreateDelegate(getFunc)
+    // TODO: Emit IL for performance
+    fun instance -> delegate2.DynamicInvoke [| instance |] |> unbox<bool>
+
+
+/// <summary>
+/// Reflection Shim around the <see href="https://github.com/dotnet/fsharp/blob/7725ddbd61ab3e5bf7e2fc35d76a0ece3903a5d9/src/Compiler/Facilities/LanguageFeatures.fs#L18">LanguageFeature</see> in FSharp.Compiler.Service
+/// </summary>
+type LanguageFeatureShim(langFeature: string) =
+  static let LanguageFeatureTy =
+    lazy (Type.GetType("FSharp.Compiler.Features+LanguageFeature, FSharp.Compiler.Service"))
+
+  static let cases =
+    lazy (FSharpType.GetUnionCases(LanguageFeatureTy.Value, ReflectionDelegates.BindingFlagsToSeeAll))
+
+  let case =
+    lazy
+      (let v = cases.Value |> Array.tryFind (fun c -> c.Name = langFeature)
+
+       v
+       |> Option.map (fun x -> FSharpValue.MakeUnion(x, [||], ReflectionDelegates.BindingFlagsToSeeAll)))
+
+  member x.Case = case.Value
+
+  static member Type = LanguageFeatureTy.Value
+
+// Worth keeping commented out as they shouldn't be used until we need to find other properties/methods to support
+// member x.Properties = LanguageFeatureShim.Type.GetProperties(ReflectionDelegates.BindingFlagsToSeeAll)
+// member x.Methods = LanguageFeatureShim.Type.GetMethods(ReflectionDelegates.BindingFlagsToSeeAll)
+// member x.Fields = LanguageFeatureShim.Type.GetFields(ReflectionDelegates.BindingFlagsToSeeAll)
+// member x.Cases = cases.Value
+
+/// <summary>
+/// Reflection Shim around the <see href="https://github.com/dotnet/fsharp/blob/7725ddbd61ab3e5bf7e2fc35d76a0ece3903a5d9/src/Compiler/Facilities/LanguageFeatures.fs#L76">LanguageVersion</see> in FSharp.Compiler.Service
+/// </summary>
+type LanguageVersionShim(versionText: string) =
+  static let LanguageVersionTy =
+    lazy (Type.GetType("FSharp.Compiler.Features+LanguageVersion, FSharp.Compiler.Service"))
+
+  static let ctor = lazy (LanguageVersionTy.Value.GetConstructor([| typeof<string> |]))
+
+  static let isPreviewEnabled =
+    lazy (ReflectionDelegates.createGetter<bool> LanguageVersionTy.Value "IsPreviewEnabled")
+
+  static let supportsFeature =
+    lazy (ReflectionDelegates.createFuncArity1<bool> LanguageVersionTy.Value LanguageFeatureShim.Type "SupportsFeature")
+
+  let realLanguageVersion = ctor.Value.Invoke([| versionText |])
+
+  member x.IsPreviewEnabled = isPreviewEnabled.Value realLanguageVersion
+
+  member x.SupportsFeature(featureId: LanguageFeatureShim) =
+    match featureId.Case with
+    | None -> false
+    | Some x -> supportsFeature.Value(realLanguageVersion, x)
+
+  member x.Real = realLanguageVersion
+  static member Type = LanguageVersionTy.Value
+
+// Worth keeping commented out as they shouldn't be used until we need to find other properties/methods to support
+// member x.Properties = LanguageVersionShim.Type.GetProperties(ReflectionDelegates.BindingFlagsToSeeAll)
+// member x.Methods = LanguageVersionShim.Type.GetMethods(ReflectionDelegates.BindingFlagsToSeeAll)
+// member x.Fields = LanguageVersionShim.Type.GetFields(ReflectionDelegates.BindingFlagsToSeeAll)
+
+module LanguageVersionShim =
+
+  /// <summary>Default is "latest"</summary>
+  /// <returns></returns>
+  let defaultLanguageVersion = lazy (LanguageVersionShim("latest"))
+
+  /// <summary>Tries to parse out "--langversion:" from OtherOptions if it can't find it, returns defaultLanguageVersion</summary>
+  /// <param name="fpo">The FSharpProjectOptions to use</param>
+  /// <returns>A LanguageVersionShim from the parsed "--langversion:" or defaultLanguageVersion </returns>
+  let fromFSharpProjectOptions (fpo: FSharpProjectOptions) =
+    fpo.OtherOptions
+    |> Array.tryFind (fun x -> x.StartsWith("--langversion:"))
+    |> Option.map (fun x -> x.Split(":")[1])
+    |> Option.map (fun x -> LanguageVersionShim(x))
+    |> Option.defaultWith (fun () -> defaultLanguageVersion.Value)

--- a/src/FsAutoComplete.Core/State.fs
+++ b/src/FsAutoComplete.Core/State.fs
@@ -11,6 +11,7 @@ open FSharp.Compiler.EditorServices
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.CodeAnalysis
 open FsToolkit.ErrorHandling
+open FCSPatches
 
 [<AutoOpen>]
 module ProjInfoExtensions =
@@ -202,6 +203,10 @@ type State =
     x.ProjectController.RemoveProjectOptions(UMX.untag file)
 
   member x.FSharpProjectOptions = x.ProjectController.ProjectOptions
+
+  member x.LanguageVersions =
+    x.FSharpProjectOptions
+    |> Seq.map (fun (s, proj: FSharpProjectOptions) -> s, LanguageVersionShim.fromFSharpProjectOptions proj)
 
   member x.TryGetFileVersion(file: string<LocalPath>) : int option =
     x.Files.TryFind file |> Option.bind (fun f -> f.Version)

--- a/src/FsAutoComplete/CodeFixes.fs
+++ b/src/FsAutoComplete/CodeFixes.fs
@@ -17,6 +17,8 @@ type FcsPos = FSharp.Compiler.Text.Position
 module LspTypes = Ionide.LanguageServerProtocol.Types
 
 module Types =
+  open FsAutoComplete.FCSPatches
+  open System.Threading.Tasks
 
   type IsEnabled = unit -> bool
 
@@ -28,6 +30,8 @@ module Types =
     string<LocalPath>
       -> FSharp.Compiler.Text.Position
       -> Async<ResultOrString<ParseAndCheckResults * string * IFSACSourceText>>
+
+  type GetLanguageVersion = string<LocalPath> -> Async<LanguageVersionShim>
 
   type GetProjectOptionsForFile =
     string<LocalPath> -> Async<ResultOrString<FSharp.Compiler.CodeAnalysis.FSharpProjectOptions>>

--- a/src/FsAutoComplete/CodeFixes/ToInterpolatedString.fs
+++ b/src/FsAutoComplete/CodeFixes/ToInterpolatedString.fs
@@ -88,11 +88,9 @@ let tryFindSprintfApplication (parseAndCheck: ParseAndCheckResults) (sourceText:
     |> Option.bind (fun symbolUse ->
       match symbolUse.Symbol with
       | :? FSharpMemberOrFunctionOrValue as mfv when mfv.Assembly.QualifiedName.StartsWith("FSharp.Core") ->
-        // Verify the `sprintf` is the one from F# Core.
+        // Verify the function is from F# Core.
         Some(functionIdent, mString, xs, mLastArg)
       | _ -> None))
-
-// TODO: this whole thing should only work if the language version is high enough
 
 let fix (getParseResultsForFile: GetParseResultsForFile) (getLanguageVersion: GetLanguageVersion) : CodeFix =
   fun codeActionParams ->

--- a/src/FsAutoComplete/CodeFixes/ToInterpolatedString.fs
+++ b/src/FsAutoComplete/CodeFixes/ToInterpolatedString.fs
@@ -1,5 +1,6 @@
 ﻿module FsAutoComplete.CodeFix.ToInterpolatedString
 
+open System.Text.RegularExpressions
 open FsToolkit.ErrorHandling
 open FsAutoComplete.CodeFix.Types
 open Ionide.LanguageServerProtocol.Types
@@ -8,10 +9,13 @@ open FsAutoComplete.LspHelpers
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Text.Range
 open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text
 
 let title = "To interpolated string"
 
-let tryFindSprintfApplication (parseAndCheck: ParseAndCheckResults) lineStr fcsPos =
+let specifierRegex = Regex(@"\%(s|i)")
+
+let tryFindSprintfApplication (parseAndCheck: ParseAndCheckResults) (sourceText: IFSACSourceText) lineStr fcsPos =
   let application =
     SyntaxTraversal.Traverse(
       fcsPos,
@@ -22,46 +26,100 @@ let tryFindSprintfApplication (parseAndCheck: ParseAndCheckResults) lineStr fcsP
             | SynExpr.App(ExprAtomicFlag.NonAtomic,
                           false,
                           SynExpr.Ident(sprintfIdent),
-                          SynExpr.Const(SynConst.String(text = formatString; synStringKind = SynStringKind.Regular),
-                                        mString),
+                          SynExpr.Const(SynConst.String(synStringKind = SynStringKind.Regular), mString),
                           mApp) ->
-              if
-                sprintfIdent.idText = "sprintf"
-                && rangeContainsPos mApp fcsPos
-                && mApp.StartLine = mApp.EndLine // only support single line for now
-                && formatString.Contains("%i") // TODO: the better regex magic to detect the number of arguments
-              then
-                Some(sprintfIdent.idRange, mString, formatString, path) // probably don't want to return the entire path but just the detected argument
-              else
-                None
+              // Don't trust the value of SynConst.String, it is already a somewhat optimized version of what the user actually code.
+              match sourceText.GetText mString with
+              | Error _ -> None
+              | Ok formatString ->
+                if
+                  sprintfIdent.idText = "sprintf"
+                  && rangeContainsPos mApp fcsPos
+                  && mApp.StartLine = mApp.EndLine // only support single line for now
+                then
+                  // Find all the format parameters in the source string
+                  // Things like `%i` or `%s`
+                  let arguments =
+                    specifierRegex.Matches(formatString) |> Seq.cast<Match> |> Seq.toList
+
+                  if arguments.IsEmpty || path.Length < arguments.Length then
+                    None
+                  else
+                    let xs =
+                      let argumentsInPath = List.take arguments.Length path
+
+                      (arguments, argumentsInPath)
+                      ||> List.zip
+                      |> List.choose (fun (regexMatch, node) ->
+                        match node with
+                        | SyntaxNode.SynExpr(SynExpr.App(argExpr = ae)) -> Some(regexMatch, ae.Range)
+                        | _ -> None)
+
+                    List.tryLast xs
+                    |> Option.bind (fun (_, mLastArg) ->
+                      // Ensure the last argument of the current application is also on the same line.
+                      if mApp.StartLine <> mLastArg.EndLine then
+                        None
+                      else
+                        Some(sprintfIdent.idRange, mString, xs, mLastArg))
+                else
+                  None
             | _ -> defaultTraverse synExpr }
     )
 
   application
-  |> Option.bind (fun (mSprintf, mString, formatString, path) ->
+  |> Option.bind (fun (mSprintf, mString, xs, mLastArg) ->
     parseAndCheck.TryGetSymbolUse mSprintf.End lineStr
     |> Option.bind (fun symbolUse ->
       match symbolUse.Symbol with
       | :? FSharpMemberOrFunctionOrValue as mfv when mfv.Assembly.QualifiedName.StartsWith("FSharp.Core") ->
         // Verify the `sprintf` is the one from F# Core.
-        Some(mSprintf, mString, formatString, path)
+        Some(mSprintf, mString, xs, mLastArg)
       | _ -> None))
+
+// TODO: this whole thing should only work if the language version is high enough
 
 let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
   fun codeActionParams ->
     asyncResult {
       let filePath = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
       let fcsPos = protocolPosToPos codeActionParams.Range.Start
-      let! parseAndCheck, lineString, _ = getParseResultsForFile filePath fcsPos
+      let! parseAndCheck, lineString, sourceText = getParseResultsForFile filePath fcsPos
 
-      match tryFindSprintfApplication parseAndCheck lineString fcsPos with
+      match tryFindSprintfApplication parseAndCheck sourceText lineString fcsPos with
       | None -> return []
-      | Some(mSprintf, mString, formatString, path) ->
+      | Some(mSprintf, mString, arguments, mLastArg) ->
+        let replaceSprintfEdit =
+          { Range = fcsRangeToLsp (unionRanges mSprintf mString.StartRange)
+            NewText = "$" }
+
+        let insertArgumentEdits =
+          arguments
+          |> List.choose (fun (regexMatch, mArg) ->
+            match sourceText.GetText(mArg) with
+            | Error _ -> None
+            | Ok argText ->
+              let mReplace =
+                let stringPos =
+                  Position.mkPos mString.StartLine (mString.StartColumn + regexMatch.Index + regexMatch.Length)
+
+                mkRange mSprintf.FileName stringPos stringPos
+
+              Some
+                { Range = fcsRangeToLsp mReplace
+                  NewText = $"{{{argText}}}" })
+
+        let removeArgumentEdits =
+          let m = mkRange mSprintf.FileName mString.End mLastArg.End
+
+          { Range = fcsRangeToLsp m
+            NewText = "" }
 
         return
           [ { Edits =
-                [| { Range = fcsRangeToLsp (unionRanges mSprintf mString.StartRange)
-                     NewText = "$" } |]
+                [| yield replaceSprintfEdit
+                   yield! insertArgumentEdits
+                   yield removeArgumentEdits |]
               File = codeActionParams.TextDocument
               Title = title
               SourceDiagnostic = None

--- a/src/FsAutoComplete/CodeFixes/ToInterpolatedString.fs
+++ b/src/FsAutoComplete/CodeFixes/ToInterpolatedString.fs
@@ -1,0 +1,69 @@
+﻿module FsAutoComplete.CodeFix.ToInterpolatedString
+
+open FsToolkit.ErrorHandling
+open FsAutoComplete.CodeFix.Types
+open Ionide.LanguageServerProtocol.Types
+open FsAutoComplete
+open FsAutoComplete.LspHelpers
+open FSharp.Compiler.Symbols
+open FSharp.Compiler.Text.Range
+open FSharp.Compiler.Syntax
+
+let title = "To interpolated string"
+
+let tryFindSprintfApplication (parseAndCheck: ParseAndCheckResults) lineStr fcsPos =
+  let application =
+    SyntaxTraversal.Traverse(
+      fcsPos,
+      parseAndCheck.GetParseResults.ParseTree,
+      { new SyntaxVisitorBase<_>() with
+          member _.VisitExpr(path, traverseSynExpr, defaultTraverse, synExpr) =
+            match synExpr with
+            | SynExpr.App(ExprAtomicFlag.NonAtomic,
+                          false,
+                          SynExpr.Ident(sprintfIdent),
+                          SynExpr.Const(SynConst.String(text = formatString; synStringKind = SynStringKind.Regular),
+                                        mString),
+                          mApp) ->
+              if
+                sprintfIdent.idText = "sprintf"
+                && rangeContainsPos mApp fcsPos
+                && mApp.StartLine = mApp.EndLine // only support single line for now
+                && formatString.Contains("%i") // TODO: the better regex magic to detect the number of arguments
+              then
+                Some(sprintfIdent.idRange, mString, formatString, path) // probably don't want to return the entire path but just the detected argument
+              else
+                None
+            | _ -> defaultTraverse synExpr }
+    )
+
+  application
+  |> Option.bind (fun (mSprintf, mString, formatString, path) ->
+    parseAndCheck.TryGetSymbolUse mSprintf.End lineStr
+    |> Option.bind (fun symbolUse ->
+      match symbolUse.Symbol with
+      | :? FSharpMemberOrFunctionOrValue as mfv when mfv.Assembly.QualifiedName.StartsWith("FSharp.Core") ->
+        // Verify the `sprintf` is the one from F# Core.
+        Some(mSprintf, mString, formatString, path)
+      | _ -> None))
+
+let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
+  fun codeActionParams ->
+    asyncResult {
+      let filePath = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
+      let fcsPos = protocolPosToPos codeActionParams.Range.Start
+      let! parseAndCheck, lineString, _ = getParseResultsForFile filePath fcsPos
+
+      match tryFindSprintfApplication parseAndCheck lineString fcsPos with
+      | None -> return []
+      | Some(mSprintf, mString, formatString, path) ->
+
+        return
+          [ { Edits =
+                [| { Range = fcsRangeToLsp (unionRanges mSprintf mString.StartRange)
+                     NewText = "$" } |]
+              File = codeActionParams.TextDocument
+              Title = title
+              SourceDiagnostic = None
+              Kind = FixKind.Refactor } ]
+    }

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1692,7 +1692,8 @@ type AdaptiveFSharpLspServer
            (AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace)
          UseTripleQuotedInterpolation.fix tryGetParseResultsForFile getRangeText
          RenameParamToMatchSignature.fix tryGetParseResultsForFile
-         RemovePatternArgument.fix tryGetParseResultsForFile |])
+         RemovePatternArgument.fix tryGetParseResultsForFile
+         ToInterpolatedString.fix tryGetParseResultsForFile |])
 
   let forgetDocument (uri: DocumentUri) =
     async {

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -43,6 +43,7 @@ open System.Diagnostics
 open System.Text.RegularExpressions
 open IcedTasks
 open System.Threading.Tasks
+open FsAutoComplete.FCSPatches
 
 [<RequireQualifiedAccess>]
 type WorkspaceChosen =
@@ -57,6 +58,33 @@ type AdaptiveWorkspaceChosen =
   | Directory of aval<string<LocalPath> * DateTime> // TODO later when ionide supports sending specific choices instead of only fsprojs
   | Projs of amap<string<LocalPath>, DateTime>
   | NotChosen
+
+type LoadedProjectFile =
+  { ProjectOptions: Types.ProjectOptions
+    FSharpProjectOptions: FSharpProjectOptions
+    LanguageVersion: LanguageVersionShim }
+
+type LoadedScriptFile =
+  { FSharpProjectOptions: FSharpProjectOptions
+    LanguageVersion: LanguageVersionShim }
+
+type LoadedProject =
+  | LoadedProjectFile of LoadedProjectFile
+  | LoadedScriptFile of LoadedScriptFile
+
+  member x.FSharpProjectOptions =
+    match x with
+    | LoadedProjectFile p -> p.FSharpProjectOptions
+    | LoadedScriptFile p -> p.FSharpProjectOptions
+
+  member x.LanguageVersion =
+    match x with
+    | LoadedProjectFile p -> p.LanguageVersion
+    | LoadedScriptFile p -> p.LanguageVersion
+
+  member x.SourceFiles = x.FSharpProjectOptions.SourceFiles
+  member x.ProjectFileName = x.FSharpProjectOptions.ProjectFileName
+
 
 type AdaptiveFSharpLspServer
   (workspaceLoader: IWorkspaceLoader, lspClient: FSharpLspClient, sourceTextFactory: ISourceTextFactory) =
@@ -80,6 +108,9 @@ type AdaptiveFSharpLspServer
   /// This is extracted to make it easier to do some type of customized select
   /// in the future
   let selectProject projs = projs |> List.tryHead
+
+  let selectFSharpProject (projs: LoadedProject list) =
+    projs |> List.tryHead |> Option.map (fun p -> p.FSharpProjectOptions)
 
   let mutable traceNotifications: ProgressListener option = None
 
@@ -765,6 +796,8 @@ type AdaptiveFSharpLspServer
           |> List.map (fun o ->
             let fso = FCS.mapToFSharpProjectOptions o projectOptions
 
+            let langversion = LanguageVersionShim.fromFSharpProjectOptions fso
+
             // Set some default values as FCS uses these for identification/caching purposes
             let fso =
               { fso with
@@ -772,12 +805,14 @@ type AdaptiveFSharpLspServer
                   Stamp = fso.Stamp |> Option.orElse (Some DateTime.UtcNow.Ticks)
                   ProjectId = fso.ProjectId |> Option.orElse (Some(Guid.NewGuid().ToString())) }
 
-            fso, o)
+            { ProjectOptions = o
+              FSharpProjectOptions = fso
+              LanguageVersion = langversion })
 
         options
-        |> List.iter (fun (opts, extraInfo) ->
-          let projectFileName = opts.ProjectFileName
-          let projViewerItemsNormalized = ProjectViewer.render extraInfo
+        |> List.iter (fun loadedProject ->
+          let projectFileName = loadedProject.FSharpProjectOptions.ProjectFileName
+          let projViewerItemsNormalized = ProjectViewer.render loadedProject.ProjectOptions
 
           let responseFiles =
             projViewerItemsNormalized.Items
@@ -786,7 +821,8 @@ type AdaptiveFSharpLspServer
             |> List.choose (function
               | ProjectViewerItem.Compile(p, _) -> Some p)
 
-          let references = FscArguments.references (opts.OtherOptions |> List.ofArray)
+          let references =
+            FscArguments.references (loadedProject.FSharpProjectOptions.OtherOptions |> List.ofArray)
 
           logger.info (
             Log.setMessage "ProjectLoaded {file}"
@@ -796,9 +832,9 @@ type AdaptiveFSharpLspServer
           let ws =
             { ProjectFileName = projectFileName
               ProjectFiles = responseFiles
-              OutFileOpt = Option.ofObj extraInfo.TargetPath
+              OutFileOpt = Option.ofObj loadedProject.ProjectOptions.TargetPath
               References = references
-              Extra = extraInfo
+              Extra = loadedProject.ProjectOptions
               ProjectItems = projViewerItemsNormalized.Items
               Additionals = Map.empty }
 
@@ -809,8 +845,13 @@ type AdaptiveFSharpLspServer
 
         notifications.Trigger(not, CancellationToken.None)
 
-        return options |> List.map fst
+        return options |> List.map LoadedProject.LoadedProjectFile
     }
+
+  // let loadedFSharpProjectOptions =
+  //   loadedProjectOptions
+  //   |> AVal.mapNonAdaptive(List.map (fun o -> o.FSharpProjectOptions))
+
 
   /// <summary>
   /// Evaluates the adaptive value <see cref='F:loadedProjectOptions '/> and returns its current value.
@@ -824,7 +865,7 @@ type AdaptiveFSharpLspServer
     AVal.Observable.onOutOfDateWeak loadedProjectOptions
     |> Observable.throttleOn Concurrency.NewThreadScheduler.Default (TimeSpan.FromMilliseconds(200.))
     |> Observable.observeOn Concurrency.NewThreadScheduler.Default
-    |> Observable.subscribe (fun _ -> forceLoadProjects () |> ignore<list<FSharpProjectOptions>>)
+    |> Observable.subscribe (fun _ -> forceLoadProjects () |> ignore<list<LoadedProject>>)
     |> disposables.Add
 
 
@@ -1059,14 +1100,14 @@ type AdaptiveFSharpLspServer
         projects
         |> Array.ofList
         |> Array.Parallel.collect (fun p ->
-          let parseOpts = Utils.projectOptionsToParseOptions p
+          let parseOpts = Utils.projectOptionsToParseOptions p.FSharpProjectOptions
           p.SourceFiles |> Array.Parallel.map (fun s -> p, parseOpts, s))
         |> Array.Parallel.map (fun (opts, parseOpts, fileName) ->
           let fileName = UMX.tag fileName
 
           asyncResult {
             let! file = forceFindOpenFileOrRead fileName
-            return! parseFile checker file parseOpts opts
+            return! parseFile checker file parseOpts opts.FSharpProjectOptions
           }
           |> Async.map Result.toOption)
         |> Async.parallel75
@@ -1094,7 +1135,12 @@ type AdaptiveFSharpLspServer
                 |> Async.startImmediateAsTask ctok
 
               opts |> scriptFileProjectOptions.Trigger
-              return opts
+              // todo langeversion parse from config options
+
+              return
+                LoadedScriptFile
+                  { FSharpProjectOptions = opts
+                    LanguageVersion = LanguageVersionShim.fromFSharpProjectOptions opts }
             }
 
           return file, Option.toList projs
@@ -1107,7 +1153,7 @@ type AdaptiveFSharpLspServer
           return file, projs
       })
 
-  let allProjectOptions =
+  let allFSharpProjectOptions =
     let wins =
       openFilesToChangesAndProjectOptions
       |> AMap.map (fun k v -> v |> AsyncAVal.mapSync (fun d _ -> snd d))
@@ -1119,7 +1165,7 @@ type AdaptiveFSharpLspServer
   let getAllProjectOptions () =
     async {
       let! set =
-        allProjectOptions
+        allFSharpProjectOptions
         |> AMap.toASetValues
         |> ASet.force
         |> HashSet.toArray
@@ -1129,9 +1175,14 @@ type AdaptiveFSharpLspServer
       return set |> Array.collect (List.toArray)
     }
 
+
+  let getAllFSharpProjectOptions () =
+    getAllProjectOptions ()
+    |> Async.map (Array.map (fun x -> x.FSharpProjectOptions))
+
   let getProjectOptionsForFile (filePath: string<LocalPath>) =
     asyncAVal {
-      match! allProjectOptions |> AMapAsync.tryFindA filePath with
+      match! allFSharpProjectOptions |> AMapAsync.tryFindA filePath with
       | Some projs -> return projs
       | None -> return []
     }
@@ -1272,10 +1323,10 @@ type AdaptiveFSharpLspServer
             let! opts = selectProject projectOptions
             and! cts = tryGetOpenFileToken file
 
-            let parseOpts = Utils.projectOptionsToParseOptions opts
+            let parseOpts = Utils.projectOptionsToParseOptions opts.FSharpProjectOptions
 
             return!
-              parseFile checker info parseOpts opts
+              parseFile checker info parseOpts opts.FSharpProjectOptions
               |> Async.withCancellation cts.Token
               |> Async.startImmediateAsTask ctok
           }
@@ -1292,7 +1343,7 @@ type AdaptiveFSharpLspServer
         return
           option {
             let! opts = selectProject projectOptions
-            return! checker.TryGetRecentCheckResultsForFile(file, opts, info.Source)
+            return! checker.TryGetRecentCheckResultsForFile(file, opts.FSharpProjectOptions, info.Source)
           }
       })
 
@@ -1309,7 +1360,7 @@ type AdaptiveFSharpLspServer
             and! cts = tryGetOpenFileToken file
 
             return!
-              parseAndCheckFile checker info opts true
+              parseAndCheckFile checker info opts.FSharpProjectOptions true
               |> Async.withCancellation cts.Token
               |> fun work -> Async.StartImmediateAsTask(work, ctok)
           }
@@ -1421,6 +1472,7 @@ type AdaptiveFSharpLspServer
     filePath, pos
 
 
+
   let forceGetProjectOptions filePath =
     asyncAVal {
       let! projects = getProjectOptionsForFile filePath
@@ -1432,6 +1484,10 @@ type AdaptiveFSharpLspServer
 
     }
     |> AsyncAVal.forceAsync
+
+  let forceGetFSharpProjectOptions filePath =
+    forceGetProjectOptions filePath
+    |> Async.map (Result.map (fun p -> p.FSharpProjectOptions))
 
   let codeGenServer =
     { new ICodeGenerationService with
@@ -1487,7 +1543,7 @@ type AdaptiveFSharpLspServer
       let dependents =
         projectSnapshot
         |> Seq.filter (fun p ->
-          p.ReferencedProjects
+          p.FSharpProjectOptions.ReferencedProjects
           |> Seq.exists (fun r ->
             match r.ProjectFilePath with
             | None -> false
@@ -1498,7 +1554,7 @@ type AdaptiveFSharpLspServer
         currentPass.Clear()
       else
         for d in dependents do
-          allDependents.Add d |> ignore<bool>
+          allDependents.Add d.FSharpProjectOptions |> ignore<bool>
 
         currentPass.Clear()
         currentPass.AddRange(dependents |> Seq.map (fun p -> p.ProjectFileName))
@@ -1507,10 +1563,21 @@ type AdaptiveFSharpLspServer
 
   let getDeclarationLocation (symbolUse, text) =
     let getProjectOptions file =
-      getProjectOptionsForFile file |> AsyncAVal.forceAsync |> Async.map selectProject
+      async {
+        let! projects = getProjectOptionsForFile file |> AsyncAVal.forceAsync
+
+        return
+          selectProject projects
+          |> Option.map (fun project -> project.FSharpProjectOptions)
+
+
+      }
 
     let projectsThatContainFile file =
-      getProjectOptionsForFile file |> AsyncAVal.forceAsync
+      async {
+        let! projects = getProjectOptionsForFile file |> AsyncAVal.forceAsync
+        return projects |> List.map (fun p -> p.FSharpProjectOptions)
+      }
 
     SymbolLocation.getDeclarationLocation (
       symbolUse,
@@ -1548,14 +1615,14 @@ type AdaptiveFSharpLspServer
       }
 
     let tryGetProjectOptionsForFsproj (file: string<LocalPath>) =
-      forceGetProjectOptions file |> Async.map Option.ofResult
+      forceGetFSharpProjectOptions file |> Async.map Option.ofResult
 
     Commands.symbolUseWorkspace
       getDeclarationLocation
       findReferencesForSymbolInFile
       forceFindSourceText
       tryGetProjectOptionsForFsproj
-      (getAllProjectOptions >> Async.map Array.toSeq)
+      (getAllFSharpProjectOptions >> Async.map Array.toSeq)
       includeDeclarations
       includeBackticks
       errorOnFailureToFixRange
@@ -1629,6 +1696,16 @@ type AdaptiveFSharpLspServer
         lineStr
       |> AsyncResult.foldResult id id
 
+    let getLanguageVersion (file: string<LocalPath>) =
+      async {
+        let! projectOptions = forceGetProjectOptions file
+
+        return
+          match projectOptions with
+          | Ok projectOptions -> projectOptions.LanguageVersion
+          | Error _ -> LanguageVersionShim.defaultLanguageVersion.Value
+      }
+
     config
     |> AVal.map (fun config ->
       [| Run.ifEnabled (fun _ -> config.UnusedOpensAnalyzer) (RemoveUnusedOpens.fix forceFindSourceText)
@@ -1650,7 +1727,10 @@ type AdaptiveFSharpLspServer
          ExternalSystemDiagnostics.analyzers
          Run.ifEnabled
            (fun _ -> config.InterfaceStubGeneration)
-           (ImplementInterface.fix tryGetParseResultsForFile forceGetProjectOptions (implementInterfaceConfig config))
+           (ImplementInterface.fix
+             tryGetParseResultsForFile
+             forceGetFSharpProjectOptions
+             (implementInterfaceConfig config))
          Run.ifEnabled
            (fun _ -> config.RecordStubGeneration)
            (GenerateRecordStub.fix tryGetParseResultsForFile getRecordStub (recordStubReplacements config))
@@ -1667,7 +1747,7 @@ type AdaptiveFSharpLspServer
          WrapExpressionInParentheses.fix getRangeText
          ChangeRefCellDerefToNot.fix tryGetParseResultsForFile
          ChangeDowncastToUpcast.fix getRangeText
-         MakeDeclarationMutable.fix tryGetParseResultsForFile forceGetProjectOptions
+         MakeDeclarationMutable.fix tryGetParseResultsForFile forceGetFSharpProjectOptions
          UseMutationWhenValueIsMutable.fix tryGetParseResultsForFile
          ConvertInvalidRecordToAnonRecord.fix tryGetParseResultsForFile
          RemoveUnnecessaryReturnOrYield.fix tryGetParseResultsForFile getLineText
@@ -1678,7 +1758,7 @@ type AdaptiveFSharpLspServer
          ConvertBangEqualsToInequality.fix getRangeText
          ChangeDerefBangToValue.fix tryGetParseResultsForFile getLineText
          RemoveUnusedBinding.fix tryGetParseResultsForFile
-         AddTypeToIndeterminateValue.fix tryGetParseResultsForFile forceGetProjectOptions
+         AddTypeToIndeterminateValue.fix tryGetParseResultsForFile forceGetFSharpProjectOptions
          ChangeTypeOfNameToNameOf.fix tryGetParseResultsForFile
          AddMissingInstanceMember.fix
          AddMissingXmlDocumentation.fix tryGetParseResultsForFile
@@ -1693,7 +1773,7 @@ type AdaptiveFSharpLspServer
          UseTripleQuotedInterpolation.fix tryGetParseResultsForFile getRangeText
          RenameParamToMatchSignature.fix tryGetParseResultsForFile
          RemovePatternArgument.fix tryGetParseResultsForFile
-         ToInterpolatedString.fix tryGetParseResultsForFile |])
+         ToInterpolatedString.fix tryGetParseResultsForFile getLanguageVersion |])
 
   let forgetDocument (uri: DocumentUri) =
     async {
@@ -1782,7 +1862,7 @@ type AdaptiveFSharpLspServer
           proj.SourceFiles
           |> Array.splitAt idx
           |> snd
-          |> Array.map (fun sourceFile -> proj, sourceFile))
+          |> Array.map (fun sourceFile -> proj.FSharpProjectOptions, sourceFile))
         |> Array.distinct
     }
 
@@ -1797,6 +1877,7 @@ type AdaptiveFSharpLspServer
 
       let dependentProjects =
         projs
+        |> List.map (fun x -> x.FSharpProjectOptions)
         |> getDependentProjectsOfProjects
         |> List.toArray
         |> Array.collect (fun proj -> proj.SourceFiles |> Array.map (fun sourceFile -> proj, sourceFile))
@@ -2974,7 +3055,10 @@ type AdaptiveFSharpLspServer
           )
 
           let getProjectOptions file =
-            getProjectOptionsForFile file |> AsyncAVal.forceAsync |> Async.map List.head
+            getProjectOptionsForFile file
+            |> AsyncAVal.forceAsync
+            |> Async.map List.head
+            |> Async.map (fun x -> x.FSharpProjectOptions)
 
           let checker = checker |> AVal.force
 
@@ -2982,13 +3066,13 @@ type AdaptiveFSharpLspServer
             checker.GetUsesOfSymbol(filePath, opts, symbol)
 
           let getAllProjects () =
-            allProjectOptions
+            allFSharpProjectOptions
             |> AMap.force
             |> Seq.toList
             |> Seq.map (fun (k, v) ->
               async {
                 let! proj = AsyncAVal.forceAsync v
-                return Option.map (fun proj -> UMX.untag k, proj) (selectProject proj)
+                return Option.map (fun proj -> UMX.untag k, proj) (selectFSharpProject proj)
               })
             |> Async.parallel75
             |> Async.map (Array.choose id >> List.ofArray)

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -848,11 +848,6 @@ type AdaptiveFSharpLspServer
         return options |> List.map LoadedProject.LoadedProjectFile
     }
 
-  // let loadedFSharpProjectOptions =
-  //   loadedProjectOptions
-  //   |> AVal.mapNonAdaptive(List.map (fun o -> o.FSharpProjectOptions))
-
-
   /// <summary>
   /// Evaluates the adaptive value <see cref='F:loadedProjectOptions '/> and returns its current value.
   /// This should not be used inside the adaptive evaluation of other AdaptiveObjects since it does not track dependencies.
@@ -1135,7 +1130,6 @@ type AdaptiveFSharpLspServer
                 |> Async.startImmediateAsTask ctok
 
               opts |> scriptFileProjectOptions.Trigger
-              // todo langeversion parse from config options
 
               return
                 LoadedScriptFile

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -1229,7 +1229,8 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient, sourceTextFactory
                (AddPrivateAccessModifier.fix tryGetParseResultsForFile symbolUseWorkspace)
              UseTripleQuotedInterpolation.fix tryGetParseResultsForFile getRangeText
              RenameParamToMatchSignature.fix tryGetParseResultsForFile
-             RemovePatternArgument.fix tryGetParseResultsForFile |]
+             RemovePatternArgument.fix tryGetParseResultsForFile
+             ToInterpolatedString.fix tryGetParseResultsForFile |]
 
 
         match p.RootPath, c.AutomaticWorkspaceInit with

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -3094,6 +3094,7 @@ let tests state = testList "CodeFix-tests" [
 
   AddExplicitTypeAnnotationTests.tests state
   ToInterpolatedStringTests.tests state
+  ToInterpolatedStringTests.unavailableTests state
   addMissingEqualsToTypeDefinitionTests state
   addMissingFunKeywordTests state
   addMissingInstanceMemberTests state

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -3093,6 +3093,7 @@ let tests state = testList "CodeFix-tests" [
   HelpersTests.tests
 
   AddExplicitTypeAnnotationTests.tests state
+  ToInterpolatedStringTests.tests state
   addMissingEqualsToTypeDefinitionTests state
   addMissingFunKeywordTests state
   addMissingInstanceMemberTests state

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
@@ -1,0 +1,23 @@
+﻿module private FsAutoComplete.Tests.CodeFixTests.ToInterpolatedStringTests
+
+open Expecto
+open Helpers
+open Utils.ServerTests
+open Utils.CursorbasedTests
+open FsAutoComplete.CodeFix
+
+let tests state =
+  fserverTestList (nameof ToInterpolatedString) state defaultConfigDto None (fun server ->
+    [ let selectCodeFix = CodeFix.withTitle ToInterpolatedString.title
+
+      testCaseAsync "simple integer string format"
+      <| CodeFix.check
+        server
+        """
+        let a = sprintf$0 "Hey %i" 3
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        let a = $"Hey %i" 3
+        """ ])

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
@@ -5,9 +5,17 @@ open Helpers
 open Utils.ServerTests
 open Utils.CursorbasedTests
 open FsAutoComplete.CodeFix
+open Microsoft.FSharp.Reflection
+open FsAutoComplete.FCSPatches
+
+
+let configDto =
+  { defaultConfigDto with FSIExtraParameters = Some [|"--langversion:6.0"|] }
+   // TODO For @nojaf to determine how to test with langversion
+  // { defaultConfigDto with FSIExtraParameters = Some [|"--langversion:4.7"|] }
 
 let tests state =
-  serverTestList (nameof ToInterpolatedString) state defaultConfigDto None (fun server ->
+  fserverTestList (nameof ToInterpolatedString) state configDto None (fun server ->
     [ let selectCodeFix = CodeFix.withTitle ToInterpolatedString.title
 
       testCaseAsync "simple integer string format"
@@ -316,5 +324,11 @@ let tests state =
         """
         $"%A{ { new System.IDisposable with member _.Dispose() = () } }"
         """
+
+      testCaseAsync "Reflecting into LanguageVersion" <| async {
+        let LanguageFeatureShim = LanguageFeatureShim("StringInterpolation")
+        let languageVersion = LanguageVersionShim("5.0")
+        Expect.equal true (languageVersion.SupportsFeature LanguageFeatureShim) ""
+      }
 
       ])

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
@@ -7,7 +7,7 @@ open Utils.CursorbasedTests
 open FsAutoComplete.CodeFix
 
 let tests state =
-  fserverTestList (nameof ToInterpolatedString) state defaultConfigDto None (fun server ->
+  serverTestList (nameof ToInterpolatedString) state defaultConfigDto None (fun server ->
     [ let selectCodeFix = CodeFix.withTitle ToInterpolatedString.title
 
       testCaseAsync "simple integer string format"
@@ -46,6 +46,275 @@ let tests state =
         selectCodeFix
         """
         printfn $"%02i{9}"
+        """
+
+      testCaseAsync "leading + in format"
+      <| CodeFix.check
+        server
+        """
+        printfn $0"%+i" 9
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        printfn $"%+i{9}"
+        """
+
+      testCaseAsync "leading - in format"
+      <| CodeFix.check
+        server
+        """
+        printfn $0"%-i" 9
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        printfn $"%-i{9}"
+        """
+
+      testCaseAsync "bool in format"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%b" true
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%b{true}"
+        """
+
+      testCaseAsync "char in format"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%c" 'd'
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%c{'d'}"
+        """
+
+      testCaseAsync "int in format but as d"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%d" 9001
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%d{9001}"
+        """
+
+      testCaseAsync "unsigned int in format"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%u" 7L
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%u{7L}"
+        """
+
+      testCaseAsync "lowercase hex in format"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%x" 12
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%x{12}"
+        """
+
+      testCaseAsync "uppercase hex in format"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%X" 13
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%X{13}"
+        """
+
+      testCaseAsync "unsigned octal number in format"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%o" 9
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%o{9}"
+        """
+
+      testCaseAsync "binary number in format"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%B" 9
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%B{9}"
+        """
+
+      testCaseAsync "signed value having the form [-]d.dddde[sign]ddd, lowercase"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%e" 9
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%e{9}"
+        """
+
+      testCaseAsync "signed value having the form [-]d.dddde[sign]ddd, uppercase"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%E" 9
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%E{9}"
+        """
+
+      testCaseAsync "signed value having the form [-]dddd.dddd, lowercase"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%f" 9.4
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%f{9.4}"
+        """
+
+      testCaseAsync "signed value having the form [-]dddd.dddd, uppercase"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%F" 9.4
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%F{9.4}"
+        """
+
+      testCaseAsync "%g"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%g" 9.4
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%g{9.4}"
+        """
+
+      testCaseAsync "%G"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%G" 9.4
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%G{9.4}"
+        """
+
+      testCaseAsync "%M"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%M" 9.4M
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%M{9.4M}"
+        """
+
+      testCaseAsync "Box anonymous record"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%O" {| Foo = 2 |}
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%O{ {| Foo = 2 |} }"
+        """
+
+      testCaseAsync "%A"
+      <| CodeFix.check
+        server
+        """
+        type Foo = { Meh: int }
+        sprintf$0 "%A" { Meh = 2 }
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        type Foo = { Meh: int }
+        $"%A{ { Meh = 2 } }"
+        """
+
+      testCaseAsync "Don't do %a"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        printfn$0 "%a" (fun _ _ -> ()) 0
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+
+      testCaseAsync "Don't do %t"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        printfn$0 "%a" x 0
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+
+      testCaseAsync "Don't do %%"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        printfn$0 "%%"
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+
+      testCaseAsync "Object expressions needs a space"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "%A" { new System.IDisposable with member _.Dispose() = () }
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"%A{ { new System.IDisposable with member _.Dispose() = () } }"
         """
 
       ])

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
@@ -34,4 +34,18 @@ let tests state =
         """
         let name = "pikachu"
         let a = $"Hey you %s{name} %i{9000}"
-        """ ])
+        """
+
+      testCaseAsync "leading zeros in format"
+      <| CodeFix.check
+        server
+        """
+        printfn $0"%02i" 9
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        printfn $"%02i{9}"
+        """
+
+      ])

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
@@ -20,4 +20,18 @@ let tests state =
         selectCodeFix
         """
         let a = $"Hey %i{3}"
+        """
+
+      testCaseAsync "replace two simple formats"
+      <| CodeFix.check
+        server
+        """
+        let name = "pikachu"
+        let a = sprintf$0 "Hey you %s %i" name 9000
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        let name = "pikachu"
+        let a = $"Hey you %s{name} %i{9000}"
         """ ])

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
@@ -19,5 +19,5 @@ let tests state =
         Diagnostics.acceptAll
         selectCodeFix
         """
-        let a = $"Hey %i" 3
+        let a = $"Hey %i{3}"
         """ ])

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
@@ -27,13 +27,13 @@ let tests state =
         server
         """
         let name = "pikachu"
-        let a = sprintf$0 "Hey you %s %i" name 9000
+        printf$0 "Hey you %s %i" name 9000
         """
         Diagnostics.acceptAll
         selectCodeFix
         """
         let name = "pikachu"
-        let a = $"Hey you %s{name} %i{9000}"
+        printf $"Hey you %s{name} %i{9000}"
         """
 
       testCaseAsync "leading zeros in format"


### PR DESCRIPTION

![IonideToInterpolatedString](https://github.com/fsharp/FsAutoComplete/assets/2621499/e8a73a1f-7a3e-4d9d-b997-838166280842)

Todo:
- [ ] We should check the current `--langversion` to decide if this should be enabled or not. 
  @TheAngryByrd how would one do that?

This first version has some limitations:
- Only support regular strings (so no triple quote or verbatim)
- No multiline strings
- The entire application needs to be on one line

I think this is decent enough to throw out there and expand upon later.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cfb20e1</samp>

This pull request adds a new code fix that converts `sprintf` and `printf` calls to interpolated strings in F# 5. It updates the language server types to provide the code fix to clients and adds tests to verify its behavior. It also adds a new module and file to implement and test the code fix logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cfb20e1</samp>

> _New code fix added_
> _`ToInterpolatedString`_
> _Autumn of F# 5_

<!--
copilot:emoji
-->

🆕🛠️🧪

<!--
1.  🆕 - This emoji indicates that a new feature or module was added, in this case the `ToInterpolatedString` module and code fix.
2.  🛠️ - This emoji indicates that a bug or issue was fixed or improved, in this case the `AdaptiveFSharpLspServer` and `FSharpLspServer` types were updated to support the new code fix.
3.  🧪 - This emoji indicates that a test or experiment was performed or added, in this case the `ToInterpolatedStringTests` module and test cases were added.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cfb20e1</samp>

*  Add a new code fix that converts `sprintf` and `printf` calls to interpolated strings ([link](https://github.com/fsharp/FsAutoComplete/pull/1143/files?diff=unified&w=0#diff-1a26fef31f905c7c7bb6bde7939cc74eaebcdc549f11c256f7e1b16819f9a6ceR1-R147), [link](https://github.com/fsharp/FsAutoComplete/pull/1143/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L1694-R1695), [link](https://github.com/fsharp/FsAutoComplete/pull/1143/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L1231-R1232), [link](https://github.com/fsharp/FsAutoComplete/pull/1143/files?diff=unified&w=0#diff-76fc8863cc00a62068d47becebf42e1632f960d23fc5f85759060884583fe464R2880), [link](https://github.com/fsharp/FsAutoComplete/pull/1143/files?diff=unified&w=0#diff-395aa0bd031a113a261e60026993a246a993915b79adfd0d647a97a2c3bfedb2R1-R320))
  * Define the logic of the code fix in the `ToInterpolatedString` module in `src/FsAutoComplete/CodeFixes/ToInterpolatedString.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1143/files?diff=unified&w=0#diff-1a26fef31f905c7c7bb6bde7939cc74eaebcdc549f11c256f7e1b16819f9a6ceR1-R147))
  * Add the `ToInterpolatedString.fix` function to the list of code fixes that the `AdaptiveFSharpLspServer` and `FSharpLspServer` types can provide in `src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs` and `src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1143/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L1694-R1695), [link](https://github.com/fsharp/FsAutoComplete/pull/1143/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L1231-R1232))
  * Add the `ToInterpolatedStringTests.tests` function to the list of tests that the `tests` function runs in `test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1143/files?diff=unified&w=0#diff-76fc8863cc00a62068d47becebf42e1632f960d23fc5f85759060884583fe464R2880))
  * Define a series of test cases for the new code fix in the `ToInterpolatedStringTests` module in `test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1143/files?diff=unified&w=0#diff-395aa0bd031a113a261e60026993a246a993915b79adfd0d647a97a2c3bfedb2R1-R320))
