### PR TITLE
Update value in signature file.

### DIFF
--- a/src/FsAutoComplete/CodeFixes/ToInterpolatedString.fsi
+++ b/src/FsAutoComplete/CodeFixes/ToInterpolatedString.fsi
@@ -1,0 +1,12 @@
+module FsAutoComplete.CodeFix.ToInterpolatedString
+
+open FsAutoComplete.CodeFix.Types
+open Ionide.LanguageServerProtocol.Types
+
+val title: string
+
+val fix:
+  getParseResultsForFile: GetParseResultsForFile ->
+  getLanguageVersion: GetLanguageVersion ->
+  codeActionParams: CodeActionParams ->
+    Async<Result<Fix list, string>>

--- a/src/FsAutoComplete/CodeFixes/UpdateValueInSignatureFile.fs
+++ b/src/FsAutoComplete/CodeFixes/UpdateValueInSignatureFile.fs
@@ -79,14 +79,6 @@ let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
             // Find a matching val in the signature file.
             let sigVisitor =
               { new SyntaxVisitorBase<_>() with
-                  override x.VisitModuleSigDecl
-                    (
-                      path: SyntaxVisitorPath,
-                      defaultTraverse,
-                      synModuleSigDecl: SynModuleSigDecl
-                    ) =
-                    defaultTraverse synModuleSigDecl
-
                   override x.VisitValSig
                     (
                       path,
@@ -108,10 +100,15 @@ let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
             | Some(mValSig, sigPath) ->
 
               // Verify both nodes share the same path.
+              // TODO: not sure how relevant this check still is.
+              // Using the mfv.SignatureLocation is probably already enough to pinpoint the correct val.
+              // This check was introduced to verify vals with the same name (but in different nested modules) are not getting mixed up.
               if not (assertPaths sigPath implPath) then
                 return []
               else
                 // Find matching symbol in signature file, we need it for its DisplayContext
+                // GetValSignatureText will take the open namespaces into account when printing the types.
+                // The implementation file might have different opens than the signature.
                 let sigSymbolUseOpt =
                   sigParseAndCheckResults.GetCheckResults.GetSymbolUseAtLocation(
                     mSig.End.Line,

--- a/src/FsAutoComplete/CodeFixes/UpdateValueInSignatureFile.fs
+++ b/src/FsAutoComplete/CodeFixes/UpdateValueInSignatureFile.fs
@@ -1,0 +1,81 @@
+module FsAutoComplete.CodeFix.UpdateValueInSignatureFile
+
+open FSharp.Compiler.Symbols
+open FSharp.Compiler.Syntax
+open FsToolkit.ErrorHandling
+open Ionide.LanguageServerProtocol.Types
+open FsAutoComplete.CodeFix.Types
+open FsAutoComplete
+open FsAutoComplete.LspHelpers
+
+let visitSynModuleSigDecl (name: string) (decl: SynModuleSigDecl) =
+  match decl with
+  | SynModuleSigDecl.Val(valSig = SynValSig(ident = SynIdent(ident = ident)); range = m) when ident.idText = name ->
+    Some m
+  | _ -> None
+
+let visitSynModuleOrNamespaceSig (name: string) (SynModuleOrNamespaceSig(decls = decls)) =
+  decls |> List.tryPick (visitSynModuleSigDecl name)
+
+let visitParsedSigFileInput (name: string) (ParsedSigFileInput(contents = contents)) =
+  contents |> List.tryPick (visitSynModuleOrNamespaceSig name)
+
+let visitTree (name: string) (tree: ParsedInput) =
+  match tree with
+  | ParsedInput.ImplFile _ -> None
+  | ParsedInput.SigFile parsedSigFileInput -> visitParsedSigFileInput name parsedSigFileInput
+
+let title = "Update val in signature file"
+
+let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
+  Run.ifDiagnosticByCode (Set.ofList [ "34" ]) (fun diagnostic codeActionParams ->
+    asyncResult {
+      let implFilePath = codeActionParams.TextDocument.GetFilePath()
+      let sigFilePath = $"%s{implFilePath}i"
+
+      let implFileName = Utils.normalizePath implFilePath
+      let sigFileName = Utils.normalizePath sigFilePath
+
+      let sigTextDocumentIdentifier: TextDocumentIdentifier =
+        { Uri = $"%s{codeActionParams.TextDocument.Uri}i" }
+
+      let! (implParseAndCheckResults: ParseAndCheckResults, implLine: string, implSourceText: IFSACSourceText) =
+        getParseResultsForFile implFileName (protocolPosToPos diagnostic.Range.Start)
+
+      let! implBindingName =
+        implSourceText.GetText(protocolRangeToRange implParseAndCheckResults.GetParseResults.FileName diagnostic.Range)
+
+      let! (sigParseAndCheckResults: ParseAndCheckResults, _sigLine: string, _sigSourceText: IFSACSourceText) =
+        getParseResultsForFile sigFileName (protocolPosToPos diagnostic.Range.Start)
+
+      match visitTree implBindingName sigParseAndCheckResults.GetParseResults.ParseTree with
+      | None -> return []
+      | Some mVal ->
+        let endPos = protocolPosToPos diagnostic.Range.End
+
+        let symbolUse =
+          implParseAndCheckResults.GetCheckResults.GetSymbolUseAtLocation(
+            endPos.Line,
+            endPos.Column,
+            implLine,
+            [ implBindingName ]
+          )
+
+        match symbolUse with
+        | None -> return []
+        | Some symbolUse ->
+          match symbolUse.Symbol with
+          | :? FSharpMemberOrFunctionOrValue as mfv ->
+            match mfv.GetValSignatureText(symbolUse.DisplayContext, symbolUse.Range) with
+            | None -> return []
+            | Some valText ->
+              return
+                [ { SourceDiagnostic = None
+                    Title = title
+                    File = sigTextDocumentIdentifier
+                    Edits =
+                      [| { Range = fcsRangeToLsp mVal
+                           NewText = valText } |]
+                    Kind = FixKind.Fix } ]
+          | _ -> return []
+    })

--- a/src/FsAutoComplete/CodeFixes/UpdateValueInSignatureFile.fsi
+++ b/src/FsAutoComplete/CodeFixes/UpdateValueInSignatureFile.fsi
@@ -1,0 +1,6 @@
+module FsAutoComplete.CodeFix.UpdateValueInSignatureFile
+
+open FsAutoComplete.CodeFix.Types
+
+val title: string
+val fix: getParseResultsForFile: GetParseResultsForFile -> CodeFix

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -1768,7 +1768,8 @@ type AdaptiveState(lspClient: FSharpLspClient, sourceTextFactory: ISourceTextFac
          RenameParamToMatchSignature.fix tryGetParseResultsForFile
          RemovePatternArgument.fix tryGetParseResultsForFile
          ToInterpolatedString.fix tryGetParseResultsForFile getLanguageVersion
-         AdjustConstant.fix tryGetParseResultsForFile |])
+         AdjustConstant.fix tryGetParseResultsForFile
+         UpdateValueInSignatureFile.fix tryGetParseResultsForFile |])
 
   let forgetDocument (uri: DocumentUri) =
     async {

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/AdjustConstantTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/AdjustConstantTests.fs
@@ -47,7 +47,14 @@ module private ConvertIntToOtherBase =
           else
             ExpectedResult.After expected
 
-        do! checkFixAt (doc, diags) (source, cursor) Diagnostics.acceptAll (selectIntCodeFix base') expected
+        do!
+          checkFixAt
+            (doc, diags)
+            doc.VersionedTextDocumentIdentifier
+            (source, cursor)
+            Diagnostics.acceptAll
+            (selectIntCodeFix base')
+            expected
       })
 
   /// empty `expectedXXX`: there should be no corresponding Fix
@@ -941,7 +948,14 @@ module private ConvertCharToOtherForm =
           else
             ExpectedResult.After expected
 
-        do! checkFixAt (doc, diags) (source, cursor) Diagnostics.acceptAll (selectCharCodeFix (format)) expected
+        do!
+          checkFixAt
+            (doc, diags)
+            doc.VersionedTextDocumentIdentifier
+            (source, cursor)
+            Diagnostics.acceptAll
+            (selectCharCodeFix (format))
+            expected
       })
 
   let check

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/RenameParamToMatchSignatureTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/RenameParamToMatchSignatureTests.fs
@@ -13,8 +13,7 @@ open Utils.CursorbasedTests.CodeFix
 
 
 let tests state =
