### PR TITLE
Various Fixes

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -223,7 +223,7 @@ module Commands =
     }
 
   let docForText (lines: IFSACSourceText) (tyRes: ParseAndCheckResults) : Document =
-    { LineCount = lines.Lines.Length
+    { LineCount = lines.GetLineCount()
       FullName = tyRes.FileName // from the compiler, assumed safe
       GetText = fun _ -> string lines
       GetLineText0 = fun i -> (lines :> ISourceText).GetLineString i

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -482,8 +482,6 @@ module RoslynSourceText =
     let combineValues (values: seq<'T>) =
       (0, values) ||> Seq.fold (fun hash value -> combine (value.GetHashCode()) hash)
 
-  let weakTable = ConditionalWeakTable<SourceText, IFSACSourceText>()
-
   let rec create (fileName: string<LocalPath>, sourceText: SourceText) : IFSACSourceText =
 
     let walk

--- a/src/FsAutoComplete.Core/InlayHints.fs
+++ b/src/FsAutoComplete.Core/InlayHints.fs
@@ -977,7 +977,7 @@ let provideHints
         let line, _ = Position.toZ endPosForMethod
 
         let afterParenPosInLine =
-          getFirstPositionAfterParen (text.Lines.[line].ToString()) (endPosForMethod.Column)
+          getFirstPositionAfterParen (text.GetLineString(line)) (endPosForMethod.Column)
 
         let tupledParamInfos =
           parseAndCheck.GetParseResults.FindParameterLocations(Position.fromZ line afterParenPosInLine)

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -981,13 +981,14 @@ type AdaptiveFSharpLspServer
     | :? ObjectDisposedException as e when e.Message.Contains("CancellationTokenSource has been disposed") ->
       // ignore if already cancelled
       ()
+
   [<return: Struct>]
   let rec (|Cancelled|_|) (e: exn) =
     match e with
     | :? TaskCanceledException -> ValueSome()
     | :? OperationCanceledException -> ValueSome()
     | :? System.AggregateException as aex ->
-      if aex. InnerExceptions.Count = 1 then
+      if aex.InnerExceptions.Count = 1 then
         (|Cancelled|_|) aex.InnerException
       else
         ValueNone

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -283,6 +283,7 @@ type AdaptiveFSharpLspServer
     let filePathUntag = UMX.untag filePath
     let source = file.Source
     let version = file.Version
+    let fileName = Path.GetFileName filePathUntag
 
 
     let inline getSourceLine lineNo =
@@ -292,7 +293,7 @@ type AdaptiveFSharpLspServer
       async {
         try
           use progress = new ServerProgressReport(lspClient)
-          do! progress.Begin("Checking unused opens...", message = filePathUntag)
+          do! progress.Begin($"Checking unused opens {fileName}...", message = filePathUntag)
 
           let! unused = UnusedOpens.getUnusedOpens (tyRes.GetCheckResults, getSourceLine)
 
@@ -306,7 +307,7 @@ type AdaptiveFSharpLspServer
       async {
         try
           use progress = new ServerProgressReport(lspClient)
-          do! progress.Begin("Checking unused declarations...", message = filePathUntag)
+          do! progress.Begin($"Checking unused declarations {fileName}...", message = filePathUntag)
 
           let isScript = Utils.isAScript (filePathUntag)
           let! unused = UnusedDeclarations.getUnusedDeclarations (tyRes.GetCheckResults, isScript)
@@ -322,7 +323,7 @@ type AdaptiveFSharpLspServer
       async {
         try
           use progress = new ServerProgressReport(lspClient)
-          do! progress.Begin("Checking simplifing of names...", message = filePathUntag)
+          do! progress.Begin($"Checking simplifing of names {fileName}...", message = filePathUntag)
 
           let! simplified = SimplifyNames.getSimplifiableNames (tyRes.GetCheckResults, getSourceLine)
           let simplified = Array.ofSeq simplified


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb73003</samp>

This pull request enhances the LSP server, fixes a line count bug, removes an unused field, and improves the performance of inlay hints. It uses the `IFSACSourceText` interface more consistently and simplifies some error handling and progress reporting logic. It affects the files `AdaptiveFSharpLspServer.fs`, `Commands.fs`, `FileSystem.fs`, and `InlayHints.fs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fb73003</samp>

> _`docForText` fixed_
> _Analyzers and LSP improved_
> _Autumn of refactoring_

<!--
copilot:emoji
-->

🐛🔥🚀

<!--
1.  🐛 for fixing a bug in the `docForText` function.
2.  🔥 for removing an unused field from the `Hash` module.
3.  🚀 for improving the performance of the `getFirstPositionAfterParen` function.
-->

### WHY
- [Return proper LspResult based on exception](https://github.com/fsharp/FsAutoComplete/commit/aa9d1947d0550393e47a061f81d989ca314d95c5)
- [Adds filenames to serverprogress for analyzers](https://github.com/fsharp/FsAutoComplete/commit/222ad9a6f87acc3c3d05f33b228b98f9845a8316)
- [Various sourceText cleanups](https://github.com/fsharp/FsAutoComplete/commit/fb73003aec29fdcdf0900ca4a47633565de6d4ea)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fb73003</samp>

*  Fix line count bug in `docForText` function by using `GetLineCount` method instead of `Lines` property ([link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-f030ffbad83492980d57dd555322c7d8e9f26a1986413d60384e0730f8f54dd7L226-R226))
*  Remove unused field `weakTable` from `Hash` module in `RoslynSourceText` module ([link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-7c1d3328baa270a7e1450113731e5f1fe55cce453db26186a346965e4b66e981L485-L486))
*  Improve performance of `getFirstPositionAfterParen` function by using `GetLineString` method instead of `Lines` property and `ToString` method ([link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-b6395f63a994db1807e01fe8b1bb75322e6f998630ff9db0539d5a0c7c486604L980-R980))
*  Add local variable `fileName` to `builtInCompilerAnalyzers` function and use it to improve progress messages for analyzers ([link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0R286), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L295-R296), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L309-R310), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L325-R326))
*  Add active pattern `Cancelled` and function `returnException` to simplify error handling for LSP requests and avoid code duplication ([link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L983-R1000))
*  Replace explicit returns of internal error results with calls to `returnException` function in various LSP request handlers ([link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2092-R2109), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2198-R2215), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2532-R2549), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2632-R2649), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2697-R2714), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2794-R2811), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2884-R2901), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2914-R2931), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2944-R2961), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2980-R2997), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3021-R3038), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3095-R3112), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3132-R3149), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3171-R3188), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3213-R3230), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3266-R3283), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3333-R3350), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3371-R3388), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3440-R3457), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3610-R3627), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3656-R3673), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3682-R3699), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3710-R3727), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3815-R3832), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3857-R3874), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4052-R4069), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4089-R4106), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4141-R4158), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4173-R4190), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4206-R4223), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4244-R4261), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4286-R4303), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4322-R4339), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4351-R4368), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4380-R4397), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4409-R4426), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4438-R4455), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4469-R4486), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4511-R4528), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4557-R4574), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4611-R4628), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4640-R4657), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4670-R4687), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4700-R4717), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4729-R4746), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4758-R4775), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4788-R4805), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4822-R4839), [link](https://github.com/fsharp/FsAutoComplete/pull/1148/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4851-R4868))
