### PR TITLE
Extract out AST-collecting-walker to a separate function + abstract class

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -206,7 +206,7 @@ module Commands =
   let getRangesAtPosition (getParseResultsForFile: _ -> Async<Result<FSharpParseFileResults, _>>) file positions =
     asyncResult {
       let! ast = getParseResultsForFile file
-      return positions |> List.map (UntypedAstUtils.getRangesAtPosition ast.ParseTree)
+      return positions |> List.map (FoldingRange.getRangesAtPosition ast.ParseTree)
     }
 
   let scopesForFile

--- a/src/FsAutoComplete.Core/UntypedAstUtils.fs
+++ b/src/FsAutoComplete.Core/UntypedAstUtils.fs
@@ -1,663 +1,663 @@
-/// Code from VisualFSharpPowerTools project: https://github.com/fsprojects/VisualFSharpPowerTools/blob/master/src/FSharp.Editing/Common/UntypedAstUtils.fs
-module FsAutoComplete.UntypedAstUtils
+namespace FSharp.Compiler
 
-open FSharp.Compiler.Syntax
-open System.Collections.Generic
-open FSharp.Compiler
-open FSharp.Compiler.Text
-open FSharp.Control.Reactive.Observable
+module Syntax =
+  open FSharp.Compiler.Syntax
 
-type Range with
+  /// A pattern that collects all attributes from a `SynAttributes` into a single flat list
+  let (|AllAttrs|) (attrs: SynAttributes) =
+    attrs |> List.collect (fun attrList -> attrList.Attributes)
 
-  member inline x.IsEmpty = x.StartColumn = x.EndColumn && x.StartLine = x.EndLine
-
-type internal ShortIdent = string
-type internal Idents = ShortIdent[]
-
-let internal longIdentToArray (longIdent: LongIdent) : Idents =
-  longIdent |> Seq.map string |> Seq.toArray
-
-/// An recursive pattern that collect all sequential expressions to avoid StackOverflowException
-let rec (|Sequentials|_|) =
-  function
-  | SynExpr.Sequential(_, _, e, Sequentials es, _) -> Some(e :: es)
-  | SynExpr.Sequential(_, _, e1, e2, _) -> Some [ e1; e2 ]
-  | _ -> None
-
-let (|ConstructorPats|) =
-  function
-  | SynArgPats.Pats ps -> ps
-  | SynArgPats.NamePatPairs(pats = xs) -> xs |> List.map (fun (_, _, pat) -> pat)
-
-/// matches if the range contains the position
-let (|ContainsPos|_|) pos range =
-  if Range.rangeContainsPos range pos then Some() else None
-
-/// Active pattern that matches an ident on a given name by the ident's `idText`
-let (|Ident|_|) ofName =
-  function
-  | SynExpr.Ident ident when ident.idText = ofName -> Some()
-  | _ -> None
-
-/// matches if the range contains the position
-let (|IdentContainsPos|_|) pos (ident: Ident) = (|ContainsPos|_|) pos ident.idRange
-
-/// A pattern that collects all attributes from a `SynAttributes` into a single flat list
-let (|AllAttrs|) (attrs: SynAttributes) =
-  attrs |> List.collect (fun attrList -> attrList.Attributes)
-
-/// A pattern that collects all patterns from a `SynSimplePats` into a single flat list
-let (|AllSimplePats|) (pats: SynSimplePats) =
-  let rec loop acc pat =
-    match pat with
-    | SynSimplePats.SimplePats(pats = pats) -> acc @ pats
-
-  loop [] pats
-
-
-type UntypedSyntaxCollectorVisitor() =
-  abstract WalkSynModuleOrNamespace: SynModuleOrNamespace -> unit
-  default _.WalkSynModuleOrNamespace m = ()
-  abstract WalkAttribute: SynAttribute -> unit
-  default _.WalkAttribute a = ()
-  abstract WalkSynModuleDecl: SynModuleDecl -> unit
-  default _.WalkSynModuleDecl m = ()
-  abstract WalkExpr: SynExpr -> unit
-  default _.WalkExpr s = ()
-  abstract WalkTypar: SynTypar -> unit
-  default _.WalkTypar s = ()
-  abstract WalkTyparDecl: SynTyparDecl -> unit
-  default _.WalkTyparDecl s = ()
-  abstract WalkTypeConstraint: SynTypeConstraint -> unit
-  default _.WalkTypeConstraint s = ()
-  abstract WalkType: SynType -> unit
-  default _.WalkType s = ()
-  abstract WalkMemberSig: SynMemberSig -> unit
-  default _.WalkMemberSig s = ()
-  abstract WalkPat: SynPat -> unit
-  default _.WalkPat s = ()
-  abstract WalkValTyparDecls: SynValTyparDecls -> unit
-  default _.WalkValTyparDecls s = ()
-  abstract WalkBinding: SynBinding -> unit
-  default _.WalkBinding s = ()
-
-  abstract WalkSimplePat: SynSimplePat -> unit
-  default _.WalkSimplePat s = ()
-
-  abstract WalkInterfaceImpl: SynInterfaceImpl -> unit
-  default _.WalkInterfaceImpl s = ()
-  abstract WalkClause: SynMatchClause -> unit
-  default _.WalkClause s = ()
-  abstract WalkInterpolatedStringPart: SynInterpolatedStringPart -> unit
-  default _.WalkInterpolatedStringPart s = ()
-
-  abstract WalkMeasure: SynMeasure -> unit
-  default _.WalkMeasure s = ()
-  abstract WalkComponentInfo: SynComponentInfo -> unit
-  default _.WalkComponentInfo s = ()
-  abstract WalkTypeDefnSigRepr: SynTypeDefnSigRepr -> unit
-  default _.WalkTypeDefnSigRepr s = ()
-  abstract WalkUnionCaseType: SynUnionCaseKind -> unit
-  default _.WalkUnionCaseType s = ()
-  abstract WalkEnumCase: SynEnumCase -> unit
-  default _.WalkEnumCase s = ()
-  abstract WalkField: SynField -> unit
-  default _.WalkField s = ()
-  abstract WalkTypeDefnSimple: SynTypeDefnSimpleRepr -> unit
-  default _.WalkTypeDefnSimple s = ()
-
-  abstract WalkValSig: SynValSig -> unit
-  default _.WalkValSig s = ()
-
-  abstract WalkMember: SynMemberDefn -> unit
-  default _.WalkMember s = ()
-
-  abstract WalkUnionCase: SynUnionCase -> unit
-  default _.WalkUnionCase s = ()
-
-  abstract WalkTypeDefnRepr: SynTypeDefnRepr -> unit
-  default _.WalkTypeDefnRepr s = ()
-
-  abstract WalkTypeDefn: SynTypeDefn -> unit
-  default _.WalkTypeDefn s = ()
-
-let walkAst (walker: UntypedSyntaxCollectorVisitor) (input: ParsedInput) : unit =
-
-  let rec walkImplFileInput (ParsedImplFileInput(contents = moduleOrNamespaceList)) =
-    List.iter walkSynModuleOrNamespace moduleOrNamespaceList
-
-  and walkSynModuleOrNamespace (SynModuleOrNamespace(decls = decls; attribs = AllAttrs attrs; range = r) as s) =
-    walker.WalkSynModuleOrNamespace s
-    List.iter walkAttribute attrs
-    List.iter walkSynModuleDecl decls
-
-  and walkAttribute (attr: SynAttribute) = walkExpr attr.ArgExpr
-
-  and walkTyparDecl (SynTyparDecl(attributes = AllAttrs attrs; Item2 = typar)) =
-    List.iter walkAttribute attrs
-    walkTypar typar
-
-  and walkTyparDecls (typars: SynTyparDecls) =
-    typars.TyparDecls |> List.iter walkTyparDecl
-    typars.Constraints |> List.iter walkTypeConstraint
-
-  and walkSynValTyparDecls (SynValTyparDecls(typars, _)) = Option.iter walkTyparDecls typars
-
-  and walkTypeConstraint s =
-    walker.WalkTypeConstraint s
-
-    match s with
-    | SynTypeConstraint.WhereTyparIsValueType(t, r)
-    | SynTypeConstraint.WhereTyparIsReferenceType(t, r)
-    | SynTypeConstraint.WhereTyparIsUnmanaged(t, r)
-    | SynTypeConstraint.WhereTyparSupportsNull(t, r)
-    | SynTypeConstraint.WhereTyparIsComparable(t, r)
-    | SynTypeConstraint.WhereTyparIsEquatable(t, r) -> walkTypar t
-    | SynTypeConstraint.WhereTyparDefaultsToType(t, ty, r)
-    | SynTypeConstraint.WhereTyparSubtypeOfType(t, ty, r) ->
-      walkTypar t
-      walkType ty
-    | SynTypeConstraint.WhereTyparIsEnum(t, ts, r)
-    | SynTypeConstraint.WhereTyparIsDelegate(t, ts, r) ->
-      walkTypar t
-      List.iter walkType ts
-    | SynTypeConstraint.WhereTyparSupportsMember(t, sign, r) ->
-      walkType t
-      walkMemberSig sign
-    | SynTypeConstraint.WhereSelfConstrained(t, r) -> walkType t
-
-  and walkPat s =
-    walker.WalkPat s
-
-    match s with
-    | SynPat.Tuple(elementPats = pats; range = r)
-    | SynPat.ArrayOrList(_, pats, r)
-    | SynPat.Ands(pats, r) -> List.iter walkPat pats
-    | SynPat.Named(ident, _, _, r) -> ()
-    | SynPat.Typed(pat, t, r) ->
-      walkPat pat
-      walkType t
-    | SynPat.Attrib(pat, AllAttrs attrs, r) ->
-      walkPat pat
-      List.iter walkAttribute attrs
-    | SynPat.Or(pat1, pat2, r, _) -> List.iter walkPat [ pat1; pat2 ]
-    | SynPat.LongIdent(typarDecls = typars; argPats = ConstructorPats pats; range = r) ->
-      Option.iter walkSynValTyparDecls typars
-      List.iter walkPat pats
-    | SynPat.Paren(pat, r) -> walkPat pat
-    | SynPat.IsInst(t, r) -> walkType t
-    | SynPat.QuoteExpr(e, r) -> walkExpr e
-    | SynPat.Const(_, r) -> ()
-    | SynPat.Wild(r) -> ()
-    | SynPat.Record(_, r) -> ()
-    | SynPat.Null(r) -> ()
-    | SynPat.OptionalVal(_, r) -> ()
-    | SynPat.DeprecatedCharRange(_, _, r) -> ()
-    | SynPat.InstanceMember(_, _, _, accessibility, r) -> ()
-    | SynPat.FromParseError(_, r) -> ()
-    | SynPat.As(lpat, rpat, r) ->
-      walkPat lpat
-      walkPat rpat
-    | SynPat.ListCons(lpat, rpat, r, _) ->
-      walkPat lpat
-      walkPat rpat
-
-  and walkTypar (SynTypar(_, _, _) as s) = walker.WalkTypar s
-
-  and walkBinding
-    (SynBinding(attributes = AllAttrs attrs; headPat = pat; returnInfo = returnInfo; expr = e; range = r) as s)
-    =
-    walker.WalkBinding s
-    List.iter walkAttribute attrs
-    walkPat pat
-    walkExpr e
-
-    returnInfo
-    |> Option.iter (fun (SynBindingReturnInfo(t, r, attrs, _)) ->
-      walkType t
-      walkAttributes attrs)
-
-  and walkAttributes (attrs: SynAttributes) =
-    List.iter (fun (attrList: SynAttributeList) -> List.iter walkAttribute attrList.Attributes) attrs
-
-  and walkInterfaceImpl (SynInterfaceImpl(bindings = bindings; range = r) as s) =
-    walker.WalkInterfaceImpl s
-    List.iter walkBinding bindings
-
-  and walkType s =
-    walker.WalkType s
-
-    match s with
-    | SynType.Array(_, t, r)
-    | SynType.HashConstraint(t, r)
-    | SynType.MeasurePower(t, _, r) -> walkType t
-    | SynType.Fun(t1, t2, r, _) ->
-      // | SynType.MeasureDivide(t1, t2, r) ->
-      walkType t1
-      walkType t2
-    | SynType.App(ty, _, types, _, _, _, r) ->
-      walkType ty
-      List.iter walkType types
-    | SynType.LongIdentApp(_, _, _, types, _, _, r) -> List.iter walkType types
-    | SynType.Tuple(_, ts, r) ->
-      ts
-      |> List.iter (function
-        | SynTupleTypeSegment.Type t -> walkType t
-        | _ -> ())
-    | SynType.WithGlobalConstraints(t, typeConstraints, r) ->
-      walkType t
-      List.iter walkTypeConstraint typeConstraints
-    | SynType.LongIdent(longDotId) -> ()
-    | SynType.AnonRecd(isStruct, typeNames, r) -> ()
-    | SynType.Var(genericName, r) -> ()
-    | SynType.Anon(r) -> ()
-    | SynType.StaticConstant(constant, r) -> ()
-    | SynType.StaticConstantExpr(expr, r) -> ()
-    | SynType.StaticConstantNamed(expr, _, r) -> ()
-    | SynType.Paren(innerType, r) -> walkType innerType
-    | SynType.SignatureParameter(usedType = t; range = r) -> walkType t
-    | SynType.Or(lhs, rhs, r, _) ->
-      walkType lhs
-      walkType rhs
-    | SynType.FromParseError(r) -> ()
-
-  and walkClause (SynMatchClause(pat, e1, e2, r, _, _) as s) =
-    walker.WalkClause s
-    walkPat pat
-    walkExpr e2
-    e1 |> Option.iter walkExpr
-
-  and walkSimplePats =
+  /// An recursive pattern that collect all sequential expressions to avoid StackOverflowException
+  let rec (|Sequentials|_|) =
     function
-    | SynSimplePats.SimplePats(pats = pats; range = r) -> List.iter walkSimplePat pats
+    | SynExpr.Sequential(_, _, e, Sequentials es, _) -> Some(e :: es)
+    | SynExpr.Sequential(_, _, e1, e2, _) -> Some [ e1; e2 ]
+    | _ -> None
 
-  and walkInterpolatedStringPart s =
-    walker.WalkInterpolatedStringPart s
+  let (|ConstructorPats|) =
+    function
+    | SynArgPats.Pats ps -> ps
+    | SynArgPats.NamePatPairs(pats = xs) -> xs |> List.map (fun (_, _, pat) -> pat)
 
