### PR TITLE
Update Ionide.LanguageServerProtocol to get the skeleton of all 3.17 features

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,8 @@
     <Title>FsAutoComplete</Title>
     <Product>FsAutoComplete</Product>
     <PackageLicenseExpression Condition=" '$(PackAsTool)' != 'true' ">Apache-2.0</PackageLicenseExpression>
-    <NoWarn>3186,0042</NoWarn><!-- circumvent an error with the fake dependencymanager for paket: https://github.com/dotnet/fsharp/issues/8678 -->
+    <NoWarn>$(NoWarn);3186,0042</NoWarn><!-- circumvent an error with the fake dependencymanager for paket: https://github.com/dotnet/fsharp/issues/8678 -->
+    <NoWarn>$(NoWarn);NU1902</NoWarn><!-- NU1902 - package vulnerability detected -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ChangelogFile>$(MSBuildThisFileDirectory)CHANGELOG.md</ChangelogFile>
   </PropertyGroup>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -53,7 +53,7 @@ nuget Expecto.Diff
 nuget YoloDev.Expecto.TestSdk
 nuget AltCover
 nuget GitHubActionsTestLogger
-nuget Ionide.LanguageServerProtocol >= 0.4.12
+nuget Ionide.LanguageServerProtocol >= 0.4.16
 nuget Microsoft.Extensions.Caching.Memory
 nuget OpenTelemetry.Exporter.OpenTelemetryProtocol >= 1.3.2
 

--- a/paket.lock
+++ b/paket.lock
@@ -125,7 +125,7 @@ NUGET
       System.Collections.Immutable (>= 5.0)
       System.Reflection.Metadata (>= 5.0)
     Ionide.KeepAChangelog.Tasks (0.1.8) - copy_local: true
-    Ionide.LanguageServerProtocol (0.4.16)
+    Ionide.LanguageServerProtocol (0.4.17)
       FSharp.Core (>= 6.0)
       Newtonsoft.Json (>= 13.0.1)
       StreamJsonRpc (>= 2.10.44)

--- a/paket.lock
+++ b/paket.lock
@@ -125,7 +125,7 @@ NUGET
       System.Collections.Immutable (>= 5.0)
       System.Reflection.Metadata (>= 5.0)
     Ionide.KeepAChangelog.Tasks (0.1.8) - copy_local: true
-    Ionide.LanguageServerProtocol (0.4.14)
+    Ionide.LanguageServerProtocol (0.4.16)
       FSharp.Core (>= 6.0)
       Newtonsoft.Json (>= 13.0.1)
       StreamJsonRpc (>= 2.10.44)

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1351,7 +1351,7 @@ type Commands
               state.Files.[file] <-
                 { LastTouched = DateTime.Now
                   Source = text
-                  Version = None }
+                  Version = 0 }
 
               Some text
             | None -> None
@@ -1697,7 +1697,7 @@ type Commands
             }
 
         scriptFileProjectOptions.Trigger projectOptions
-        state.AddFileTextAndCheckerOptions(file, text, projectOptions, Some version)
+        state.AddFileTextAndCheckerOptions(file, text, projectOptions, version)
         fileStateSet.Trigger()
         return Some projectOptions
       | None ->

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -758,7 +758,7 @@ type RoslynSourceTextFactory() =
 type VolatileFile =
   { LastTouched: DateTime
     Source: IFSACSourceText
-    Version: int option }
+    Version: int }
 
   member this.FileName = this.Source.FileName
 
@@ -775,7 +775,7 @@ type VolatileFile =
 
 
   /// <summary>Helper method to create a VolatileFile</summary>
-  static member Create(source: IFSACSourceText, ?version: int, ?touched: DateTime) =
+  static member Create(source: IFSACSourceText, version: int, ?touched: DateTime) =
     let touched =
       match touched with
       | Some t -> t

--- a/src/FsAutoComplete.Core/SignatureHelp.fs
+++ b/src/FsAutoComplete.Core/SignatureHelp.fs
@@ -22,7 +22,7 @@ type SignatureHelpInfo =
     /// if present, the index of the method we think is the current one (will never be outside the bounds of the Methods array)
     ActiveOverload: int option
     /// if present, the index of the parameter on the active method (will never be outside the bounds of the Parameters array on the selected method)
-    ActiveParameter: int option
+    ActiveParameter: uint option
     SigHelpKind: SignatureHelpKind
   }
 
@@ -116,7 +116,7 @@ let private getSignatureHelpForFunctionApplication
           tyRes.GetCheckResults.GetMethods(symbolStart.Line, symbolUse.Range.EndColumn, symbolStartLineText, None)
 
         return
-          { ActiveParameter = Some argumentIndex
+          { ActiveParameter = Some (uint argumentIndex)
             Methods = methods.Methods
             ActiveOverload = None
             SigHelpKind = FunctionApplication }
@@ -202,7 +202,7 @@ let private getSignatureHelpForMethod
 
 
       return
-        { ActiveParameter = Some argumentIndex
+        { ActiveParameter = Some (uint argumentIndex)
           Methods = filteredMethods
           ActiveOverload = methodCandidate
           SigHelpKind = MethodCall }

--- a/src/FsAutoComplete.Core/SignatureHelp.fs
+++ b/src/FsAutoComplete.Core/SignatureHelp.fs
@@ -116,7 +116,7 @@ let private getSignatureHelpForFunctionApplication
           tyRes.GetCheckResults.GetMethods(symbolStart.Line, symbolUse.Range.EndColumn, symbolStartLineText, None)
 
         return
-          { ActiveParameter = Some (uint argumentIndex)
+          { ActiveParameter = Some(uint argumentIndex)
             Methods = methods.Methods
             ActiveOverload = None
             SigHelpKind = FunctionApplication }
@@ -202,7 +202,7 @@ let private getSignatureHelpForMethod
 
 
       return
-        { ActiveParameter = Some (uint argumentIndex)
+        { ActiveParameter = Some(uint argumentIndex)
           Methods = filteredMethods
           ActiveOverload = methodCandidate
           SigHelpKind = MethodCall }

--- a/src/FsAutoComplete.Core/State.fs
+++ b/src/FsAutoComplete.Core/State.fs
@@ -189,7 +189,7 @@ type State =
       x.Files.[file] <-
         { Source = text
           LastTouched = DateTime.Now
-          Version = None }
+          Version = 0 }
 
       opts)
 
@@ -209,14 +209,14 @@ type State =
     |> Seq.map (fun (s, proj: FSharpProjectOptions) -> s, LanguageVersionShim.fromFSharpProjectOptions proj)
 
   member x.TryGetFileVersion(file: string<LocalPath>) : int option =
-    x.Files.TryFind file |> Option.bind (fun f -> f.Version)
+    x.Files.TryFind file |> Option.map (fun f -> f.Version)
 
   member x.TryGetLastCheckedVersion(file: string<LocalPath>) : int option = x.LastCheckedVersion.TryFind file
 
   member x.SetFileVersion (file: string<LocalPath>) (version: int) =
     x.Files.TryFind file
     |> Option.iter (fun n ->
-      let fileState = { n with Version = Some version }
+      let fileState = { n with Version = version }
       x.Files.[file] <- fileState)
 
   member x.SetLastCheckedVersion (file: string<LocalPath>) (version: int) = x.LastCheckedVersion.[file] <- version

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -131,11 +131,13 @@ module Conversions =
         { Uri = uri
           Range = fcsRangeToLsp decl.Range }
 
-      let sym =
-        { SymbolInformation.Name = decl.LogicalName
+      let sym: SymbolInformation =
+        { Name = decl.LogicalName
           Kind = kind
           Location = location
-          ContainerName = container }
+          ContainerName = container
+          Tags = None
+          Deprecated = None }
 
       if symbolFilter sym then Some sym else None
 
@@ -428,7 +430,8 @@ module Structure =
       StartLine = lsp.Start.Line
       EndCharacter = Some lsp.End.Character
       EndLine = lsp.End.Line
-      Kind = kind }
+      Kind = kind
+      CollapsedText = None }
 
 module ClassificationUtils =
   [<RequireQualifiedAccess>]

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -16,6 +16,8 @@ open Newtonsoft.Json.Linq
 open Ionide.ProjInfo.ProjectSystem
 open System.Reactive
 open System.Reactive.Linq
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
 open FsAutoComplete.Adaptive
 
 open FSharp.Control.Reactive
