### PR TITLE
Remove Async.SwitchToNewThreadCalls

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -165,8 +165,6 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize) =
 
       let allFlags = Array.append [| "--targetprofile:mscorlib" |] fsiAdditionalArguments
 
-      do! Async.SwitchToNewThread()
-
       let! (opts, errors) =
         checker.GetProjectOptionsFromScript(
           UMX.untag file,
@@ -191,8 +189,6 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize) =
 
       let allFlags =
         Array.append [| "--targetprofile:netstandard" |] fsiAdditionalArguments
-
-      do! Async.SwitchToNewThread()
 
       let! (opts, errors) =
         checker.GetProjectOptionsFromScript(
@@ -269,7 +265,6 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize) =
       )
 
       let path = UMX.untag filePath
-      do! Async.SwitchToNewThread()
       return! checker.ParseFile(path, source, options)
     }
 
@@ -299,7 +294,6 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize) =
       let path = UMX.untag filePath
 
       try
-        do! Async.SwitchToNewThread()
         let! (p, c) = checker.ParseAndCheckFileInProject(path, version, source, options, userOpName = opName)
 
         let parseErrors = p.Diagnostics |> Array.map (fun p -> p.Message)
@@ -394,8 +388,6 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize) =
         >> Log.addContextDestructured "file" file
       )
 
-      do! Async.SwitchToNewThread()
-
       match FSharpCompilerServiceChecker.GetDependingProjects file options with
       | None -> return [||]
       | Some(opts, []) ->
@@ -407,7 +399,6 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize) =
           opts :: dependentProjects
           |> List.map (fun (opts) ->
             async {
-              do! Async.SwitchToNewThread()
               let opts = clearProjectReferences opts
               let! res = checker.ParseAndCheckProject opts
               return res.GetUsesOfSymbol symbol
@@ -423,8 +414,6 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize) =
         Log.setMessage "FindReferencesForSymbolInFile - {file}"
         >> Log.addContextDestructured "file" file
       )
-
-      do! Async.SwitchToNewThread()
 
       return!
         checker.FindBackgroundReferencesInFile(
@@ -444,7 +433,6 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize) =
         >> Log.addContextDestructured "file" fileName
       )
 
-      do! Async.SwitchToNewThread()
       let! parseResult = checker.ParseFile(UMX.untag fileName, source, options)
       return parseResult.GetNavigationItems().Declarations
     }

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -354,6 +354,7 @@ type AdaptiveFSharpLspServer
 
           match parseAndCheck.GetCheckResults.ImplementationFile with
           | Some tast ->
+            // Since analyzers are not async, we need to switch to a new thread to not block threadpool
             do! Async.SwitchToNewThread()
 
             let res =


### PR DESCRIPTION

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ad32f1</samp>

This pull request improves the performance of the F# language service by removing unnecessary thread switching from the `FSharpCompilerServiceChecker` type in `CompilerServiceInterface.fs`. It also adds a comment to clarify why thread switching is still needed for running the F# analyzers in `AdaptiveFSharpLspServer.fs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8ad32f1</samp>

> _Sing, O Muse, of the swift and skillful changes_
> _That the wise and learned F# developers made_
> _To improve the performance of their language service_
> _And to avoid the wrath of the blocking thread pool._

<!--
copilot:emoji
-->

:memo::zap::wrench:

<!--
1.  :memo: - This emoji represents the addition of a comment to the code, which is a common way of documenting or explaining the code logic.
2.  :zap: - This emoji represents the improvement of the performance of the code, which is a common goal of code optimization or refactoring.
3.  :wrench: - This emoji represents the removal of unnecessary or redundant code, which is a common way of simplifying or cleaning up the code.
-->

### WHY
since https://github.com/dotnet/fsharp/issues/14899 got merged in FCS, it seems we don't hit threadpool exhaustion issues anymore

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8ad32f1</samp>

*  Remove unnecessary calls to `Async.SwitchToNewThread()` in various methods of the `FSharpCompilerServiceChecker` type in `CompilerServiceInterface.fs` to improve performance ([link](https://github.com/fsharp/FsAutoComplete/pull/1144/files?diff=unified&w=0#diff-d3a131711af73b7dfc9dad588cea6f40c3d483f43d8a0f4f0d02ef4ac339a916L168-L169), [link](https://github.com/fsharp/FsAutoComplete/pull/1144/files?diff=unified&w=0#diff-d3a131711af73b7dfc9dad588cea6f40c3d483f43d8a0f4f0d02ef4ac339a916L195-L196), [link](https://github.com/fsharp/FsAutoComplete/pull/1144/files?diff=unified&w=0#diff-d3a131711af73b7dfc9dad588cea6f40c3d483f43d8a0f4f0d02ef4ac339a916L272), [link](https://github.com/fsharp/FsAutoComplete/pull/1144/files?diff=unified&w=0#diff-d3a131711af73b7dfc9dad588cea6f40c3d483f43d8a0f4f0d02ef4ac339a916L302), [link](https://github.com/fsharp/FsAutoComplete/pull/1144/files?diff=unified&w=0#diff-d3a131711af73b7dfc9dad588cea6f40c3d483f43d8a0f4f0d02ef4ac339a916L397-L398), [link](https://github.com/fsharp/FsAutoComplete/pull/1144/files?diff=unified&w=0#diff-d3a131711af73b7dfc9dad588cea6f40c3d483f43d8a0f4f0d02ef4ac339a916L410), [link](https://github.com/fsharp/FsAutoComplete/pull/1144/files?diff=unified&w=0#diff-d3a131711af73b7dfc9dad588cea6f40c3d483f43d8a0f4f0d02ef4ac339a916L427-L428), [link](https://github.com/fsharp/FsAutoComplete/pull/1144/files?diff=unified&w=0#diff-d3a131711af73b7dfc9dad588cea6f40c3d483f43d8a0f4f0d02ef4ac339a916L447))
* Add a comment to explain why `runAnalyzers` function in `AdaptiveFSharpLspServer` type in `AdaptiveFSharpLspServer.fs` switches to a new thread before running the F# analyzers, which are not async and may block the thread pool ([link](https://github.com/fsharp/FsAutoComplete/pull/1144/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0R357))
