### PR TITLE
Ignore requests that would cause circular dependencies

### DIFF
--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -4379,9 +4379,9 @@ type AdaptiveFSharpLspServer
 
           if p.Target <> p.Reference then
             do!
-                Commands.DotnetAddProject p.Target p.Reference
-                |> AsyncResult.ofCoreResponse
-                |> AsyncResult.ignore<unit option, JsonRpc.Error> // mapping unit option to unit
+              Commands.DotnetAddProject p.Target p.Reference
+              |> AsyncResult.ofCoreResponse
+              |> AsyncResult.ignore<unit option, JsonRpc.Error> // mapping unit option to unit
 
           return None
         with e ->

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -4377,10 +4377,11 @@ type AdaptiveFSharpLspServer
             >> Log.addContextDestructured "parms" p
           )
 
-          do!
-            Commands.DotnetAddProject p.Target p.Reference
-            |> AsyncResult.ofCoreResponse
-            |> AsyncResult.ignore<unit option, JsonRpc.Error> // mapping unit option to unit
+          if p.Target <> p.Reference then
+            do!
+                Commands.DotnetAddProject p.Target p.Reference
+                |> AsyncResult.ofCoreResponse
+                |> AsyncResult.ignore<unit option, JsonRpc.Error> // mapping unit option to unit
 
           return None
         with e ->

--- a/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
+++ b/src/FsAutoComplete/LspServers/FsAutoComplete.Lsp.fs
@@ -2418,11 +2418,15 @@ type FSharpLspServer(state: State, lspClient: FSharpLspClient, sourceTextFactory
           >> Log.addContextDestructured "parms" p
         )
 
-        let! res = Commands.DotnetAddProject p.Target p.Reference
+        let! res =
+          if p.Target <> p.Reference then
+            Commands.DotnetAddProject p.Target p.Reference
+          else
+            async.Return(CoreResponse.Res())
 
         let res =
           match res with
-          | CoreResponse.InfoRes msg -> success None
+          | CoreResponse.InfoRes _msg -> success None
           | CoreResponse.ErrorRes msg -> LspResult.internalError msg
           | CoreResponse.Res(_) -> success None
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4efa4e</samp>

This pull request adds a feature to support adding project references via code actions in the LSP server. It also prevents adding a project reference to itself and simplifies some pattern matching logic in `AdaptiveFSharpLspServer.fs` and `FsAutoComplete.Lsp.fs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e4efa4e</samp>

> _`DotnetAddProject`_
> _Avoids self-reference now_
> _A winter bug fixed_

<!--
copilot:emoji
-->

🛠️🔄🧹

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate that the change adds a condition to avoid an error and improve the functionality of the feature.
2.  🔄 - This emoji represents a cycle or a loop, and can be used to indicate that the change applies the same logic to another type that shares the same behavior as the original type.
3.  🧹 - This emoji represents a broom or a cleanup, and can be used to indicate that the change simplifies the code by removing an unused value and making the pattern matching more concise.
-->

### WHY
Help people who chose the target project by accident.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e4efa4e</samp>

*  Prevent adding project references to self by checking project equality ([link](https://github.com/fsharp/FsAutoComplete/pull/1173/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L4380-R4384), [link](https://github.com/fsharp/FsAutoComplete/pull/1173/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L2421-R2429))
*  Simplify pattern matching on `CoreResponse` by ignoring unused message ([link](https://github.com/fsharp/FsAutoComplete/pull/1173/files?diff=unified&w=0#diff-ead6765f7b44c7de4806f392a2ceb30c009cda9bf468a8a53513095c1df1ed01L2421-R2429))
