### PR TITLE
Make test explorer work with fsac tests and fix an expecto test detection

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -50,7 +50,7 @@ nuget Microsoft.NETFramework.ReferenceAssemblies
 nuget Ionide.KeepAChangelog.Tasks copy_local: true
 nuget Expecto
 nuget Expecto.Diff
-nuget YoloDev.Expecto.TestSdk 0.14.2
+nuget YoloDev.Expecto.TestSdk
 nuget AltCover
 nuget GitHubActionsTestLogger
 nuget Ionide.LanguageServerProtocol >= 0.4.16

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -50,7 +50,7 @@ nuget Microsoft.NETFramework.ReferenceAssemblies
 nuget Ionide.KeepAChangelog.Tasks copy_local: true
 nuget Expecto
 nuget Expecto.Diff
-nuget YoloDev.Expecto.TestSdk
+nuget YoloDev.Expecto.TestSdk 0.14.2
 nuget AltCover
 nuget GitHubActionsTestLogger
 nuget Ionide.LanguageServerProtocol >= 0.4.16

--- a/paket.lock
+++ b/paket.lock
@@ -42,9 +42,9 @@ NUGET
       Microsoft.SourceLink.Bitbucket.Git (>= 1.1.1)
       Microsoft.SourceLink.GitHub (>= 1.1.1)
       Microsoft.SourceLink.GitLab (>= 1.1.1)
-    Expecto (9.0.4)
-      FSharp.Core (>= 4.6)
-      Mono.Cecil (>= 0.11.3)
+    Expecto (10.1)
+      FSharp.Core (>= 7.0.200) - restriction: || (== net6.0) (== net7.0) (&& (== netstandard2.0) (>= net6.0)) (&& (== netstandard2.1) (>= net6.0))
+      Mono.Cecil (>= 0.11.4 < 1.0) - restriction: || (== net6.0) (== net7.0) (&& (== netstandard2.0) (>= net6.0)) (&& (== netstandard2.1) (>= net6.0))
     Expecto.Diff (9.0.4)
       DiffPlex (>= 1.6.3)
       Expecto (>= 9.0.4)
@@ -485,10 +485,10 @@ NUGET
       System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (== net6.0) (>= net461)) (&& (== net6.0) (< netcoreapp2.1)) (&& (== net6.0) (< netstandard1.0)) (&& (== net6.0) (< netstandard2.0)) (&& (== net6.0) (>= wp8)) (&& (== net7.0) (>= net461)) (&& (== net7.0) (< netcoreapp2.1)) (&& (== net7.0) (< netstandard1.0)) (&& (== net7.0) (< netstandard2.0)) (&& (== net7.0) (>= wp8)) (== netstandard2.0) (== netstandard2.1)
     System.Windows.Extensions (7.0) - copy_local: false, restriction: || (== net6.0) (== net7.0) (&& (== netstandard2.0) (>= net6.0)) (&& (== netstandard2.1) (>= net6.0))
       System.Drawing.Common (>= 7.0) - restriction: || (== net6.0) (== net7.0) (&& (== netstandard2.0) (>= net6.0)) (&& (== netstandard2.1) (>= net6.0))
-    YoloDev.Expecto.TestSdk (0.13.3)
-      Expecto (>= 9.0 < 10.0) - restriction: || (== net6.0) (== net7.0) (&& (== netstandard2.0) (>= netcoreapp3.1)) (&& (== netstandard2.1) (>= netcoreapp3.1))
-      FSharp.Core (>= 4.6.2) - restriction: || (== net6.0) (== net7.0) (&& (== netstandard2.0) (>= netcoreapp3.1)) (&& (== netstandard2.1) (>= netcoreapp3.1))
-      System.Collections.Immutable (>= 6.0) - restriction: || (== net6.0) (== net7.0) (&& (== netstandard2.0) (>= netcoreapp3.1)) (&& (== netstandard2.1) (>= netcoreapp3.1))
+    YoloDev.Expecto.TestSdk (0.14.2)
+      Expecto (>= 10.0 < 11.0) - restriction: || (== net6.0) (== net7.0) (&& (== netstandard2.0) (>= net6.0)) (&& (== netstandard2.1) (>= net6.0))
+      FSharp.Core (>= 7.0.200) - restriction: || (== net6.0) (== net7.0) (&& (== netstandard2.0) (>= net6.0)) (&& (== netstandard2.1) (>= net6.0))
+      System.Collections.Immutable (>= 6.0) - restriction: || (== net6.0) (== net7.0) (&& (== netstandard2.0) (>= net6.0)) (&& (== netstandard2.1) (>= net6.0))
 
 GROUP Build
 STORAGE: NONE

