### PR TITLE
Better Completion for ExternalAutocomplete functions

### DIFF
--- a/src/FsAutoComplete.Core/KeywordList.fs
+++ b/src/FsAutoComplete.Core/KeywordList.fs
@@ -42,13 +42,16 @@ module KeywordList =
   let hashSymbolCompletionItems =
     hashDirectives
     |> Seq.map (fun kv ->
+      let label = "#" + kv.Key
+
       { CompletionItem.Create(kv.Key) with
+          Data = Some(Newtonsoft.Json.Linq.JValue(label))
           Kind = Some CompletionItemKind.Keyword
           InsertText = Some kv.Key
           FilterText = Some kv.Key
           SortText = Some kv.Key
           Documentation = Some(Documentation.String kv.Value)
-          Label = "#" + kv.Key })
+          Label = label })
     |> Seq.toArray
 
   let allKeywords: string list =
@@ -58,6 +61,7 @@ module KeywordList =
     allKeywords
     |> List.mapi (fun id k ->
       { CompletionItem.Create(k) with
+          Data = Some(Newtonsoft.Json.Linq.JValue(k))
           Kind = Some CompletionItemKind.Keyword
           InsertText = Some k
           SortText = Some(sprintf "1000000%d" id)

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -636,6 +636,7 @@ type FSharpConfigDto =
     ExcludeProjectDirectories: string[] option
     KeywordsAutocomplete: bool option
     ExternalAutocomplete: bool option
+    FullNameExternalAutocomplete: bool option
     Linter: bool option
     LinterConfig: string option
     IndentationSize: int option
@@ -771,6 +772,7 @@ type FSharpConfig =
     ExcludeProjectDirectories: string[]
     KeywordsAutocomplete: bool
     ExternalAutocomplete: bool
+    FullNameExternalAutocomplete: bool
     Linter: bool
     LinterConfig: string option
     IndentationSize: int
@@ -816,6 +818,7 @@ type FSharpConfig =
       ExcludeProjectDirectories = [||]
       KeywordsAutocomplete = false
       ExternalAutocomplete = false
+      FullNameExternalAutocomplete = false
       IndentationSize = 4
       Linter = false
       LinterConfig = None
@@ -861,6 +864,7 @@ type FSharpConfig =
       ExcludeProjectDirectories = defaultArg dto.ExcludeProjectDirectories [||]
       KeywordsAutocomplete = defaultArg dto.KeywordsAutocomplete false
       ExternalAutocomplete = defaultArg dto.ExternalAutocomplete false
+      FullNameExternalAutocomplete = defaultArg dto.ExternalAutocomplete false
       IndentationSize = defaultArg dto.IndentationSize 4
       Linter = defaultArg dto.Linter false
       LinterConfig = dto.LinterConfig
@@ -958,6 +962,7 @@ type FSharpConfig =
       ExcludeProjectDirectories = defaultArg dto.ExcludeProjectDirectories x.ExcludeProjectDirectories
       KeywordsAutocomplete = defaultArg dto.KeywordsAutocomplete x.KeywordsAutocomplete
       ExternalAutocomplete = defaultArg dto.ExternalAutocomplete x.ExternalAutocomplete
+      FullNameExternalAutocomplete = defaultArg dto.FullNameExternalAutocomplete x.FullNameExternalAutocomplete
       IndentationSize = defaultArg dto.IndentationSize x.IndentationSize
       Linter = defaultArg dto.Linter x.Linter
       LinterConfig = dto.LinterConfig

--- a/src/FsAutoComplete/LspHelpers.fsi
+++ b/src/FsAutoComplete/LspHelpers.fsi
@@ -269,6 +269,7 @@ type FSharpConfigDto =
     ExcludeProjectDirectories: string[] option
     KeywordsAutocomplete: bool option
     ExternalAutocomplete: bool option
+    FullNameExternalAutocomplete: bool option
     Linter: bool option
     LinterConfig: string option
     IndentationSize: int option
@@ -363,6 +364,7 @@ type FSharpConfig =
     ExcludeProjectDirectories: string[]
     KeywordsAutocomplete: bool
     ExternalAutocomplete: bool
+    FullNameExternalAutocomplete: bool
     Linter: bool
     LinterConfig: string option
     IndentationSize: int

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -2602,20 +2602,11 @@ type AdaptiveFSharpLspServer
                     let items =
                       decls
                       |> Array.mapi (fun id d ->
-                        let code =
-                          if
-                            System.Text.RegularExpressions.Regex.IsMatch(d.NameInList, """^[a-zA-Z][a-zA-Z0-9']+$""")
-                          then
-                            d.NameInList
-                          elif d.NamespaceToOpen.IsSome then
-                            d.NameInList
-                          else
-                            FSharpKeywords.NormalizeIdentifierBackticks d.NameInList
-
-                        let label =
+                        let code, label =
                           match d.NamespaceToOpen with
-                          | Some no -> sprintf "%s (open %s)" d.NameInList no
-                          | None -> d.NameInList
+                          | Some no when config.FullNameExternalAutocomplete -> sprintf "%s.%s" no d.NameInCode, sprintf "%s (of %s)" d.NameInList no
+                          | Some no -> d.NameInCode, sprintf "%s (open %s)" d.NameInList no
+                          | None -> d.NameInCode, d.NameInList
 
                         { CompletionItem.Create(d.NameInList) with
                             Kind = (AVal.force glyphToCompletionKind) d.Glyph

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -2642,6 +2642,8 @@ type AdaptiveFSharpLspServer
       }
 
     override __.CompletionItemResolve(ci: CompletionItem) =
+      let config = AVal.force config
+
       let mapHelpText (ci: CompletionItem) (text: HelpText) =
         match text with
         | HelpText.Simple(symbolName, text) ->
@@ -2700,8 +2702,8 @@ type AdaptiveFSharpLspServer
 
               let n =
                 match getAutoCompleteNamespacesByDeclName sym |> AVal.force with
-                | None -> None
-                | Some s -> Some s
+                | Some s when not config.FullNameExternalAutocomplete -> Some s
+                | _ -> None
 
               CoreResponse.Res(HelpText.Full(sym, tip, n))
 

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -2604,7 +2604,8 @@ type AdaptiveFSharpLspServer
                       |> Array.mapi (fun id d ->
                         let code, label =
                           match d.NamespaceToOpen with
-                          | Some no when config.FullNameExternalAutocomplete -> sprintf "%s.%s" no d.NameInCode, sprintf "%s (of %s)" d.NameInList no
+                          | Some no when config.FullNameExternalAutocomplete ->
+                            sprintf "%s.%s" no d.NameInCode, sprintf "%s (of %s)" d.NameInList no
                           | Some no -> d.NameInCode, sprintf "%s (open %s)" d.NameInList no
                           | None -> d.NameInCode, d.NameInList
 

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -2612,7 +2612,9 @@ type AdaptiveFSharpLspServer
                         let label, filterText =
                           match d.NamespaceToOpen with
                           | Some no when config.FullNameExternalAutocomplete ->
-                            // allow filter "Ceiling (System.Math)" by "System.Math.Ceiling" or "CeilingSystem.Math"
+                            // completion "System.Math.Ceiling" will be displayed as "Ceiling (System.Math)"
+                            // filter text is "CeilingSystem.Math.Ceiling"
+                            // can be filtered out by "SysMaCe" or "CeSysMa"
                             sprintf "%s (%s)" d.NameInList no, d.NameInList + code
                           | Some no -> sprintf "%s (open %s)" d.NameInList no, d.NameInList
                           | None -> d.NameInList, d.NameInList
@@ -2620,7 +2622,7 @@ type AdaptiveFSharpLspServer
                         { CompletionItem.Create(d.NameInList) with
                             Data = Some(JValue(d.FullName))
                             Kind = (AVal.force glyphToCompletionKind) d.Glyph
-                            InsertText = Some(getCodeToInsert d)
+                            InsertText = Some code
                             SortText = Some(sprintf "%06d" id)
                             FilterText = Some filterText
                             Label = label })

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -47,7 +47,7 @@ let tests state =
           let! response = server.TextDocumentCompletion completionParams
 
           match response with
-          | Ok (Some completions) ->
+          | Ok(Some completions) ->
             Expect.isLessThan
               completions.Items.Length
               100
@@ -73,23 +73,25 @@ let tests state =
           let line = 15
           let character = lineUnderTest.Length
 
-          let textChange : DidChangeTextDocumentParams =
-            {
-              TextDocument = { Uri = Path.FilePathToUri path ; Version = 1}
-              ContentChanges =  [|
-                {
-                  Range = Some { Start = { Line = line; Character = character }; End = { Line = line; Character = character } }
-                  RangeLength = Some 0
-                  Text = "."
-                }
-              |]
-            }
+          let textChange: DidChangeTextDocumentParams =
+            { TextDocument =
+                { Uri = Path.FilePathToUri path
+                  Version = 1 }
+              ContentChanges =
+                [| { Range =
+                       Some
+                         { Start = { Line = line; Character = character }
+                           End = { Line = line; Character = character } }
+                     RangeLength = Some 0
+                     Text = "." } |] }
 
           let! c = server.TextDocumentDidChange textChange |> Async.StartChild
 
           let completionParams: CompletionParams =
             { TextDocument = { Uri = Path.FilePathToUri path }
-              Position = { Line = line; Character = character + 1 }
+              Position =
+                { Line = line
+                  Character = character + 1 }
               Context =
                 Some
                   { triggerKind = CompletionTriggerKind.TriggerCharacter
@@ -99,7 +101,7 @@ let tests state =
           do! c
 
           match response with
-          | Ok (Some completions) ->
+          | Ok(Some completions) ->
             Expect.isLessThan
               completions.Items.Length
               100
@@ -135,7 +137,7 @@ let tests state =
           let! response = server.TextDocumentCompletion completionParams
 
           match response with
-          | Ok (Some completions) ->
+          | Ok(Some completions) ->
             Expect.isLessThan
               completions.Items.Length
               100
@@ -160,23 +162,25 @@ let tests state =
           let lineUnderTest = "\"bareString\""
           let character = lineUnderTest.Length
 
-          let textChange : DidChangeTextDocumentParams =
-            {
-              TextDocument = { Uri = Path.FilePathToUri path ; Version = 1}
-              ContentChanges =  [|
-                {
-                  Range = Some { Start = { Line = line; Character = character }; End = { Line = line; Character = character } }
-                  RangeLength = Some 0
-                  Text = "."
-                }
-              |]
-            }
+          let textChange: DidChangeTextDocumentParams =
+            { TextDocument =
+                { Uri = Path.FilePathToUri path
+                  Version = 1 }
+              ContentChanges =
+                [| { Range =
+                       Some
+                         { Start = { Line = line; Character = character }
+                           End = { Line = line; Character = character } }
+                     RangeLength = Some 0
+                     Text = "." } |] }
 
           let! c = server.TextDocumentDidChange textChange |> Async.StartChild
 
           let completionParams: CompletionParams =
             { TextDocument = { Uri = Path.FilePathToUri path }
-              Position = { Line = line; Character = character + 1 }
+              Position =
+                { Line = line
+                  Character = character + 1 }
               Context =
                 Some
                   { triggerKind = CompletionTriggerKind.TriggerCharacter
@@ -186,7 +190,7 @@ let tests state =
           do! c
 
           match response with
-          | Ok (Some completions) ->
+          | Ok(Some completions) ->
             Expect.isLessThan
               completions.Items.Length
               100
@@ -222,7 +226,7 @@ let tests state =
           let! response = server.TextDocumentCompletion completionParams
 
           match response with
-          | Ok (Some completions) ->
+          | Ok(Some completions) ->
             Expect.isLessThan
               completions.Items.Length
               100
@@ -247,23 +251,25 @@ let tests state =
           let lineUnderTest = "[1;2;3]"
           let character = lineUnderTest.Length
 
-          let textChange : DidChangeTextDocumentParams =
-            {
-              TextDocument = { Uri = Path.FilePathToUri path ; Version = 1}
-              ContentChanges =  [|
-                {
-                  Range = Some { Start = { Line = line; Character = character }; End = { Line = line; Character = character } }
-                  RangeLength = Some 0
-                  Text = "."
-                }
-              |]
-            }
+          let textChange: DidChangeTextDocumentParams =
+            { TextDocument =
+                { Uri = Path.FilePathToUri path
+                  Version = 1 }
+              ContentChanges =
+                [| { Range =
+                       Some
+                         { Start = { Line = line; Character = character }
+                           End = { Line = line; Character = character } }
+                     RangeLength = Some 0
+                     Text = "." } |] }
 
           let! c = server.TextDocumentDidChange textChange |> Async.StartChild
 
           let completionParams: CompletionParams =
             { TextDocument = { Uri = Path.FilePathToUri path }
-              Position = { Line = line; Character = character + 1 }
+              Position =
+                { Line = line
+                  Character = character + 1 }
               Context =
                 Some
                   { triggerKind = CompletionTriggerKind.TriggerCharacter
@@ -273,7 +279,7 @@ let tests state =
           do! c
 
           match response with
-          | Ok (Some completions) ->
+          | Ok(Some completions) ->
             Expect.isLessThan
               completions.Items.Length
               100
@@ -309,7 +315,7 @@ let tests state =
           let! response = server.TextDocumentCompletion completionParams
 
           match response with
-          | Ok (Some completions) ->
+          | Ok(Some completions) ->
             Expect.isLessThan
               completions.Items.Length
               100
@@ -341,7 +347,7 @@ let tests state =
           let! response = server.TextDocumentCompletion completionParams
 
           match response with
-          | Ok (Some completions) ->
+          | Ok(Some completions) ->
             Expect.equal completions.Items.Length 106 "at time of writing the List module has 106 exposed members"
             let firstItem = completions.Items.[0]
 
@@ -369,7 +375,7 @@ let tests state =
           let! response = server.TextDocumentCompletion completionParams
 
           match response with
-          | Ok (Some completions) ->
+          | Ok(Some completions) ->
             Expect.equal completions.Items.Length 106 "at time of writing the List module has 106 exposed members"
             let firstItem = completions.Items.[0]
 
@@ -396,67 +402,84 @@ let tests state =
           let! response = server.TextDocumentCompletion completionParams
 
           match response with
-          | Ok (Some completions) ->
+          | Ok(Some completions) ->
             Expect.isLessThan
               completions.Items.Length
               300
               "shouldn't have a very long list of completion items that are only types"
+
             Expect.isGreaterThan
               completions.Items.Length
               100
               "should have a reasonable number of completion items that are only types"
 
-            Expect.exists
-              completions.Items
-              (fun item -> item.Label = "list")
-              "completion should contain the list type"
+            Expect.exists completions.Items (fun item -> item.Label = "list") "completion should contain the list type"
           | Ok None -> failtest "Should have gotten some completion items"
           | Error e -> failtestf "Got an error while retrieving completions: %A" e
         })
 
-      testCaseAsync "completion before first character of expression" (async {
-        let! server, path = server
-        let completionParams : CompletionParams =
-          {
-            TextDocument = { Uri = Path.FilePathToUri path }
-            Position = { Line = 8; Character = 12 } // after the 'L' in 'List.'
-            Context = Some { triggerKind = CompletionTriggerKind.Invoked; triggerCharacter = None }
-          }
-        let! response = server.TextDocumentCompletion completionParams
-        match response with
-        | Ok (Some completions) ->
-          Expect.isGreaterThan completions.Items.Length 100 "should have a very long list of all symbols"
-          let firstItem = completions.Items.[0]
-          Expect.equal firstItem.Label "async" "first member should be async, alphabetically first in the full symbol list"
-        | Ok None ->
-          failtest "Should have gotten some completion items"
-        | Error e ->
-          failtestf "Got an error while retrieving completions: %A" e
-      })
+      testCaseAsync
+        "completion before first character of expression"
+        (async {
+          let! server, path = server
 
-      testCaseAsync "completion after first character of expression" (async {
-        let! server, path = server
-        let completionParams : CompletionParams =
-          {
-            TextDocument = { Uri = Path.FilePathToUri path }
-            Position = { Line = 8; Character = 11 } // before the 'L' in 'List.'
-            Context = Some { triggerKind = CompletionTriggerKind.Invoked; triggerCharacter = None }
-          }
-        let! response = server.TextDocumentCompletion completionParams
-        match response with
-        | Ok (Some completions) ->
-          Expect.isGreaterThan completions.Items.Length 100 "should have a very long list of all symbols"
-          let firstItem = completions.Items.[0]
-          Expect.equal firstItem.Label "async" "first member should be async, alphabetically first in the full symbol list"
-        | Ok None ->
-          failtest "Should have gotten some completion items"
-        | Error e ->
-          failtestf "Got an error while retrieving completions: %A" e
-      })
+          let completionParams: CompletionParams =
+            { TextDocument = { Uri = Path.FilePathToUri path }
+              Position = { Line = 8; Character = 12 } // after the 'L' in 'List.'
+              Context =
+                Some
+                  { triggerKind = CompletionTriggerKind.Invoked
+                    triggerCharacter = None } }
 
-      testCaseAsync "no backticks in completionitem signatures" (asyncResult {
-        let! server, path = server
-        let completionParams: CompletionParams =
+          let! response = server.TextDocumentCompletion completionParams
+
+          match response with
+          | Ok(Some completions) ->
+            Expect.isGreaterThan completions.Items.Length 100 "should have a very long list of all symbols"
+            let firstItem = completions.Items.[0]
+
+            Expect.equal
+              firstItem.Label
+              "async"
+              "first member should be async, alphabetically first in the full symbol list"
+          | Ok None -> failtest "Should have gotten some completion items"
+          | Error e -> failtestf "Got an error while retrieving completions: %A" e
+        })
+
+      testCaseAsync
+        "completion after first character of expression"
+        (async {
+          let! server, path = server
+
+          let completionParams: CompletionParams =
+            { TextDocument = { Uri = Path.FilePathToUri path }
+              Position = { Line = 8; Character = 11 } // before the 'L' in 'List.'
+              Context =
+                Some
+                  { triggerKind = CompletionTriggerKind.Invoked
+                    triggerCharacter = None } }
+
+          let! response = server.TextDocumentCompletion completionParams
+
+          match response with
+          | Ok(Some completions) ->
+            Expect.isGreaterThan completions.Items.Length 100 "should have a very long list of all symbols"
+            let firstItem = completions.Items.[0]
+
+            Expect.equal
+              firstItem.Label
+              "async"
+              "first member should be async, alphabetically first in the full symbol list"
+          | Ok None -> failtest "Should have gotten some completion items"
+          | Error e -> failtestf "Got an error while retrieving completions: %A" e
+        })
+
+      testCaseAsync
+        "no backticks in completionitem signatures"
+        (asyncResult {
+          let! server, path = server
+
+          let completionParams: CompletionParams =
             { TextDocument = { Uri = Path.FilePathToUri path }
               Position = { Line = 3; Character = 9 } // the '.' in 'Async.'
               Context =
@@ -464,13 +487,22 @@ let tests state =
                   { triggerKind = CompletionTriggerKind.TriggerCharacter
                     triggerCharacter = Some '.' } }
 
-        let! response = server.TextDocumentCompletion completionParams |> AsyncResult.map Option.get
-        let ctokMember = response.Items[0]
-        let! resolved = server.CompletionItemResolve(ctokMember)
-        Expect.equal resolved.Label "CancellationToken" "Just making sure we're on the right member, one that should have backticks"
-        Expect.equal resolved.Detail (Some "property Async.CancellationToken: Async<System.Threading.CancellationToken> with get") "Signature shouldn't have backticks"
+          let! response = server.TextDocumentCompletion completionParams |> AsyncResult.map Option.get
+          let ctokMember = response.Items[0]
+          let! resolved = server.CompletionItemResolve(ctokMember)
 
-      } |> AsyncResult.bimap id (fun e -> failwithf "%O" e))
+          Expect.equal
+            resolved.Label
+            "CancellationToken"
+            "Just making sure we're on the right member, one that should have backticks"
+
+          Expect.equal
+            resolved.Detail
+            (Some "property Async.CancellationToken: Async<System.Threading.CancellationToken> with get")
+            "Signature shouldn't have backticks"
+
+         }
+         |> AsyncResult.bimap id (fun e -> failwithf "%O" e))
 
       testCaseAsync
         "completion in interpolated string"
@@ -488,7 +520,7 @@ let tests state =
           let! response = server.TextDocumentCompletion completionParams
 
           match response with
-          | Ok (Some completions) ->
+          | Ok(Some completions) ->
             Expect.equal completions.Items.Length 106 "at time of writing the List module has 106 exposed members"
             let firstItem = completions.Items.[0]
 
@@ -516,7 +548,7 @@ let tests state =
           let! response = server.TextDocumentCompletion completionParams
 
           match response with
-          | Ok (Some completions) ->
+          | Ok(Some completions) ->
             Expect.equal completions.Items.Length 106 "at time of writing the List module has 106 exposed members"
             let firstItem = completions.Items.[0]
 
@@ -526,7 +558,7 @@ let tests state =
               "first member should be List.Empty, since properties are preferred over functions"
           | Ok None -> failtest "Should have gotten some completion items"
           | Error e -> failtestf "Got an error while retrieving completions: %A" e
-        })]
+        }) ]
 
 ///Tests for getting autocomplete
 let autocompleteTest state =
@@ -572,7 +604,7 @@ let autocompleteTest state =
           match res with
           | Result.Error e -> failtestf "Request failed: %A" e
           | Result.Ok None -> failtest "Request none"
-          | Result.Ok (Some res) ->
+          | Result.Ok(Some res) ->
 
             Expect.equal res.Items.Length 2 "Autocomplete has all symbols"
             Expect.exists res.Items (fun n -> n.Label = "func") "Autocomplete contains given symbol"
@@ -594,7 +626,7 @@ let autocompleteTest state =
           match res with
           | Result.Error e -> failtestf "Request failed: %A" e
           | Result.Ok None -> failtest "Request none"
-          | Result.Ok (Some res) ->
+          | Result.Ok(Some res) ->
             //TODO
             // Expect.equal res.Items.Length 1 "Autocomplete has all symbols"
             Expect.exists res.Items (fun n -> n.Label = "System") "Autocomplete contains given symbol"
@@ -616,7 +648,7 @@ let autocompleteTest state =
           match res with
           | Result.Error e -> failtestf "Request failed: %A" e
           | Result.Ok None -> failtest "Request none"
-          | Result.Ok (Some res) ->
+          | Result.Ok(Some res) ->
             //TODO
             // Expect.equal res.Items.Length 1 "Autocomplete has all symbols"
             Expect.exists res.Items (fun n -> n.Label = "DateTime") "Autocomplete contains given symbol"
@@ -638,7 +670,7 @@ let autocompleteTest state =
           match res with
           | Result.Error e -> failtestf "Request failed: %A" e
           | Result.Ok None -> failtest "Request none"
-          | Result.Ok (Some res) ->
+          | Result.Ok(Some res) ->
 
             Expect.equal res.Items.Length 1 "Autocomplete has all symbols"
             Expect.exists res.Items (fun n -> n.Label = "z") "Autocomplete contains given symbol"
@@ -659,7 +691,7 @@ let autocompleteTest state =
           match res with
           | Result.Error e -> failtestf "Request failed: %A" e
           | Result.Ok None -> failtest "Request none"
-          | Result.Ok (Some res) ->
+          | Result.Ok(Some res) ->
             Expect.exists res.Items (fun n -> n.Label = "bar") "Autocomplete contains given symbol"
             Expect.exists res.Items (fun n -> n.Label = "baz") "Autocomplete contains given symbol"
         })