-    match s with
-    | SynInterpolatedStringPart.FillExpr(expr, ident) -> walkExpr expr
-    | SynInterpolatedStringPart.String(s, r) -> ()
+  /// A pattern that collects all patterns from a `SynSimplePats` into a single flat list
+  let (|AllSimplePats|) (pats: SynSimplePats) =
+    let rec loop acc pat =
+      match pat with
+      | SynSimplePats.SimplePats(pats = pats) -> acc @ pats
 
-  and walkExpr s =
-    walker.WalkExpr s
+    loop [] pats
 
-    match s with
-    | SynExpr.Typed(e, _, r) -> walkExpr e
-    | SynExpr.Paren(e, _, _, r)
-    | SynExpr.Quote(_, _, e, _, r)
-    | SynExpr.InferredUpcast(e, r)
-    | SynExpr.InferredDowncast(e, r)
-    | SynExpr.AddressOf(_, e, _, r)
-    | SynExpr.DoBang(e, r)
-    | SynExpr.YieldOrReturn(_, e, r)
-    | SynExpr.ArrayOrListComputed(_, e, r)
-    | SynExpr.ComputationExpr(_, e, r)
-    | SynExpr.Do(e, r)
-    | SynExpr.Assert(e, r)
-    | SynExpr.Lazy(e, r)
-    | SynExpr.YieldOrReturnFrom(_, e, r) -> walkExpr e
-    | SynExpr.SequentialOrImplicitYield(_, e1, e2, ifNotE, r) ->
-      walkExpr e1
-      walkExpr e2
-      walkExpr ifNotE
-    | SynExpr.Lambda(args = pats; body = e; range = r) ->
-      walkSimplePats pats
-      walkExpr e
-    | SynExpr.New(_, t, e, r)
-    | SynExpr.TypeTest(e, t, r)
-    | SynExpr.Upcast(e, t, r)
-    | SynExpr.Downcast(e, t, r) ->
-      walkExpr e
-      walkType t
-    | SynExpr.Tuple(_, es, _, _)
-    | Sequentials es -> List.iter walkExpr es //TODO??
-    | SynExpr.ArrayOrList(_, es, r) -> List.iter walkExpr es
-    | SynExpr.App(_, _, e1, e2, r)
-    | SynExpr.TryFinally(e1, e2, r, _, _, _)
-    | SynExpr.While(_, e1, e2, r) -> List.iter walkExpr [ e1; e2 ]
-    | SynExpr.Record(_, _, fields, r) ->
+  type SyntaxCollectorBase() =
+    abstract WalkSynModuleOrNamespace: SynModuleOrNamespace -> unit
+    default _.WalkSynModuleOrNamespace m = ()
+    abstract WalkAttribute: SynAttribute -> unit
+    default _.WalkAttribute a = ()
+    abstract WalkSynModuleDecl: SynModuleDecl -> unit
+    default _.WalkSynModuleDecl m = ()
+    abstract WalkExpr: SynExpr -> unit
+    default _.WalkExpr s = ()
+    abstract WalkTypar: SynTypar -> unit
+    default _.WalkTypar s = ()
+    abstract WalkTyparDecl: SynTyparDecl -> unit
+    default _.WalkTyparDecl s = ()
+    abstract WalkTypeConstraint: SynTypeConstraint -> unit
+    default _.WalkTypeConstraint s = ()
+    abstract WalkType: SynType -> unit
+    default _.WalkType s = ()
+    abstract WalkMemberSig: SynMemberSig -> unit
+    default _.WalkMemberSig s = ()
+    abstract WalkPat: SynPat -> unit
+    default _.WalkPat s = ()
+    abstract WalkValTyparDecls: SynValTyparDecls -> unit
+    default _.WalkValTyparDecls s = ()
+    abstract WalkBinding: SynBinding -> unit
+    default _.WalkBinding s = ()
+    abstract WalkSimplePat: SynSimplePat -> unit
+    default _.WalkSimplePat s = ()
+    abstract WalkInterfaceImpl: SynInterfaceImpl -> unit
+    default _.WalkInterfaceImpl s = ()
+    abstract WalkClause: SynMatchClause -> unit
+    default _.WalkClause s = ()
+    abstract WalkInterpolatedStringPart: SynInterpolatedStringPart -> unit
+    default _.WalkInterpolatedStringPart s = ()
+    abstract WalkMeasure: SynMeasure -> unit
+    default _.WalkMeasure s = ()
+    abstract WalkComponentInfo: SynComponentInfo -> unit
+    default _.WalkComponentInfo s = ()
+    abstract WalkTypeDefnSigRepr: SynTypeDefnSigRepr -> unit
+    default _.WalkTypeDefnSigRepr s = ()
+    abstract WalkUnionCaseType: SynUnionCaseKind -> unit
+    default _.WalkUnionCaseType s = ()
+    abstract WalkEnumCase: SynEnumCase -> unit
+    default _.WalkEnumCase s = ()
+    abstract WalkField: SynField -> unit
+    default _.WalkField s = ()
+    abstract WalkTypeDefnSimple: SynTypeDefnSimpleRepr -> unit
+    default _.WalkTypeDefnSimple s = ()
+    abstract WalkValSig: SynValSig -> unit
+    default _.WalkValSig s = ()
+    abstract WalkMember: SynMemberDefn -> unit
+    default _.WalkMember s = ()
+    abstract WalkUnionCase: SynUnionCase -> unit
+    default _.WalkUnionCase s = ()
+    abstract WalkTypeDefnRepr: SynTypeDefnRepr -> unit
+    default _.WalkTypeDefnRepr s = ()
+    abstract WalkTypeDefn: SynTypeDefn -> unit
+    default _.WalkTypeDefn s = ()
 
-      fields
-      |> List.iter (fun (SynExprRecordField(fieldName = (ident, _); expr = e)) -> e |> Option.iter walkExpr)
-    | SynExpr.ObjExpr(ty, argOpt, _, bindings, _, ifaces, _, r) ->
+  let walkAst (walker: SyntaxCollectorBase) (input: ParsedInput) : unit =
 
-      argOpt |> Option.iter (fun (e, ident) -> walkExpr e)
+    let rec walkImplFileInput (ParsedImplFileInput(contents = moduleOrNamespaceList)) =
+      List.iter walkSynModuleOrNamespace moduleOrNamespaceList
 
-      walkType ty
-      List.iter walkBinding bindings
-      List.iter walkInterfaceImpl ifaces
-    | SynExpr.For(identBody = e1; toBody = e2; doBody = e3; range = r) -> List.iter walkExpr [ e1; e2; e3 ]
-    | SynExpr.ForEach(_, _, _, _, pat, e1, e2, r) ->
-      walkPat pat
-      List.iter walkExpr [ e1; e2 ]
-    | SynExpr.MatchLambda(_, _, synMatchClauseList, _, r) -> List.iter walkClause synMatchClauseList
-    | SynExpr.Match(expr = e; clauses = synMatchClauseList; range = r) ->
-      walkExpr e
-      List.iter walkClause synMatchClauseList
-    | SynExpr.TypeApp(e, _, tys, _, _, tr, r) ->
-      List.iter walkType tys
-      walkExpr e
-    | SynExpr.LetOrUse(bindings = bindings; body = e; range = r) ->
-      List.iter walkBinding bindings
-      walkExpr e
-    | SynExpr.TryWith(tryExpr = e; withCases = clauses; range = r) ->
-      List.iter walkClause clauses
-      walkExpr e
-    | SynExpr.IfThenElse(ifExpr = e1; thenExpr = e2; elseExpr = e3; range = r) ->
-      List.iter walkExpr [ e1; e2 ]
-      e3 |> Option.iter walkExpr
-    | SynExpr.LongIdentSet(ident, e, r)
-    | SynExpr.DotGet(e, _, ident, r) -> walkExpr e
-    | SynExpr.DotSet(e1, idents, e2, r) ->
-      walkExpr e1
-      walkExpr e2
-    | SynExpr.DotIndexedGet(e, args, _, r) ->
-      walkExpr e
-      walkExpr args
-    | SynExpr.DotIndexedSet(e1, args, e2, _, _, r) ->
-      walkExpr e1
-      walkExpr args
-      walkExpr e2
-    | SynExpr.NamedIndexedPropertySet(ident, e1, e2, r) -> List.iter walkExpr [ e1; e2 ]
-    | SynExpr.DotNamedIndexedPropertySet(e1, ident, e2, e3, r) -> List.iter walkExpr [ e1; e2; e3 ]
-    | SynExpr.JoinIn(e1, _, e2, r) -> List.iter walkExpr [ e1; e2 ]
-    | SynExpr.LetOrUseBang(pat = pat; rhs = e1; andBangs = ands; body = e2; range = r) ->
-      walkPat pat
-      walkExpr e1
-
-      for (SynExprAndBang(pat = pat; body = body; range = r)) in ands do
-        walkPat pat
-        walkExpr body
-
-      walkExpr e2
-    | SynExpr.TraitCall(t, sign, e, r) ->
-      walkType t
-      walkMemberSig sign
-      walkExpr e
-    | SynExpr.Const(SynConst.Measure(_, _, m), r) -> walkMeasure m
-    | SynExpr.Const(_, r) -> ()
-    | SynExpr.AnonRecd(isStruct, copyInfo, recordFields, r, trivia) -> ()
-    | SynExpr.Sequential(seqPoint, isTrueSeq, expr1, expr2, r) -> ()
-    | SynExpr.Ident(_) -> ()
-    | SynExpr.LongIdent(isOptional, longDotId, altNameRefCell, r) -> ()
-    | SynExpr.Set(_, _, r) -> ()
-    | SynExpr.Null(r) -> ()
-    | SynExpr.ImplicitZero(r) -> ()
-    | SynExpr.MatchBang(range = r) -> ()
-    | SynExpr.LibraryOnlyILAssembly(_, _, _, _, r) -> ()
-    | SynExpr.LibraryOnlyStaticOptimization(_, _, _, r) -> ()
-    | SynExpr.LibraryOnlyUnionCaseFieldGet(expr, longId, _, r) -> ()
-    | SynExpr.LibraryOnlyUnionCaseFieldSet(_, longId, _, _, r) -> ()
-    | SynExpr.ArbitraryAfterError(debugStr, r) -> ()
-    | SynExpr.FromParseError(expr, r) -> ()
-    | SynExpr.DiscardAfterMissingQualificationAfterDot(_, _, r) -> ()
-    | SynExpr.Fixed(expr, r) -> ()
-    | SynExpr.InterpolatedString(parts, kind, r) ->
-
-      for part in parts do
-        walkInterpolatedStringPart part
-    | SynExpr.IndexFromEnd(itemExpr, r) -> walkExpr itemExpr
-    | SynExpr.IndexRange(e1, _, e2, _, _, r) ->
-      Option.iter walkExpr e1
-      Option.iter walkExpr e2
-    | SynExpr.DebugPoint(innerExpr = expr) -> walkExpr expr
-    | SynExpr.Dynamic(funcExpr = e1; argExpr = e2; range = range) ->
-      walkExpr e1
-      walkExpr e2
-    | SynExpr.Typar(t, r) -> walkTypar t
-
-  and walkMeasure s =
-    walker.WalkMeasure s
-
-    match s with
-    | SynMeasure.Product(m1, m2, r)
-    | SynMeasure.Divide(m1, m2, r) ->
-      walkMeasure m1
-      walkMeasure m2
-    | SynMeasure.Named(longIdent, r) -> ()
-    | SynMeasure.Seq(ms, r) -> List.iter walkMeasure ms
-    | SynMeasure.Power(m, _, r) -> walkMeasure m
-    | SynMeasure.Var(ty, r) -> walkTypar ty
-    | SynMeasure.Paren(m, r) -> walkMeasure m
-    | SynMeasure.One
-    | SynMeasure.Anon _ -> ()
-
-  and walkSimplePat s =
-    walker.WalkSimplePat s
-
-    match s with
-    | SynSimplePat.Attrib(pat, AllAttrs attrs, r) ->
-      walkSimplePat pat
+    and walkSynModuleOrNamespace (SynModuleOrNamespace(decls = decls; attribs = AllAttrs attrs; range = r) as s) =
+      walker.WalkSynModuleOrNamespace s
       List.iter walkAttribute attrs
