### PR TITLE
Fix ionide/ionide-vscode-fsharp#1906

### DIFF
--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -214,6 +214,9 @@ type NamedText(fileName: string<LocalPath>, str: string) =
 
   /// Provides safe access to a substring of the file via FCS-provided Range
   member x.GetText(m: FSharp.Compiler.Text.Range) : Result<string, string> =
+    // indexing into first line of empty file can be encountered when typing from an empty file
+    // if we don't check it, GetLineString will throw IndexOutOfRangeException
+    if (x :> ISourceText).GetLineCount() = 0 then Ok "" else
     if not (Range.rangeContainsRange x.TotalRange m) then
       Error $"%A{m} is outside of the bounds of the file"
     else if m.StartLine = m.EndLine then // slice of a single line, just do that
@@ -248,6 +251,8 @@ type NamedText(fileName: string<LocalPath>, str: string) =
 
   /// Provides safe access to a line of the file via FCS-provided Position
   member x.GetLine(pos: FSharp.Compiler.Text.Position) : string option =
+    // indexing into first line of empty file can be encountered when typing from an empty file
+    if (x :> ISourceText).GetLineCount() = 0 then Some "" else
     if pos.Line < 1 || pos.Line > getLines.Value.Length then
       None
     else
@@ -265,6 +270,9 @@ type NamedText(fileName: string<LocalPath>, str: string) =
   /// Also available in indexer form: <code lang="fsharp">x[pos]</code></summary>
   member x.TryGetChar(pos: FSharp.Compiler.Text.Position) : char option =
     option {
+      // indexing into first line of empty file can be encountered when typing from an empty file
+      // if we don't check it, GetLineUnsafe will throw IndexOutOfRangeException
+      do! Option.guard ((x :> ISourceText).GetLineCount() > 0)
       do! Option.guard (Range.rangeContainsPos (x.TotalRange) pos)
       let lineText = x.GetLineUnsafe(pos)
 

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -216,8 +216,9 @@ type NamedText(fileName: string<LocalPath>, str: string) =
   member x.GetText(m: FSharp.Compiler.Text.Range) : Result<string, string> =
     // indexing into first line of empty file can be encountered when typing from an empty file
     // if we don't check it, GetLineString will throw IndexOutOfRangeException
-    if (x :> ISourceText).GetLineCount() = 0 then Ok "" else
-    if not (Range.rangeContainsRange x.TotalRange m) then
+    if (x :> ISourceText).GetLineCount() = 0 then
+      Ok ""
+    else if not (Range.rangeContainsRange x.TotalRange m) then
       Error $"%A{m} is outside of the bounds of the file"
     else if m.StartLine = m.EndLine then // slice of a single line, just do that
       let lineText = (x :> ISourceText).GetLineString(m.StartLine - 1)
@@ -252,8 +253,9 @@ type NamedText(fileName: string<LocalPath>, str: string) =
   /// Provides safe access to a line of the file via FCS-provided Position
   member x.GetLine(pos: FSharp.Compiler.Text.Position) : string option =
     // indexing into first line of empty file can be encountered when typing from an empty file
-    if (x :> ISourceText).GetLineCount() = 0 then Some "" else
-    if pos.Line < 1 || pos.Line > getLines.Value.Length then
+    if (x :> ISourceText).GetLineCount() = 0 then
+      Some ""
+    else if pos.Line < 1 || pos.Line > getLines.Value.Length then
       None
     else
       Some(x.GetLineUnsafe pos)

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -417,8 +417,8 @@ type AdaptiveFSharpLspServer
     disposables.Add
     <| fileChecked.Publish.Subscribe(fun (parseAndCheck, volatileFile, ct) ->
       if volatileFile.Source.Length = 0 then
-        ()
-      else // Don't analyze and error on an empty file
+        () // Don't analyze and error on an empty file
+      else
         async {
           let config = config |> AVal.force
           do! builtInCompilerAnalyzers config volatileFile parseAndCheck
@@ -2443,8 +2443,8 @@ type AdaptiveFSharpLspServer
           let! volatileFile = forceFindOpenFileOrRead filePath |> AsyncResult.ofStringErr
 
           if volatileFile.Source.Length = 0 then
-            return None
-          else // An empty file has empty completions. Otherwise we would error down there
+            return None // An empty file has empty completions. Otherwise we would error down there
+          else
 
             let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
 

--- a/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
@@ -89,7 +89,7 @@ let tests state =
                   let! compilerResults = waitForCompilerDiagnosticsForFile "EmptyFile.fsx" events |> Async.StartChild
 
                   match! compilerResults with
-                  | Ok () -> failtest "should get an F# compiler checking error from an 'c' by itself"
+                  | Ok () -> failtest "should get an F# compiler checking error from a 'c' by itself"
                   | Core.Result.Error errors ->
                     Expect.hasLength errors 1 "should have only an error FS0039: identifier not defined"
                     Expect.exists errors (fun error -> error.Code = Some "39") "should have an error FS0039: identifier not defined"

--- a/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
@@ -1,0 +1,110 @@
+module FsAutoComplete.Tests.EmptyFileTests
+
+open Expecto
+open System.IO
+open Helpers
+open Ionide.LanguageServerProtocol.Types
+open FsAutoComplete.Utils
+open FsAutoComplete.Lsp
+open FsToolkit.ErrorHandling
+open Utils.Server
+open Helpers.Expecto.ShadowedTimeouts
+
+let tests state =
+  let createServer() =
+    async {
+      let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "EmptyFileTests")
+
+      let scriptPath = Path.Combine(path, "EmptyFile.fsx")
+
+      let! (server, events) = serverInitialize path defaultConfigDto state
+
+      do! waitForWorkspaceFinishedParsing events
+      return server, events, scriptPath
+    }
+    |> Async.Cache
+  let server1 = createServer()
+  let server2 = createServer()
+
+  testList
+    "empty file features"
+    [ testList
+        "tests"
+        [
+            testCaseAsync
+                "no parsing/checking errors"
+                (async {
+                  let! server, events, scriptPath = server1
+                  do! server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath }
+
+                  match! waitForParseResultsForFile "EmptyFile.fsx" events with
+                  | Ok () -> () // all good, no parsing/checking errors
+                  | Core.Result.Error errors -> failwithf "Errors while parsing script %s: %A" scriptPath errors
+                  do! server.TextDocumentDidClose { TextDocument = { Uri = Path.FilePathToUri scriptPath } }
+                })
+            
+            testCaseAsync
+                "auto completion does not throw and is empty"
+                (async {
+                  let! server, _, path = server1
+                  do! server.TextDocumentDidOpen { TextDocument = loadDocument path }
+
+                  let completionParams: CompletionParams =
+                    { TextDocument = { Uri = Path.FilePathToUri path }
+                      Position = { Line = 0; Character = 0 }
+                      Context =
+                          Some
+                            { triggerKind = CompletionTriggerKind.Invoked
+                              triggerCharacter = None } }
+
+                  let! response = server.TextDocumentCompletion completionParams
+
+                  match response with
+                  | Ok (Some _) -> failtest "An empty file has empty completions"
+                  | Ok None -> ()
+                  | Error e -> failtestf "Got an error while retrieving completions: %A" e
+                })
+            testCaseAsync
+                "type 'c' for checking error and autocompletion starts with 'async'"
+                (async {
+                  let! server, events, scriptPath = server2
+                  do! server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath }
+                  
+                  do! server.TextDocumentDidChange {
+                      TextDocument = { Uri = Path.FilePathToUri scriptPath; Version = 1 }
+                      ContentChanges =  [| {
+                          Range = Some { Start = { Line = 0; Character = 0 }; End = { Line = 0; Character = 0 } }
+                          RangeLength = Some 0
+                          Text = "c"
+                      } |]
+                    }
+
+                  let! completions =
+                    server.TextDocumentCompletion {
+                      TextDocument = { Uri = Path.FilePathToUri scriptPath }
+                      Position = { Line = 0; Character = 1 }
+                      Context =
+                        Some
+                          { triggerKind = CompletionTriggerKind.Invoked
+                            triggerCharacter = None }
+                    } |> Async.StartChild
+
+                  match! waitForCompilerDiagnosticsForFile "EmptyFile.fsx" events with
+                  | Ok () -> failtest "should get a checking error from an 'c' by itself"
+                  | Core.Result.Error errors ->
+                    Expect.hasLength errors 1 "should have an error FS0039: identifier not defined"
+                    Expect.exists errors (fun error -> error.Code = Some "39") "should have an error FS0039: identifier not defined"
+
+                  match! completions with
+                  | Ok (Some completions) ->
+                    Expect.isGreaterThan
+                      completions.Items.Length
+                      30
+                      "should have a complete completion list all containing c"
+
+                    let firstItem = completions.Items.[0]
+                    Expect.equal firstItem.Label "async" "first member should be async"
+                  | Ok None -> failtest "Should have gotten some completion items"
+                  | Error e -> failtestf "Got an error while retrieving completions: %A" e
+                })
+        ]]