@@ -679,7 +711,7 @@ let autocompleteTest state =
           match res with
           | Result.Error e -> failtestf "Request failed: %A" e
           | Result.Ok None -> failtest "Request none"
-          | Result.Ok (Some res) ->
+          | Result.Ok(Some res) ->
             Expect.exists res.Items (fun n -> n.Label = "Bar") "Autocomplete contains given symbol"
             Expect.exists res.Items (fun n -> n.Label = "Baz") "Autocomplete contains given symbol"
         }) ]
@@ -722,9 +754,7 @@ let autoOpenTests state =
     let text = edit.NewText
     let pos = edit.Range.Start
 
-    let indentation =
-      pos.Character
-      + (text.Length - text.TrimStart().Length)
+    let indentation = pos.Character + (text.Length - text.TrimStart().Length)
 
     { Line = pos.Line
       Character = indentation }
@@ -749,21 +779,17 @@ let autoOpenTests state =
               Only = None
               TriggerKind = None } }
 
-      let (|ContainsOpenAction|_|) (codeActions: CodeAction []) =
+      let (|ContainsOpenAction|_|) (codeActions: CodeAction[]) =
         codeActions
-        |> Array.tryFind (fun ca ->
-          ca.Kind = Some "quickfix"
-          && ca.Title.StartsWith "open ")
+        |> Array.tryFind (fun ca -> ca.Kind = Some "quickfix" && ca.Title.StartsWith "open ")
 
       match! server.TextDocumentCodeAction p with
       | Error e -> return failtestf "Quick fix Request failed: %A" e
       | Ok None -> return failtest "Quick fix Request none"