-  let selectCodeFix expectedName =
-    CodeFix.withTitle (RenameParamToMatchSignature.title expectedName)
+  let selectCodeFix expectedName = CodeFix.withTitle (RenameParamToMatchSignature.title expectedName)
 
   // requires `fsi` and corresponding `fs` file (and a project!)
   // -> cannot use untitled doc
@@ -33,7 +32,7 @@ let tests state =
             fsSourceWithCursor |> Text.trimTripleQuotation |> Cursor.assertExtractRange
 
           let! (fsiDoc, diags) = server |> Server.openDocumentWithText fsiFile fsiSource
-          use fsiDoc = fsiDoc
+          use _fsiDoc = fsiDoc
           Expect.isEmpty diags "There should be no diagnostics in fsi doc"
           let! (fsDoc, diags) = server |> Server.openDocumentWithText fsFile fsSource
           use fsDoc = fsDoc

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/RenameParamToMatchSignatureTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/RenameParamToMatchSignatureTests.fs
@@ -13,7 +13,8 @@ open Utils.CursorbasedTests.CodeFix
 
 
 let tests state =
-  let selectCodeFix expectedName = CodeFix.withTitle (RenameParamToMatchSignature.title expectedName)
+  let selectCodeFix expectedName =
+    CodeFix.withTitle (RenameParamToMatchSignature.title expectedName)
 
   // requires `fsi` and corresponding `fs` file (and a project!)
   // -> cannot use untitled doc
