### PR TITLE
fix and improves l10n

### DIFF
--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -892,10 +892,13 @@ let private xmlDocCache =
 
 let private findCultures v =
   let rec loop state (v: System.Globalization.CultureInfo) =
-      let state' = v.Name :: state
-      if v.Parent = System.Globalization.CultureInfo.InvariantCulture then
-          "" :: state' |> List.rev
-      else loop state' v.Parent
+    let state' = v.Name :: state
+
+    if v.Parent = System.Globalization.CultureInfo.InvariantCulture then
+      "" :: state' |> List.rev
+    else
+      loop state' v.Parent
+
   loop [] v
 
 let private findLocalizedXmlFile (xmlFile: string) =
@@ -903,7 +906,7 @@ let private findLocalizedXmlFile (xmlFile: string) =
   let path = Path.GetDirectoryName xmlFile
 
   findCultures System.Globalization.CultureInfo.CurrentUICulture
-  |> List.map (fun culture -> Path.Combine (path, culture, xmlName))
+  |> List.map (fun culture -> Path.Combine(path, culture, xmlName))
   |> List.tryFind (fun i -> File.Exists i)
   |> Option.defaultValue xmlFile
 

--- a/src/FsAutoComplete/CodeFixes.fs
+++ b/src/FsAutoComplete/CodeFixes.fs
@@ -327,9 +327,7 @@ module Run =
     runDiagnostics (fun d -> d.Message.Contains checkMessage) handler
 
   let ifDiagnosticByCheckMessage (checkMessageFunc: (string -> bool) list) handler : CodeFix =
-    runDiagnostics (fun d ->
-      checkMessageFunc
-      |> List.exists (fun f -> f d.Message)) handler
+    runDiagnostics (fun d -> checkMessageFunc |> List.exists (fun f -> f d.Message)) handler
 
   let ifDiagnosticByType (diagnosticType: string) handler : CodeFix =
     runDiagnostics

--- a/src/FsAutoComplete/CodeFixes.fs
+++ b/src/FsAutoComplete/CodeFixes.fs
@@ -326,6 +326,11 @@ module Run =
   let ifDiagnosticByMessage (checkMessage: string) handler : CodeFix =
     runDiagnostics (fun d -> d.Message.Contains checkMessage) handler
 