-      | Ok (Some (CodeActions (ContainsOpenAction quickfix))) ->
+      | Ok(Some(CodeActions(ContainsOpenAction quickfix))) ->
         let ns = quickfix.Title.Substring("open ".Length)
 
-        let edit =
-          quickfix.Edit.Value.DocumentChanges.Value.[0]
-            .Edits.[0]
+        let edit = quickfix.Edit.Value.DocumentChanges.Value.[0].Edits.[0]
 
         let openPos = calcOpenPos edit
         return (edit, ns, openPos)
@@ -789,11 +815,7 @@ let autoOpenTests state =
           (expectedOpen.Line)
           (expectedOpen.Character))
 
-    let runner =
-      if pending then
-        ptestCaseAsync
-      else
-        testCaseAsync
+    let runner = if pending then ptestCaseAsync else testCaseAsync
 
     runner name
     <| async {
@@ -808,10 +830,14 @@ let autoOpenTests state =
       match! server.TextDocumentCompletion p with
       | Error e -> failtestf "Request failed: %A" e
       | Ok None -> failtest "Request none"
-      | Ok (Some res) ->
+      | Ok(Some res) ->
         Expect.isFalse res.IsIncomplete "Result is incomplete"
         let ci = res.Items |> Array.tryFind (fun c -> c.Label = word)
-        if ci = None then failwithf $"Couldn't find completion item for `{word}` among the items %A{res.Items |> Array.map (fun i -> i.Label)}" |> ignore
+
+        if ci = None then
+          failwithf
+            $"Couldn't find completion item for `{word}` among the items %A{res.Items |> Array.map (fun i -> i.Label)}"
+          |> ignore
 
         // now get details: `completionItem/resolve` (previous request was `textDocument/completion` -> List of all completions, but without details)
         match! server.CompletionItemResolve ci.Value with
@@ -938,3 +964,127 @@ let autoOpenTests state =
         "with implicit top level module with open and new lines"
         "ImplicitTopLevelModuleWithOpenAndNewLines.fsx"
       testScript "with root module with comments and new line before open" "ModuleDocsAndNewLineBeforeOpen.fsx" ]