-    | SynSimplePat.Typed(pat, t, r) ->
-      walkSimplePat pat
+      List.iter walkSynModuleDecl decls
+
+    and walkAttribute (attr: SynAttribute) = walkExpr attr.ArgExpr
+
+    and walkTyparDecl (SynTyparDecl(attributes = AllAttrs attrs; Item2 = typar)) =
+      List.iter walkAttribute attrs
+      walkTypar typar
+
+    and walkTyparDecls (typars: SynTyparDecls) =
+      typars.TyparDecls |> List.iter walkTyparDecl
+      typars.Constraints |> List.iter walkTypeConstraint
+
+    and walkSynValTyparDecls (SynValTyparDecls(typars, _)) = Option.iter walkTyparDecls typars
+
+    and walkTypeConstraint s =
+      walker.WalkTypeConstraint s
+
+      match s with
+      | SynTypeConstraint.WhereTyparIsValueType(t, r)
+      | SynTypeConstraint.WhereTyparIsReferenceType(t, r)
+      | SynTypeConstraint.WhereTyparIsUnmanaged(t, r)
+      | SynTypeConstraint.WhereTyparSupportsNull(t, r)
+      | SynTypeConstraint.WhereTyparIsComparable(t, r)
+      | SynTypeConstraint.WhereTyparIsEquatable(t, r) -> walkTypar t
+      | SynTypeConstraint.WhereTyparDefaultsToType(t, ty, r)
+      | SynTypeConstraint.WhereTyparSubtypeOfType(t, ty, r) ->
+        walkTypar t
+        walkType ty
+      | SynTypeConstraint.WhereTyparIsEnum(t, ts, r)
+      | SynTypeConstraint.WhereTyparIsDelegate(t, ts, r) ->
+        walkTypar t
+        List.iter walkType ts
+      | SynTypeConstraint.WhereTyparSupportsMember(t, sign, r) ->
+        walkType t
+        walkMemberSig sign
+      | SynTypeConstraint.WhereSelfConstrained(t, r) -> walkType t
+
+    and walkPat s =
+      walker.WalkPat s
+
+      match s with
+      | SynPat.Tuple(elementPats = pats; range = r)
+      | SynPat.ArrayOrList(_, pats, r)
+      | SynPat.Ands(pats, r) -> List.iter walkPat pats
+      | SynPat.Named(ident, _, _, r) -> ()
+      | SynPat.Typed(pat, t, r) ->
+        walkPat pat
+        walkType t
+      | SynPat.Attrib(pat, AllAttrs attrs, r) ->
+        walkPat pat
+        List.iter walkAttribute attrs
+      | SynPat.Or(pat1, pat2, r, _) -> List.iter walkPat [ pat1; pat2 ]
+      | SynPat.LongIdent(typarDecls = typars; argPats = ConstructorPats pats; range = r) ->
+        Option.iter walkSynValTyparDecls typars
+        List.iter walkPat pats
+      | SynPat.Paren(pat, r) -> walkPat pat
+      | SynPat.IsInst(t, r) -> walkType t
+      | SynPat.QuoteExpr(e, r) -> walkExpr e
+      | SynPat.Const(_, r) -> ()
+      | SynPat.Wild(r) -> ()
+      | SynPat.Record(_, r) -> ()
+      | SynPat.Null(r) -> ()
+      | SynPat.OptionalVal(_, r) -> ()
+      | SynPat.DeprecatedCharRange(_, _, r) -> ()
+      | SynPat.InstanceMember(_, _, _, accessibility, r) -> ()
+      | SynPat.FromParseError(_, r) -> ()
+      | SynPat.As(lpat, rpat, r) ->
+        walkPat lpat
+        walkPat rpat
+      | SynPat.ListCons(lpat, rpat, r, _) ->
+        walkPat lpat
+        walkPat rpat
+
+    and walkTypar (SynTypar(_, _, _) as s) = walker.WalkTypar s
+
+    and walkBinding
+      (SynBinding(attributes = AllAttrs attrs; headPat = pat; returnInfo = returnInfo; expr = e; range = r) as s)
+      =
+      walker.WalkBinding s
+      List.iter walkAttribute attrs
+      walkPat pat
+      walkExpr e
+
+      returnInfo
+      |> Option.iter (fun (SynBindingReturnInfo(t, r, attrs, _)) ->
+        walkType t
+        walkAttributes attrs)
+
+    and walkAttributes (attrs: SynAttributes) =
+      List.iter (fun (attrList: SynAttributeList) -> List.iter walkAttribute attrList.Attributes) attrs
+
+    and walkInterfaceImpl (SynInterfaceImpl(bindings = bindings; range = r) as s) =
+      walker.WalkInterfaceImpl s
+      List.iter walkBinding bindings
+
+    and walkType s =
+      walker.WalkType s
+
+      match s with
+      | SynType.Array(_, t, r)
+      | SynType.HashConstraint(t, r)
+      | SynType.MeasurePower(t, _, r) -> walkType t
+      | SynType.Fun(t1, t2, r, _) ->
+        // | SynType.MeasureDivide(t1, t2, r) ->
+        walkType t1
+        walkType t2
+      | SynType.App(ty, _, types, _, _, _, r) ->
+        walkType ty
+        List.iter walkType types
+      | SynType.LongIdentApp(_, _, _, types, _, _, r) -> List.iter walkType types
+      | SynType.Tuple(_, ts, r) ->
+        ts
+        |> List.iter (function
+          | SynTupleTypeSegment.Type t -> walkType t
+          | _ -> ())
+      | SynType.WithGlobalConstraints(t, typeConstraints, r) ->
+        walkType t
+        List.iter walkTypeConstraint typeConstraints
+      | SynType.LongIdent(longDotId) -> ()
+      | SynType.AnonRecd(isStruct, typeNames, r) -> ()
+      | SynType.Var(genericName, r) -> ()
+      | SynType.Anon(r) -> ()
+      | SynType.StaticConstant(constant, r) -> ()
+      | SynType.StaticConstantExpr(expr, r) -> ()
+      | SynType.StaticConstantNamed(expr, _, r) -> ()
+      | SynType.Paren(innerType, r) -> walkType innerType
+      | SynType.SignatureParameter(usedType = t; range = r) -> walkType t
+      | SynType.Or(lhs, rhs, r, _) ->
+        walkType lhs
+        walkType rhs
+      | SynType.FromParseError(r) -> ()
+
+    and walkClause (SynMatchClause(pat, e1, e2, r, _, _) as s) =
+      walker.WalkClause s
+      walkPat pat
+      walkExpr e2
+      e1 |> Option.iter walkExpr
+
+    and walkSimplePats =
+      function
+      | SynSimplePats.SimplePats(pats = pats; range = r) -> List.iter walkSimplePat pats
+
+    and walkInterpolatedStringPart s =
+      walker.WalkInterpolatedStringPart s
+
+      match s with
+      | SynInterpolatedStringPart.FillExpr(expr, ident) -> walkExpr expr
+      | SynInterpolatedStringPart.String(s, r) -> ()
+
+    and walkExpr s =
+      walker.WalkExpr s
+
+      match s with
+      | SynExpr.Typed(e, _, r) -> walkExpr e
+      | SynExpr.Paren(e, _, _, r)
+      | SynExpr.Quote(_, _, e, _, r)
+      | SynExpr.InferredUpcast(e, r)
+      | SynExpr.InferredDowncast(e, r)
+      | SynExpr.AddressOf(_, e, _, r)
+      | SynExpr.DoBang(e, r)
+      | SynExpr.YieldOrReturn(_, e, r)
+      | SynExpr.ArrayOrListComputed(_, e, r)
+      | SynExpr.ComputationExpr(_, e, r)
+      | SynExpr.Do(e, r)
+      | SynExpr.Assert(e, r)
+      | SynExpr.Lazy(e, r)
+      | SynExpr.YieldOrReturnFrom(_, e, r) -> walkExpr e
+      | SynExpr.SequentialOrImplicitYield(_, e1, e2, ifNotE, r) ->
+        walkExpr e1
+        walkExpr e2
+        walkExpr ifNotE
+      | SynExpr.Lambda(args = pats; body = e; range = r) ->
+        walkSimplePats pats
+        walkExpr e
+      | SynExpr.New(_, t, e, r)
+      | SynExpr.TypeTest(e, t, r)
+      | SynExpr.Upcast(e, t, r)
+      | SynExpr.Downcast(e, t, r) ->
+        walkExpr e
+        walkType t
+      | SynExpr.Tuple(_, es, _, _)
+      | Sequentials es -> List.iter walkExpr es //TODO??
+      | SynExpr.ArrayOrList(_, es, r) -> List.iter walkExpr es
+      | SynExpr.App(_, _, e1, e2, r)
+      | SynExpr.TryFinally(e1, e2, r, _, _, _)
+      | SynExpr.While(_, e1, e2, r) -> List.iter walkExpr [ e1; e2 ]
+      | SynExpr.Record(_, _, fields, r) ->
+
+        fields
+        |> List.iter (fun (SynExprRecordField(fieldName = (ident, _); expr = e)) -> e |> Option.iter walkExpr)
+      | SynExpr.ObjExpr(ty, argOpt, _, bindings, _, ifaces, _, r) ->
+
+        argOpt |> Option.iter (fun (e, ident) -> walkExpr e)
+
+        walkType ty
+        List.iter walkBinding bindings
+        List.iter walkInterfaceImpl ifaces
+      | SynExpr.For(identBody = e1; toBody = e2; doBody = e3; range = r) -> List.iter walkExpr [ e1; e2; e3 ]
+      | SynExpr.ForEach(_, _, _, _, pat, e1, e2, r) ->
+        walkPat pat
+        List.iter walkExpr [ e1; e2 ]
+      | SynExpr.MatchLambda(_, _, synMatchClauseList, _, r) -> List.iter walkClause synMatchClauseList
+      | SynExpr.Match(expr = e; clauses = synMatchClauseList; range = r) ->
+        walkExpr e
+        List.iter walkClause synMatchClauseList
+      | SynExpr.TypeApp(e, _, tys, _, _, tr, r) ->
+        List.iter walkType tys
+        walkExpr e
+      | SynExpr.LetOrUse(bindings = bindings; body = e; range = r) ->
+        List.iter walkBinding bindings
+        walkExpr e
+      | SynExpr.TryWith(tryExpr = e; withCases = clauses; range = r) ->
+        List.iter walkClause clauses
+        walkExpr e
+      | SynExpr.IfThenElse(ifExpr = e1; thenExpr = e2; elseExpr = e3; range = r) ->
+        List.iter walkExpr [ e1; e2 ]
+        e3 |> Option.iter walkExpr
+      | SynExpr.LongIdentSet(ident, e, r)
+      | SynExpr.DotGet(e, _, ident, r) -> walkExpr e
+      | SynExpr.DotSet(e1, idents, e2, r) ->
+        walkExpr e1
+        walkExpr e2
+      | SynExpr.DotIndexedGet(e, args, _, r) ->
+        walkExpr e
+        walkExpr args
+      | SynExpr.DotIndexedSet(e1, args, e2, _, _, r) ->
+        walkExpr e1
+        walkExpr args
+        walkExpr e2
+      | SynExpr.NamedIndexedPropertySet(ident, e1, e2, r) -> List.iter walkExpr [ e1; e2 ]
+      | SynExpr.DotNamedIndexedPropertySet(e1, ident, e2, e3, r) -> List.iter walkExpr [ e1; e2; e3 ]
+      | SynExpr.JoinIn(e1, _, e2, r) -> List.iter walkExpr [ e1; e2 ]
+      | SynExpr.LetOrUseBang(pat = pat; rhs = e1; andBangs = ands; body = e2; range = r) ->
+        walkPat pat
+        walkExpr e1
+
+        for (SynExprAndBang(pat = pat; body = body; range = r)) in ands do
+          walkPat pat
+          walkExpr body
+
+        walkExpr e2
+      | SynExpr.TraitCall(t, sign, e, r) ->
+        walkType t
+        walkMemberSig sign
+        walkExpr e
+      | SynExpr.Const(SynConst.Measure(_, _, m), r) -> walkMeasure m
+      | SynExpr.Const(_, r) -> ()
+      | SynExpr.AnonRecd(isStruct, copyInfo, recordFields, r, trivia) -> ()
+      | SynExpr.Sequential(seqPoint, isTrueSeq, expr1, expr2, r) -> ()
+      | SynExpr.Ident(_) -> ()
+      | SynExpr.LongIdent(isOptional, longDotId, altNameRefCell, r) -> ()
+      | SynExpr.Set(_, _, r) -> ()
+      | SynExpr.Null(r) -> ()
+      | SynExpr.ImplicitZero(r) -> ()
+      | SynExpr.MatchBang(range = r) -> ()
+      | SynExpr.LibraryOnlyILAssembly(_, _, _, _, r) -> ()
+      | SynExpr.LibraryOnlyStaticOptimization(_, _, _, r) -> ()
+      | SynExpr.LibraryOnlyUnionCaseFieldGet(expr, longId, _, r) -> ()
+      | SynExpr.LibraryOnlyUnionCaseFieldSet(_, longId, _, _, r) -> ()
+      | SynExpr.ArbitraryAfterError(debugStr, r) -> ()
+      | SynExpr.FromParseError(expr, r) -> ()
+      | SynExpr.DiscardAfterMissingQualificationAfterDot(_, _, r) -> ()
+      | SynExpr.Fixed(expr, r) -> ()
+      | SynExpr.InterpolatedString(parts, kind, r) ->
+
+        for part in parts do
+          walkInterpolatedStringPart part
+      | SynExpr.IndexFromEnd(itemExpr, r) -> walkExpr itemExpr
+      | SynExpr.IndexRange(e1, _, e2, _, _, r) ->
+        Option.iter walkExpr e1
+        Option.iter walkExpr e2
+      | SynExpr.DebugPoint(innerExpr = expr) -> walkExpr expr
+      | SynExpr.Dynamic(funcExpr = e1; argExpr = e2; range = range) ->
+        walkExpr e1
+        walkExpr e2
+      | SynExpr.Typar(t, r) -> walkTypar t
+
+    and walkMeasure s =
+      walker.WalkMeasure s
+
+      match s with
+      | SynMeasure.Product(m1, m2, r)
+      | SynMeasure.Divide(m1, m2, r) ->
+        walkMeasure m1
+        walkMeasure m2
+      | SynMeasure.Named(longIdent, r) -> ()
+      | SynMeasure.Seq(ms, r) -> List.iter walkMeasure ms
+      | SynMeasure.Power(m, _, r) -> walkMeasure m
+      | SynMeasure.Var(ty, r) -> walkTypar ty
+      | SynMeasure.Paren(m, r) -> walkMeasure m
+      | SynMeasure.One
+      | SynMeasure.Anon _ -> ()
+
+    and walkSimplePat s =
+      walker.WalkSimplePat s
+
+      match s with
+      | SynSimplePat.Attrib(pat, AllAttrs attrs, r) ->
+        walkSimplePat pat
+        List.iter walkAttribute attrs
+      | SynSimplePat.Typed(pat, t, r) ->
+        walkSimplePat pat
+        walkType t
+      | SynSimplePat.Id(ident, altNameRefCell, isCompilerGenerated, isThisVar, isOptArg, r) -> ()
+
+    and walkField (SynField(attributes = AllAttrs attrs; fieldType = t; range = r) as s) =
+      walker.WalkField s
+      List.iter walkAttribute attrs
       walkType t
-    | SynSimplePat.Id(ident, altNameRefCell, isCompilerGenerated, isThisVar, isOptArg, r) -> ()
 
-  and walkField (SynField(attributes = AllAttrs attrs; fieldType = t; range = r) as s) =
-    walker.WalkField s
-    List.iter walkAttribute attrs
-    walkType t
+    and walkValSig
+      (SynValSig(attributes = AllAttrs attrs; synType = t; arity = SynValInfo(argInfos, argInfo); range = r) as s)
+      =
+      walker.WalkValSig s
+      List.iter walkAttribute attrs
+      walkType t
 
-  and walkValSig
-    (SynValSig(attributes = AllAttrs attrs; synType = t; arity = SynValInfo(argInfos, argInfo); range = r) as s)
-    =
-    walker.WalkValSig s
-    List.iter walkAttribute attrs
-    walkType t
+      argInfo :: (argInfos |> List.concat)
+      |> List.collect (fun (SynArgInfo(attributes = AllAttrs attrs)) -> attrs)
+      |> List.iter walkAttribute
 