@@ -234,7 +236,8 @@ type AdaptiveFSharpLspServer
   let sendDiagnostics (uri: DocumentUri) (diags: Diagnostic[]) =
     logger.info (Log.setMessageI $"SendDiag for {uri:file}: {diags.Length:diags} entries")
 
-    { Uri = uri; Diagnostics = diags } |> lspClient.TextDocumentPublishDiagnostics
+    // TODO: providing version would be very useful
+    { Uri = uri; Diagnostics = diags; Version = None } |> lspClient.TextDocumentPublishDiagnostics
 
   let mutable lastFSharpDocumentationTypeCheck: ParseAndCheckResults option = None
 
@@ -359,7 +362,7 @@ type AdaptiveFSharpLspServer
         lspClient.NotifyDocumentAnalyzed
           { TextDocument =
               { Uri = filePath |> Path.LocalPathToUri
-                Version = version } }
+                Version = defaultArg version 0 } }
     }
 
 
@@ -916,10 +919,10 @@ type AdaptiveFSharpLspServer
 
           let changes =
             ps
-            |> Seq.sortBy (fun (x, _) -> x.TextDocument.Version.Value)
+            |> Seq.sortBy (fun (x, _) -> x.TextDocument.Version)
             |> Seq.collect (fun (p, touched) ->
               p.ContentChanges
-              |> Array.map (fun x -> x, p.TextDocument.Version.Value, touched))
+              |> Array.map (fun x -> x, p.TextDocument.Version, touched))
 
           let file =
             (file, changes)
@@ -2094,6 +2097,22 @@ type AdaptiveFSharpLspServer
 
   member __.ScriptFileProjectOptions = scriptFileProjectOptions.Publish
 
+  member private x.logUnimplementedRequest<'t, 'u>(argValue: 't, [<CallerMemberName; Optional; DefaultParameterValue("")>] caller: string) =
+    logger.info (
+      Log.setMessage $"{caller} request: {{parms}}"
+      >> Log.addContextDestructured "parms" argValue
+    )
+
+    Helpers.notImplemented<'u>
+
+  member private x.logIgnoredNotification<'t>(argValue: 't, [<CallerMemberName; Optional; DefaultParameterValue("")>] caller: string) =
+    logger.info (
+      Log.setMessage $"{caller} request: {{parms}}"
+      >> Log.addContextDestructured "parms" argValue
+    )
+
+    Helpers.ignoreNotification
+
   interface IFSharpLspServer with
     override x.Shutdown() =
       (x :> System.IDisposable).Dispose() |> async.Return
@@ -2118,7 +2137,7 @@ type AdaptiveFSharpLspServer
             >> Log.addContextDestructured "items" c
           )
 
-          let inlineValueToggle =
+          let inlineValueToggle: InlineValueOptions option =
             match c.InlineValues.Enabled with
             | Some true -> Some { ResolveProvider = Some false }
             | Some false -> None
@@ -2394,7 +2413,8 @@ type AdaptiveFSharpLspServer
           if lineStr.StartsWith "#" then
             let completionList =
               { IsIncomplete = false
-                Items = KeywordList.hashSymbolCompletionItems }
+                Items = KeywordList.hashSymbolCompletionItems
+                ItemDefaults = None }
 
 
             return! success (Some completionList)
@@ -2517,7 +2537,7 @@ type AdaptiveFSharpLspServer
                     else
                       Array.append items KeywordList.keywordCompletionItems
 
-                  let completionList = { IsIncomplete = false; Items = its }
+                  let completionList = { IsIncomplete = false; Items = its; ItemDefaults = None }
                   success (Some completionList)
 
         with e ->
@@ -2670,14 +2690,15 @@ type AdaptiveFSharpLspServer
                 let parameters =
                   m.Parameters
                   |> Array.map (fun p ->
-                    { ParameterInformation.Label = p.ParameterName
+                    { ParameterInformation.Label = U2.First p.ParameterName
                       Documentation = Some(Documentation.String p.CanonicalTypeTextForSorting) })
 
                 let d = Documentation.Markup(markdown comment)
 
                 { SignatureInformation.Label = signature
                   Documentation = Some d
-                  Parameters = Some parameters })
+                  Parameters = Some parameters
+                  ActiveParameter = 0u })
 
             let res =
               { Signatures = sigs
@@ -3156,6 +3177,7 @@ type AdaptiveFSharpLspServer
               ns
               |> Array.collect (fun n ->
                 getSymbolInformations uri glyphToSymbolKind n (applyQuery symbolRequest.Query)))
+            |> U2.First
             |> Some
 
           return res
@@ -3858,151 +3880,67 @@ type AdaptiveFSharpLspServer
       }
 
     //unsupported -- begin
