### PR TITLE
CI wasn't failing on focused tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         BuildNet7: ${{ matrix.build_net7 }}
 
     - name: Run and report tests
-      run: dotnet test -c Release -f ${{ matrix.test_tfm }} --no-restore --no-build --no-build --logger GitHubActions /p:AltCover=true /p:AltCoverAssemblyExcludeFilter="System.Reactive|FSharp.Compiler.Service|Ionide.ProjInfo|FSharp.Analyzers|Analyzer|Humanizer|FSharp.Core|FSharp.DependencyManager"
+      run: dotnet test -c Release -f ${{ matrix.test_tfm }} --no-restore --no-build --no-build --logger GitHubActions /p:AltCover=true /p:AltCoverAssemblyExcludeFilter="System.Reactive|FSharp.Compiler.Service|Ionide.ProjInfo|FSharp.Analyzers|Analyzer|Humanizer|FSharp.Core|FSharp.DependencyManager" -- Expecto.fail-on-focused-tests=true
       working-directory: test/FsAutoComplete.Tests.Lsp
       env:
         BuildNet7: ${{ matrix.build_net7 }}

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -2874,7 +2874,7 @@ let private removeRedundantAttributeSuffixTests state =
         """ ])
 
 let private removePatternArgumentTests state =
-  fserverTestList (nameof RemovePatternArgument) state defaultConfigDto None (fun server -> [
+  serverTestList (nameof RemovePatternArgument) state defaultConfigDto None (fun server -> [
     let selectCodeFix = CodeFix.withTitle RemovePatternArgument.title
     testCaseAsync "Literal pattern qualified single parameter" <|
       CodeFix.check server


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f37fc12</samp>

This pull request improves the testing workflow and consistency by adding a flag to fail focused tests in `.github/workflows/build.yml` and by updating the test code in `test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs` to use the refactored testing infrastructure.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f37fc12</samp>

> _`dotnet test` flag_
> _ensures focused tests only_
> _autumn leaves no room_

<!--
copilot:emoji
-->

🚩🔧♻️

<!--
1.  🚩 - This emoji represents the addition of a flag or option to a command or feature, and can also imply a sense of urgency or importance. In this case, the flag is used to enforce a stricter testing policy and avoid skipping tests unintentionally.
2.  🔧 - This emoji represents a tool or a configuration change, and can also imply a sense of improvement or optimization. In this case, the change is related to the testing infrastructure and how it is set up and torn down for each test file.
3.  ♻️ - This emoji represents recycling or refactoring, and can also imply a sense of cleaning up or simplifying code. In this case, the change is related to removing an unnecessary function and using a more consistent one instead.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f37fc12</samp>

*  Add flag to fail tests on focused cases ([link](https://github.com/fsharp/FsAutoComplete/pull/1145/files?diff=unified&w=0#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L90-R90))
*  Use simplified test setup and teardown ([link](https://github.com/fsharp/FsAutoComplete/pull/1145/files?diff=unified&w=0#diff-76fc8863cc00a62068d47becebf42e1632f960d23fc5f85759060884583fe464L2877-R2877))