+
+let fullNameExternalAutocompleteTest state =
+  let server =
+    async {
+      let config =
+        { defaultConfigDto with
+            ExternalAutocomplete = Some true
+            FullNameExternalAutocomplete = Some true }
+
+      let path =
+        Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "FullNameExternalAutocompleteTest")
+
+      let! (server, event) = serverInitialize path config state
+      let projectPath = Path.Combine(path, "FullNameExternalAutocompleteTest.fsproj")
+      do! waitForWorkspaceFinishedParsing event
+      do! parseProject projectPath server
+      let path = Path.Combine(path, "Script.fs")
+      let tdop: DidOpenTextDocumentParams = { TextDocument = loadDocument path }
+      do! server.TextDocumentDidOpen tdop
+      return (server, path)
+    }
+    |> Async.Cache
+
+  let scriptServer =
+    async {
+      let config =
+        { defaultConfigDto with
+            ExternalAutocomplete = Some true
+            FullNameExternalAutocomplete = Some true }
+
+      let path =
+        Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "FullNameExternalAutocompleteTest")
+
+      let! (server, event) = serverInitialize path config state
+      do! waitForWorkspaceFinishedParsing event
+      let path = Path.Combine(path, "Script.fsx")
+      let tdop: DidOpenTextDocumentParams = { TextDocument = loadDocument path }
+      do! server.TextDocumentDidOpen tdop
+      return (server, path)
+    }
+    |> Async.Cache
+
+  let makeAutocompleteTest (serverConfig: (IFSharpLspServer * string) Async) testName (line, character) expects =
+    testCaseAsync
+      testName
+      (async {
+        let! server, path = serverConfig
+
+        let p: CompletionParams =
+          { TextDocument = { Uri = Path.FilePathToUri path }
+            Position = { Line = line; Character = character }
+            Context =
+              Some
+                { triggerKind = CompletionTriggerKind.Invoked
+                  triggerCharacter = None } }
+
+        let! res = server.TextDocumentCompletion p
+
+        match res with
+        | Result.Error e -> failtestf "Request failed: %A" e
+        | Result.Ok None -> failtest "Request none"
+        | Result.Ok(Some res) -> expects res
+      })
+
+  let makeAutocompleteTestList (serverConfig: (IFSharpLspServer * string) Async) =
+    [ makeAutocompleteTest serverConfig "Autocomplete for Array.map contains no backticks" (0, 8) (fun res ->
+        let n = res.Items |> Array.tryFind (fun i -> i.Label = "Array.map")
+        Expect.isSome n "Completion doesn't exist"
+        Expect.equal n.Value.InsertText (Some "Array.map") "Autocomplete for Array.map contains backticks")
+
+      makeAutocompleteTest serverConfig "Autocomplete for ``a.b`` contains backticks" (2, 1) (fun res ->
+        let n = res.Items |> Array.tryFind (fun i -> i.Label = "a.b")
+        Expect.isSome n "Completion doesn't exist"
+        Expect.equal n.Value.InsertText (Some "``a.b``") "Autocomplete for a.b contains no backticks")
+
+      testCaseAsync
+        "Autocompletes with same label have different description"
+        (asyncResult {
+          let! server, path = serverConfig
+
+          let p: CompletionParams =
+            { TextDocument = { Uri = Path.FilePathToUri path }
+              Position = { Line = 3; Character = 4 }
+              Context =
+                Some
+                  { triggerKind = CompletionTriggerKind.Invoked
+                    triggerCharacter = None } }
+
+          let! response = server.TextDocumentCompletion p |> AsyncResult.map Option.get
+
+          let! items =
+            response.Items
+            |> Array.filter (fun i -> i.Label = "bind")
+            |> Array.map (server.CompletionItemResolve)
+            |> Async.Parallel
+
+          let count =
+            items
+            |> Array.distinctBy (function Ok x -> x.Detail | Error _ -> None)
+            |> Array.length
+
+          Expect.equal count items.Length "These completions doesn't have different description"
+         }
+         |> AsyncResult.bimap id (fun e -> failwithf "%O" e))
+
+      makeAutocompleteTest
+        serverConfig
+        "Check Autocomplete for System.Text.RegularExpressions.Regex"
+        (4, 5)
+        (fun res ->
+          let n = res.Items |> Array.tryFind (fun i -> i.Label = "Regex (System.Text.RegularExpressions)")
+          Expect.isSome n "Completion doesn't exist"
+          Expect.equal n.Value.InsertText (Some "System.Text.RegularExpressions.Regex") "Autocomplete for Regex is not System.Text.RegularExpressions.Regex"
+          Expect.equal n.Value.FilterText (Some "RegexSystem.Text.RegularExpressions.Regex") "Autocomplete for Regex is not System.Text.RegularExpressions.Regex")
+
+      makeAutocompleteTest serverConfig "Autocomplete for Result is just Result" (5, 6) (fun res ->
+        let n = res.Items |> Array.tryFind (fun i -> i.Label = "Result")
+        Expect.isSome n "Completion doesn't exist"
+        Expect.equal n.Value.InsertText (Some "Result") "Autocomplete contains given symbol") ]
+
+  testList
+    "fullNameExternalAutocompleteTest Tests"
+    [ testList "fullNameExternalAutocompleteTest within project files" (makeAutocompleteTestList server)
+      testList "fullNameExternalAutocompleteTest within script files" (makeAutocompleteTestList scriptServer) ]

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -212,6 +212,7 @@ let defaultConfigDto: FSharpConfigDto =
     ExcludeProjectDirectories = None
     KeywordsAutocomplete = None
     ExternalAutocomplete = None