--- a/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
@@ -89,9 +89,9 @@ let tests state =
                   let! compilerResults = waitForCompilerDiagnosticsForFile "EmptyFile.fsx" events |> Async.StartChild
 
                   match! compilerResults with
-                  | Ok () -> failtest "should get a checking error from an 'c' by itself"
+                  | Ok () -> failtest "should get an F# compiler checking error from an 'c' by itself"
                   | Core.Result.Error errors ->
-                    Expect.hasLength errors 1 "should have an error FS0039: identifier not defined"
+                    Expect.hasLength errors 1 "should have only an error FS0039: identifier not defined"
                     Expect.exists errors (fun error -> error.Code = Some "39") "should have an error FS0039: identifier not defined"
 
                   match! completions with

--- a/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
@@ -37,18 +37,9 @@ let tests state =
                   let! server, events, scriptPath = server1
                   do! server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath }
 
-                  let! parseResults = waitForParseResultsForFile "EmptyFile.fsx" events |> Async.StartChild
-                  let! fsacResults = waitForFsacDiagnosticsForFile "EmptyFile.fsx" events |> Async.StartChild
-                  let! compilerResults = waitForCompilerDiagnosticsForFile "EmptyFile.fsx" events |> Async.StartChild
-                  match! parseResults with
-                  | Ok () -> () // all good, no parsing/checking errors
+                  match! waitForParseResultsForFile "EmptyFile.fsx" events with
+                  | Ok _ -> () // all good, no parsing/checking errors
                   | Core.Result.Error errors -> failwithf "Errors while parsing script %s: %A" scriptPath errors
