### PR TITLE
Default RoslynSourceText

### DIFF
--- a/src/FsAutoComplete/Parser.fs
+++ b/src/FsAutoComplete/Parser.fs
@@ -107,8 +107,8 @@ module Parser =
     Option<SourceTextFactoryOptions>(
       "--source-text-factory",
       description =
-        "Set the source text factory to use. NamedText is the default, and uses an old F# compiler's implementation. RoslynSourceText uses Roslyn's implementation.",
-      getDefaultValue = fun () -> SourceTextFactoryOptions.NamedText
+        "Set the source text factory to use.  RoslynSourceText is the default, uses Roslyn's implementation. NamedText uses an old F# compiler's implementation.",
+      getDefaultValue = fun () -> SourceTextFactoryOptions.RoslynSourceText
     )
 
   let otelTracingOption =
@@ -156,7 +156,7 @@ module Parser =
           match sourceTextFactoryOption with
           | SourceTextFactoryOptions.NamedText -> new NamedTextFactory()
           | SourceTextFactoryOptions.RoslynSourceText -> new RoslynSourceTextFactory()
-          | _ -> new NamedTextFactory()
+          | _ -> new RoslynSourceTextFactory()
 
         let dotnetPath =
           if

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -57,7 +57,7 @@ let lspServers =
     ]
 
 let sourceTextFactories: (string * ISourceTextFactory) list = [
-  "NamedText", NamedTextFactory()
+  // "NamedText", NamedTextFactory()
   "RoslynSourceText", RoslynSourceTextFactory()
 ]
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at afea923</samp>

The pull request updates the parser to use `RoslynSourceText` for better performance and compatibility. It also adjusts the tests to use the new source text option.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at afea923</samp>

> _`RoslynSourceText`_
> _Faster parsing in the spring_
> _`NamedText` rests now_

<!--
copilot:emoji
-->

🚀🔧🧪

<!--
1.  🚀 - This emoji represents the performance improvement of using `RoslynSourceText` over `NamedText`, as well as the potential for faster and smoother integration with Roslyn-based tools and libraries.
2.  🔧 - This emoji represents the change in the parser's configuration and the need to adjust any existing code that relies on `NamedText` or its specific features or behavior.
3.  🧪 - This emoji represents the testing aspect of the change, which involves commenting out the `NamedText` option from the test setup and ensuring that the parser works correctly with `RoslynSourceText`.
-->

### WHY

Just sets SourceText to default to Roslyn for now.  We can discuss when to start removing the older SourceText/LSPServers later.

[See this comment](https://github.com/fsharp/FsAutoComplete/pull/1167#discussion_r1337734573)


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at afea923</samp>

*  Change the default and fallback source text factory options to `RoslynSourceText` for better performance and memory usage ([link](https://github.com/fsharp/FsAutoComplete/pull/1168/files?diff=unified&w=0#diff-83138e39ec2a1b48ab9298036c49a450021f15bbebf1085f9b1d58c2fd5ae08aL111-R111), [link](https://github.com/fsharp/FsAutoComplete/pull/1168/files?diff=unified&w=0#diff-83138e39ec2a1b48ab9298036c49a450021f15bbebf1085f9b1d58c2fd5ae08aL159-R159))
*  Disable the `NamedText` option from the test cases in `Program.fs` to simplify the test setup and focus on the new option ([link](https://github.com/fsharp/FsAutoComplete/pull/1168/files?diff=unified&w=0#diff-617db9e831fb074eb5a368b2c99f6e50f1e568cb70c7c37377ba7be3333aa17bL60-R60))
