### PR TITLE
Adds basic issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,93 @@
+name: 🐛 Bug report
+description: Report broken functionality.
+labels: [bug]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        - Avoid generic or vague titles such as "Something's not working" or "A couple of problems" — be as descriptive as possible.
+        - Keep your issue focused on one single problem. If you have multiple bug reports, please create a separate issue for each of them.
+        - Issues should represent **complete and actionable** work items. If you are unsure about something or have a question, please start a [discussion](https://github.com/fsharp/FsAutoComplete/discussions/new/choose) instead.
+        - Remember that **FsAutocomplete** is an open-source project funded by the community contributions and free time.
+        ___
+
+  - type: input
+    attributes:
+      label: Version
+      description: Which version of the package does this bug affect? Make sure you're not using an outdated version.
+      placeholder: v1.0.0
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Dotnet Info
+      description: What is the output of `dotnet --info`?
+      placeholder: "Paste output here"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: >
+        Minimum steps required to reproduce the bug, including prerequisites, code snippets, or other relevant items.
+        The information provided in this field must be readily actionable, meaning that anyone should be able to reproduce the bug by following these steps.
+        If the reproduction steps are too complex to fit in this field, please provide a link to a repository instead.
+        If you don't provide actionable reproduction steps, your issue won't be investigated.
+      placeholder: |
+        - Step 1
+        - Step 2
+        - Step 3
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Details
+      description: Clear and thorough explanation of the bug, including any additional information you may find relevant.
+      placeholder: |
+        - Expected behavior: ...
+        - Actual behavior: ...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Logs
+      description: >
+        Please add any logs from your LSP client or server that you think might be relevant.
+        Be sure to look through logs and obfuscate anything you don't want to share.
+
+        * For VSCode:
+          * Enable `FSharp.verboseLogging` and set `FSharp.trace.server` to a higher level
+          * Then copy output from
+            * `View -> Output -> Fsharp`
+            * `View -> Output -> Ionide`
+            * Any others that you think might be relevant
+      placeholder: |
+        - [21:11:05 DEBUG] [LanguageService] FSAC (NETCORE): ...
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Quick list of checks to ensure that everything is in order.
+      options:
+        - label: I have looked through existing issues to make sure that this bug has not been reported before
+          required: true
+        - label: I have provided a descriptive title for this issue
+          required: true
+        - label: I have made sure that that this bug is reproducible on the latest version of the package
+          required: true
+        - label: I have provided all the information needed to reproduce this bug as efficiently as possible
+          required: true
+        - label: I or my company would be willing to contribute this fix
+          required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        If you are struggling to provide actionable reproduction steps, or if something else is preventing you from creating a complete bug report, please start a [discussion](https://github.com/fsharp/FsAutoComplete/discussions/new/choose) instead.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🗨 Discussions
+    url: https://github.com/fsharp/FsAutoComplete/discussions/new/choose
+    about: Ask and answer questions.
+  - name: 💬 Discord server
+    url: https://discord.gg/R6n7c54
+    about: Chat with the community.


### PR DESCRIPTION


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b4e3de7</samp>

This pull request adds a new issue template for bug reports using GitHub Forms and updates the issue template chooser to disable blank issues and add contact links. These changes aim to improve the quality and clarity of the issues and to direct users to the appropriate channels for questions and discussions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b4e3de7</samp>

> _New `issue` template_
> _Guides users to report bugs_
> _Forms help fix problems_

<!--
copilot:emoji
-->

🐛🗣️🚫

<!--
1.  🐛 - This emoji represents the bug report template, as it is a common symbol for bugs or errors in software. It also conveys a sense of urgency and importance, as bugs need to be fixed as soon as possible.
2.  🗣️ - This emoji represents the contact links, as it suggests communication and dialogue with other people. It also implies that the user has something to say or ask, and that they can find an audience or a response in the discussions or the discord server.
3.  🚫 - This emoji represents the disabling of blank issues, as it indicates that the user cannot create an issue without choosing a template or a contact link. It also implies that blank issues are not welcome or helpful, and that the user should follow the guidelines and provide the necessary information.
-->

### WHY

Many issues come in with very lackluster information and it's hard to get a grasp on what needs to be investigated. Based on https://github.com/Tyrrrz/CliWrap/issues/new/choose I changed somethings I think are relevant to us.  I only did bug report for now as I'm sure we'll want to go thru some iterations.


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b4e3de7</samp>

* Add a new issue template for bug reports using GitHub Forms ([link](https://github.com/fsharp/FsAutoComplete/pull/1169/files?diff=unified&w=0#diff-7c49a365610d935ce439e3f241cd3f5d1df89a95d1a674d11ebdb1e518c7335cR1-R93))
* Disable the option to create blank issues and add two contact links to the issue template chooser ([link](https://github.com/fsharp/FsAutoComplete/pull/1169/files?diff=unified&w=0#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2R1-R8))