-                  match! fsacResults with
-                  | Ok () -> () // all good, no parsing/checking errors
-                  | Core.Result.Error errors -> failwithf "FSAC error while checking script %s: %A" scriptPath errors
-                  match! compilerResults with
-                  | Ok () -> () // all good, no parsing/checking errors
-                  | Core.Result.Error errors -> failwithf "Compiler error while checking script %s: %A" scriptPath errors
                 })
             
             testCaseAsync

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -119,7 +119,7 @@ let lspTests =
                 InlayHintTests.tests createServer
                 DependentFileChecking.tests createServer
                 UnusedDeclarationsTests.tests createServer
-
+                EmptyFileTests.tests createServer
                 ] ]
 
 /// Tests that do not require a LSP server


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ff5882</samp>

This pull request improves the support for empty or unsaved files in the F# language server and the `NamedText` type. It fixes potential exceptions, skips unnecessary operations, and adds tests for the language server features on empty files. It affects the files `src/FsAutoComplete.Core/FileSystem.fs`, `src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs`, `test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs`, and `test/FsAutoComplete.Tests.Lsp/Program.fs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8ff5882</samp>

> _The F# language server is great_
> _But it had some issues of late_
> _With empty files_
> _It threw some trials_
> _So this pull request fixes its state_

<!--
copilot:emoji
-->

🧪🛠️📄

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate the addition of new tests or test modules.
2.  🛠️ - This emoji represents tools, fixing, or construction, and can be used to indicate the improvement or enhancement of existing features or functionality.
3.  📄 - This emoji represents paper, documents, or files, and can be used to indicate the handling or manipulation of files or file contents.
-->

### WHY
Fixes https://github.com/ionide/ionide-vscode-fsharp/issues/1906

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8ff5882</samp>

*  Prevent errors and handle empty files in the `NamedText` type ([link](https://github.com/fsharp/FsAutoComplete/pull/1152/files?diff=unified&w=0#diff-7c1d3328baa270a7e1450113731e5f1fe55cce453db26186a346965e4b66e981R217-R219), [link](https://github.com/fsharp/FsAutoComplete/pull/1152/files?diff=unified&w=0#diff-7c1d3328baa270a7e1450113731e5f1fe55cce453db26186a346965e4b66e981R254-R255), [link](https://github.com/fsharp/FsAutoComplete/pull/1152/files?diff=unified&w=0#diff-7c1d3328baa270a7e1450113731e5f1fe55cce453db26186a346965e4b66e981R273-R275)) and the `AdaptiveFSharpLspServer` type ([link](https://github.com/fsharp/FsAutoComplete/pull/1152/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0R419), [link](https://github.com/fsharp/FsAutoComplete/pull/1152/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L1057-R1072), [link](https://github.com/fsharp/FsAutoComplete/pull/1152/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2435-R2442)) by adding checks for the length of the source text and returning default or empty values as appropriate.
