### PR TITLE
Fixes a race condition with ProgressListener.End

### DIFF
--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fs
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fs
@@ -163,10 +163,10 @@ type ServerProgressReport(lspClient: FSharpLspClient, ?token: ProgressToken) =
     cancellableTask {
       use! __ = fun ct -> locker.LockAsync(ct)
       let stillNeedsToSend = canReportProgress && not endSent
-      endSent <- true
 
       if stillNeedsToSend then
         do! lspClient.Progress(x.Token, WorkDoneProgressEnd.Create(?message = message))
+        endSent <- true
     }
 
   interface IAsyncDisposable with


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46dcebc</samp>

Fix a race condition in progress reporting for the F# language server. Ensure that the `WorkDoneProgressEnd` message is always sent last by moving the `endSent` flag assignment in `FSharpLspClient.fs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 46dcebc</samp>

> _`endSent` too soon_
> _A race condition in spring_
> _Fixed by this change_

<!--
copilot:emoji
-->

🐛🚀🌐

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change.
2.  🚀 - This emoji represents a performance improvement, which is a secondary benefit of this change, as it avoids unnecessary progress updates and network traffic.
3.  🌐 - This emoji represents a language server feature, which is the context of this change, as it affects the communication between the F# language server and the client editor.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 46dcebc</samp>

* Fix a bug where the end message for progress reporting could be sent out of order ([link](https://github.com/fsharp/FsAutoComplete/pull/1183/files?diff=unified&w=0#diff-8ff27bd6886726bcfabce64ed8bac2ba936954fbf00e2c4d3e9c642a663c172aL166-R169))