-    override x.CodeActionResolve(p) =
-      logger.info (
-        Log.setMessage "CodeActionResolve Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.CodeActionResolve(p) = x.logUnimplementedRequest p
 
-      Helpers.notImplemented
+    override x.DocumentLinkResolve(p) = x.logUnimplementedRequest p
 
-    override x.DocumentLinkResolve(p) =
-      logger.info (
-        Log.setMessage "CodeActionResolve Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.Exit() = x.logIgnoredNotification(())
 
-      Helpers.notImplemented
+    override x.InlayHintResolve p = x.logUnimplementedRequest p
 
-    override x.Exit() = Helpers.ignoreNotification
+    override x.TextDocumentDocumentColor p = x.logUnimplementedRequest p
 
-    override x.InlayHintResolve p =
-      logger.info (
-        Log.setMessage "InlayHintResolve Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.TextDocumentColorPresentation p = x.logUnimplementedRequest p
 
-      Helpers.notImplemented
+    override x.TextDocumentDocumentLink p = x.logUnimplementedRequest p
 
-    override x.TextDocumentDocumentColor p =
-      logger.info (
-        Log.setMessage "TextDocumentDocumentColor Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.TextDocumentOnTypeFormatting p = x.logUnimplementedRequest p
 
-      Helpers.notImplemented
+    override x.TextDocumentSemanticTokensFullDelta p = x.logUnimplementedRequest p
 
-    override x.TextDocumentColorPresentation p =
-      logger.info (
-        Log.setMessage "TextDocumentColorPresentation Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.TextDocumentWillSave p = x.logIgnoredNotification p
 
-      Helpers.notImplemented
+    override x.TextDocumentWillSaveWaitUntil p = x.logUnimplementedRequest p
 
-    override x.TextDocumentDocumentLink p =
-      logger.info (
-        Log.setMessage "TextDocumentDocumentLink Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.WorkspaceDidChangeWorkspaceFolders p = x.logIgnoredNotification p
 
-      Helpers.notImplemented
+    override x.WorkspaceDidCreateFiles p = x.logIgnoredNotification p
 
-    override x.TextDocumentOnTypeFormatting p =
-      logger.info (
-        Log.setMessage "TextDocumentOnTypeFormatting Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.WorkspaceDidDeleteFiles p = x.logIgnoredNotification p
 
-      Helpers.notImplemented
+    override x.WorkspaceDidRenameFiles p = x.logIgnoredNotification p
 
-    override x.TextDocumentSemanticTokensFullDelta p =
-      logger.info (
-        Log.setMessage "TextDocumentSemanticTokensFullDelta Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.WorkspaceExecuteCommand p = x.logUnimplementedRequest p
 
-      Helpers.notImplemented
+    override x.WorkspaceWillCreateFiles p = x.logUnimplementedRequest p
 
-    override x.TextDocumentWillSave p =
-      logger.info (
-        Log.setMessage "TextDocumentWillSave Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.WorkspaceWillDeleteFiles p = x.logUnimplementedRequest p
 
-      Helpers.ignoreNotification
+    override x.WorkspaceWillRenameFiles p = x.logUnimplementedRequest p
 
-    override x.TextDocumentWillSaveWaitUntil p =
-      logger.info (
-        Log.setMessage "TextDocumentWillSaveWaitUntil Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.CallHierarchyIncomingCalls p = x.logUnimplementedRequest p
 
-      Helpers.notImplemented
+    override x.CallHierarchyOutgoingCalls p = x.logUnimplementedRequest p
 
-    override x.WorkspaceDidChangeWorkspaceFolders p =
-      logger.info (
-        Log.setMessage "WorkspaceDidChangeWorkspaceFolders Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.TextDocumentPrepareCallHierarchy p = x.logUnimplementedRequest p
 
-      Helpers.ignoreNotification
+    override x.TextDocumentPrepareTypeHierarchy p = x.logUnimplementedRequest p
 
-    override x.WorkspaceDidCreateFiles p =
-      logger.info (
-        Log.setMessage "WorkspaceDidCreateFiles Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.TypeHierarchySubtypes p = x.logUnimplementedRequest p
 
-      Helpers.ignoreNotification
+    override x.TypeHierarchySupertypes p = x.logUnimplementedRequest p
 
-    override x.WorkspaceDidDeleteFiles p =
-      logger.info (
-        Log.setMessage "WorkspaceDidDeleteFiles Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.TextDocumentDeclaration p = x.logUnimplementedRequest p
 
-      Helpers.ignoreNotification
+    override x.TextDocumentDiagnostic p = x.logUnimplementedRequest p
 
-    override x.WorkspaceDidRenameFiles p =
-      logger.info (
-        Log.setMessage "WorkspaceDidRenameFiles Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.TextDocumentLinkedEditingRange p = x.logUnimplementedRequest p
 
-      Helpers.ignoreNotification
+    override x.TextDocumentMoniker p = x.logUnimplementedRequest p
 
-    override x.WorkspaceExecuteCommand p =
-      logger.info (
-        Log.setMessage "WorkspaceExecuteCommand Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
+    override x.WorkspaceDiagnostic p = x.logUnimplementedRequest p
 
-      Helpers.notImplemented
-
-    override x.WorkspaceWillCreateFiles p =
-      logger.info (
-        Log.setMessage "WorkspaceWillCreateFiles Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
-
-      Helpers.notImplemented
-
-    override x.WorkspaceWillDeleteFiles p =
-      logger.info (
-        Log.setMessage "WorkspaceWillDeleteFiles Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
-
-      Helpers.notImplemented
-
-    override x.WorkspaceWillRenameFiles p =
-      logger.info (
-        Log.setMessage "WorkspaceWillRenameFiles Request: {parms}"
-        >> Log.addContextDestructured "parms" p
-      )
-
-      Helpers.notImplemented
+    override x.WorkspaceSymbolResolve p = x.logUnimplementedRequest p
 
     //unsupported -- end
 
@@ -4120,7 +4058,7 @@ type AdaptiveFSharpLspServer
                 Edit =
                   { DocumentChanges =
                       Some
-                        [| { TextDocument = p.TextDocument
+                        [| { TextDocument = { Uri = p.TextDocument.Uri; Version = Some p.TextDocument.Version }
                              Edits =
                                [| { Range = fcsPosToProtocolRange insertPos
                                     NewText = text } |] } |]
@@ -4878,36 +4816,6 @@ type AdaptiveFSharpLspServer
 
         return ()
       }
-
-    member this.CallHierarchyIncomingCalls
-      (arg1: CallHierarchyIncomingCallsParams)
-      : AsyncLspResult<CallHierarchyIncomingCall array option> =
-      failwith "Not Implemented"
-
-    member this.CallHierarchyOutgoingCalls
-      (arg1: CallHierarchyOutgoingCallsParams)
-      : AsyncLspResult<CallHierarchyOutgoingCall array option> =
-      failwith "Not Implemented"
-
-    member this.TextDocumentPrepareCallHierarchy
-      (arg1: CallHierarchyPrepareParams)
-      : AsyncLspResult<CallHierarchyItem array option> =
-      failwith "Not Implemented"
-
-    member this.TextDocumentPrepareTypeHierarchy
-      (arg1: TypeHierarchyPrepareParams)
-      : AsyncLspResult<TypeHierarchyItem array option> =
-      failwith "Not Implemented"
-
-    member this.TypeHierarchySubtypes
-      (arg1: TypeHierarchySubtypesParams)
-      : AsyncLspResult<TypeHierarchyItem array option> =
-      failwith "Not Implemented"
-
-    member this.TypeHierarchySupertypes
-      (arg1: TypeHierarchySupertypesParams)
-      : AsyncLspResult<TypeHierarchyItem array option> =
-      failwith "Not Implemented"
 
 module AdaptiveFSharpLspServer =
 

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -2698,7 +2698,7 @@ type AdaptiveFSharpLspServer
                 { SignatureInformation.Label = signature
                   Documentation = Some d
                   Parameters = Some parameters
-                  ActiveParameter = 0u })
+                  ActiveParameter = None })
 
             let res =
               { Signatures = sigs

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -237,7 +237,10 @@ type AdaptiveFSharpLspServer
     logger.info (Log.setMessageI $"SendDiag for {uri:file}: {diags.Length:diags} entries")
 
     // TODO: providing version would be very useful
-    { Uri = uri; Diagnostics = diags; Version = None } |> lspClient.TextDocumentPublishDiagnostics
+    { Uri = uri
+      Diagnostics = diags
+      Version = None }
+    |> lspClient.TextDocumentPublishDiagnostics
 
   let mutable lastFSharpDocumentationTypeCheck: ParseAndCheckResults option = None
 
@@ -921,8 +924,7 @@ type AdaptiveFSharpLspServer
             ps
             |> Seq.sortBy (fun (x, _) -> x.TextDocument.Version)
             |> Seq.collect (fun (p, touched) ->
-              p.ContentChanges
-              |> Array.map (fun x -> x, p.TextDocument.Version, touched))
+              p.ContentChanges |> Array.map (fun x -> x, p.TextDocument.Version, touched))
 
           let file =
             (file, changes)
@@ -2097,7 +2099,11 @@ type AdaptiveFSharpLspServer
 
   member __.ScriptFileProjectOptions = scriptFileProjectOptions.Publish
 
-  member private x.logUnimplementedRequest<'t, 'u>(argValue: 't, [<CallerMemberName; Optional; DefaultParameterValue("")>] caller: string) =
+  member private x.logUnimplementedRequest<'t, 'u>
+    (
+      argValue: 't,
+      [<CallerMemberName; Optional; DefaultParameterValue("")>] caller: string
+    ) =
     logger.info (
       Log.setMessage $"{caller} request: {{parms}}"
       >> Log.addContextDestructured "parms" argValue
@@ -2105,7 +2111,11 @@ type AdaptiveFSharpLspServer
 
     Helpers.notImplemented<'u>
 
-  member private x.logIgnoredNotification<'t>(argValue: 't, [<CallerMemberName; Optional; DefaultParameterValue("")>] caller: string) =
+  member private x.logIgnoredNotification<'t>
+    (
+      argValue: 't,
+      [<CallerMemberName; Optional; DefaultParameterValue("")>] caller: string
+    ) =
     logger.info (
       Log.setMessage $"{caller} request: {{parms}}"
       >> Log.addContextDestructured "parms" argValue
@@ -2537,7 +2547,11 @@ type AdaptiveFSharpLspServer
                     else
                       Array.append items KeywordList.keywordCompletionItems
 
-                  let completionList = { IsIncomplete = false; Items = its; ItemDefaults = None }
+                  let completionList =
+                    { IsIncomplete = false
+                      Items = its
+                      ItemDefaults = None }
+
                   success (Some completionList)
 
         with e ->
@@ -3884,7 +3898,7 @@ type AdaptiveFSharpLspServer
 
     override x.DocumentLinkResolve(p) = x.logUnimplementedRequest p
 
-    override x.Exit() = x.logIgnoredNotification(())
+    override x.Exit() = x.logIgnoredNotification (())
 
     override x.InlayHintResolve p = x.logUnimplementedRequest p
 
@@ -4058,7 +4072,9 @@ type AdaptiveFSharpLspServer
                 Edit =
                   { DocumentChanges =
                       Some
-                        [| { TextDocument = { Uri = p.TextDocument.Uri; Version = Some p.TextDocument.Version }
+                        [| { TextDocument =
+                               { Uri = p.TextDocument.Uri
+                                 Version = Some p.TextDocument.Version }
                              Edits =
                                [| { Range = fcsPosToProtocolRange insertPos
                                     NewText = text } |] } |]

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -365,7 +365,7 @@ type AdaptiveFSharpLspServer
         lspClient.NotifyDocumentAnalyzed
           { TextDocument =
               { Uri = filePath |> Path.LocalPathToUri
-                Version = defaultArg version 0 } }
+                Version = version } }
     }
 
 
@@ -1043,7 +1043,7 @@ type AdaptiveFSharpLspServer
           return
             { LastTouched = File.getLastWriteTimeOrDefaultNow file
               Source = source
-              Version = None }
+              Version = 0 }
 
         with e ->
           logger.warn (
@@ -2373,9 +2373,7 @@ type AdaptiveFSharpLspServer
             }
             |> Option.defaultWith (fun () ->
               // Very unlikely to get here
-              VolatileFile.Create(sourceTextFactory.Create(filePath, p.Text.Value))
-
-            )
+              VolatileFile.Create(sourceTextFactory.Create(filePath, p.Text.Value), 0))
 
           transact (fun () ->
             updateOpenFiles file
@@ -2893,7 +2891,7 @@ type AdaptiveFSharpLspServer
                 let! version =
                   async {
                     let! file = forceFindOpenFileOrRead file
-                    return file |> Option.ofResult |> Option.bind (fun (f) -> f.Version)
+                    return file |> Option.ofResult |> Option.map (fun (f) -> f.Version)
                   }
 
                 return
@@ -3343,7 +3341,7 @@ type AdaptiveFSharpLspServer
           let tryGetFileVersion filePath =
             async {
               let! foo = forceFindOpenFileOrRead filePath
-              return foo |> Option.ofResult |> Option.bind (fun (f) -> f.Version)
+              return foo |> Option.ofResult |> Option.map (fun (f) -> f.Version)
             }
 
           let clientCapabilities = clientCapabilities |> AVal.force

--- a/src/FsAutoComplete/LspServers/Common.fs
+++ b/src/FsAutoComplete/LspServers/Common.fs
@@ -216,8 +216,8 @@ module Helpers =
         ImplementationProvider = Some true
         ReferencesProvider = Some true
         DocumentHighlightProvider = Some true
-        DocumentSymbolProvider = Some true
-        WorkspaceSymbolProvider = Some true
+        DocumentSymbolProvider = Some (U2.Second { Label = Some "F#" })
+        WorkspaceSymbolProvider = Some (U2.Second { ResolveProvider = Some true })
         DocumentFormattingProvider = Some true
         DocumentRangeFormattingProvider = Some true
         SignatureHelpProvider =
@@ -229,12 +229,13 @@ module Helpers =
             { ResolveProvider = Some true
               TriggerCharacters = Some([| '.'; ''' |])
               AllCommitCharacters = None //TODO: what chars shoudl commit completions?
+              CompletionItem = None
             }
         CodeLensProvider = Some { CodeLensOptions.ResolveProvider = Some true }
         CodeActionProvider =
-          Some
+          Some (U2.Second
             { CodeActionKinds = None
-              ResolveProvider = None }
+              ResolveProvider = None } )
         TextDocumentSync =
           Some
             { TextDocumentSyncOptions.Default with

--- a/src/FsAutoComplete/LspServers/Common.fs
+++ b/src/FsAutoComplete/LspServers/Common.fs
@@ -216,8 +216,8 @@ module Helpers =
         ImplementationProvider = Some true
         ReferencesProvider = Some true
         DocumentHighlightProvider = Some true
-        DocumentSymbolProvider = Some (U2.Second { Label = Some "F#" })
-        WorkspaceSymbolProvider = Some (U2.Second { ResolveProvider = Some true })
+        DocumentSymbolProvider = Some(U2.Second { Label = Some "F#" })
+        WorkspaceSymbolProvider = Some(U2.Second { ResolveProvider = Some true })
         DocumentFormattingProvider = Some true
         DocumentRangeFormattingProvider = Some true
         SignatureHelpProvider =
@@ -229,13 +229,14 @@ module Helpers =
             { ResolveProvider = Some true
               TriggerCharacters = Some([| '.'; ''' |])
               AllCommitCharacters = None //TODO: what chars shoudl commit completions?
-              CompletionItem = None
-            }
+              CompletionItem = None }
         CodeLensProvider = Some { CodeLensOptions.ResolveProvider = Some true }
         CodeActionProvider =
-          Some (U2.Second
-            { CodeActionKinds = None
-              ResolveProvider = None } )
+          Some(
+            U2.Second
+              { CodeActionKinds = None
+                ResolveProvider = None }
+          )
         TextDocumentSync =
           Some
             { TextDocumentSyncOptions.Default with

--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fs
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fs
@@ -49,7 +49,7 @@ type FSharpLspClient(sendServerNotification: ClientNotificationSender, sendServe
   override __.WorkspaceSemanticTokensRefresh() =
     sendServerNotification "workspace/semanticTokens/refresh" () |> Async.Ignore
 
-  override __.TextDocumentPublishDiagnostics(p) =
+  override __.TextDocumentPublishDiagnostics(p: PublishDiagnosticsParams) =
     sendServerNotification "textDocument/publishDiagnostics" (box p) |> Async.Ignore
 
   ///Custom notification for workspace/solution/project loading events

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -1249,7 +1249,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient, sourceTextFactory
           >> Log.addContextDestructured "parms" filePath
         )
 
-        commands.SetFileContent(filePath, content, Some doc.Version)
+        commands.SetFileContent(filePath, content, doc.Version)
 
         do!
           checkFile (filePath, doc.Version, content, true)
@@ -1301,7 +1301,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient, sourceTextFactory
                 text)
 
 
-        commands.SetFileContent(filePath, evolvedFileContent, Some endVersion)
+        commands.SetFileContent(filePath, evolvedFileContent, endVersion)
 
         checkFileDebouncer.Bounce p
       }

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -1488,8 +1488,7 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient, sourceTextFactory
                 { SignatureInformation.Label = signature
                   Documentation = Some d
                   Parameters = Some parameters
-                  // TODO: this should become an Option of value None
-                  ActiveParameter = 0u })
+                  ActiveParameter = None })
 
             let res =
               { Signatures = sigs

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -185,7 +185,10 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient, sourceTextFactory
     )
 
     //TODO: it would be _amazing_ to flow version through to here
-    { Uri = uri; Diagnostics = diags; Version = None } |> lspClient.TextDocumentPublishDiagnostics
+    { Uri = uri
+      Diagnostics = diags
+      Version = None }
+    |> lspClient.TextDocumentPublishDiagnostics
 
   let diagnosticCollections = new DiagnosticCollection(sendDiagnostics)
 
@@ -888,7 +891,11 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient, sourceTextFactory
           | Some encoded -> return! success (Some { Data = encoded; ResultId = None }) // TODO: provide a resultId when we support delta ranges
     }
 
-  member private x.logUnimplementedRequest<'t, 'u>(argValue: 't, [<CallerMemberName; Optional; DefaultParameterValue("")>] caller: string) =
+  member private x.logUnimplementedRequest<'t, 'u>
+    (
+      argValue: 't,
+      [<CallerMemberName; Optional; DefaultParameterValue("")>] caller: string
+    ) =
     logger.info (
       Log.setMessage $"{caller} request: {{parms}}"
       >> Log.addContextDestructured "parms" argValue
@@ -896,7 +903,11 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient, sourceTextFactory
 
     Helpers.notImplemented<'u>
 
-  member private x.logIgnoredNotification<'t>(argValue: 't, [<CallerMemberName; Optional; DefaultParameterValue("")>] caller: string) =
+  member private x.logIgnoredNotification<'t>
+    (
+      argValue: 't,
+      [<CallerMemberName; Optional; DefaultParameterValue("")>] caller: string
+    ) =
     logger.info (
       Log.setMessage $"{caller} request: {{parms}}"
       >> Log.addContextDestructured "parms" argValue
@@ -911,50 +922,50 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient, sourceTextFactory
 
     //unsupported -- begin
 
-    override x.CodeActionResolve(p) = x.logUnimplementedRequest(p)
+    override x.CodeActionResolve(p) = x.logUnimplementedRequest (p)
 
-    override x.DocumentLinkResolve(p) = x.logUnimplementedRequest(p)
+    override x.DocumentLinkResolve(p) = x.logUnimplementedRequest (p)
 
-    override x.Exit() = x.logIgnoredNotification(())
+    override x.Exit() = x.logIgnoredNotification (())
 
-    override x.InlayHintResolve p = x.logUnimplementedRequest(p)
+    override x.InlayHintResolve p = x.logUnimplementedRequest (p)
 
-    override x.TextDocumentDocumentColor p = x.logUnimplementedRequest(p)
+    override x.TextDocumentDocumentColor p = x.logUnimplementedRequest (p)
 
-    override x.TextDocumentColorPresentation p = x.logUnimplementedRequest(p)
+    override x.TextDocumentColorPresentation p = x.logUnimplementedRequest (p)
 
-    override x.TextDocumentDocumentLink p = x.logUnimplementedRequest(p)
+    override x.TextDocumentDocumentLink p = x.logUnimplementedRequest (p)
 
-    override x.TextDocumentOnTypeFormatting p = x.logUnimplementedRequest(p)
+    override x.TextDocumentOnTypeFormatting p = x.logUnimplementedRequest (p)
 
-    override x.TextDocumentSemanticTokensFullDelta p = x.logUnimplementedRequest(p)
+    override x.TextDocumentSemanticTokensFullDelta p = x.logUnimplementedRequest (p)
 
-    override x.TextDocumentWillSave p = x.logIgnoredNotification(p)
+    override x.TextDocumentWillSave p = x.logIgnoredNotification (p)
 
-    override x.TextDocumentWillSaveWaitUntil p = x.logUnimplementedRequest(p)
+    override x.TextDocumentWillSaveWaitUntil p = x.logUnimplementedRequest (p)
 
-    override x.WorkspaceDidChangeWorkspaceFolders p = x.logIgnoredNotification(p)
+    override x.WorkspaceDidChangeWorkspaceFolders p = x.logIgnoredNotification (p)
 
-    override x.WorkspaceDidCreateFiles p = x.logIgnoredNotification(p)
+    override x.WorkspaceDidCreateFiles p = x.logIgnoredNotification (p)
 
-    override x.WorkspaceDidDeleteFiles p = x.logIgnoredNotification(p)
+    override x.WorkspaceDidDeleteFiles p = x.logIgnoredNotification (p)
 
-    override x.WorkspaceDidRenameFiles p = x.logIgnoredNotification(p)
+    override x.WorkspaceDidRenameFiles p = x.logIgnoredNotification (p)
 
-    override x.WorkspaceExecuteCommand p = x.logUnimplementedRequest(p)
+    override x.WorkspaceExecuteCommand p = x.logUnimplementedRequest (p)
 
-    override x.WorkspaceWillCreateFiles p = x.logUnimplementedRequest(p)
+    override x.WorkspaceWillCreateFiles p = x.logUnimplementedRequest (p)
 
-    override x.WorkspaceWillDeleteFiles p = x.logUnimplementedRequest(p)
+    override x.WorkspaceWillDeleteFiles p = x.logUnimplementedRequest (p)
 
-    override x.WorkspaceWillRenameFiles p = x.logUnimplementedRequest(p)
+    override x.WorkspaceWillRenameFiles p = x.logUnimplementedRequest (p)
 
-    override x.TextDocumentDeclaration p = x.logUnimplementedRequest(p)
-    override x.TextDocumentDiagnostic p = x.logUnimplementedRequest(p)
-    override x.TextDocumentLinkedEditingRange p = x.logUnimplementedRequest(p)
-    override x.TextDocumentMoniker p = x.logUnimplementedRequest(p)
-    override x.WorkspaceDiagnostic p = x.logUnimplementedRequest(p)
-    override x.WorkspaceSymbolResolve p = x.logUnimplementedRequest(p)
+    override x.TextDocumentDeclaration p = x.logUnimplementedRequest (p)
+    override x.TextDocumentDiagnostic p = x.logUnimplementedRequest (p)
+    override x.TextDocumentLinkedEditingRange p = x.logUnimplementedRequest (p)
+    override x.TextDocumentMoniker p = x.logUnimplementedRequest (p)
+    override x.WorkspaceDiagnostic p = x.logUnimplementedRequest (p)
+    override x.WorkspaceSymbolResolve p = x.logUnimplementedRequest (p)
 
     //unsupported -- end
 
@@ -1389,11 +1400,22 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient, sourceTextFactory
                   else
                     Array.append items KeywordList.keywordCompletionItems
 
-                let completionList = { IsIncomplete = false; Items = its; ItemDefaults = None }
+                let completionList =
+                  { IsIncomplete = false
+                    Items = its
+                    ItemDefaults = None }
+
                 return! success (Some completionList)
               | _ ->
                 logger.info (Log.setMessage "TextDocumentCompletion - no completion results")
-                return! success (Some { IsIncomplete = false; Items = [||]; ItemDefaults = None })
+
+                return!
+                  success (
+                    Some
+                      { IsIncomplete = false
+                        Items = [||]
+                        ItemDefaults = None }
+                  )
       }
 
     override __.CompletionItemResolve(ci: CompletionItem) =
@@ -2233,7 +2255,9 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient, sourceTextFactory
                 Edit =
                   { DocumentChanges =
                       Some
-                        [| { TextDocument = { Uri = p.TextDocument.Uri; Version = Some p.TextDocument.Version }
+                        [| { TextDocument =
+                               { Uri = p.TextDocument.Uri
+                                 Version = Some p.TextDocument.Version }
                              Edits =
                                [| { Range = fcsPosToProtocolRange insertPos
                                     NewText = text } |] } |]

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -75,7 +75,7 @@ let tests state =
 
           let textChange : DidChangeTextDocumentParams =
             {
-              TextDocument = { Uri = Path.FilePathToUri path ; Version = Some 1}
+              TextDocument = { Uri = Path.FilePathToUri path ; Version = 1}
               ContentChanges =  [|
                 {
                   Range = Some { Start = { Line = line; Character = character }; End = { Line = line; Character = character } }
@@ -162,7 +162,7 @@ let tests state =
 
           let textChange : DidChangeTextDocumentParams =
             {
-              TextDocument = { Uri = Path.FilePathToUri path ; Version = Some 1}
+              TextDocument = { Uri = Path.FilePathToUri path ; Version = 1}
               ContentChanges =  [|
                 {
                   Range = Some { Start = { Line = line; Character = character }; End = { Line = line; Character = character } }
@@ -249,7 +249,7 @@ let tests state =
 
           let textChange : DidChangeTextDocumentParams =
             {
-              TextDocument = { Uri = Path.FilePathToUri path ; Version = Some 1}
+              TextDocument = { Uri = Path.FilePathToUri path ; Version = 1}
               ContentChanges =  [|
                 {
                   Range = Some { Start = { Line = line; Character = character }; End = { Line = line; Character = character } }

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -37,6 +37,7 @@ let initTests createServer =
       let p: InitializeParams =
         { ProcessId = Some 1
           RootPath = Some __SOURCE_DIRECTORY__
+          Locale = None
           RootUri = None
           InitializationOptions = Some(Server.serialize defaultConfigDto)
           Capabilities = Some clientCaps
@@ -58,9 +59,9 @@ let initTests createServer =
 
         Expect.equal
           res.Capabilities.CodeActionProvider
-          (Some
+          (Some (U2.Second
             { CodeActionOptions.ResolveProvider = None
-              CodeActionOptions.CodeActionKinds = None })
+              CodeActionOptions.CodeActionKinds = None }))
           "Code Action Provider"
 
         Expect.equal
@@ -74,7 +75,7 @@ let initTests createServer =
         Expect.equal res.Capabilities.DocumentLinkProvider None "Document Link Provider"
         Expect.equal res.Capabilities.DocumentOnTypeFormattingProvider None "Document OnType Formatting Provider"
         Expect.equal res.Capabilities.DocumentRangeFormattingProvider (Some true) "Document Range Formatting Provider"
-        Expect.equal res.Capabilities.DocumentSymbolProvider (Some true) "Document Symbol Provider"
+        Expect.equal res.Capabilities.DocumentSymbolProvider (Some (U2.Second { Label = Some "F#" })) "Document Symbol Provider"
         Expect.equal res.Capabilities.ExecuteCommandProvider None "Execute Command Provider"
         Expect.equal res.Capabilities.Experimental None "Experimental"
         Expect.equal res.Capabilities.HoverProvider (Some true) "Hover Provider"
@@ -99,7 +100,7 @@ let initTests createServer =
 
         Expect.equal res.Capabilities.TextDocumentSync (Some td) "Text Document Provider"
         Expect.equal res.Capabilities.TypeDefinitionProvider (Some true) "Type Definition Provider"
-        Expect.equal res.Capabilities.WorkspaceSymbolProvider (Some true) "Workspace Symbol Provider"
+        Expect.equal res.Capabilities.WorkspaceSymbolProvider (Some (U2.Second { ResolveProvider = Some true })) "Workspace Symbol Provider"
         Expect.equal res.Capabilities.FoldingRangeProvider (Some true) "Folding Range Provider active"
       | Result.Error e -> failtest "Initialization failed"
     })

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -290,7 +290,9 @@ let clientCaps: ClientCapabilities =
 
     let symbolCaps: SymbolCapabilities =
       { DynamicRegistration = Some true
-        SymbolKind = None }
+        SymbolKind = None
+        TagSupport = None
+        ResolveSupport = None }
 
     let semanticTokenCaps: SemanticTokensWorkspaceClientCapabilities =
       { RefreshSupport = Some true }
@@ -307,12 +309,17 @@ let clientCaps: ClientCapabilities =
     { ApplyEdit = Some true
       WorkspaceEdit = Some weCaps
       DidChangeConfiguration = Some dynCaps
-      DidChangeWatchedFiles = Some dynCaps
+      DidChangeWatchedFiles = None
       Symbol = Some symbolCaps
       SemanticTokens = Some semanticTokenCaps
       InlayHint = Some inlayHintCaps
       InlineValue = Some inlineValueCaps
-      CodeLens = Some codeLensCaps }
+      CodeLens = Some codeLensCaps
+      ExecuteCommand = Some dynCaps
+      WorkspaceFolders = Some false
+      Configuration = Some true
+      FileOperations = None
+      Diagnostics = Some { RefreshSupport = Some false } }
 
   let textCaps: TextDocumentClientCapabilities =
     let syncCaps: SynchronizationCapabilities =
@@ -321,16 +328,26 @@ let clientCaps: ClientCapabilities =
         WillSaveWaitUntil = Some true
         DidSave = Some true }
 
-    let diagCaps: PublishDiagnosticsCapabilities =
+    let publishDiagCaps: PublishDiagnosticsCapabilities =
       let diagnosticTags: DiagnosticTagSupport = { ValueSet = [||] }
 
       { RelatedInformation = Some true
-        TagSupport = Some diagnosticTags }
+        TagSupport = Some diagnosticTags
+        VersionSupport = Some false
+        CodeDescriptionSupport = Some true
+        DataSupport = Some false }
 
     let ciCaps: CompletionItemCapabilities =
       { SnippetSupport = Some true
         CommitCharactersSupport = Some true
-        DocumentationFormat = None }
+        DocumentationFormat = None
+        DeprecatedSupport = Some false
+        PreselectSupport = Some false
+        TagSupport = None
+        InsertReplaceSupport = Some false
+        ResolveSupport = None
+        InsertTextModeSupport = None
+        LabelDetailsSupport = Some true }
 
     let cikCaps: CompletionItemKindCapabilities = { ValueSet = None }
 
@@ -338,7 +355,11 @@ let clientCaps: ClientCapabilities =
       { DynamicRegistration = Some true
         CompletionItem = Some ciCaps
         CompletionItemKind = Some cikCaps
-        ContextSupport = Some true }
+        ContextSupport = Some true
+        InsertTextMode = Some InsertTextMode.AsIs
+        CompletionList = Some {
+          ItemDefaults = None
+        } }
 
     let hoverCaps: HoverCapabilities =
       { DynamicRegistration = Some true
@@ -346,22 +367,29 @@ let clientCaps: ClientCapabilities =
 
     let sigCaps: SignatureHelpCapabilities =
       let siCaps: SignatureInformationCapabilities =
-        { DocumentationFormat = Some [| "markdown" |] }
+        { DocumentationFormat = Some [| "markdown" |]
+          ParameterInformation = Some { LabelOffsetSupport = Some true }
+          ActiveParameterSupport = Some true }
 
       { DynamicRegistration = Some true
-        SignatureInformation = Some siCaps }
+        SignatureInformation = Some siCaps
+        ContextSupport = Some true }
 
     let docSymCaps: DocumentSymbolCapabilities =
       let skCaps: SymbolKindCapabilities = { ValueSet = None }
 
       { DynamicRegistration = Some true
         SymbolKind = Some skCaps
-        HierarchicalDocumentSymbolSupport = Some false }
+        HierarchicalDocumentSymbolSupport = Some false
+        TagSupport = None
+        LabelSupport = Some true  }
 
     let foldingRangeCaps: FoldingRangeCapabilities =
       { DynamicRegistration = Some true
         LineFoldingOnly = Some true
-        RangeLimit = Some 100 }
+        RangeLimit = Some 100
+        FoldingRange = Some { CollapsedText = Some true }
+        FoldingRangeKind = None }
 
     let semanticTokensCaps: SemanticTokensClientCapabilities =
       { DynamicRegistration = Some true
@@ -372,7 +400,9 @@ let clientCaps: ClientCapabilities =
         TokenModifiers = [||]
         Formats = [| TokenFormat.Relative |]
         OverlappingTokenSupport = None
-        MultilineTokenSupport = None }
+        MultilineTokenSupport = None
+        ServerCancelSupport = Some true
+        AugmentsSyntaxTokens = Some true }
 
     let codeActionCaps =
       { DynamicRegistration = Some true
@@ -394,10 +424,39 @@ let clientCaps: ClientCapabilities =
     let renameCaps: RenameClientCapabilities =
       { DynamicRegistration = Some true
         HonorsChangeAnnotations = Some false
-        PrepareSupport = Some false }
+        PrepareSupport = Some false
+        PrepareSupportDefaultBehavior = Some PrepareSupportDefaultBehavior.Identifier }
+
+    let linkCaps: DynamicLinkSupportCapabilities =
+      { DynamicRegistration = Some true
+        LinkSupport = Some false }
+
+    let defCaps: DynamicLinkSupportCapabilities =
+      { DynamicRegistration = Some true
+        LinkSupport = Some false }
+
+    let typeDefCaps: DynamicLinkSupportCapabilities =
+      { DynamicRegistration = Some true
+        LinkSupport = Some false }
+
+    let implCaps: DynamicLinkSupportCapabilities =
+      { DynamicRegistration = Some true
+        LinkSupport = Some false }
+
+    let docLinkCaps: DocumentLinkCapabilities =
+      {
+        DynamicRegistration = Some true
+        TooltipSupport = Some true
+      }
+
+    let diagCaps: DiagnosticCapabilities =
+      {
+        DynamicRegistration = Some true
+        RelatedDocumentSupport = Some true
+      }
 
     { Synchronization = Some syncCaps
-      PublishDiagnostics = Some diagCaps
+      PublishDiagnostics = Some publishDiagCaps
       Completion = Some compCaps
       Hover = Some hoverCaps
       SignatureHelp = Some sigCaps
@@ -407,24 +466,32 @@ let clientCaps: ClientCapabilities =
       Formatting = Some dynCaps
       RangeFormatting = Some dynCaps
       OnTypeFormatting = Some dynCaps
-      Definition = Some dynCaps
+      Definition = Some defCaps
       CodeAction = Some codeActionCaps
       CodeLens = Some dynCaps
-      DocumentLink = Some dynCaps
+      DocumentLink = Some docLinkCaps
       Rename = Some renameCaps
       FoldingRange = Some foldingRangeCaps
       SelectionRange = Some dynCaps
       SemanticTokens = Some semanticTokensCaps
       InlayHint = Some inlayHintCaps
       CallHierarchy = None
-      TypeHierarchy = None }
-      // InlineValue = Some inlineValueCaps }
-
+      TypeHierarchy = None
+      Declaration = Some linkCaps
+      TypeDefinition = Some typeDefCaps
+      Implementation = Some implCaps
+      ColorProvider = Some dynCaps
+      LinkedEditingRange = Some dynCaps
+      Moniker = Some dynCaps
+      InlineValue = Some dynCaps
+      Diagnostic = Some diagCaps
+       }
 
   { Workspace = Some workspaceCaps
     TextDocument = Some textCaps
     Experimental = None
-    Window = None }
+    Window = None
+    General = None }
 
 open Expecto.Logging
 open Expecto.Logging.Message
@@ -502,7 +569,8 @@ let serverInitialize path (config: FSharpConfigDto) createServer =
           Some
             [| { Uri = Path.FilePathToUri path
                  Name = "Test Folder" } |]
-        trace = None }
+        trace = None
+        Locale = None }
 
     let! result = server.Initialize p
 

--- a/test/FsAutoComplete.Tests.Lsp/SignatureHelpTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/SignatureHelpTests.fs
@@ -67,7 +67,7 @@ let private functionApplicationEdgeCasesTests server =
       f 1 $0 // preserve last space
       """ Manual (fun resp ->
         match resp with
-        | Some sigHelp -> Expect.equal sigHelp.ActiveParameter (Some 1) "should have suggested the second parameter"
+        | Some sigHelp -> Expect.equal sigHelp.ActiveParameter (Some 1u) "should have suggested the second parameter"
         | None -> failwithf "There should be sighelp for this position")
       ptestCaseAsync "issue 745 - signature help shows tuples in parens"
       <| testSignatureHelp server """

--- a/test/FsAutoComplete.Tests.Lsp/Utils/TextEdit.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/TextEdit.fs
@@ -498,11 +498,11 @@ module WorkspaceEdit =
       if uri <> textDocument.Uri then
         Some $"Edit should be for document `{textDocument.Uri}`, but was for `{uri}`"
       else
-        match textDocument.Version, version with
-        // only compare `Version` when `textDocument` and `version` has a Version. Otherwise ignore
-        | Some textDocVersion, Some version when textDocVersion <> version ->
-            Some $"Edit should be for document version `{textDocVersion}`, but version was `{version}`"
-        | _ -> None
+        if Some textDocument.Version <> version then
+          // only compare `Version` when `textDocument` and `version` has a Version. Otherwise ignore
+          Some $"Edit should be for document version `{textDocument.Version}`, but version was `{version}`"
+        else
+          None
 
     match (workspaceEdit.DocumentChanges, workspaceEdit.Changes) with
     | None, None ->

--- a/test/FsAutoComplete.Tests.Lsp/XmlGenerationTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/XmlGenerationTests.fs
@@ -48,7 +48,7 @@ let tests state =
 
           let! result =
             server.FSharpDocumentationGenerator(
-              { TextDocument = { Uri = fileUri; Version = Some 1 }
+              { TextDocument = { Uri = fileUri; Version = 1 }
                 // the start of the 'add' symbol name
                 Position = { Line = 0; Character = 5 } }
             )


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b017462</samp>

The pull request updates the FsAutoComplete library and tests to align with the latest Language Server Protocol (LSP) specification. It changes some types and properties related to text document versions, signature help, symbol information, folding range, and other LSP features. It also improves the logging and readability of the LSP server code and fixes some minor issues. It updates the `Ionide.LanguageServerProtocol` package and suppresses a NuGet warning.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b017462</samp>

> _We're updating the LSP, me hearties, yo ho ho_
> _We're aligning with the spec, me hearties, yo ho ho_
> _We're changing types and properties, on the count of three_
> _We're making FsAutoComplete better, me hearties, yo ho ho_

<!--
copilot:emoji
-->

:arrow_up::mute::test_tube:

<!--
1.  :arrow_up: This emoji indicates that something was updated, upgraded, or improved, such as a package version, a type signature, or a LSP feature.
2. :mute: This emoji indicates that something was silenced, suppressed, or ignored, such as a warning, a request, or a notification.
3. :test_tube: This emoji indicates that something was tested, verified, or validated, such as a test case, a capability, or a parameter.
-->

### WHY

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b017462</samp>

*  Suppress NuGet package vulnerability warning by adding `NU1902` to `NoWarn` property ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL7-R8))
*  Update `Ionide.LanguageServerProtocol` package to version `0.4.16` ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-377fe73bf860b37e7d9a8ca5be27762668b3a08aac581b435d4c31b737d905cdL56-R56))
*  Change `ActiveParameter` property of `SignatureHelpInfo` type from `int option` to `uint option` and cast `argumentIndex` values to `uint` to match LSP specification for `SignatureInformation.activeParameter` ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-eba3b23ba360ad506d15e56d3bf96a0f2e88a1686c7d64e7416535eccc7481b8L25-R25), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-eba3b23ba360ad506d15e56d3bf96a0f2e88a1686c7d64e7416535eccc7481b8L119-R119), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-eba3b23ba360ad506d15e56d3bf96a0f2e88a1686c7d64e7416535eccc7481b8L205-R205))
*  Add `Tags` and `Deprecated` properties to `SymbolInformation` type and `CollapsedText` property to `FoldingRange` type with `None` values to match LSP specification ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-a0cc27b1398830cb3ce332015ecbd44c9649503474a0bfe34a6330dc04e99c55L134-R140), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-a0cc27b1398830cb3ce332015ecbd44c9649503474a0bfe34a6330dc04e99c55L431-R434))
*  Add `open` statements for `System.Runtime.CompilerServices` and `System.Runtime.InteropServices` namespaces to use `CallerMemberName` and `Optional` attributes ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0R19-R20), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01R31-R32))
*  Add `Version` property to `TextDocumentPublishDiagnostics` function and `TextDocument` type with `None` or `int` values to match LSP specification for `PublishDiagnosticsParams` and `VersionedTextDocumentIdentifier` ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L237-R240), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L362-R365), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L919-R925), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L78-R80), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L150-R152), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L185-R188), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL78-R78), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL165-R165), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL252-R252), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df6ecd6ffb2a39ad6403458fff9fb4a701bc5ef4e49f04142a7c93517fc7b21cL38-R38), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df6ecd6ffb2a39ad6403458fff9fb4a701bc5ef4e49f04142a7c93517fc7b21cL309-R310), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df6ecd6ffb2a39ad6403458fff9fb4a701bc5ef4e49f04142a7c93517fc7b21cL328-R332))
*  Add `logUnimplementedRequest` and `logIgnoredNotification` methods to `AdaptiveFSharpLspServer` and `FSharpLspServer` types to simplify logging of unsupported LSP requests and notifications and use them in various methods ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0R2100-R2115), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2121-R2140), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2397-R2417), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2520-R2540), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2673-R2693), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2680-R2701), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0R3180), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L3861-R3944), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4123-R4061), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4882-L4911), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L888-R958), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L2320-R2236))
*  Change `DocumentSymbolProvider` and `CodeActionProvider` properties to use `U2.Second` to indicate support for `DocumentSymbolOptions` and `CodeActionOptions` types ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-444833594f5cf1c53d97749a712d8a6dd25b635ecea7891390e37746a66a7f6fL219-R220), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-444833594f5cf1c53d97749a712d8a6dd25b635ecea7891390e37746a66a7f6fL232-R238), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-98d95065c549b6388e32cda6d77f0a620ff8ffe20be488ecdee740ffd8659888L61-R64), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-98d95065c549b6388e32cda6d77f0a620ff8ffe20be488ecdee740ffd8659888L77-R78))
*  Add `CompletionItem` property to `CompletionOptions` type with `None` value to match LSP specification ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-444833594f5cf1c53d97749a712d8a6dd25b635ecea7891390e37746a66a7f6fL232-R238))
*  Change `Label` property of `ParameterInformation` type from `string` to `U2<string, ParameterLabel>` and use `U2.First` to match LSP specification for `ParameterInformation.label` ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L1569-R1483))
*  Add `ActiveParameter` property to `SignatureInformation` type with `None` value to match LSP specification for `SignatureInformation.activeParameter` ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L1576-R1491))
*  Apply `U2.First` to `fcsRangeToLsp` function result to match LSP specification for `Location.range` ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01R1772))
*  Add `ItemDefaults` property to `CompletionList` type with `None` value to match LSP specification for `CompletionList` ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L1428-R1342), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L1478-R1396))
*  Explicitly type `inlineValueToggle` as `InlineValueOptions option` to avoid ambiguity with `InlayHintOptions` type ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L1117-R1030))
*  Explicitly type `p` parameter of `TextDocumentPublishDiagnostics` method as `PublishDiagnosticsParams` to avoid ambiguity with `TextDocumentDiagnostic` method ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-8ff27bd6886726bcfabce64ed8bac2ba936954fbf00e2c4d3e9c642a663c172aL52-R52))
*  Add `Locale` property to `InitializeParams` type with `None` value to match LSP specification for `InitializeParams.locale` ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-98d95065c549b6388e32cda6d77f0a620ff8ffe20be488ecdee740ffd8659888R40), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fL505-R573), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df6ecd6ffb2a39ad6403458fff9fb4a701bc5ef4e49f04142a7c93517fc7b21cR74))
*  Change `WorkspaceSymbolProvider` property to use `U2.Second` to indicate support for `WorkspaceSymbolOptions` type and add `ResolveProvider` property with `Some true` value ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-98d95065c549b6388e32cda6d77f0a620ff8ffe20be488ecdee740ffd8659888L102-R103))
*  Add various properties to `ClientCapabilities`, `WorkspaceClientCapabilities`, `TextDocumentClientCapabilities`, and related types to match LSP specification and represent client capabilities for various features ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fL293-R295), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fL310-R322), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fL324-R350), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fL341-R362), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fL349-R376), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fL359-R392), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fL375-R405), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fL397-R459), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fL410-R472), [link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fL420-R494))
*  Change `ActiveParameter` property of `SignatureHelp` type from `int option` to `uint option` and use `Some 1u` value ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-5b98e72b8edbc60cfe97e18a0c751e2cbbc9b1b438b4d5e427abf722338930fdL70-R70))
*  Compare `version` value with `Some textDocument.Version` instead of `textDocument.Version` to match new type signature ([link](https://github.com/fsharp/FsAutoComplete/pull/1149/files?diff=unified&w=0#diff-2a92438459a16ec39f7e144d1b231179084039e1d05dc64a46f1a139e188ea1aL501-R505))
