### PR TITLE
Add feature requests github template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -15,12 +15,15 @@ body:
   - type: input
     attributes:
       label: Version
-      description: Which version of the package does this bug affect? Make sure you're not using an outdated version.
+      description: |
+        Which version of the package does this bug affect? Make sure you're not using an outdated version.
+        - If you are using VSCode, the version of Ionide can be used. You can can find this by going to `View -> Extensions -> Ionide for F#`. It will be displayed next to the name at the top.
+        - If you are using the tool directly, you can find the version by running `dotnet fsautocomplete --version` in your terminal.
       placeholder: v1.0.0
     validations:
       required: true
 
-  - type: input
+  - type: textarea
     attributes:
       label: Dotnet Info
       description: What is the output of `dotnet --info`?
@@ -35,7 +38,7 @@ body:
         Minimum steps required to reproduce the bug, including prerequisites, code snippets, or other relevant items.
         The information provided in this field must be readily actionable, meaning that anyone should be able to reproduce the bug by following these steps.
         If the reproduction steps are too complex to fit in this field, please provide a link to a repository instead.
-        If you don't provide actionable reproduction steps, your issue won't be investigated.
+        ⚠️ If you don't provide actionable reproduction steps, your issue won't be investigated. ⚠️
       placeholder: |
         - Step 1
         - Step 2

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: ✨ Feature request
+description: Request a new feature.
+labels: [enhancement]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        - Avoid generic or vague titles such as "Something's not working" or "A couple of problems" — be as descriptive as possible.
+        - Keep your issue focused on one single problem. If you have multiple feature requests, please create a separate issue for each of them.
+        - Issues should represent **complete and actionable** work items. If you are unsure about something or have a question, please start a [discussion](https://github.com/fsharp/FsAutoComplete/discussions/new/choose) instead.
+        - Remember that **FsAutocomplete** is an open-source project funded by the community contributions and free time.
+        ___
+
+  - type: textarea
+    attributes:
+      label: Details
+      description: Clear and thorough explanation of the feature you have in mind.
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Quick list of checks to ensure that everything is in order.
+      options:
+        - label: I have looked through existing issues to make sure that this feature has not been requested before
+          required: true
+        - label: I have provided a descriptive title for this issue
+          required: true
+        - label: I am aware that even valid feature requests may be rejected if they do not align with the project's goals
+          required: true
+        - label: I or my company would be willing to contribute this feature
+          required: false


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 470d140</samp>

Improved the bug report template in `.github/ISSUE_TEMPLATE/bug-report.yml` by clarifying the Version field and emphasizing the Reproduction Steps field.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 470d140</samp>

> _`Version` field grows_
> _Repro steps need attention_
> _Winter of bug reports_

<!--
copilot:emoji
-->

📝🔎⚠️

<!--
1.  📝 - This emoji can be used to represent the act of writing or editing a document, such as a bug report template. It suggests that some changes have been made to the text or format of the template to improve its clarity or usefulness.
2.  🔎 - This emoji can be used to represent the concept of searching or investigating something, such as a bug or an issue. It suggests that the Version field is important for finding and reproducing the bug, and that the bug report should include as much detail as possible about the software version and environment where the bug occurred.
3.  ⚠️ - This emoji can be used to represent the idea of warning or alerting someone about something, such as a potential problem or a required action. It suggests that the Reproduction Steps field is critical for verifying and fixing the bug, and that the bug report should provide clear and precise instructions on how to trigger the bug consistently.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 470d140</samp>

* Expand the version field description to include instructions for finding the Ionide or fsautocomplete version ([link](https://github.com/fsharp/FsAutoComplete/pull/1171/files?diff=unified&w=0#diff-7c49a365610d935ce439e3f241cd3f5d1df89a95d1a674d11ebdb1e518c7335cL18-R21))
* Add a warning sign to the reproduction steps field description to emphasize the importance of providing actionable steps ([link](https://github.com/fsharp/FsAutoComplete/pull/1171/files?diff=unified&w=0#diff-7c49a365610d935ce439e3f241cd3f5d1df89a95d1a674d11ebdb1e518c7335cL38-R41))