--- a/src/FsAutoComplete.Core/TestAdapter.fs
+++ b/src/FsAutoComplete.Core/TestAdapter.fs
@@ -142,7 +142,8 @@ let getExpectoTests (ast: ParsedInput) : TestAdapterEntry<range> list =
         visitExpr entry expr2
       | Case, SynExpr.ComputationExpr _
       | Case, SynExpr.Lambda _
-      | Case, SynExpr.Paren(SynExpr.Lambda _, _, _, _) ->
+      | Case, SynExpr.Paren(expr = SynExpr.App(argExpr = SynExpr.ComputationExpr _))
+      | Case, SynExpr.Paren(expr = (SynExpr.Lambda _)) ->
         ident <- ident + 1
 
         let entry =

--- a/test/FsAutoComplete.Tests.Lsp/DetectUnitTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/DetectUnitTests.fs
@@ -55,5 +55,5 @@ let tests state =
         (async {
           let! testNotification = getTestNotification "ExpectoTests" "Sample.fs"
           Expect.hasLength testNotification.Tests 1 "Expected to have found 1 expecto test list"
-          Expect.hasLength testNotification.Tests.[0].Childs 13 "Expected to have found 13 expecto tests"
+          Expect.hasLength testNotification.Tests.[0].Childs 15 "Expected to have found 13 expecto tests"
         }) ]