-    argInfo :: (argInfos |> List.concat)
-    |> List.collect (fun (SynArgInfo(attributes = AllAttrs attrs)) -> attrs)
-    |> List.iter walkAttribute
+    and walkMemberSig s =
+      walker.WalkMemberSig s
 
-  and walkMemberSig s =
-    walker.WalkMemberSig s
+      match s with
+      | SynMemberSig.Inherit(t, r)
+      | SynMemberSig.Interface(t, r) -> walkType t
+      | SynMemberSig.Member(vs, _, r, _) -> walkValSig vs
+      | SynMemberSig.ValField(f, r) -> walkField f
+      | SynMemberSig.NestedType(SynTypeDefnSig(typeInfo = info; typeRepr = repr; members = memberSigs), r) ->
 
-    match s with
-    | SynMemberSig.Inherit(t, r)
-    | SynMemberSig.Interface(t, r) -> walkType t
-    | SynMemberSig.Member(vs, _, r, _) -> walkValSig vs
-    | SynMemberSig.ValField(f, r) -> walkField f
-    | SynMemberSig.NestedType(SynTypeDefnSig(typeInfo = info; typeRepr = repr; members = memberSigs), r) ->
+        let isTypeExtensionOrAlias =
+          match repr with
+          | SynTypeDefnSigRepr.Simple(SynTypeDefnSimpleRepr.TypeAbbrev _, _)
+          | SynTypeDefnSigRepr.ObjectModel(SynTypeDefnKind.Abbrev, _, _)
+          | SynTypeDefnSigRepr.ObjectModel(SynTypeDefnKind.Augmentation _, _, _) -> true
+          | _ -> false
+
+        walkComponentInfo isTypeExtensionOrAlias info
+        walkTypeDefnSigRepr repr
+        List.iter walkMemberSig memberSigs
+
+    and walkMember s =
+      walker.WalkMember s
+
+      match s with
+      | SynMemberDefn.AbstractSlot(valSig, _, r, _) -> walkValSig valSig
+      | SynMemberDefn.Member(binding, r) -> walkBinding binding
+      | SynMemberDefn.ImplicitCtor(_, AllAttrs attrs, AllSimplePats pats, _, _, r, _) ->
+        List.iter walkAttribute attrs
+        List.iter walkSimplePat pats
+      | SynMemberDefn.ImplicitInherit(t, e, _, r) ->
+        walkType t
+        walkExpr e
+      | SynMemberDefn.LetBindings(bindings, _, _, r) -> List.iter walkBinding bindings
+      | SynMemberDefn.Interface(t, _, members, r) ->
+        walkType t
+        members |> Option.iter (List.iter walkMember)
+      | SynMemberDefn.Inherit(t, _, r) -> walkType t
+      | SynMemberDefn.ValField(field, r) -> walkField field
+      | SynMemberDefn.NestedType(tdef, _, r) -> walkTypeDefn tdef
+      | SynMemberDefn.AutoProperty(attributes = AllAttrs attrs; typeOpt = t; synExpr = e; range = r) ->
+        List.iter walkAttribute attrs
+        Option.iter walkType t
+        walkExpr e
+      | SynMemberDefn.Open(longId, r) -> ()
+      | SynMemberDefn.GetSetMember(memberDefnForGet = getter; memberDefnForSet = setter; range = range) ->
+        Option.iter walkBinding getter
+        Option.iter walkBinding setter
+
+    and walkEnumCase (SynEnumCase(attributes = AllAttrs attrs; range = r) as s) =
+      walker.WalkEnumCase s
+      List.iter walkAttribute attrs
+
+    and walkUnionCaseType s =
+      walker.WalkUnionCaseType s
+
+      match s with
+      | SynUnionCaseKind.Fields fields -> List.iter walkField fields
+      | SynUnionCaseKind.FullType(t, _) -> walkType t
+
+    and walkUnionCase (SynUnionCase(attributes = AllAttrs attrs; caseType = t; range = r) as s) =
+      walker.WalkUnionCase s
+      List.iter walkAttribute attrs
+      walkUnionCaseType t
+
+    and walkTypeDefnSimple s =
+      walker.WalkTypeDefnSimple s
+
+      match s with
+      | SynTypeDefnSimpleRepr.Enum(cases, r) -> List.iter walkEnumCase cases
+      | SynTypeDefnSimpleRepr.Union(_, cases, r) -> List.iter walkUnionCase cases
+      | SynTypeDefnSimpleRepr.Record(_, fields, r) -> List.iter walkField fields
+      | SynTypeDefnSimpleRepr.TypeAbbrev(_, t, r) -> walkType t
+      | SynTypeDefnSimpleRepr.General(_, _, _, _, _, _, _, r) -> ()
+      | SynTypeDefnSimpleRepr.LibraryOnlyILAssembly(_, r) -> ()
+      | SynTypeDefnSimpleRepr.None(r) -> ()
+      | SynTypeDefnSimpleRepr.Exception(_) -> ()
+
+    and walkComponentInfo
+      isTypeExtensionOrAlias
+      (SynComponentInfo(
+        attributes = AllAttrs attrs; typeParams = typars; constraints = constraints; longId = longIdent; range = r) as s)
+      =
+      walker.WalkComponentInfo s
+      List.iter walkAttribute attrs
+      Option.iter walkTyparDecls typars
+      List.iter walkTypeConstraint constraints
+
+    and walkTypeDefnRepr s =
+      walker.WalkTypeDefnRepr s
+
+      match s with
+      | SynTypeDefnRepr.ObjectModel(_, defns, r) -> List.iter walkMember defns
+      | SynTypeDefnRepr.Simple(defn, r) -> walkTypeDefnSimple defn
+      | SynTypeDefnRepr.Exception _ -> ()
+
+    and walkTypeDefnSigRepr s =
+      walker.WalkTypeDefnSigRepr s
+
+      match s with
+      | SynTypeDefnSigRepr.ObjectModel(_, defns, _) -> List.iter walkMemberSig defns
+      | SynTypeDefnSigRepr.Simple(defn, _) -> walkTypeDefnSimple defn
+      | SynTypeDefnSigRepr.Exception _ -> ()
+
+    and walkTypeDefn (SynTypeDefn(info, repr, members, implicitCtor, r, _) as s) =
+      walker.WalkTypeDefn s
 
       let isTypeExtensionOrAlias =
         match repr with
-        | SynTypeDefnSigRepr.Simple(SynTypeDefnSimpleRepr.TypeAbbrev _, _)
-        | SynTypeDefnSigRepr.ObjectModel(SynTypeDefnKind.Abbrev, _, _)
-        | SynTypeDefnSigRepr.ObjectModel(SynTypeDefnKind.Augmentation _, _, _) -> true
+        | SynTypeDefnRepr.ObjectModel(SynTypeDefnKind.Augmentation _, _, _)
+        | SynTypeDefnRepr.ObjectModel(SynTypeDefnKind.Abbrev, _, _)
+        | SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.TypeAbbrev _, _) -> true
         | _ -> false
 
       walkComponentInfo isTypeExtensionOrAlias info
-      walkTypeDefnSigRepr repr
-      List.iter walkMemberSig memberSigs
+      walkTypeDefnRepr repr
+      Option.iter walkMember implicitCtor
+      List.iter walkMember members
 
-  and walkMember s =
-    walker.WalkMember s
+    and walkSynModuleDecl (decl: SynModuleDecl) =
+      walker.WalkSynModuleDecl decl
 
-    match s with
-    | SynMemberDefn.AbstractSlot(valSig, _, r, _) -> walkValSig valSig
-    | SynMemberDefn.Member(binding, r) -> walkBinding binding
-    | SynMemberDefn.ImplicitCtor(_, AllAttrs attrs, AllSimplePats pats, _, _, r, _) ->
-      List.iter walkAttribute attrs
-      List.iter walkSimplePat pats
-    | SynMemberDefn.ImplicitInherit(t, e, _, r) ->
-      walkType t
-      walkExpr e
-    | SynMemberDefn.LetBindings(bindings, _, _, r) -> List.iter walkBinding bindings
-    | SynMemberDefn.Interface(t, _, members, r) ->
-      walkType t
-      members |> Option.iter (List.iter walkMember)
-    | SynMemberDefn.Inherit(t, _, r) -> walkType t
-    | SynMemberDefn.ValField(field, r) -> walkField field
-    | SynMemberDefn.NestedType(tdef, _, r) -> walkTypeDefn tdef
-    | SynMemberDefn.AutoProperty(attributes = AllAttrs attrs; typeOpt = t; synExpr = e; range = r) ->
-      List.iter walkAttribute attrs
-      Option.iter walkType t
-      walkExpr e
-    | SynMemberDefn.Open(longId, r) -> ()
-    | SynMemberDefn.GetSetMember(memberDefnForGet = getter; memberDefnForSet = setter; range = range) ->
-      Option.iter walkBinding getter
-      Option.iter walkBinding setter
+      match decl with
+      | SynModuleDecl.NamespaceFragment fragment -> walkSynModuleOrNamespace fragment
+      | SynModuleDecl.NestedModule(info, _, modules, _, r, _) ->
+        walkComponentInfo false info
+        List.iter walkSynModuleDecl modules
+      | SynModuleDecl.Let(_, bindings, r) -> List.iter walkBinding bindings
+      | SynModuleDecl.Expr(expr, r) -> walkExpr expr
+      | SynModuleDecl.Types(types, r) -> List.iter walkTypeDefn types
+      | SynModuleDecl.Attributes(attributes = AllAttrs attrs; range = r) -> List.iter walkAttribute attrs
+      | SynModuleDecl.ModuleAbbrev(ident, longId, r) -> ()
+      | SynModuleDecl.Exception(_, r) -> ()
+      | SynModuleDecl.Open(longDotId, r) -> ()
+      | SynModuleDecl.HashDirective(_, r) -> ()
 
