### PR TITLE
Format after building

### DIFF
--- a/.fantomasignore
+++ b/.fantomasignore
@@ -1,0 +1,5 @@
+test/
+build/
+benchmarks/
+utils/
+demo.fsx

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,8 @@
     "*.*proj": "msbuild",
     "*.props": "msbuild",
     "*.targets": "msbuild"
+  },
+  "[fsharp]": {
+      "editor.formatOnSave": true
   }
 }

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,12 +1,30 @@
 <Project>
 
-<Target Name="SupportPrereleaseVersion"
-    AfterTargets="SetVersionFromChangelog">
-    <PropertyGroup Condition="'$(VersionSuffix)' != ''">
-        <Version>$(Version)-$(VersionSuffix)</Version>
-        <PackageVersion>$(Version)</PackageVersion>
-    </PropertyGroup>
-</Target>
+  <PropertyGroup>
+    <_BuildProjBaseIntermediateOutputPath>$(MSBuildThisFileDirectory)build/obj/</_BuildProjBaseIntermediateOutputPath>
+    <_DotnetToolManifestFile>$(MSBuildThisFileDirectory).config/dotnet-tools.json</_DotnetToolManifestFile>
+    <_DotnetToolRestoreOutputFile>$(_BuildProjBaseIntermediateOutputPath)/dotnet-tool-restore-$(NETCoreSdkVersion)</_DotnetToolRestoreOutputFile>
+    <_DotnetFantomasOutputFile>$(BaseIntermediateOutputPath)dotnet-fantomas-msbuild</_DotnetFantomasOutputFile>
+  </PropertyGroup>
 
+  <Target Name="SupportPrereleaseVersion"
+      AfterTargets="SetVersionFromChangelog">
+      <PropertyGroup Condition="'$(VersionSuffix)' != ''">
+          <Version>$(Version)-$(VersionSuffix)</Version>
+          <PackageVersion>$(Version)</PackageVersion>
+      </PropertyGroup>
+  </Target>
 
+  <!-- Make sure that dotnet tools (including paket) are restored before restoring any project -->
+  <Target Name="ToolRestore" BeforeTargets="Restore;CollectPackageReferences;PaketRestore" Inputs="$(_DotnetToolManifestFile)" Outputs="$(_DotnetToolRestoreOutputFile)">
+    <Exec Command="dotnet tool restore" WorkingDirectory="$(MSBuildThisFileDirectory)" StandardOutputImportance="High" StandardErrorImportance="High" />
+    <MakeDir Directories="$(_BuildProjBaseIntermediateOutputPath)"/>
+    <Touch Files="$(_DotnetToolRestoreOutputFile)" AlwaysCreate="True" ForceTouch="True" />
+  </Target>
+
+  <!-- Make sure that files are formatted before building -->
+  <Target Name="Format" BeforeTargets="BeforeBuild" Inputs="@(Compile)" Outputs="$(_DotnetFantomasOutputFile)" >
+    <Exec Command="dotnet fantomas $(MSBuildProjectDirectory)" StandardOutputImportance="High" StandardErrorImportance="High" WorkingDirectory="$(MSBuildThisFileDirectory)" />
+    <Touch Files="$(_DotnetFantomasOutputFile)" AlwaysCreate="True" ForceTouch="True" />
+  </Target>
 </Project>

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -1,13 +1,11 @@
 <Project>
-  <ItemGroup>
-    <FormatInputs Include="src/**/*.fs;src/**/*.fsi" Exclude="src/**/obj/**/*.fs" />
-  </ItemGroup>
+
 
   <Target Name="Format">
-    <Exec Command="dotnet fantomas @(FormatInputs, ' ') " />
+    <Exec Command="dotnet fantomas $(MSBuildThisFileDirectory)" />
   </Target>
 
   <Target Name="CheckFormat">
-    <Exec Command="dotnet fantomas --check @(FormatInputs, ' ') " />
+    <Exec Command="dotnet fantomas --check $(MSBuildThisFileDirectory) " />
   </Target>
 </Project>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1723ad8</samp>

This pull request adds and modifies some files to integrate the Fantomas tool for formatting F# code. It enables automatic formatting on save in VS Code, and adds targets to restore and run Fantomas as part of the build process. It also adds a `.fantomasignore` file to exclude non-source files from formatting.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1723ad8</samp>

> _`Fantomas` formats_
> _code with ease and beauty_
> _autumn leaves no mess_

<!--
copilot:emoji
-->

📝🛠️🏗️

<!--
1.  📝 - This emoji represents the addition of the `.fantomasignore` file, which is a text file that documents the formatting exclusions.
2.  🛠️ - This emoji represents the modification of the `.vscode/settings.json` file, which is a configuration file that affects the VS Code editor and its tools.
3.  🏗️ - This emoji represents the modification of the `Directory.Build.targets` and `Directory.Solution.targets` files, which are build files that affect the dotnet and MSBuild tools.
-->

### WHY

Let's make it harder to fail CI formatting.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1723ad8</samp>

*  Add a `.fantomasignore` file to exclude non-source files from formatting ([link](https://github.com/fsharp/FsAutoComplete/pull/1166/files?diff=unified&w=0#diff-eefdab292c879e70487bb14214f59ed01c3bb4335beef841236cb03598b945bbR1-R5))
*  Enable automatic formatting on save for F# files in VS Code ([link](https://github.com/fsharp/FsAutoComplete/pull/1166/files?diff=unified&w=0#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L22-R26))
*  Define properties and targets for dotnet tools and fantomas in `Directory.Build.targets` ([link](https://github.com/fsharp/FsAutoComplete/pull/1166/files?diff=unified&w=0#diff-50e91c82311ea26f2a73202525dfdf2b0a89c178ee666b2bf3ad4c84ac4c06dcL3-R29))
*  Simplify format inputs to use solution directory and `.fantomasignore` file in `Directory.Solution.targets` ([link](https://github.com/fsharp/FsAutoComplete/pull/1166/files?diff=unified&w=0#diff-26f6d3a499ec53afd3755424ed93ffe5800fe9dafe4a63367a441cb5066bb9adL2-R9))