+    FullNameExternalAutocomplete = None
     Linter = None
     LinterConfig = None
     IndentationSize = None

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -77,6 +77,7 @@ let lspTests =
                 documentSymbolTest createServer
                 Completion.autocompleteTest createServer
                 Completion.autoOpenTests createServer
+                Completion.fullNameExternalAutocompleteTest createServer
                 foldingTests createServer
                 tooltipTests createServer
                 Highlighting.tests createServer

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/FullNameExternalAutocompleteTest/FullNameExternalAutocompleteTest.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/FullNameExternalAutocompleteTest/FullNameExternalAutocompleteTest.fsproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Script.fs" />
+  </ItemGroup>
+</Project>

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/FullNameExternalAutocompleteTest/Script.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/FullNameExternalAutocompleteTest/Script.fs
@@ -1,0 +1,6 @@
+arraymap
+let ``a.b`` = 1
+a
+bind
+Regex
+Result

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/FullNameExternalAutocompleteTest/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/FullNameExternalAutocompleteTest/Script.fsx
@@ -1,0 +1,6 @@
+arraymap
+let ``a.b`` = 1
+a
+bind
+Regex
+Result


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b053be9</samp>

This pull request adds a new feature to the F# language server, which allows the user to configure how completion items for external symbols are displayed. It also improves the completion items for hash directives and keywords, and adds tests for the new feature. The main files affected are `src/FsAutoComplete.Core/KeywordList.fs`, `src/FsAutoComplete/LspHelpers.fs`, `src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs`, and `test/FsAutoComplete.Tests.Lsp/CompletionTests.fs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b053be9</samp>