@@ -32,7 +33,7 @@ let tests state =
             fsSourceWithCursor |> Text.trimTripleQuotation |> Cursor.assertExtractRange
 
           let! (fsiDoc, diags) = server |> Server.openDocumentWithText fsiFile fsiSource
-          use _fsiDoc = fsiDoc
+          use fsiDoc = fsiDoc
           Expect.isEmpty diags "There should be no diagnostics in fsi doc"
           let! (fsDoc, diags) = server |> Server.openDocumentWithText fsFile fsSource
           use fsDoc = fsDoc
@@ -40,6 +41,7 @@ let tests state =
           do!
             checkFixAt
               (fsDoc, diags)
+              fsDoc.VersionedTextDocumentIdentifier
               (fsSource, cursor)
               (Diagnostics.expectCode "3218")
               selectCodeFix

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -3351,4 +3351,5 @@ let tests textFactory state =
       useTripleQuotedInterpolationTests state
       wrapExpressionInParenthesesTests state
       removeRedundantAttributeSuffixTests state
-      removePatternArgumentTests state ]
+      removePatternArgumentTests state
+      UpdateValueInSignatureFileTests.tests state ]

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/UpdateValueInSignatureFileTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/UpdateValueInSignatureFileTests.fs
@@ -46,7 +46,7 @@ let tests state =
   serverTestList (nameof UpdateValueInSignatureFile) state defaultConfigDto (Some path) (fun server ->
     [ let selectCodeFix = CodeFix.withTitle UpdateValueInSignatureFile.title
 
-      ftestCaseAsync "first unit test for UpdateValueInSignatureFile"
+      testCaseAsync "first unit test for UpdateValueInSignatureFile"
       <| checkWithFsi
         server
         """

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/UpdateValueInSignatureFileTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/UpdateValueInSignatureFileTests.fs
@@ -1,0 +1,68 @@
+module private FsAutoComplete.Tests.CodeFixTests.UpdateValueInSignatureFileTests
+
+open System.IO
+open Expecto
+open Helpers
+open Utils.ServerTests
+open Utils.CursorbasedTests
+open FsAutoComplete.CodeFix
+open Utils.Utils
+open Utils.TextEdit
+open Utils.Server
+open Utils.CursorbasedTests.CodeFix
+
+let path = Path.Combine(__SOURCE_DIRECTORY__, @"../TestCases/CodeFixTests/RenameParamToMatchSignature/")
+let fsiFile, fsFile = ("Code.fsi", "Code.fs")
+
+let checkWithFsi
+  server
+  fsiSource
+  fsSourceWithCursor
+  selectCodeFix
+  fsiSourceExpected
+  = async {
+    let fsiSource = fsiSource |> Text.trimTripleQuotation
+    let cursor, fsSource =
+      fsSourceWithCursor
+      |> Text.trimTripleQuotation
+      |> Cursor.assertExtractRange
+    let! fsiDoc, diags = server |> Server.openDocumentWithText fsiFile fsiSource
+    use fsiDoc = fsiDoc
+    Expect.isEmpty diags "There should be no diagnostics in fsi doc"
+    let! fsDoc, diags = server |> Server.openDocumentWithText fsFile fsSource
+    use fsDoc = fsDoc
+
+    do!
+      checkFixAt
+        (fsDoc, diags)
+        fsiDoc.VersionedTextDocumentIdentifier
+        (fsiSource, cursor)
+        (Diagnostics.expectCode "34")
+        selectCodeFix
+        (After (fsiSourceExpected |> Text.trimTripleQuotation))
+  }
+
+let tests state =
+  serverTestList (nameof UpdateValueInSignatureFile) state defaultConfigDto (Some path) (fun server ->
+    [ let selectCodeFix = CodeFix.withTitle UpdateValueInSignatureFile.title
+
+      ftestCaseAsync "first unit test for UpdateValueInSignatureFile"
+      <| checkWithFsi
+        server
+        """
+module A
+
+val a: b:int -> int
+"""
+"""
+module A
+
+let a$0 (b:int) (c: string) = 0
+"""
+        selectCodeFix
+        """
+module A
+
+val a: b: int -> c: string -> int
+"""
+    ])

--- a/test/FsAutoComplete.Tests.Lsp/Utils/CursorbasedTests.fsi
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/CursorbasedTests.fsi
@@ -1,13 +1,8 @@
 module Utils.CursorbasedTests
 
 open Expecto
-open Expecto.Diff
 open Ionide.LanguageServerProtocol.Types
-open FsToolkit.ErrorHandling
-open Utils.Utils
 open Utils.Server
-open Utils.TextEdit
-open Ionide.ProjInfo.Logging
 
 /// Checks for CodeFixes, CodeActions
 ///
@@ -15,138 +10,139 @@ open Ionide.ProjInfo.Logging
 /// * `check`: Check to use inside a `testCaseAsync`. Not a Test itself!
 /// * `test`: Returns Expecto Test. Usually combines multiple tests (like: test all positions).
 module CodeFix =
-    /// Note: Return should be just ONE `CodeAction` (for Applicable) or ZERO `CodeAction` (for Not Applicable).
-    ///       But actual return type is an array of `CodeAction`s:
-    ///       * Easier to successive filter CodeActions down with simple pipe and `Array.filter`
-    ///       * Returning `CodeAction option` would mean different filters for `check` (exactly one fix) and `checkNotApplicable` (exactly zero fix).
-    ///         Both error with multiple matching fixes!
-    type ChooseFix = CodeAction[] -> CodeAction[]
+  /// Note: Return should be just ONE `CodeAction` (for Applicable) or ZERO `CodeAction` (for Not Applicable).
+  ///       But actual return type is an array of `CodeAction`s:
+  ///       * Easier to successive filter CodeActions down with simple pipe and `Array.filter`
+  ///       * Returning `CodeAction option` would mean different filters for `check` (exactly one fix) and `checkNotApplicable` (exactly zero fix).
+  ///         Both error with multiple matching fixes!
+  type ChooseFix = CodeAction[] -> CodeAction[]
 
-    type ExpectedResult =
-        | NotApplicable
-        | Applicable
-        | After of string
+  type ExpectedResult =
+    | NotApplicable
+    | Applicable
+    | After of string
 
-    val checkFixAt:
-        doc: Document * diagnostics: Diagnostic[] ->
-            beforeWithoutCursor: string * cursorRange: Range ->
-                validateDiagnostics: (Diagnostic[] -> unit) ->
-                chooseFix: ChooseFix ->
-                expected: ExpectedResult ->
-                    Async<unit>
+  val checkFixAt:
+    doc: Document * diagnostics: Diagnostic[] ->
+      editsFrom: VersionedTextDocumentIdentifier ->
+      beforeWithoutCursor: string * cursorRange: Range ->
+        validateDiagnostics: (Diagnostic[] -> unit) ->
+        chooseFix: ChooseFix ->
+        expected: ExpectedResult ->
+          Async<unit>
 
-    /// Checks a CodeFix (CodeAction) for validity.
+  /// Checks a CodeFix (CodeAction) for validity.
+  ///
+  /// * Extracts cursor position (`$0`) or range (between two `$0`) from `beforeWithCursor`
+  /// * Opens untitled Doc with source `beforeWithCursor` (with cursor removed)
+  ///   * Note: untitled Document acts as Script file!
+  ///   * Note: untitled Documents doesn't exist on disk!
+  /// * Waits for Diagnostics in that doc
+  /// * Filters Diags down to diags matching cursor position/range
+  /// * Then validates diags with `validateDiagnostics`
+  ///   * Note: Validates filtered diags (-> only diags at cursor pos); not all diags in doc!
+  /// * Gets CodeFixes (CodeActions) from LSP server (`textDocument/codeAction`) for cursor range
+  ///   * Request includes filtered diags
+  /// * Selects CodeFix from returned CodeFixes with `chooseFix`
+  ///   * Note: `chooseFix` should return a single CodeFix. No CodeFix or multiple CodeFixes count as Failure!
+  ///     * Use `checkNotApplicable` when there shouldn't be a CodeFix
+  ///   * Note: Though `chooseFix` should return one CodeFix, the function actually returns an array of CodeFixes.
+  ///           Reasons:
+  ///           * Easier to filter down CodeFixes (`CodeFix.ofKind "..." >> CodeFix.withTitle "..."`)
+  ///           * Better error messages: Can differentiate between no CodeFixes and too many CodeFixes
+  /// * Validates selected CodeFix:
+  /// * Applies selected CodeFix to source (`beforeWithCursor` with cursor removed)
+  /// * Compares result with `expected`
+  ///
+  /// Note:
+  /// `beforeWithCursor` as well as `expected` get trimmed with `Text.trimTripleQuotation`: Leading empty line and indentation gets removed.
+  ///
+  /// Note:
+  /// `beforeWithCursor` and `expected` MUST use `\n` for linebreaks -- using `\r` (either alone or as `\r\n`) results in test failure!
+  /// Linebreaks from edits in selected CodeFix are all transformed to just `\n`
+  /// -> CodeFix can use `\r` and `\r\n`
+  /// If you want to validate Line Endings of CodeFix, add a validation step to your `chooseFix`
+  val check:
+    server: CachedServer ->
+    beforeWithCursor: string ->
+    validateDiagnostics: (Diagnostic array -> unit) ->
+    chooseFix: ChooseFix ->
+    expected: string ->
+      Async<unit>
+
+  /// Note: Doesn't apply Fix! Just checks its existence!
+  val checkApplicable:
+    server: CachedServer ->
+    beforeWithCursor: string ->
+    validateDiagnostics: (Diagnostic array -> unit) ->
+    chooseFix: ChooseFix ->
+      Async<unit>
+
+  val checkNotApplicable:
+    server: CachedServer ->
+    beforeWithCursor: string ->
+    validateDiagnostics: (Diagnostic array -> unit) ->
+    chooseFix: ChooseFix ->
+      Async<unit>
+
+  val matching: cond: (CodeAction -> bool) -> fixes: CodeAction array -> CodeAction array
+  val withTitle: title: string -> (CodeAction array -> CodeAction array)
+  val ofKind: kind: string -> (CodeAction array -> CodeAction array)
+
+  /// Bundled tests in Expecto test
+  module private Test =
+    /// One `testCaseAsync` for each cursorRange.
+    /// All test cases use same document (`ServerTests.documentTestList`) with source `beforeWithoutCursor`.
     ///
-    /// * Extracts cursor position (`$0`) or range (between two `$0`) from `beforeWithCursor`
-    /// * Opens untitled Doc with source `beforeWithCursor` (with cursor removed)
-    ///   * Note: untitled Document acts as Script file!
-    ///   * Note: untitled Documents doesn't exist on disk!
-    /// * Waits for Diagnostics in that doc
-    /// * Filters Diags down to diags matching cursor position/range
-    /// * Then validates diags with `validateDiagnostics`
-    ///   * Note: Validates filtered diags (-> only diags at cursor pos); not all diags in doc!
-    /// * Gets CodeFixes (CodeActions) from LSP server (`textDocument/codeAction`) for cursor range
-    ///   * Request includes filtered diags
-    /// * Selects CodeFix from returned CodeFixes with `chooseFix`
-    ///   * Note: `chooseFix` should return a single CodeFix. No CodeFix or multiple CodeFixes count as Failure!
-    ///     * Use `checkNotApplicable` when there shouldn't be a CodeFix
-    ///   * Note: Though `chooseFix` should return one CodeFix, the function actually returns an array of CodeFixes.
-    ///           Reasons:
-    ///           * Easier to filter down CodeFixes (`CodeFix.ofKind "..." >> CodeFix.withTitle "..."`)
-    ///           * Better error messages: Can differentiate between no CodeFixes and too many CodeFixes
-    /// * Validates selected CodeFix:
-    /// * Applies selected CodeFix to source (`beforeWithCursor` with cursor removed)
-    /// * Compares result with `expected`
+    /// Test names:
+    /// * `name` is name of outer test list.
+    /// * Each test case: `Cursor {i} at {pos or range}`
     ///
-    /// Note:
-    /// `beforeWithCursor` as well as `expected` get trimmed with `Text.trimTripleQuotation`: Leading empty line and indentation gets removed.
+    /// Note: Sharing a common `Document` is just barely faster than using a new `Document` for each test (at least for simple source in `beforeWithoutCursor`).
+    val checkFixAll:
+      name: string ->
+      server: CachedServer ->
+      beforeWithoutCursor: string ->
+      cursorRanges: Range seq ->
+      validateDiagnostics: (Diagnostic[] -> unit) ->
+      chooseFix: ChooseFix ->
+      expected: ExpectedResult ->
+        Test
+
+    /// One test for each Cursor.
     ///
-    /// Note:
-    /// `beforeWithCursor` and `expected` MUST use `\n` for linebreaks -- using `\r` (either alone or as `\r\n`) results in test failure!
-    /// Linebreaks from edits in selected CodeFix are all transformed to just `\n`
-    /// -> CodeFix can use `\r` and `\r\n`
-    /// If you want to validate Line Endings of CodeFix, add a validation step to your `chooseFix`
-    val check:
-        server: CachedServer ->
-        beforeWithCursor: string ->
-        validateDiagnostics: (Diagnostic array -> unit) ->
-        chooseFix: ChooseFix ->
-        expected: string ->
-            Async<unit>
+    /// Note: Tests single positions -> each `$0` gets checked.
+    ///       -> Every test is for single-position range (`Start=End`)!
+    val checkAllPositions:
+      name: string ->
+      server: CachedServer ->
+      beforeWithCursors: string ->
+      validateDiagnostics: (Diagnostic[] -> unit) ->
+      chooseFix: ChooseFix ->
+      expected: (unit -> ExpectedResult) ->
+        Test
 
-    /// Note: Doesn't apply Fix! Just checks its existence!
-    val checkApplicable:
-        server: CachedServer ->
-        beforeWithCursor: string ->
-        validateDiagnostics: (Diagnostic array -> unit) ->
-        chooseFix: ChooseFix ->
-            Async<unit>
+  val testAllPositions:
+    name: string ->
+    server: CachedServer ->
+    beforeWithCursors: string ->
+    validateDiagnostics: (Diagnostic array -> unit) ->
+    chooseFix: ChooseFix ->
+    expected: string ->
+      Test
 
-    val checkNotApplicable:
-        server: CachedServer ->
-        beforeWithCursor: string ->
-        validateDiagnostics: (Diagnostic array -> unit) ->
-        chooseFix: ChooseFix ->
-            Async<unit>
+  val testApplicableAllPositions:
+    name: string ->
+    server: CachedServer ->
+    beforeWithCursors: string ->
+    validateDiagnostics: (Diagnostic array -> unit) ->
+    chooseFix: ChooseFix ->
+      Test
 
-    val matching: cond: (CodeAction -> bool) -> fixes: CodeAction array -> CodeAction array
-    val withTitle: title: string -> (CodeAction array -> CodeAction array)
-    val ofKind: kind: string -> (CodeAction array -> CodeAction array)
-
-    /// Bundled tests in Expecto test
-    module private Test =
-        /// One `testCaseAsync` for each cursorRange.
-        /// All test cases use same document (`ServerTests.documentTestList`) with source `beforeWithoutCursor`.
-        ///
-        /// Test names:
-        /// * `name` is name of outer test list.
-        /// * Each test case: `Cursor {i} at {pos or range}`
-        ///
-        /// Note: Sharing a common `Document` is just barely faster than using a new `Document` for each test (at least for simple source in `beforeWithoutCursor`).
-        val checkFixAll:
-            name: string ->
-            server: CachedServer ->
-            beforeWithoutCursor: string ->
-            cursorRanges: Range seq ->
-            validateDiagnostics: (Diagnostic[] -> unit) ->
-            chooseFix: ChooseFix ->
-            expected: ExpectedResult ->
-                Test
-
-        /// One test for each Cursor.
-        ///
-        /// Note: Tests single positions -> each `$0` gets checked.
-        ///       -> Every test is for single-position range (`Start=End`)!
-        val checkAllPositions:
-            name: string ->
-            server: CachedServer ->
-            beforeWithCursors: string ->
-            validateDiagnostics: (Diagnostic[] -> unit) ->
-            chooseFix: ChooseFix ->
-            expected: (unit -> ExpectedResult) ->
-                Test
-
-    val testAllPositions:
-        name: string ->
-        server: CachedServer ->
-        beforeWithCursors: string ->
-        validateDiagnostics: (Diagnostic array -> unit) ->
-        chooseFix: ChooseFix ->
-        expected: string ->
-            Test
-
-    val testApplicableAllPositions:
-        name: string ->
-        server: CachedServer ->
-        beforeWithCursors: string ->
-        validateDiagnostics: (Diagnostic array -> unit) ->
-        chooseFix: ChooseFix ->
-            Test
-
-    val testNotApplicableAllPositions:
-        name: string ->
-        server: CachedServer ->
-        beforeWithCursors: string ->
-        validateDiagnostics: (Diagnostic array -> unit) ->
-        chooseFix: ChooseFix ->
-            Test
+  val testNotApplicableAllPositions:
+    name: string ->
+    server: CachedServer ->
+    beforeWithCursors: string ->
+    validateDiagnostics: (Diagnostic array -> unit) ->
+    chooseFix: ChooseFix ->
+      Test


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ffe2cca</samp>

This pull request adds a new code fix feature that updates the value declaration in a signature file to match the implementation file, and integrates it into the language server and the test suite. It also refactors and cleans up some existing test modules and utilities for code fixes, and adds a new module for a code fix that converts string concatenation to interpolated strings.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ffe2cca</samp>

> _We're the crew of the `FsAutoComplete` ship_
> _We sail the seas of code with skill and wit_
> _We fix the strings and values as we go_
> _And test them all with `testCaseAsync` so_

<!--
copilot:emoji
-->

🧵🔄🧪

<!--
1.  🧵 - This emoji represents the code fix that converts string concatenation to interpolated strings, which are also known as string interpolation or template strings. The emoji suggests the idea of stitching together strings with placeholders, which is what interpolated strings do.
2.  🔄 - This emoji represents the code fix that updates the value declaration in a signature file to match the implementation file. The emoji suggests the idea of syncing or updating two files that are related to each other, which is what the code fix does.
3.  🧪 - This emoji represents the test cases and test utilities for the code fixes. The emoji suggests the idea of testing or experimenting with the code, which is what the tests do.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ffe2cca</samp>

*  Add two new code fixes for string concatenation and value declaration mismatch ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-508569818bc07d6f0e23c6bbc6e93e7562849d4d1be4c84f7c42e96317dffdafR1-R12), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-046ed2493df8514ad477da80f8154e49057fc18596b8b143889b85cc7ad56428R1-R81), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-166bb52f12f972696c57efc50e53337aabf3e851f8d0e3b04292ca234739366aR1-R6), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L1838-R1839), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01R1176), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-76fc8863cc00a62068d47becebf42e1632f960d23fc5f85759060884583fe464L3354-R3355), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-f1f75a208898f83fd77ad893350034bb49735dae4032cbe394b8184986c105a5R1-R68))
  - The `ToInterpolatedString.fix` function converts string concatenation expressions to interpolated strings using the `$` syntax ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-508569818bc07d6f0e23c6bbc6e93e7562849d4d1be4c84f7c42e96317dffdafR1-R12))
  - The `UpdateValueInSignatureFile.fix` function updates the value declaration in a signature file to match the implementation file using the `FSharpSymbolUse` information ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-046ed2493df8514ad477da80f8154e49057fc18596b8b143889b85cc7ad56428R1-R81))
  - The signature files `ToInterpolatedString.fsi` and `UpdateValueInSignatureFile.fsi` declare the public types and values of the new code fix modules ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-508569818bc07d6f0e23c6bbc6e93e7562849d4d1be4c84f7c42e96317dffdafR1-R12), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-166bb52f12f972696c57efc50e53337aabf3e851f8d0e3b04292ca234739366aR1-R6))
  - The `AdaptiveFSharpLspServer` and `FSharpLspServer` types can handle the new code fixes by adding them to the list of code fix providers ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L1838-R1839), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01R1176))
  - The `UpdateValueInSignatureFileTests.fs` file contains the test cases for the `UpdateValueInSignatureFile` code fix, using the `checkFixAt` function with different document identifiers ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-f1f75a208898f83fd77ad893350034bb49735dae4032cbe394b8184986c105a5R1-R68))
  - The `tests` function in `Tests.fs` runs the new code fix tests along with the existing ones ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-76fc8863cc00a62068d47becebf42e1632f960d23fc5f85759060884583fe464L3354-R3355))
* Enhance the test utilities to support code fixes that affect multiple files ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L36-R42), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L74-R110), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L118-R134), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L228-R226))
  - The `checkFixAt` function takes a new parameter `editsFrom` that specifies the text document identifier from which the code fix edits should be extracted ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L36-R42))
  - The `checkFixAt` function applies the code fix edits to the document specified by `editsFrom`, which may not be the same as the document that triggered the code fix ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L74-R110))
  - The `checkFix` and `checkFixAll` functions pass the document identifier of the untitled or shared document to the `checkFixAt` function, which is the same as the document that triggered the code fix ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L118-R134), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L228-R226))
* Format and refactor the test code and utilities for readability and consistency ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L16-R52), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L69-R71), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L87-R90), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L105-R109), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L131-R136), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L149-R155), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L170-R177), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L192-R200), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L210-R219), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L228-R238), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L246-R257), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L264-R276), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L282-R295), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L300-R314), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L318-R333), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L336-R349), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L2-R3), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L20-R20), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597R28), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L46-R56), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L161-R179), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L253-R253), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-2cff2a24292f1643fa5c41b0444f3d4def15b2d8540d351f61a86b2294394e86L4-R5), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-2cff2a24292f1643fa5c41b0444f3d4def15b2d8540d351f61a86b2294394e86L18-R148))
  - The `RenameParamToMatchSignatureTests.fs` file adds new lines before each `testCaseAsync` expression to improve the readability and consistency of the test code ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L16-R52), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L69-R71), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L87-R90), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L105-R109), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L131-R136), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L149-R155), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L170-R177), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L192-R200), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L210-R219), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L228-R238), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L246-R257), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L264-R276), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L282-R295), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L300-R314), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L318-R333))
  - The `RenameParamToMatchSignatureTests.fs` file removes an extra empty line at the end of the module ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-afc2835d253497486593083a479021cb31577c36578c3a210d1d76b0b4d08c94L336-R349))
  - The `CursorbasedTests.fs` and `CursorbasedTests.fsi` files remove some unused open statements from the `Utils.CursorbasedTests` module ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L2-R3), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L253-R253), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-2cff2a24292f1643fa5c41b0444f3d4def15b2d8540d351f61a86b2294394e86L4-R5), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-2cff2a24292f1643fa5c41b0444f3d4def15b2d8540d351f61a86b2294394e86L18-R148))
  - The `CursorbasedTests.fs` file removes some extra spaces and new lines from the `diagnosticsIn`, `checkFixAt`, and `checkFixAll` functions ([link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L20-R20), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597R28), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L46-R56), [link](https://github.com/fsharp/FsAutoComplete/pull/1161/files?diff=unified&w=0#diff-ca601cd76cdb8ac89509a37b114ce8a7e81c205ebf666af7ae78b87ff9267597L161-R179))

Dog feeding https://github.com/fsharp/FsAutoComplete/pull/1158 a bit.
I think I'm doing something wrong on the Expecto side. `dotnet run` isn't exiting correctly.

The actual code fix needs to be expanded a bit more. I would, however, very much like to have this.
I could use a first round of feedback if anybody is up for it.