+  let ifDiagnosticByCheckMessage (checkMessageFunc: (string -> bool) list) handler : CodeFix =
+    runDiagnostics (fun d ->
+      checkMessageFunc
+      |> List.exists (fun f -> f d.Message)) handler
+
   let ifDiagnosticByType (diagnosticType: string) handler : CodeFix =
     runDiagnostics
       (fun d ->

--- a/src/FsAutoComplete/CodeFixes.fsi
+++ b/src/FsAutoComplete/CodeFixes.fsi
@@ -162,6 +162,11 @@ module Run =
     handler: (Diagnostic -> CodeActionParams -> Async<Result<Fix list, string>>) ->
       (CodeActionParams -> Async<Result<Fix list, string>>)
 
+  val ifDiagnosticByCheckMessage:
+    checkMessageFunc: (string -> bool) list ->
+    handler: (Diagnostic -> CodeActionParams -> Async<Result<Fix list, string>>) ->
+      (CodeActionParams -> Async<Result<Fix list, string>>)
+
   val ifDiagnosticByType:
     diagnosticType: string ->
     handler: (Diagnostic -> CodeActionParams -> Async<Result<Fix list, string>>) ->

--- a/src/FsAutoComplete/CodeFixes/ReplaceWithSuggestion.fs
+++ b/src/FsAutoComplete/CodeFixes/ReplaceWithSuggestion.fs
@@ -9,8 +9,7 @@ open FSharp.Compiler.Syntax
 let title suggestion = $"Replace with '%s{suggestion}'"
 
 let undefinedName =
-  [
-    "Maybe you want one of the following:"
+  [ "Maybe you want one of the following:"
     "Možná budete potřebovat něco z tohoto:"
     "Vielleicht möchten Sie eine der folgenden Bezeichnungen verwenden:"
     "Puede elegir una de las opciones siguientes:"
@@ -23,8 +22,8 @@ let undefinedName =
     "Возможно, требуется одно из следующих:"
     "Aşağıdakilerden birini arıyor olabilirsiniz:"
     "你可能需要以下之一:"
-    "您可能需要下列其中一項:"
-  ] |> List.map (fun i -> fun (j: string) -> j.Contains(i, System.StringComparison.Ordinal))
+    "您可能需要下列其中一項:" ]
+  |> List.map (fun i -> fun (j: string) -> j.Contains(i, System.StringComparison.Ordinal))
 
 /// a codefix that replaces the use of an unknown identifier with a suggested identifier
 let fix =

--- a/src/FsAutoComplete/CodeFixes/ReplaceWithSuggestion.fs
+++ b/src/FsAutoComplete/CodeFixes/ReplaceWithSuggestion.fs
@@ -8,10 +8,28 @@ open FSharp.Compiler.Syntax
 
 let title suggestion = $"Replace with '%s{suggestion}'"
 
+let undefinedName =
+  [
+    "Maybe you want one of the following:"
+    "Možná budete potřebovat něco z tohoto:"
+    "Vielleicht möchten Sie eine der folgenden Bezeichnungen verwenden:"
+    "Puede elegir una de las opciones siguientes:"
+    "Peut-être souhaitez-vous l'une des options suivantes :"
+    "Si può specificare uno dei nomi seguenti:"
+    "次のいずれかの可能性はありませんか:"
+    "다음 중 하나가 필요할 수 있습니다:"
+    "Możliwe, że chcesz wykonać jedną z następujących czynności:"
+    "Talvez você queira um dos seguintes:"
+    "Возможно, требуется одно из следующих:"
+    "Aşağıdakilerden birini arıyor olabilirsiniz:"
+    "你可能需要以下之一:"
+    "您可能需要下列其中一項:"
+  ] |> List.map (fun i -> fun (j: string) -> j.Contains(i, System.StringComparison.Ordinal))
+
 /// a codefix that replaces the use of an unknown identifier with a suggested identifier
 let fix =
-  Run.ifDiagnosticByMessage "Maybe you want one of the following:" (fun diagnostic codeActionParams ->
-    diagnostic.Message.Split('\n').[1..]
+  Run.ifDiagnosticByCheckMessage undefinedName (fun diagnostic codeActionParams ->
+    diagnostic.Message.Split('\n', '\u001b').[1..]
     |> Array.map (fun suggestion ->
       let suggestion = suggestion.Trim() |> PrettyNaming.NormalizeIdentifierBackticks
 

--- a/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
+++ b/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
@@ -13,8 +13,7 @@ open System.Text.RegularExpressions
 type LineText = string
 
 let undefinedName =
-  [
-    "not define"
+  [ "not define"
     "nedefinuje|Není definovaný|Není definované|Není definovaná|Nemáte definovaný"
     "definiert nicht|nicht.*? definiert"
     "no define|no está definido|no está definida"
@@ -27,10 +26,10 @@ let undefinedName =
     "не определяет|не определено|не определены|не определен"
     "tanımlamıyor|tanımlı değil"
     "未.*?定义"
-    "未定義"
-  ] |> List.map (fun i ->
-        let regex = Regex(i, RegexOptions.IgnoreCase ||| RegexOptions.Compiled)
-        fun (j: string) -> regex.IsMatch(j))
+    "未定義" ]
+  |> List.map (fun i ->
+    let regex = Regex(i, RegexOptions.IgnoreCase ||| RegexOptions.Compiled)
+    fun (j: string) -> regex.IsMatch(j))
 
 /// a codefix the provides suggestions for opening modules or using qualified names when an identifier is found that needs qualification
 let fix

--- a/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
+++ b/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
@@ -8,8 +8,29 @@ open FsAutoComplete.LspHelpers
 open FsAutoComplete
 open FSharp.Compiler.Text
 open FSharp.Compiler.EditorServices
+open System.Text.RegularExpressions
 
 type LineText = string
+
+let undefinedName =
+  [
+    "not define"
+    "nedefinuje|Není definovaný|Není definované|Není definovaná|Nemáte definovaný"
+    "definiert nicht|nicht.*? definiert"
+    "no define|no está definido|no está definida"
+    "ne définit|n'est pas défini"
+    "non definisce|non è definito|non è definita"
+    "定義(され|し)ていません"
+    "정의(하지 않|되지 않았|되어 있지 않)습니다"
+    "nie definiuje|Nie zdefiniowano|nie jest zdefiniowany"
+    "não define|não está definido"
+    "не определяет|не определено|не определены|не определен"
+    "tanımlamıyor|tanımlı değil"
+    "未.*?定义"
+    "未定義"
+  ] |> List.map (fun i ->
+        let regex = Regex(i, RegexOptions.IgnoreCase ||| RegexOptions.Compiled)
+        fun (j: string) -> regex.IsMatch(j))
 
 /// a codefix the provides suggestions for opening modules or using qualified names when an identifier is found that needs qualification
 let fix
@@ -112,7 +133,7 @@ let fix
       Title = $"open %s{actualOpen}"
       Kind = FixKind.Fix }
 
-  Run.ifDiagnosticByMessage "is not defined" (fun diagnostic codeActionParameter ->
+  Run.ifDiagnosticByCheckMessage undefinedName (fun diagnostic codeActionParameter ->
     asyncResult {
       let pos = protocolPosToPos diagnostic.Range.Start
 


### PR DESCRIPTION

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26bce28</samp>

This pull request adds support for localized tooltips and code fixes for F# keywords, operators, errors, and warnings. It introduces new helper functions and modules to find and load localized XML files and match diagnostic messages. It modifies existing code fix modules to use the new functions and handle different message formats. It affects the files `TipFormatter.fs`, `ResolveNamespace.fs`, `CodeFixes.fs`, `CodeFixes.fsi`, and `ReplaceWithSuggestion.fs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 26bce28</samp>

> _We're sailing on the F# sea, with code fixes for you and me_
> _We match the messages by check, and handle colors with a regex_
> _Heave away, me hearties, heave away_
> _We'll make the code work in any tongue, with `ifDiagnosticByCheckMessage` and `findLocalizedXmlFile`_

<!--
copilot:emoji
-->

🌐🔧💡

<!--
1.  🌐 - This emoji represents the feature of supporting localized code fixes and tooltips for F# errors and warnings. It is a common symbol for internationalization and localization, and it conveys the idea of making the F# tooling more accessible and user-friendly for different languages and cultures.
2.  🔧 - This emoji represents the code fixes that are implemented or updated to use the new `ifDiagnosticByCheckMessage` function and the localized messages. It is a common symbol for tools and fixing, and it conveys the idea of improving the quality and usability of the F# code fixes.
3.  💡 - This emoji represents the tooltips that are enhanced to use the localized XML files for F# keywords and operators. It is a common symbol for tips and suggestions, and it conveys the idea of providing more helpful and informative tooltips for F# users.
-->

### WHY
1. fix: codefix ReplaceWithSuggestion and ResolveNamespace can now deal with localized compiler texts
2. improves: now can load localized xml documents

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 26bce28</samp>

*  Add support for localized tooltips for F# keywords and operators ([link](https://github.com/fsharp/FsAutoComplete/pull/1181/files?diff=unified&w=0#diff-feb3e5048685e57aced3b12771a9533041ef007bcd34232b317aa6a245308f6aR893-R909), [link](https://github.com/fsharp/FsAutoComplete/pull/1181/files?diff=unified&w=0#diff-feb3e5048685e57aced3b12771a9533041ef007bcd34232b317aa6a245308f6aR923-R924))
* Add support for localized code fixes for F# errors and warnings ([link](https://github.com/fsharp/FsAutoComplete/pull/1181/files?diff=unified&w=0#diff-3783280055135124c81a6a85083c21c691c8401f8b34a64c03b92aa2c0edb671R329-R333), [link](https://github.com/fsharp/FsAutoComplete/pull/1181/files?diff=unified&w=0#diff-3efb1499c1ff92f6842f1c6d3b5b9fb07e5fe3a36c5bf94272fcba40bba360ceR165-R169), [link](https://github.com/fsharp/FsAutoComplete/pull/1181/files?diff=unified&w=0#diff-33c20a6e1d23bdd34c1e58fc1644589a5d9a8780fb4cab3b1374cfa4ac6792a0L11-R32), [link](https://github.com/fsharp/FsAutoComplete/pull/1181/files?diff=unified&w=0#diff-f37825a3859af30ed38586f7eedfcedda8e1a060b9fe397fafff92329754ada9L11-R34), [link](https://github.com/fsharp/FsAutoComplete/pull/1181/files?diff=unified&w=0#diff-f37825a3859af30ed38586f7eedfcedda8e1a060b9fe397fafff92329754ada9L115-R136))