-  and walkEnumCase (SynEnumCase(attributes = AllAttrs attrs; range = r) as s) =
-    walker.WalkEnumCase s
-    List.iter walkAttribute attrs
-
-  and walkUnionCaseType s =
-    walker.WalkUnionCaseType s
-
-    match s with
-    | SynUnionCaseKind.Fields fields -> List.iter walkField fields
-    | SynUnionCaseKind.FullType(t, _) -> walkType t
-
-  and walkUnionCase (SynUnionCase(attributes = AllAttrs attrs; caseType = t; range = r) as s) =
-    walker.WalkUnionCase s
-    List.iter walkAttribute attrs
-    walkUnionCaseType t
-
-  and walkTypeDefnSimple s =
-    walker.WalkTypeDefnSimple s
-
-    match s with
-    | SynTypeDefnSimpleRepr.Enum(cases, r) -> List.iter walkEnumCase cases
-    | SynTypeDefnSimpleRepr.Union(_, cases, r) -> List.iter walkUnionCase cases
-    | SynTypeDefnSimpleRepr.Record(_, fields, r) -> List.iter walkField fields
-    | SynTypeDefnSimpleRepr.TypeAbbrev(_, t, r) -> walkType t
-    | SynTypeDefnSimpleRepr.General(_, _, _, _, _, _, _, r) -> ()
-    | SynTypeDefnSimpleRepr.LibraryOnlyILAssembly(_, r) -> ()
-    | SynTypeDefnSimpleRepr.None(r) -> ()
-    | SynTypeDefnSimpleRepr.Exception(_) -> ()
-
-  and walkComponentInfo
-    isTypeExtensionOrAlias
-    (SynComponentInfo(
-      attributes = AllAttrs attrs; typeParams = typars; constraints = constraints; longId = longIdent; range = r) as s)
-    =
-    walker.WalkComponentInfo s
-    List.iter walkAttribute attrs
-    Option.iter walkTyparDecls typars
-    List.iter walkTypeConstraint constraints
-
-  and walkTypeDefnRepr s =
-    walker.WalkTypeDefnRepr s
-
-    match s with
-    | SynTypeDefnRepr.ObjectModel(_, defns, r) -> List.iter walkMember defns
-    | SynTypeDefnRepr.Simple(defn, r) -> walkTypeDefnSimple defn
-    | SynTypeDefnRepr.Exception _ -> ()
-
-  and walkTypeDefnSigRepr s =
-    walker.WalkTypeDefnSigRepr s
-
-    match s with
-    | SynTypeDefnSigRepr.ObjectModel(_, defns, _) -> List.iter walkMemberSig defns
-    | SynTypeDefnSigRepr.Simple(defn, _) -> walkTypeDefnSimple defn
-    | SynTypeDefnSigRepr.Exception _ -> ()
-
-  and walkTypeDefn (SynTypeDefn(info, repr, members, implicitCtor, r, _) as s) =
-    walker.WalkTypeDefn s
-
-    let isTypeExtensionOrAlias =
-      match repr with
-      | SynTypeDefnRepr.ObjectModel(SynTypeDefnKind.Augmentation _, _, _)
-      | SynTypeDefnRepr.ObjectModel(SynTypeDefnKind.Abbrev, _, _)
-      | SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.TypeAbbrev _, _) -> true
-      | _ -> false
-
-    walkComponentInfo isTypeExtensionOrAlias info
-    walkTypeDefnRepr repr
-    Option.iter walkMember implicitCtor
-    List.iter walkMember members
-
-  and walkSynModuleDecl (decl: SynModuleDecl) =
-    walker.WalkSynModuleDecl decl
-
-    match decl with
-    | SynModuleDecl.NamespaceFragment fragment -> walkSynModuleOrNamespace fragment
-    | SynModuleDecl.NestedModule(info, _, modules, _, r, _) ->
-      walkComponentInfo false info
-      List.iter walkSynModuleDecl modules
-    | SynModuleDecl.Let(_, bindings, r) -> List.iter walkBinding bindings
-    | SynModuleDecl.Expr(expr, r) -> walkExpr expr
-    | SynModuleDecl.Types(types, r) -> List.iter walkTypeDefn types
-    | SynModuleDecl.Attributes(attributes = AllAttrs attrs; range = r) -> List.iter walkAttribute attrs
-    | SynModuleDecl.ModuleAbbrev(ident, longId, r) -> ()
-    | SynModuleDecl.Exception(_, r) -> ()
-    | SynModuleDecl.Open(longDotId, r) -> ()
-    | SynModuleDecl.HashDirective(_, r) -> ()
-
-  match input with
-  | ParsedInput.ImplFile input -> walkImplFileInput input
-  | _ -> ()
-
-#nowarn "3535"
-
-type private HasRange<'t when 't :> HasRange<'t>> =
-  abstract Range: Range
-
-type private RangeCollectorWalker(pos: Position) =
-  inherit UntypedSyntaxCollectorVisitor()
-  let ranges = ResizeArray<Range>()
-
-  let addIfInside (m: Range) =
-    if (Range.rangeContainsPos m pos) then
-      ranges.Add m
-
-  override _.WalkSynModuleOrNamespace m = addIfInside m.Range
-  override _.WalkAttribute a = addIfInside a.Range
-  override _.WalkTypeConstraint c = addIfInside c.Range
-  override _.WalkPat p = addIfInside p.Range
-
-  override _.WalkBinding(SynBinding(range = r; returnInfo = ri)) =
-    addIfInside r
-    ri |> Option.iter (fun (SynBindingReturnInfo(range = r')) -> addIfInside r')
-
-  override _.WalkInterfaceImpl(SynInterfaceImpl(range = range)) = addIfInside range
-  override _.WalkType t = addIfInside t.Range
-  override _.WalkClause c = addIfInside c.Range
-
-  override _.WalkInterpolatedStringPart i =
-    match i with
-    | SynInterpolatedStringPart.FillExpr(qualifiers = Some ident) -> addIfInside ident.idRange
-    | SynInterpolatedStringPart.String(s, r) -> addIfInside r
+    match input with
+    | ParsedInput.ImplFile input -> walkImplFileInput input
     | _ -> ()
 
-  override _.WalkExpr e = addIfInside e.Range
+namespace FsAutoComplete
 
-  override _.WalkMeasure m =
-    match m with
-    | SynMeasure.Product(range = r)
-    | SynMeasure.Divide(range = r)
-    | SynMeasure.Named(range = r)
-    | SynMeasure.Seq(range = r)
-    | SynMeasure.Power(range = r)
-    | SynMeasure.Var(range = r)
-    | SynMeasure.Paren(range = r) -> addIfInside r
-    | SynMeasure.One
-    | SynMeasure.Anon _ -> ()
+module UntypedAstUtils =
 
-  override _.WalkSimplePat p = addIfInside p.Range
-  override _.WalkField(SynField(range = r)) = addIfInside r
-  override _.WalkValSig(SynValSig(range = r)) = addIfInside r
-  override _.WalkMemberSig m = addIfInside m.Range
-  override _.WalkMember m = addIfInside m.Range
-  override _.WalkEnumCase e = addIfInside e.Range
-  override _.WalkUnionCase u = addIfInside u.Range
-  override _.WalkTypeDefnSimple s = addIfInside s.Range
-  override _.WalkComponentInfo c = addIfInside c.Range
-  override _.WalkTypeDefnRepr t = addIfInside t.Range
-  override _.WalkTypeDefnSigRepr t = addIfInside t.Range
-  override _.WalkTypeDefn t = addIfInside t.Range
-  override _.WalkSynModuleDecl s = addIfInside s.Range
+  open FSharp.Compiler.Syntax
+  open System.Collections.Generic
+  open FSharp.Compiler
+  open FSharp.Compiler.Text
+  open FSharp.Control.Reactive.Observable
 
-  member _.Ranges = ranges
+  type Range with
 
-let internal getRangesAtPosition input (r: Position) : Range list =
-  let walker = new RangeCollectorWalker(r)
-  walkAst walker input
-  walker.Ranges |> Seq.toList
+    member inline x.IsEmpty = x.StartColumn = x.EndColumn && x.StartLine = x.EndLine
+
+  type internal ShortIdent = string
+  type internal Idents = ShortIdent[]
+
+  let internal longIdentToArray (longIdent: LongIdent) : Idents =
+    longIdent |> Seq.map string |> Seq.toArray
+
+  /// matches if the range contains the position
+  let (|ContainsPos|_|) pos range =
+    if Range.rangeContainsPos range pos then Some() else None
+
+  /// Active pattern that matches an ident on a given name by the ident's `idText`
+  let (|Ident|_|) ofName =
+    function
+    | SynExpr.Ident ident when ident.idText = ofName -> Some()
+    | _ -> None
+
+  /// matches if the range contains the position
+  let (|IdentContainsPos|_|) pos (ident: Ident) = (|ContainsPos|_|) pos ident.idRange
+
+module FoldingRange =
+  open FSharp.Compiler.Text
+  open FSharp.Compiler.Syntax
+
+  /// a walker that collects all ranges of syntax elements that contain the given position
+  [<RequireQualifiedAccess>]
+  type private RangeCollectorWalker(pos: Position) =
+    inherit SyntaxCollectorBase()
+    let ranges = ResizeArray<Range>()
+
+    let addIfInside (m: Range) =
+      if (Range.rangeContainsPos m pos) then
+        ranges.Add m
+
+    override _.WalkSynModuleOrNamespace m = addIfInside m.Range
+    override _.WalkAttribute a = addIfInside a.Range
+    override _.WalkTypeConstraint c = addIfInside c.Range
+    override _.WalkPat p = addIfInside p.Range
+
+    override _.WalkBinding(SynBinding(range = r; returnInfo = ri)) =
+      addIfInside r
+      ri |> Option.iter (fun (SynBindingReturnInfo(range = r')) -> addIfInside r')
+
+    override _.WalkInterfaceImpl(SynInterfaceImpl(range = range)) = addIfInside range
+    override _.WalkType t = addIfInside t.Range
+    override _.WalkClause c = addIfInside c.Range
+
+    override _.WalkInterpolatedStringPart i =
+      match i with
+      | SynInterpolatedStringPart.FillExpr(qualifiers = Some ident) -> addIfInside ident.idRange
+      | SynInterpolatedStringPart.String(s, r) -> addIfInside r
+      | _ -> ()
+
+    override _.WalkExpr e = addIfInside e.Range
+
+    override _.WalkMeasure m =
+      match m with
+      | SynMeasure.Product(range = r)
+      | SynMeasure.Divide(range = r)
+      | SynMeasure.Named(range = r)
+      | SynMeasure.Seq(range = r)
+      | SynMeasure.Power(range = r)
+      | SynMeasure.Var(range = r)
+      | SynMeasure.Paren(range = r) -> addIfInside r
+      | SynMeasure.One
+      | SynMeasure.Anon _ -> ()
+
+    override _.WalkSimplePat p = addIfInside p.Range
+    override _.WalkField(SynField(range = r)) = addIfInside r
+    override _.WalkValSig(SynValSig(range = r)) = addIfInside r
+    override _.WalkMemberSig m = addIfInside m.Range
+    override _.WalkMember m = addIfInside m.Range
+    override _.WalkEnumCase e = addIfInside e.Range
+    override _.WalkUnionCase u = addIfInside u.Range
+    override _.WalkTypeDefnSimple s = addIfInside s.Range
+    override _.WalkComponentInfo c = addIfInside c.Range
+    override _.WalkTypeDefnRepr t = addIfInside t.Range
+    override _.WalkTypeDefnSigRepr t = addIfInside t.Range
+    override _.WalkTypeDefn t = addIfInside t.Range
+    override _.WalkSynModuleDecl s = addIfInside s.Range
+
+    member _.Ranges = ranges
+
+  let getRangesAtPosition input (r: Position) : Range list =
+    let walker = new RangeCollectorWalker(r)
+    walkAst walker input
+    walker.Ranges |> Seq.toList
 
 module Completion =
+  open FSharp.Compiler.Text
+  open FSharp.Compiler.Syntax
 
   [<RequireQualifiedAccess>]
   type Context =

--- a/src/FsAutoComplete.Core/UntypedAstUtils.fs
+++ b/src/FsAutoComplete.Core/UntypedAstUtils.fs
@@ -54,32 +54,84 @@ let (|AllSimplePats|) (pats: SynSimplePats) =
 
   loop [] pats
 
-/// Gives all ranges for current position
-let internal getRangesAtPosition input (r: Position) : Range list =
-  let mutable result = []
 
+type UntypedSyntaxCollectorVisitor() =
+  abstract WalkSynModuleOrNamespace: SynModuleOrNamespace -> unit
+  default _.WalkSynModuleOrNamespace m = ()
+  abstract WalkAttribute: SynAttribute -> unit
+  default _.WalkAttribute a = ()
+  abstract WalkSynModuleDecl: SynModuleDecl -> unit
+  default _.WalkSynModuleDecl m = ()
+  abstract WalkExpr: SynExpr -> unit
+  default _.WalkExpr s = ()
+  abstract WalkTypar: SynTypar -> unit
+  default _.WalkTypar s = ()
+  abstract WalkTyparDecl: SynTyparDecl -> unit
+  default _.WalkTyparDecl s = ()
+  abstract WalkTypeConstraint: SynTypeConstraint -> unit
+  default _.WalkTypeConstraint s = ()
+  abstract WalkType: SynType -> unit
+  default _.WalkType s = ()
+  abstract WalkMemberSig: SynMemberSig -> unit
+  default _.WalkMemberSig s = ()
+  abstract WalkPat: SynPat -> unit
+  default _.WalkPat s = ()
+  abstract WalkValTyparDecls: SynValTyparDecls -> unit
+  default _.WalkValTyparDecls s = ()
+  abstract WalkBinding: SynBinding -> unit
+  default _.WalkBinding s = ()
 
-  let addIfInside (ran: Range) =
-    let addToResult r = result <- r :: result
+  abstract WalkSimplePat: SynSimplePat -> unit
+  default _.WalkSimplePat s = ()
 
-    let isInside (ran: Range) = Range.rangeContainsPos ran r
+  abstract WalkInterfaceImpl: SynInterfaceImpl -> unit
+  default _.WalkInterfaceImpl s = ()
+  abstract WalkClause: SynMatchClause -> unit
+  default _.WalkClause s = ()
+  abstract WalkInterpolatedStringPart: SynInterpolatedStringPart -> unit
+  default _.WalkInterpolatedStringPart s = ()
 
-    if isInside ran then
-      addToResult ran
+  abstract WalkMeasure: SynMeasure -> unit
+  default _.WalkMeasure s = ()
+  abstract WalkComponentInfo: SynComponentInfo -> unit
+  default _.WalkComponentInfo s = ()
+  abstract WalkTypeDefnSigRepr: SynTypeDefnSigRepr -> unit
+  default _.WalkTypeDefnSigRepr s = ()
+  abstract WalkUnionCaseType: SynUnionCaseKind -> unit
+  default _.WalkUnionCaseType s = ()
+  abstract WalkEnumCase: SynEnumCase -> unit
+  default _.WalkEnumCase s = ()
+  abstract WalkField: SynField -> unit
+  default _.WalkField s = ()
+  abstract WalkTypeDefnSimple: SynTypeDefnSimpleRepr -> unit
+  default _.WalkTypeDefnSimple s = ()
 
+  abstract WalkValSig: SynValSig -> unit
+  default _.WalkValSig s = ()
 
+  abstract WalkMember: SynMemberDefn -> unit
+  default _.WalkMember s = ()
+
+  abstract WalkUnionCase: SynUnionCase -> unit
+  default _.WalkUnionCase s = ()
+
+  abstract WalkTypeDefnRepr: SynTypeDefnRepr -> unit
+  default _.WalkTypeDefnRepr s = ()
+
+  abstract WalkTypeDefn: SynTypeDefn -> unit
+  default _.WalkTypeDefn s = ()
+
+let walkAst (walker: UntypedSyntaxCollectorVisitor) (input: ParsedInput) : unit =
 
   let rec walkImplFileInput (ParsedImplFileInput(contents = moduleOrNamespaceList)) =
     List.iter walkSynModuleOrNamespace moduleOrNamespaceList
 
-  and walkSynModuleOrNamespace (SynModuleOrNamespace(decls = decls; attribs = AllAttrs attrs; range = r)) =
-    addIfInside r
+  and walkSynModuleOrNamespace (SynModuleOrNamespace(decls = decls; attribs = AllAttrs attrs; range = r) as s) =
+    walker.WalkSynModuleOrNamespace s
     List.iter walkAttribute attrs
     List.iter walkSynModuleDecl decls
 
-  and walkAttribute (attr: SynAttribute) =
-    addIfInside attr.Range
-    walkExpr attr.ArgExpr
+  and walkAttribute (attr: SynAttribute) = walkExpr attr.ArgExpr
 
   and walkTyparDecl (SynTyparDecl(attributes = AllAttrs attrs; Item2 = typar)) =
     List.iter walkAttribute attrs
@@ -91,184 +143,146 @@ let internal getRangesAtPosition input (r: Position) : Range list =
 
   and walkSynValTyparDecls (SynValTyparDecls(typars, _)) = Option.iter walkTyparDecls typars
 
-  and walkTypeConstraint =
-    function
+  and walkTypeConstraint s =
+    walker.WalkTypeConstraint s
+
+    match s with
     | SynTypeConstraint.WhereTyparIsValueType(t, r)
     | SynTypeConstraint.WhereTyparIsReferenceType(t, r)
     | SynTypeConstraint.WhereTyparIsUnmanaged(t, r)
     | SynTypeConstraint.WhereTyparSupportsNull(t, r)
     | SynTypeConstraint.WhereTyparIsComparable(t, r)
-    | SynTypeConstraint.WhereTyparIsEquatable(t, r) ->
-      addIfInside r
-      walkTypar t
+    | SynTypeConstraint.WhereTyparIsEquatable(t, r) -> walkTypar t
     | SynTypeConstraint.WhereTyparDefaultsToType(t, ty, r)
     | SynTypeConstraint.WhereTyparSubtypeOfType(t, ty, r) ->
-      addIfInside r
       walkTypar t
       walkType ty
     | SynTypeConstraint.WhereTyparIsEnum(t, ts, r)
     | SynTypeConstraint.WhereTyparIsDelegate(t, ts, r) ->
-      addIfInside r
       walkTypar t
       List.iter walkType ts
     | SynTypeConstraint.WhereTyparSupportsMember(t, sign, r) ->
-      addIfInside r
       walkType t
       walkMemberSig sign
-    | SynTypeConstraint.WhereSelfConstrained(t, r) ->
-      addIfInside r
-      walkType t
+    | SynTypeConstraint.WhereSelfConstrained(t, r) -> walkType t
 
-  and walkPat =
-    function
+  and walkPat s =
+    walker.WalkPat s
+
+    match s with
     | SynPat.Tuple(elementPats = pats; range = r)
     | SynPat.ArrayOrList(_, pats, r)
-    | SynPat.Ands(pats, r) ->
-      addIfInside r
-      List.iter walkPat pats
-    | SynPat.Named(ident, _, _, r) -> addIfInside r
+    | SynPat.Ands(pats, r) -> List.iter walkPat pats
+    | SynPat.Named(ident, _, _, r) -> ()
     | SynPat.Typed(pat, t, r) ->
-      addIfInside r
       walkPat pat
       walkType t
     | SynPat.Attrib(pat, AllAttrs attrs, r) ->
-      addIfInside r
       walkPat pat
       List.iter walkAttribute attrs
-    | SynPat.Or(pat1, pat2, r, _) ->
-      addIfInside r
-      List.iter walkPat [ pat1; pat2 ]
+    | SynPat.Or(pat1, pat2, r, _) -> List.iter walkPat [ pat1; pat2 ]
     | SynPat.LongIdent(typarDecls = typars; argPats = ConstructorPats pats; range = r) ->
-      addIfInside r
       Option.iter walkSynValTyparDecls typars
       List.iter walkPat pats
-    | SynPat.Paren(pat, r) ->
-      addIfInside r
-      walkPat pat
-    | SynPat.IsInst(t, r) ->
-      addIfInside r
-      walkType t
-    | SynPat.QuoteExpr(e, r) ->
-      addIfInside r
-      walkExpr e
-    | SynPat.Const(_, r) -> addIfInside r
-    | SynPat.Wild(r) -> addIfInside r
-    | SynPat.Record(_, r) -> addIfInside r
-    | SynPat.Null(r) -> addIfInside r
-    | SynPat.OptionalVal(_, r) -> addIfInside r
-    | SynPat.DeprecatedCharRange(_, _, r) -> addIfInside r
-    | SynPat.InstanceMember(_, _, _, accessibility, r) -> addIfInside r
-    | SynPat.FromParseError(_, r) -> addIfInside r
+    | SynPat.Paren(pat, r) -> walkPat pat
+    | SynPat.IsInst(t, r) -> walkType t
+    | SynPat.QuoteExpr(e, r) -> walkExpr e
+    | SynPat.Const(_, r) -> ()
+    | SynPat.Wild(r) -> ()
+    | SynPat.Record(_, r) -> ()
+    | SynPat.Null(r) -> ()
+    | SynPat.OptionalVal(_, r) -> ()
+    | SynPat.DeprecatedCharRange(_, _, r) -> ()
+    | SynPat.InstanceMember(_, _, _, accessibility, r) -> ()
+    | SynPat.FromParseError(_, r) -> ()
     | SynPat.As(lpat, rpat, r) ->
-      addIfInside r
       walkPat lpat
       walkPat rpat
     | SynPat.ListCons(lpat, rpat, r, _) ->
-      addIfInside r
       walkPat lpat
       walkPat rpat
 
-  and walkTypar (SynTypar(_, _, _)) = ()
+  and walkTypar (SynTypar(_, _, _) as s) = walker.WalkTypar s
 
   and walkBinding
-    (SynBinding(attributes = AllAttrs attrs; headPat = pat; returnInfo = returnInfo; expr = e; range = r))
+    (SynBinding(attributes = AllAttrs attrs; headPat = pat; returnInfo = returnInfo; expr = e; range = r) as s)
     =
-    addIfInside r
+    walker.WalkBinding s
     List.iter walkAttribute attrs
     walkPat pat
     walkExpr e
 
     returnInfo
     |> Option.iter (fun (SynBindingReturnInfo(t, r, attrs, _)) ->
-      addIfInside r
       walkType t
       walkAttributes attrs)
 
   and walkAttributes (attrs: SynAttributes) =
-    List.iter
-      (fun (attrList: SynAttributeList) ->
-        addIfInside attrList.Range
-        List.iter walkAttribute attrList.Attributes)
-      attrs
+    List.iter (fun (attrList: SynAttributeList) -> List.iter walkAttribute attrList.Attributes) attrs
 
-  and walkInterfaceImpl (SynInterfaceImpl(bindings = bindings; range = r)) =
-    addIfInside r
+  and walkInterfaceImpl (SynInterfaceImpl(bindings = bindings; range = r) as s) =
+    walker.WalkInterfaceImpl s
     List.iter walkBinding bindings
 
-  and walkType =
-    function
+  and walkType s =
+    walker.WalkType s
+
+    match s with
     | SynType.Array(_, t, r)
     | SynType.HashConstraint(t, r)
-    | SynType.MeasurePower(t, _, r) ->
-      addIfInside r
-      walkType t
+    | SynType.MeasurePower(t, _, r) -> walkType t
     | SynType.Fun(t1, t2, r, _) ->
       // | SynType.MeasureDivide(t1, t2, r) ->
-      addIfInside r
       walkType t1
       walkType t2
     | SynType.App(ty, _, types, _, _, _, r) ->
-      addIfInside r
       walkType ty
       List.iter walkType types
-    | SynType.LongIdentApp(_, _, _, types, _, _, r) ->
-      addIfInside r
-      List.iter walkType types
+    | SynType.LongIdentApp(_, _, _, types, _, _, r) -> List.iter walkType types
     | SynType.Tuple(_, ts, r) ->
-      addIfInside r
-
       ts
       |> List.iter (function
         | SynTupleTypeSegment.Type t -> walkType t
         | _ -> ())
     | SynType.WithGlobalConstraints(t, typeConstraints, r) ->
-      addIfInside r
       walkType t
       List.iter walkTypeConstraint typeConstraints
     | SynType.LongIdent(longDotId) -> ()
-    | SynType.AnonRecd(isStruct, typeNames, r) -> addIfInside r
-    | SynType.Var(genericName, r) -> addIfInside r
-    | SynType.Anon(r) -> addIfInside r
-    | SynType.StaticConstant(constant, r) -> addIfInside r
-    | SynType.StaticConstantExpr(expr, r) -> addIfInside r
-    | SynType.StaticConstantNamed(expr, _, r) -> addIfInside r
-    | SynType.Paren(innerType, r) ->
-      addIfInside r
-      walkType innerType
-    | SynType.SignatureParameter(usedType = t; range = r) ->
-      addIfInside r
-      walkType t
+    | SynType.AnonRecd(isStruct, typeNames, r) -> ()
+    | SynType.Var(genericName, r) -> ()
+    | SynType.Anon(r) -> ()
+    | SynType.StaticConstant(constant, r) -> ()
+    | SynType.StaticConstantExpr(expr, r) -> ()
+    | SynType.StaticConstantNamed(expr, _, r) -> ()
+    | SynType.Paren(innerType, r) -> walkType innerType
+    | SynType.SignatureParameter(usedType = t; range = r) -> walkType t
     | SynType.Or(lhs, rhs, r, _) ->
-      addIfInside r
       walkType lhs
       walkType rhs
-    | SynType.FromParseError(r) -> addIfInside r
+    | SynType.FromParseError(r) -> ()
 
-  and walkClause (SynMatchClause(pat, e1, e2, r, _, _)) =
-    addIfInside r
+  and walkClause (SynMatchClause(pat, e1, e2, r, _, _) as s) =
+    walker.WalkClause s
     walkPat pat
     walkExpr e2
     e1 |> Option.iter walkExpr
 
   and walkSimplePats =
     function
-    | SynSimplePats.SimplePats(pats = pats; range = r) ->
-      addIfInside r
-      List.iter walkSimplePat pats
+    | SynSimplePats.SimplePats(pats = pats; range = r) -> List.iter walkSimplePat pats
 
-  and walkInterpolatedStringPart =
-    function
-    | SynInterpolatedStringPart.FillExpr(expr, ident) ->
-      ident |> Option.iter (fun ident -> addIfInside ident.idRange)
+  and walkInterpolatedStringPart s =
+    walker.WalkInterpolatedStringPart s
 
-      walkExpr expr
-    | SynInterpolatedStringPart.String(s, r) -> addIfInside r
+    match s with
+    | SynInterpolatedStringPart.FillExpr(expr, ident) -> walkExpr expr
+    | SynInterpolatedStringPart.String(s, r) -> ()
 
-  and walkExpr =
-    function
-    | SynExpr.Typed(e, _, r) ->
-      addIfInside r
-      walkExpr e
+  and walkExpr s =
+    walker.WalkExpr s
+
+    match s with
+    | SynExpr.Typed(e, _, r) -> walkExpr e
     | SynExpr.Paren(e, _, _, r)
     | SynExpr.Quote(_, _, e, _, r)
     | SynExpr.InferredUpcast(e, r)
@@ -281,207 +295,154 @@ let internal getRangesAtPosition input (r: Position) : Range list =
     | SynExpr.Do(e, r)
     | SynExpr.Assert(e, r)
     | SynExpr.Lazy(e, r)
-    | SynExpr.YieldOrReturnFrom(_, e, r) ->
-      addIfInside r
-      walkExpr e
+    | SynExpr.YieldOrReturnFrom(_, e, r) -> walkExpr e
     | SynExpr.SequentialOrImplicitYield(_, e1, e2, ifNotE, r) ->
-      addIfInside r
       walkExpr e1
       walkExpr e2
       walkExpr ifNotE
     | SynExpr.Lambda(args = pats; body = e; range = r) ->
-      addIfInside r
       walkSimplePats pats
       walkExpr e
     | SynExpr.New(_, t, e, r)
     | SynExpr.TypeTest(e, t, r)
     | SynExpr.Upcast(e, t, r)
     | SynExpr.Downcast(e, t, r) ->
-      addIfInside r
       walkExpr e
       walkType t
     | SynExpr.Tuple(_, es, _, _)
     | Sequentials es -> List.iter walkExpr es //TODO??
-    | SynExpr.ArrayOrList(_, es, r) ->
-      addIfInside r
-      List.iter walkExpr es
+    | SynExpr.ArrayOrList(_, es, r) -> List.iter walkExpr es
     | SynExpr.App(_, _, e1, e2, r)
     | SynExpr.TryFinally(e1, e2, r, _, _, _)
-    | SynExpr.While(_, e1, e2, r) ->
-      addIfInside r
-      List.iter walkExpr [ e1; e2 ]
+    | SynExpr.While(_, e1, e2, r) -> List.iter walkExpr [ e1; e2 ]
     | SynExpr.Record(_, _, fields, r) ->
-      addIfInside r
 
       fields
       |> List.iter (fun (SynExprRecordField(fieldName = (ident, _); expr = e)) -> e |> Option.iter walkExpr)
     | SynExpr.ObjExpr(ty, argOpt, _, bindings, _, ifaces, _, r) ->
-      addIfInside r
 
       argOpt |> Option.iter (fun (e, ident) -> walkExpr e)
 
       walkType ty
       List.iter walkBinding bindings
       List.iter walkInterfaceImpl ifaces
-    | SynExpr.For(identBody = e1; toBody = e2; doBody = e3; range = r) ->
-      addIfInside r
-      List.iter walkExpr [ e1; e2; e3 ]
+    | SynExpr.For(identBody = e1; toBody = e2; doBody = e3; range = r) -> List.iter walkExpr [ e1; e2; e3 ]
     | SynExpr.ForEach(_, _, _, _, pat, e1, e2, r) ->
-      addIfInside r
       walkPat pat
       List.iter walkExpr [ e1; e2 ]
-    | SynExpr.MatchLambda(_, _, synMatchClauseList, _, r) ->
-      addIfInside r
-      List.iter walkClause synMatchClauseList
+    | SynExpr.MatchLambda(_, _, synMatchClauseList, _, r) -> List.iter walkClause synMatchClauseList
     | SynExpr.Match(expr = e; clauses = synMatchClauseList; range = r) ->
-      addIfInside r
       walkExpr e
       List.iter walkClause synMatchClauseList
     | SynExpr.TypeApp(e, _, tys, _, _, tr, r) ->
-      addIfInside tr
-      addIfInside r
       List.iter walkType tys
       walkExpr e
     | SynExpr.LetOrUse(bindings = bindings; body = e; range = r) ->
-      addIfInside r
       List.iter walkBinding bindings
       walkExpr e
     | SynExpr.TryWith(tryExpr = e; withCases = clauses; range = r) ->
-      addIfInside r
       List.iter walkClause clauses
       walkExpr e
     | SynExpr.IfThenElse(ifExpr = e1; thenExpr = e2; elseExpr = e3; range = r) ->
-      addIfInside r
       List.iter walkExpr [ e1; e2 ]
       e3 |> Option.iter walkExpr
     | SynExpr.LongIdentSet(ident, e, r)
-    | SynExpr.DotGet(e, _, ident, r) ->
-      addIfInside r
-      walkExpr e
+    | SynExpr.DotGet(e, _, ident, r) -> walkExpr e
     | SynExpr.DotSet(e1, idents, e2, r) ->
-      addIfInside r
       walkExpr e1
       walkExpr e2
     | SynExpr.DotIndexedGet(e, args, _, r) ->
-      addIfInside r
       walkExpr e
       walkExpr args
     | SynExpr.DotIndexedSet(e1, args, e2, _, _, r) ->
-      addIfInside r
       walkExpr e1
       walkExpr args
       walkExpr e2
-    | SynExpr.NamedIndexedPropertySet(ident, e1, e2, r) ->
-      addIfInside r
-      List.iter walkExpr [ e1; e2 ]
-    | SynExpr.DotNamedIndexedPropertySet(e1, ident, e2, e3, r) ->
-      addIfInside r
-      List.iter walkExpr [ e1; e2; e3 ]
-    | SynExpr.JoinIn(e1, _, e2, r) ->
-      addIfInside r
-      List.iter walkExpr [ e1; e2 ]
+    | SynExpr.NamedIndexedPropertySet(ident, e1, e2, r) -> List.iter walkExpr [ e1; e2 ]
+    | SynExpr.DotNamedIndexedPropertySet(e1, ident, e2, e3, r) -> List.iter walkExpr [ e1; e2; e3 ]
+    | SynExpr.JoinIn(e1, _, e2, r) -> List.iter walkExpr [ e1; e2 ]
     | SynExpr.LetOrUseBang(pat = pat; rhs = e1; andBangs = ands; body = e2; range = r) ->
-      addIfInside r
       walkPat pat
       walkExpr e1
 
       for (SynExprAndBang(pat = pat; body = body; range = r)) in ands do
-        addIfInside r
         walkPat pat
         walkExpr body
 
       walkExpr e2
     | SynExpr.TraitCall(t, sign, e, r) ->
-      addIfInside r
       walkType t
       walkMemberSig sign
       walkExpr e
-    | SynExpr.Const(SynConst.Measure(_, _, m), r) ->
-      addIfInside r
-      walkMeasure m
-    | SynExpr.Const(_, r) -> addIfInside r
-    | SynExpr.AnonRecd(isStruct, copyInfo, recordFields, r, trivia) -> addIfInside r
+    | SynExpr.Const(SynConst.Measure(_, _, m), r) -> walkMeasure m
+    | SynExpr.Const(_, r) -> ()
+    | SynExpr.AnonRecd(isStruct, copyInfo, recordFields, r, trivia) -> ()
     | SynExpr.Sequential(seqPoint, isTrueSeq, expr1, expr2, r) -> ()
     | SynExpr.Ident(_) -> ()
-    | SynExpr.LongIdent(isOptional, longDotId, altNameRefCell, r) -> addIfInside r
-    | SynExpr.Set(_, _, r) -> addIfInside r
-    | SynExpr.Null(r) -> addIfInside r
-    | SynExpr.ImplicitZero(r) -> addIfInside r
-    | SynExpr.MatchBang(range = r) -> addIfInside r
-    | SynExpr.LibraryOnlyILAssembly(_, _, _, _, r) -> addIfInside r
-    | SynExpr.LibraryOnlyStaticOptimization(_, _, _, r) -> addIfInside r
-    | SynExpr.LibraryOnlyUnionCaseFieldGet(expr, longId, _, r) -> addIfInside r
-    | SynExpr.LibraryOnlyUnionCaseFieldSet(_, longId, _, _, r) -> addIfInside r
-    | SynExpr.ArbitraryAfterError(debugStr, r) -> addIfInside r
-    | SynExpr.FromParseError(expr, r) -> addIfInside r
-    | SynExpr.DiscardAfterMissingQualificationAfterDot(_, _, r) -> addIfInside r
-    | SynExpr.Fixed(expr, r) -> addIfInside r
+    | SynExpr.LongIdent(isOptional, longDotId, altNameRefCell, r) -> ()
+    | SynExpr.Set(_, _, r) -> ()
+    | SynExpr.Null(r) -> ()
+    | SynExpr.ImplicitZero(r) -> ()
+    | SynExpr.MatchBang(range = r) -> ()
+    | SynExpr.LibraryOnlyILAssembly(_, _, _, _, r) -> ()
+    | SynExpr.LibraryOnlyStaticOptimization(_, _, _, r) -> ()
+    | SynExpr.LibraryOnlyUnionCaseFieldGet(expr, longId, _, r) -> ()
+    | SynExpr.LibraryOnlyUnionCaseFieldSet(_, longId, _, _, r) -> ()
+    | SynExpr.ArbitraryAfterError(debugStr, r) -> ()
+    | SynExpr.FromParseError(expr, r) -> ()
+    | SynExpr.DiscardAfterMissingQualificationAfterDot(_, _, r) -> ()
+    | SynExpr.Fixed(expr, r) -> ()
     | SynExpr.InterpolatedString(parts, kind, r) ->
-      addIfInside r
 
       for part in parts do
         walkInterpolatedStringPart part
-    | SynExpr.IndexFromEnd(itemExpr, r) ->
-      addIfInside r
-      walkExpr itemExpr
+    | SynExpr.IndexFromEnd(itemExpr, r) -> walkExpr itemExpr
     | SynExpr.IndexRange(e1, _, e2, _, _, r) ->
-      addIfInside r
       Option.iter walkExpr e1
       Option.iter walkExpr e2
     | SynExpr.DebugPoint(innerExpr = expr) -> walkExpr expr
     | SynExpr.Dynamic(funcExpr = e1; argExpr = e2; range = range) ->
-      addIfInside range
       walkExpr e1
       walkExpr e2
-    | SynExpr.Typar(t, r) ->
-      addIfInside r
-      walkTypar t
+    | SynExpr.Typar(t, r) -> walkTypar t
 
-  and walkMeasure =
-    function
+  and walkMeasure s =
+    walker.WalkMeasure s
+
+    match s with
     | SynMeasure.Product(m1, m2, r)
     | SynMeasure.Divide(m1, m2, r) ->
-      addIfInside r
       walkMeasure m1
       walkMeasure m2
-    | SynMeasure.Named(longIdent, r) -> addIfInside r
-    | SynMeasure.Seq(ms, r) ->
-      addIfInside r
-      List.iter walkMeasure ms
-    | SynMeasure.Power(m, _, r) ->
-      addIfInside r
-      walkMeasure m
-    | SynMeasure.Var(ty, r) ->
-      addIfInside r
-      walkTypar ty
-    | SynMeasure.Paren(m, r) ->
-      addIfInside r
-      walkMeasure m
+    | SynMeasure.Named(longIdent, r) -> ()
+    | SynMeasure.Seq(ms, r) -> List.iter walkMeasure ms
+    | SynMeasure.Power(m, _, r) -> walkMeasure m
+    | SynMeasure.Var(ty, r) -> walkTypar ty
+    | SynMeasure.Paren(m, r) -> walkMeasure m
     | SynMeasure.One
     | SynMeasure.Anon _ -> ()
 
-  and walkSimplePat =
-    function
+  and walkSimplePat s =
+    walker.WalkSimplePat s
+
+    match s with
     | SynSimplePat.Attrib(pat, AllAttrs attrs, r) ->
-      addIfInside r
       walkSimplePat pat
       List.iter walkAttribute attrs
     | SynSimplePat.Typed(pat, t, r) ->
-      addIfInside r
       walkSimplePat pat
       walkType t
-    | SynSimplePat.Id(ident, altNameRefCell, isCompilerGenerated, isThisVar, isOptArg, r) -> addIfInside r
+    | SynSimplePat.Id(ident, altNameRefCell, isCompilerGenerated, isThisVar, isOptArg, r) -> ()
 
-
-  and walkField (SynField(attributes = AllAttrs attrs; fieldType = t; range = r)) =
-    addIfInside r
+  and walkField (SynField(attributes = AllAttrs attrs; fieldType = t; range = r) as s) =
+    walker.WalkField s
     List.iter walkAttribute attrs
     walkType t
 
   and walkValSig
-    (SynValSig(attributes = AllAttrs attrs; synType = t; arity = SynValInfo(argInfos, argInfo); range = r))
+    (SynValSig(attributes = AllAttrs attrs; synType = t; arity = SynValInfo(argInfos, argInfo); range = r) as s)
     =
-    addIfInside r
+    walker.WalkValSig s
     List.iter walkAttribute attrs
     walkType t
 
@@ -489,20 +450,15 @@ let internal getRangesAtPosition input (r: Position) : Range list =
     |> List.collect (fun (SynArgInfo(attributes = AllAttrs attrs)) -> attrs)
     |> List.iter walkAttribute
 
-  and walkMemberSig =
-    function
+  and walkMemberSig s =
+    walker.WalkMemberSig s
+
+    match s with
     | SynMemberSig.Inherit(t, r)
-    | SynMemberSig.Interface(t, r) ->
-      addIfInside r
-      walkType t
-    | SynMemberSig.Member(vs, _, r, _) ->
-      addIfInside r
-      walkValSig vs
-    | SynMemberSig.ValField(f, r) ->
-      addIfInside r
-      walkField f
+    | SynMemberSig.Interface(t, r) -> walkType t
+    | SynMemberSig.Member(vs, _, r, _) -> walkValSig vs
+    | SynMemberSig.ValField(f, r) -> walkField f
     | SynMemberSig.NestedType(SynTypeDefnSig(typeInfo = info; typeRepr = repr; members = memberSigs), r) ->
-      addIfInside r
 
       let isTypeExtensionOrAlias =
         match repr with
@@ -515,110 +471,91 @@ let internal getRangesAtPosition input (r: Position) : Range list =
       walkTypeDefnSigRepr repr
       List.iter walkMemberSig memberSigs
 
-  and walkMember =
-    function
-    | SynMemberDefn.AbstractSlot(valSig, _, r, _) ->
-      addIfInside r
-      walkValSig valSig
-    | SynMemberDefn.Member(binding, r) ->
-      addIfInside r
-      walkBinding binding
+  and walkMember s =
+    walker.WalkMember s
+
+    match s with
+    | SynMemberDefn.AbstractSlot(valSig, _, r, _) -> walkValSig valSig
+    | SynMemberDefn.Member(binding, r) -> walkBinding binding
     | SynMemberDefn.ImplicitCtor(_, AllAttrs attrs, AllSimplePats pats, _, _, r, _) ->
-      addIfInside r
       List.iter walkAttribute attrs
       List.iter walkSimplePat pats
     | SynMemberDefn.ImplicitInherit(t, e, _, r) ->
-      addIfInside r
       walkType t
       walkExpr e
-    | SynMemberDefn.LetBindings(bindings, _, _, r) ->
-      addIfInside r
-      List.iter walkBinding bindings
+    | SynMemberDefn.LetBindings(bindings, _, _, r) -> List.iter walkBinding bindings
     | SynMemberDefn.Interface(t, _, members, r) ->
-      addIfInside r
       walkType t
       members |> Option.iter (List.iter walkMember)
-    | SynMemberDefn.Inherit(t, _, r) ->
-      addIfInside r
-      walkType t
-    | SynMemberDefn.ValField(field, r) ->
-      addIfInside r
-      walkField field
-    | SynMemberDefn.NestedType(tdef, _, r) ->
-      addIfInside r
-      walkTypeDefn tdef
+    | SynMemberDefn.Inherit(t, _, r) -> walkType t
+    | SynMemberDefn.ValField(field, r) -> walkField field
+    | SynMemberDefn.NestedType(tdef, _, r) -> walkTypeDefn tdef
     | SynMemberDefn.AutoProperty(attributes = AllAttrs attrs; typeOpt = t; synExpr = e; range = r) ->
-      addIfInside r
       List.iter walkAttribute attrs
       Option.iter walkType t
       walkExpr e
-    | SynMemberDefn.Open(longId, r) -> addIfInside r
+    | SynMemberDefn.Open(longId, r) -> ()
     | SynMemberDefn.GetSetMember(memberDefnForGet = getter; memberDefnForSet = setter; range = range) ->
-      addIfInside range
       Option.iter walkBinding getter
       Option.iter walkBinding setter
 
-  and walkEnumCase (SynEnumCase(attributes = AllAttrs attrs; range = r)) =
-    addIfInside r
+  and walkEnumCase (SynEnumCase(attributes = AllAttrs attrs; range = r) as s) =
+    walker.WalkEnumCase s
     List.iter walkAttribute attrs
 
-  and walkUnionCaseType =
-    function
+  and walkUnionCaseType s =
+    walker.WalkUnionCaseType s
+
+    match s with
     | SynUnionCaseKind.Fields fields -> List.iter walkField fields
     | SynUnionCaseKind.FullType(t, _) -> walkType t
 
-  and walkUnionCase (SynUnionCase(attributes = AllAttrs attrs; caseType = t; range = r)) =
-    addIfInside r
+  and walkUnionCase (SynUnionCase(attributes = AllAttrs attrs; caseType = t; range = r) as s) =
+    walker.WalkUnionCase s
     List.iter walkAttribute attrs
     walkUnionCaseType t
 
-  and walkTypeDefnSimple =
-    function
-    | SynTypeDefnSimpleRepr.Enum(cases, r) ->
-      addIfInside r
-      List.iter walkEnumCase cases
-    | SynTypeDefnSimpleRepr.Union(_, cases, r) ->
-      addIfInside r
-      List.iter walkUnionCase cases
-    | SynTypeDefnSimpleRepr.Record(_, fields, r) ->
-      addIfInside r
-      List.iter walkField fields
-    | SynTypeDefnSimpleRepr.TypeAbbrev(_, t, r) ->
-      addIfInside r
-      walkType t
-    | SynTypeDefnSimpleRepr.General(_, _, _, _, _, _, _, r) -> addIfInside r
-    | SynTypeDefnSimpleRepr.LibraryOnlyILAssembly(_, r) -> addIfInside r
-    | SynTypeDefnSimpleRepr.None(r) -> addIfInside r
+  and walkTypeDefnSimple s =
+    walker.WalkTypeDefnSimple s
+
+    match s with
+    | SynTypeDefnSimpleRepr.Enum(cases, r) -> List.iter walkEnumCase cases
+    | SynTypeDefnSimpleRepr.Union(_, cases, r) -> List.iter walkUnionCase cases
+    | SynTypeDefnSimpleRepr.Record(_, fields, r) -> List.iter walkField fields
+    | SynTypeDefnSimpleRepr.TypeAbbrev(_, t, r) -> walkType t
+    | SynTypeDefnSimpleRepr.General(_, _, _, _, _, _, _, r) -> ()
+    | SynTypeDefnSimpleRepr.LibraryOnlyILAssembly(_, r) -> ()
+    | SynTypeDefnSimpleRepr.None(r) -> ()
     | SynTypeDefnSimpleRepr.Exception(_) -> ()
 
   and walkComponentInfo
     isTypeExtensionOrAlias
     (SynComponentInfo(
-      attributes = AllAttrs attrs; typeParams = typars; constraints = constraints; longId = longIdent; range = r))
+      attributes = AllAttrs attrs; typeParams = typars; constraints = constraints; longId = longIdent; range = r) as s)
     =
-    addIfInside r
+    walker.WalkComponentInfo s
     List.iter walkAttribute attrs
     Option.iter walkTyparDecls typars
     List.iter walkTypeConstraint constraints
 
-  and walkTypeDefnRepr =
-    function
-    | SynTypeDefnRepr.ObjectModel(_, defns, r) ->
-      addIfInside r
-      List.iter walkMember defns
-    | SynTypeDefnRepr.Simple(defn, r) ->
-      addIfInside r
-      walkTypeDefnSimple defn
+  and walkTypeDefnRepr s =
+    walker.WalkTypeDefnRepr s
+
+    match s with
+    | SynTypeDefnRepr.ObjectModel(_, defns, r) -> List.iter walkMember defns
+    | SynTypeDefnRepr.Simple(defn, r) -> walkTypeDefnSimple defn
     | SynTypeDefnRepr.Exception _ -> ()
 
-  and walkTypeDefnSigRepr =
-    function
+  and walkTypeDefnSigRepr s =
+    walker.WalkTypeDefnSigRepr s
+
+    match s with
     | SynTypeDefnSigRepr.ObjectModel(_, defns, _) -> List.iter walkMemberSig defns
     | SynTypeDefnSigRepr.Simple(defn, _) -> walkTypeDefnSimple defn
     | SynTypeDefnSigRepr.Exception _ -> ()
 
-  and walkTypeDefn (SynTypeDefn(info, repr, members, implicitCtor, r, _)) =
-    addIfInside r
+  and walkTypeDefn (SynTypeDefn(info, repr, members, implicitCtor, r, _) as s) =
+    walker.WalkTypeDefn s
 
     let isTypeExtensionOrAlias =
       match repr with
@@ -633,34 +570,92 @@ let internal getRangesAtPosition input (r: Position) : Range list =
     List.iter walkMember members
 
   and walkSynModuleDecl (decl: SynModuleDecl) =
+    walker.WalkSynModuleDecl decl
+
     match decl with
     | SynModuleDecl.NamespaceFragment fragment -> walkSynModuleOrNamespace fragment
     | SynModuleDecl.NestedModule(info, _, modules, _, r, _) ->
-      addIfInside r
       walkComponentInfo false info
       List.iter walkSynModuleDecl modules
-    | SynModuleDecl.Let(_, bindings, r) ->
-      addIfInside r
-      List.iter walkBinding bindings
-    | SynModuleDecl.Expr(expr, r) ->
-      addIfInside r
-      walkExpr expr
-    | SynModuleDecl.Types(types, r) ->
-      addIfInside r
-      List.iter walkTypeDefn types
-    | SynModuleDecl.Attributes(attributes = AllAttrs attrs; range = r) ->
-      addIfInside r
-      List.iter walkAttribute attrs
-    | SynModuleDecl.ModuleAbbrev(ident, longId, r) -> addIfInside r
-    | SynModuleDecl.Exception(_, r) -> addIfInside r
-    | SynModuleDecl.Open(longDotId, r) -> addIfInside r
-    | SynModuleDecl.HashDirective(_, r) -> addIfInside r
+    | SynModuleDecl.Let(_, bindings, r) -> List.iter walkBinding bindings
+    | SynModuleDecl.Expr(expr, r) -> walkExpr expr
+    | SynModuleDecl.Types(types, r) -> List.iter walkTypeDefn types
+    | SynModuleDecl.Attributes(attributes = AllAttrs attrs; range = r) -> List.iter walkAttribute attrs
+    | SynModuleDecl.ModuleAbbrev(ident, longId, r) -> ()
+    | SynModuleDecl.Exception(_, r) -> ()
+    | SynModuleDecl.Open(longDotId, r) -> ()
+    | SynModuleDecl.HashDirective(_, r) -> ()
 
   match input with
   | ParsedInput.ImplFile input -> walkImplFileInput input
   | _ -> ()
-  //debug "%A" idents
-  result
+
+#nowarn "3535"
+
+type private HasRange<'t when 't :> HasRange<'t>> =
+  abstract Range: Range
+
+type private RangeCollectorWalker(pos: Position) =
+  inherit UntypedSyntaxCollectorVisitor()
+  let ranges = ResizeArray<Range>()
+
+  let addIfInside (m: Range) =
+    if (Range.rangeContainsPos m pos) then
+      ranges.Add m
+
+  override _.WalkSynModuleOrNamespace m = addIfInside m.Range
+  override _.WalkAttribute a = addIfInside a.Range
+  override _.WalkTypeConstraint c = addIfInside c.Range
+  override _.WalkPat p = addIfInside p.Range
+
+  override _.WalkBinding(SynBinding(range = r; returnInfo = ri)) =
+    addIfInside r
+    ri |> Option.iter (fun (SynBindingReturnInfo(range = r')) -> addIfInside r')
+
+  override _.WalkInterfaceImpl(SynInterfaceImpl(range = range)) = addIfInside range
+  override _.WalkType t = addIfInside t.Range
+  override _.WalkClause c = addIfInside c.Range
+
+  override _.WalkInterpolatedStringPart i =
+    match i with
+    | SynInterpolatedStringPart.FillExpr(qualifiers = Some ident) -> addIfInside ident.idRange
+    | SynInterpolatedStringPart.String(s, r) -> addIfInside r
+    | _ -> ()
+
+  override _.WalkExpr e = addIfInside e.Range
+
+  override _.WalkMeasure m =
+    match m with
+    | SynMeasure.Product(range = r)
+    | SynMeasure.Divide(range = r)
+    | SynMeasure.Named(range = r)
+    | SynMeasure.Seq(range = r)
+    | SynMeasure.Power(range = r)
+    | SynMeasure.Var(range = r)
+    | SynMeasure.Paren(range = r) -> addIfInside r
+    | SynMeasure.One
+    | SynMeasure.Anon _ -> ()
+
+  override _.WalkSimplePat p = addIfInside p.Range
+  override _.WalkField(SynField(range = r)) = addIfInside r
+  override _.WalkValSig(SynValSig(range = r)) = addIfInside r
+  override _.WalkMemberSig m = addIfInside m.Range
+  override _.WalkMember m = addIfInside m.Range
+  override _.WalkEnumCase e = addIfInside e.Range
+  override _.WalkUnionCase u = addIfInside u.Range
+  override _.WalkTypeDefnSimple s = addIfInside s.Range
+  override _.WalkComponentInfo c = addIfInside c.Range
+  override _.WalkTypeDefnRepr t = addIfInside t.Range
+  override _.WalkTypeDefnSigRepr t = addIfInside t.Range
+  override _.WalkTypeDefn t = addIfInside t.Range
+  override _.WalkSynModuleDecl s = addIfInside s.Range
+
+  member _.Ranges = ranges
+
+let internal getRangesAtPosition input (r: Position) : Range list =
+  let walker = new RangeCollectorWalker(r)
+  walkAst walker input
+  walker.Ranges |> Seq.toList
 
 module Completion =
 

--- a/src/FsAutoComplete.Core/UntypedAstUtils.fsi
+++ b/src/FsAutoComplete.Core/UntypedAstUtils.fsi
@@ -1,36 +1,81 @@
-/// Code from VisualFSharpPowerTools project: https://github.com/fsprojects/VisualFSharpPowerTools/blob/master/src/FSharp.Editing/Common/UntypedAstUtils.fs
-module FsAutoComplete.UntypedAstUtils
+namespace FSharp.Compiler
 
-open FSharp.Compiler.Syntax
-open System.Collections.Generic
-open FSharp.Compiler
-open FSharp.Compiler.Text
-open FSharp.Control.Reactive.Observable
+module Syntax =
+  open FSharp.Compiler.Syntax
 
-type Range with
+  type SyntaxCollectorBase =
+    new: unit -> SyntaxCollectorBase
+    abstract WalkSynModuleOrNamespace: SynModuleOrNamespace -> unit
+    abstract WalkAttribute: SynAttribute -> unit
+    abstract WalkSynModuleDecl: SynModuleDecl -> unit
+    abstract WalkExpr: SynExpr -> unit
+    abstract WalkTypar: SynTypar -> unit
+    abstract WalkTyparDecl: SynTyparDecl -> unit
+    abstract WalkTypeConstraint: SynTypeConstraint -> unit
+    abstract WalkType: SynType -> unit
+    abstract WalkMemberSig: SynMemberSig -> unit
+    abstract WalkPat: SynPat -> unit
+    abstract WalkValTyparDecls: SynValTyparDecls -> unit
+    abstract WalkBinding: SynBinding -> unit
+    abstract WalkSimplePat: SynSimplePat -> unit
+    abstract WalkInterfaceImpl: SynInterfaceImpl -> unit
+    abstract WalkClause: SynMatchClause -> unit
+    abstract WalkInterpolatedStringPart: SynInterpolatedStringPart -> unit
+    abstract WalkMeasure: SynMeasure -> unit
+    abstract WalkComponentInfo: SynComponentInfo -> unit
+    abstract WalkTypeDefnSigRepr: SynTypeDefnSigRepr -> unit
+    abstract WalkUnionCaseType: SynUnionCaseKind -> unit
+    abstract WalkEnumCase: SynEnumCase -> unit
+    abstract WalkField: SynField -> unit
+    abstract WalkTypeDefnSimple: SynTypeDefnSimpleRepr -> unit
+    abstract WalkValSig: SynValSig -> unit
+    abstract WalkMember: SynMemberDefn -> unit
+    abstract WalkUnionCase: SynUnionCase -> unit
+    abstract WalkTypeDefnRepr: SynTypeDefnRepr -> unit
+    abstract WalkTypeDefn: SynTypeDefn -> unit
 
-  member inline IsEmpty: bool
+  val walkAst: walker: SyntaxCollectorBase -> input: ParsedInput -> unit
 
-type internal ShortIdent = string
-type internal Idents = ShortIdent[]
-val internal longIdentToArray: longIdent: LongIdent -> Idents
-/// An recursive pattern that collect all sequential expressions to avoid StackOverflowException
-val (|Sequentials|_|): (SynExpr -> SynExpr list option)
-val (|ConstructorPats|): (SynArgPats -> SynPat list)
-/// matches if the range contains the position
-val (|ContainsPos|_|): pos: pos -> range: range -> unit option
-/// Active pattern that matches an ident on a given name by the ident's `idText`
-val (|Ident|_|): ofName: string -> (SynExpr -> unit option)
-/// matches if the range contains the position
-val (|IdentContainsPos|_|): pos: pos -> ident: Ident -> unit option
-/// A pattern that collects all attributes from a `SynAttributes` into a single flat list
-val (|AllAttrs|): attrs: SynAttributes -> SynAttribute list
-/// A pattern that collects all patterns from a `SynSimplePats` into a single flat list
-val (|AllSimplePats|): pats: SynSimplePats -> SynSimplePat list
-/// Gives all ranges for current position
-val internal getRangesAtPosition: input: ParsedInput -> r: Position -> Range list
+  /// An recursive pattern that collect all sequential expressions to avoid StackOverflowException
+  val (|Sequentials|_|): (SynExpr -> SynExpr list option)
+  val (|ConstructorPats|): (SynArgPats -> SynPat list)
+  /// A pattern that collects all attributes from a `SynAttributes` into a single flat list
+  val (|AllAttrs|): attrs: SynAttributes -> SynAttribute list
+  /// A pattern that collects all patterns from a `SynSimplePats` into a single flat list
+  val (|AllSimplePats|): pats: SynSimplePats -> SynSimplePat list
+
+namespace FsAutoComplete
+
+module UntypedAstUtils =
+
+  open FSharp.Compiler.Syntax
+  open FSharp.Compiler.Text
+
+  type Range with
+
+    member inline IsEmpty: bool
+
+  type internal ShortIdent = string
+  type internal Idents = ShortIdent[]
+  val internal longIdentToArray: longIdent: LongIdent -> Idents
+
+  /// matches if the range contains the position
+  val (|ContainsPos|_|): pos: pos -> range: range -> unit option
+  /// Active pattern that matches an ident on a given name by the ident's `idText`
+  val (|Ident|_|): ofName: string -> (SynExpr -> unit option)
+  /// matches if the range contains the position
+  val (|IdentContainsPos|_|): pos: pos -> ident: Ident -> unit option
+
+module FoldingRange =
+  open FSharp.Compiler.Syntax
+  open FSharp.Compiler.Text
+
+  val getRangesAtPosition: input: ParsedInput -> r: Position -> Range list
 
 module Completion =
+  open FSharp.Compiler.Syntax
+  open FSharp.Compiler.Text
+
   [<RequireQualifiedAccess>]
   type Context =
     | StringLiteral


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c7037be</samp>

Refactored the code for finding folding ranges in F# files. Moved the logic to a new `FoldingRange` module and used a custom syntax walker to collect the ranges. Split the `UntypedAstUtils.fsi` file into `Syntax.fs` and `UntypedAstUtils.fs` for better modularity.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c7037be</samp>

> _`FoldingRange` walks_
> _Syntax trees in separate file_
> _Winter of refactor_

<!--
copilot:emoji
-->

🔧📦📑

<!--
1.  🔧 - This emoji represents a wrench or a tool, and it can be used to indicate a refactoring or an improvement of the code quality or structure.
2.  📦 - This emoji represents a package or a box, and it can be used to indicate a change in the modularity or organization of the code, such as splitting or adding files or modules.
3.  📑 - This emoji represents a document or a page, and it can be used to indicate a change in the syntax or the AST of the code, such as using a custom syntax walker or a different node type.
-->

### WHY
I logged an issue at dotnet/fsharp a while ago to pull out this walker from UntypedAstUtils into a reusable component because I thought it would be helpful. This walker gives the opportunity to do an action at every node which is helpful for 'collecting' style operations, like folding ranges and the soon-to-be-implemented nested language support.

This PR is the infrastructure for that - it pulls out the collecting walker into an abstract class for the caller to override, and a walking function that the walker is passed to - very much like the existing position-finding walker. It then uses that walker to reimplement the folding-range detection, which now is very simple to understand.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c7037be</samp>

*  Refactor the logic for finding folding ranges to a separate module and use a custom syntax walker ([link](https://github.com/fsharp/FsAutoComplete/pull/1154/files?diff=unified&w=0#diff-f030ffbad83492980d57dd555322c7d8e9f26a1986413d60384e0730f8f54dd7L209-R209), [link](https://github.com/fsharp/FsAutoComplete/pull/1154/files?diff=unified&w=0#diff-0b281fa0adfec9e033ea42edb61599324e0a42defbbeba3ab9546a50b3b41825L1-R78))
* Split the `UntypedAstUtils.fsi` file into two files: `Syntax.fs` and `UntypedAstUtils.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1154/files?diff=unified&w=0#diff-0b281fa0adfec9e033ea42edb61599324e0a42defbbeba3ab9546a50b3b41825L1-R78))
