### PR TITLE
Add support for dot in sprintf format.

### DIFF
--- a/src/FsAutoComplete/CodeFixes/ToInterpolatedString.fs
+++ b/src/FsAutoComplete/CodeFixes/ToInterpolatedString.fs
@@ -18,7 +18,7 @@ let languageFeature = lazy (LanguageFeatureShim("StringInterpolation"))
 
 /// See https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/plaintext-formatting#format-specifiers-for-printf
 let specifierRegex =
-  Regex("\\%(\\+|\\-)?\\d*(b|s|c|d|i|u|x|X|o|B|e|E|f|F|g|G|M|O|A)")
+  Regex(@"\%(\+|\-)?\.?\d*(b|s|c|d|i|u|x|X|o|B|e|E|f|F|g|G|M|O|A)")
 
 let validFunctionNames = set [| "printf"; "printfn"; "sprintf" |]
 

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ToInterpolatedStringTests.fs
@@ -322,6 +322,18 @@ let tests state =
         $"%A{ { new System.IDisposable with member _.Dispose() = () } }"
         """
 
+      testCaseAsync "Dot in decimal format"
+      <| CodeFix.check
+        server
+        """
+        sprintf$0 "£%.2f" location.price
+        """
+        Diagnostics.acceptAll
+        selectCodeFix
+        """
+        $"£%.2f{location.price}"
+        """
+
       testCaseAsync "Reflecting into LanguageVersion"
       <| async {
         let LanguageFeatureShim = LanguageFeatureShim("StringInterpolation")


### PR DESCRIPTION
Of course the first time I wanted to try out the new code fix, my use-case was not yet supported 😸.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 623f4bc</samp>

This pull request improves the code fix for converting `printf`-style formatting to interpolated strings in F#. It fixes a bug with decimal format specifiers and adds a test case for it.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 623f4bc</samp>

> _`sprintf` to string_
> _decimal format with dot_
> _autumn code cleanup_

<!--
copilot:emoji
-->

🌟🔧🧪

<!--
1.  🌟 - This emoji can be used to indicate a new feature or enhancement, such as adding support for decimal format specifiers.
2.  🔧 - This emoji can be used to indicate a bug fix or improvement, such as updating the regular expression to match the new syntax.
3.  🧪 - This emoji can be used to indicate a test or experiment, such as adding a new test case to verify the behavior of the code fix.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 623f4bc</samp>

*  Update `specifierRegex` to support decimal format specifiers ([link](https://github.com/fsharp/FsAutoComplete/pull/1146/files?diff=unified&w=0#diff-1a26fef31f905c7c7bb6bde7939cc74eaebcdc549f11c256f7e1b16819f9a6ceL21-R21))
*  Add test case for code fix with dot in format specifier ([link](https://github.com/fsharp/FsAutoComplete/pull/1146/files?diff=unified&w=0#diff-395aa0bd031a113a261e60026993a246a993915b79adfd0d647a97a2c3bfedb2R325-R336))
*  Improve readability and type-safety of `printf`-style formatting by converting to interpolated strings ([link](https://github.com/fsharp/FsAutoComplete/pull/1146/files?diff=unified&w=0#diff-1a26fef31f905c7c7bb6bde7939cc74eaebcdc549f11c256f7e1b16819f9a6ceL21-R21), [link](https://github.com/fsharp/FsAutoComplete/pull/1146/files?diff=unified&w=0#diff-395aa0bd031a113a261e60026993a246a993915b79adfd0d647a97a2c3bfedb2R325-R336))