--- a/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
@@ -33,15 +33,15 @@ let tests state =
         [
             testCaseAsync
                 "no parsing/checking errors"
-                (async {
+                <| async {
                   let! server, events, scriptPath = server1
                   do! server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath }
 
                   match! waitForParseResultsForFile "EmptyFile.fsx" events with
                   | Ok _ -> () // all good, no parsing/checking errors
                   | Core.Result.Error errors -> failwithf "Errors while parsing script %s: %A" scriptPath errors
-                })
-            
+                }
+
             testCaseAsync
                 "auto completion does not throw and is empty"
                 (async {
@@ -66,7 +66,7 @@ let tests state =
                 (async {
                   let! server, events, scriptPath = server2
                   do! server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath }
-                  
+
                   do! server.TextDocumentDidChange {
                       TextDocument = { Uri = Path.FilePathToUri scriptPath; Version = 1 }
                       ContentChanges =  [| {

--- a/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
@@ -33,14 +33,14 @@ let tests state =
         [
             testCaseAsync
                 "no parsing/checking errors"
-                <| async {
+                (async {
                   let! server, events, scriptPath = server1
                   do! server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath }
 
                   match! waitForParseResultsForFile "EmptyFile.fsx" events with
                   | Ok _ -> () // all good, no parsing/checking errors
                   | Core.Result.Error errors -> failwithf "Errors while parsing script %s: %A" scriptPath errors
-                }
+                })
 
             testCaseAsync
                 "auto completion does not throw and is empty"

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -539,11 +539,15 @@ let inline expectExitCodeZero (r: BufferedCommandResult) =
     0
     $"Expected exit code zero but was %i{r.ExitCode}.\nStdOut: %s{r.StandardOutput}\nStdErr: %s{r.StandardError}"
 
-let dotnetRestore dir =
-  runProcess dir "dotnet" "restore" |> Async.map expectExitCodeZero
+let dotnetRestore dir = async {
+  let! r = runProcess (DirectoryInfo(dir).FullName) "dotnet" "restore -v d"
+  return expectExitCodeZero r
+}
 
-let dotnetToolRestore dir =
-  runProcess dir "dotnet" "tool restore" |> Async.map expectExitCodeZero
+let dotnetToolRestore dir = async {
+  let! r = runProcess (DirectoryInfo(dir).FullName) "dotnet" "tool restore"
+  return expectExitCodeZero r
+}
 
 let serverInitialize path (config: FSharpConfigDto) createServer =
   async {

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -245,14 +245,13 @@ let main args =
 
   let cts = new CancellationTokenSource(testTimeout)
 
-  let config =
-    { defaultConfig with
-        // failOnFocusedTests = true
-        printer = Expecto.Impl.TestPrinters.summaryWithLocationPrinter defaultConfig.printer
-        verbosity = logLevel
-        // runInParallel = false
-         }
+  let args  =
+    [
+      CLIArguments.Printer (Expecto.Impl.TestPrinters.summaryWithLocationPrinter defaultConfig.printer)
+      CLIArguments.Verbosity logLevel
+      // CLIArguments.Parallel
+    ]
 
-  runTestsWithArgsAndCancel cts.Token config fixedUpArgs tests
+  runTestsWithCLIArgsAndCancel cts.Token args fixedUpArgs tests
 
 

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/ExpectoTests/Sample.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/ExpectoTests/Sample.fs
@@ -44,6 +44,14 @@ let tests =
       Expect.equal 4 (2+2) "2+2"
     }
 
+    testCaseAsync "async test case backpipe" <| async {
+        Expect.equal 4 (2+2) "2+2"
+      }
+
+    testCaseAsync "async test case paren"(async {
+        Expect.equal 4 (2+2) "2+2"
+      })
+
     testTheory "odd numbers" [1; 3; 5] ( fun x ->
       Expect.isTrue (x % 2 = 1) "should be odd" )
 

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.Tests.fs
@@ -276,7 +276,6 @@ let tests state = testList (nameof(Server)) [
 
     testSequenced <| testList "contesting" [
       let projectDir = inTestCases "Project"
-      dotnetRestore projectDir.Value |> Async.RunSynchronously
       serverTestList "dir with project and no analyzers" state noAnalyzersConfig projectDir (fun server -> [
         testCaseAsync "can load file in project" (async {
           let! (doc, diags) = server |> Server.openDocument "Other.fs"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 841c093</samp>

This pull request improves the test suite for the LSP features of FsAutoComplete by fixing a build error, reformatting a test file, and enhancing the test setup and runner functions. It also updates the `paket.dependencies` file and removes a redundant call to `dotnetRestore` in one of the test files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 841c093</samp>

> _To fix a build error they faced_
> _They updated `YoloDev.Expecto.TestSdk`_
> _They also improved the test setup and run_
> _With `DirectoryInfo` and `-v d` for fun_
> _And reformatted `EmptyFileTests.fs` for heck_

<!--
copilot:emoji
-->

📦🛠️🧹

<!--
1.  📦 - This emoji represents the update of a package dependency, which is a common and important task in software development.
2.  🛠️ - This emoji represents the improvement of the test setup process, which is a form of maintenance and bug fixing.
3.  🧹 - This emoji represents the removal of redundant code and the reformatting of existing code, which is a form of code cleanup and refactoring.
-->

### WHY

Project work to make [Test Run Debugger](https://github.com/ionide/ionide-vscode-fsharp/pull/1927) usable in FSAC.

https://github.com/fsharp/FsAutoComplete/assets/1490044/e200ae68-8d22-435f-bad9-acc27286bb02



### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 841c093</samp>

*  Fixed a build error by pinning the version of `YoloDev.Expecto.TestSdk` to 0.14.2 in `paket.dependencies` ([link](https://github.com/fsharp/FsAutoComplete/pull/1165/files?diff=unified&w=0#diff-377fe73bf860b37e7d9a8ca5be27762668b3a08aac581b435d4c31b737d905cdL53-R53))
*  Simplified the test runner configuration by using the `runTestsWithCLIArgsAndCancel` function in `Program.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1165/files?diff=unified&w=0#diff-617db9e831fb074eb5a368b2c99f6e50f1e568cb70c7c37377ba7be3333aa17bL248-R255))
*  Improved the test setup reliability and debugging by using the `DirectoryInfo` type and the `-v d` option for the `dotnet restore` command in `Helpers.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1165/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fL542-R550))
*  Removed unnecessary and redundant calls to `dotnetRestore` in `Server.Tests.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1165/files?diff=unified&w=0#diff-a373b6364e402a3008d688190d5bdc176b4615f1981c9ecb328221372e1f5879L279))
*  Reformatted `EmptyFileTests.fs` to use the `<|` operator and remove extra blank lines for readability and consistency ([link](https://github.com/fsharp/FsAutoComplete/pull/1165/files?diff=unified&w=0#diff-4692649138780b2f1eb118337938dcd8e781985a05929d61463b37440194dbe0L36-R36), [link](https://github.com/fsharp/FsAutoComplete/pull/1165/files?diff=unified&w=0#diff-4692649138780b2f1eb118337938dcd8e781985a05929d61463b37440194dbe0L43-R44), [link](https://github.com/fsharp/FsAutoComplete/pull/1165/files?diff=unified&w=0#diff-4692649138780b2f1eb118337938dcd8e781985a05929d61463b37440194dbe0L69-R69), [link](https://github.com/fsharp/FsAutoComplete/pull/1165/files?diff=unified&w=0#diff-4692649138780b2f1eb118337938dcd8e781985a05929d61463b37440194dbe0L109-R109))