> _`FullNameExternal`_
> _Option for completion items_
> _Autumn of symbols_

<!--
copilot:emoji
-->

🧑‍💻🔧🧪

<!--
1.  🧑‍💻 - This emoji represents the enhancement of the completion feature for external symbols, which is a developer-oriented feature that improves the coding experience and productivity.
2.  🔧 - This emoji represents the addition of a new configuration option for the F# language server, which is a tooling-related feature that allows users to customize the behavior of the completion feature.
3.  🧪 - This emoji represents the addition and improvement of the completion tests, which is a testing-related feature that ensures the quality and correctness of the completion feature.
-->

### WHY

1. Try fix insert "Array.map" become  "``Array.map``"

Before:
![GIF 2023-10-18 23-07-09](https://github.com/fsharp/FsAutoComplete/assets/43789618/30538ce4-94f6-4581-91eb-7eae1df44f4e)

After:
![GIF 2023-10-18 23-05-58](https://github.com/fsharp/FsAutoComplete/assets/43789618/ea9d2d81-c815-4375-964b-efb57b03094e)

2. Fix completions with same label have same description

Before: 
![GIF 2023-10-19 22-04-52](https://github.com/fsharp/FsAutoComplete/assets/43789618/d6d7eed0-e33b-4fe1-a443-c3d5d9779c9b)

After:
![GIF 2023-10-19 22-08-33](https://github.com/fsharp/FsAutoComplete/assets/43789618/33018212-dd2f-49b5-95a1-c9cf51ca28f4)

4. Add `FullNameExternalAutocomplete`

Before: 
![GIF 2023-10-18 23-01-10](https://github.com/fsharp/FsAutoComplete/assets/43789618/40d48089-a059-4ce8-8f9a-ba9c83226e11)

With `FullNameExternalAutocomplete`:
![GIF 2023-10-18 22-59-03](https://github.com/fsharp/FsAutoComplete/assets/43789618/c7f5a72b-6182-410e-b094-02fbea4438ab)

![GIF 2023-10-19 22-09-38](https://github.com/fsharp/FsAutoComplete/assets/43789618/b51c02f1-4cd6-419f-9388-6efb68351d49)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b053be9</samp>

*  Add a new configuration option for full name external autocomplete, which controls whether the completion items for external symbols should use their full names instead of suggesting to open their namespaces ([link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-a0cc27b1398830cb3ce332015ecbd44c9649503474a0bfe34a6330dc04e99c55R639), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-a0cc27b1398830cb3ce332015ecbd44c9649503474a0bfe34a6330dc04e99c55R775), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-a0cc27b1398830cb3ce332015ecbd44c9649503474a0bfe34a6330dc04e99c55R821), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-a0cc27b1398830cb3ce332015ecbd44c9649503474a0bfe34a6330dc04e99c55R867), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-a0cc27b1398830cb3ce332015ecbd44c9649503474a0bfe34a6330dc04e99c55R965), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-9c50a17e9aa561dc55e32178e54656bdc0e07f21fda5f20d17a866bc1c2308aeR272), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-9c50a17e9aa561dc55e32178e54656bdc0e07f21fda5f20d17a866bc1c2308aeR367), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-617db9e831fb074eb5a368b2c99f6e50f1e568cb70c7c37377ba7be3333aa17bR80), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-8f2fa3034cc70b7b04b77a24243feb2478199c03391b393fe0e12990829b2b22R1-R10), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-8b8d23f72f317328b9544efff5e8082f9030b204525af0af2ad6dbeb31cef68cR1-R6), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-5888c007599b07130f8657f99870938a14e1cb6febc15ae1575462066bb031bbR1-R6))
*  Implement the logic for creating and resolving completion items based on the full name external autocomplete option, using the `getCodeToInsert` function and the `data` field of the completion items ([link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0R2578-R2582), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2595-R2600), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2605-R2625), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0R2654-R2655), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2711-R2715), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2728-R2734))
*  Add a `label` field and a `data` field to the completion items for hash directives and keywords, using the `#` prefix for directives ([link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-ef9da2134c7dd3039c217a7759f2e7da60e406971eebc195b8c1895cf35ffb2aL45-R48), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-ef9da2134c7dd3039c217a7759f2e7da60e406971eebc195b8c1895cf35ffb2aL51-R54), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-ef9da2134c7dd3039c217a7759f2e7da60e406971eebc195b8c1895cf35ffb2aR64))
*  Reformat the code for creating and checking completion requests and responses in the test cases, to make it more consistent and readable ([link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL50-R50), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL76-R86), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL92-R94), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL102-R104), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL138-R140), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL163-R175), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL179-R183), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL189-R193), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL225-R229), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL250-R264), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL266-R272), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL276-R282), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL312-R318), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL344-R350), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL372-R378), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL399-R410), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL409-R483), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL467-R506), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL491-R523), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL519-R551), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL529-R561), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL575-R607), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL597-R629), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL619-R651), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL641-R673), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL662-R694), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL682-R714), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL725-R757), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL752-R792), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL792-R818), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eL811-R841))
*  Add a new test list for testing the full name external autocomplete feature, using the `fullNameExternalAutocompleteTest` function and the `Range.FullNameExternalAutocomplete` field ([link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-48a5d0ce09baa3b52e3133b5482d0cfa7c8e04f8febabc7f3f9a6209d623629eR967-R1090), [link](https://github.com/fsharp/FsAutoComplete/pull/1178/files?diff=unified&w=0#diff-df93a61310361c4e5158c21b40cf0d01f9951913ae006c462868983c85fe6c4fR215))
