### PR TITLE
Fix code action scaffold

### DIFF
--- a/build/ScaffoldCodeFix.fs
+++ b/build/ScaffoldCodeFix.fs
@@ -8,12 +8,12 @@ open Fantomas.Core.SyntaxOak
 
 let repositoryRoot = __SOURCE_DIRECTORY__ </> ".."
 
-let AdaptiveFSharpLspServerPath =
+let AdaptiveServerStatePath =
   repositoryRoot
   </> "src"
   </> "FsAutoComplete"
   </> "LspServers"
-  </> "AdaptiveFSharpLspServer.fs"
+  </> "AdaptiveServerState.fs"
 
 
 let TestsPath =
@@ -248,15 +248,15 @@ let findTypeWithNameOfFail (typeName: string) (mn: ModuleOrNamespaceNode) : ITyp
     | _ -> None)
 
 let findArrayInAdaptiveFSharpLspServer () : ExprArrayOrListNode =
-  let oak = getOakFor AdaptiveFSharpLspServerPath
+  let oak = getOakFor AdaptiveServerStatePath
 
   // namespace FsAutoComplete.Lsp
   let ns =
     oak.ModulesOrNamespaces
     |> List.exactlyOneOrFail "Expected a single namespace in Oak."
 
-  // type AdaptiveFSharpLspServer
-  let t = findTypeWithNameOfFail "AdaptiveFSharpLspServer" ns
+  // type AdaptiveState
+  let t = findTypeWithNameOfFail "AdaptiveState" ns
 
   // let codefixes =
   let codefixesValue =
@@ -299,12 +299,12 @@ let wireCodeFixInAdaptiveFSharpLspServer codeFixName =
   try
     let array = findArrayInAdaptiveFSharpLspServer ()
 
-    appendItemToArrayOrList $"%s{codeFixName}.fix tryGetParseResultsForFile" AdaptiveFSharpLspServerPath array
+    appendItemToArrayOrList $"%s{codeFixName}.fix tryGetParseResultsForFile" AdaptiveServerStatePath array
   with ex ->
     Trace.traceException ex
 
     Trace.traceError
-      $"Unable to find array of codefixes in %s{AdaptiveFSharpLspServerPath}.\nDid the code structure change?"
+      $"Unable to find array of codefixes in %s{AdaptiveServerStatePath}.\nDid the code structure change?"
 
 
 let mkCodeFixTests codeFixName =

--- a/docs/Creating a new code fix.md
+++ b/docs/Creating a new code fix.md
@@ -27,7 +27,7 @@ The above command accomplishes the following tasks:
 
 Furthermore, this command updates the following files to properly register the new code fix:
 
-- `src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs`
+- `src/FsAutoComplete/LspServers/AdaptiveState.fs`
 - `test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs`
 
 The unit test file contains a [single focused test](https://github.com/haf/expecto#focusing-tests), allowing you to promptly verify the functionality. To run this initial test, you have two options:


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba14bf0</samp>

Refactored the code fix scaffolding logic to separate state management from server logic. Updated the documentation to match the new file names.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ba14bf0</samp>

> _`AdaptiveServerState`_
> _Separates state from logic_
> _A clear refactor_

<!--
copilot:emoji
-->

📝🔧🚚

<!--
1.  📝 - This emoji represents the documentation update, since it is often used to indicate writing or editing text.
2.  🔧 - This emoji represents the renaming and refactoring of the type and file, since it is often used to indicate fixing or adjusting something.
3.  🚚 - This emoji represents the separation of state management from server logic, since it is often used to indicate moving or relocating something.
-->

### WHY
Moved codefixes in https://github.com/fsharp/FsAutoComplete/pull/1179

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ba14bf0</samp>

*  Rename `AdaptiveFSharpLspServerPath` to `AdaptiveServerStatePath` and update it to point to `AdaptiveServerState.fs` where the type `AdaptiveState` was moved ([link](https://github.com/fsharp/FsAutoComplete/pull/1188/files?diff=unified&w=0#diff-a2b2718f149af50ea2f213f55c647cd41ec74e8e2a231303e9efaf83946ce1bcL11-R16))
*  Update `findArrayInAdaptiveFSharpLspServer` to use `AdaptiveServerStatePath` and `AdaptiveState` instead of the old values ([link](https://github.com/fsharp/FsAutoComplete/pull/1188/files?diff=unified&w=0#diff-a2b2718f149af50ea2f213f55c647cd41ec74e8e2a231303e9efaf83946ce1bcL251-R251), [link](https://github.com/fsharp/FsAutoComplete/pull/1188/files?diff=unified&w=0#diff-a2b2718f149af50ea2f213f55c647cd41ec74e8e2a231303e9efaf83946ce1bcL258-R259))
*  Update `wireCodeFixInAdaptiveFSharpLspServer` to use `AdaptiveServerStatePath` instead of the old value ([link](https://github.com/fsharp/FsAutoComplete/pull/1188/files?diff=unified&w=0#diff-a2b2718f149af50ea2f213f55c647cd41ec74e8e2a231303e9efaf83946ce1bcL302-R307))
*  Update the documentation in `docs/Creating a new code fix.md` to use `AdaptiveState.fs` instead of the old file name ([link](https://github.com/fsharp/FsAutoComplete/pull/1188/files?diff=unified&w=0#diff-cd19118b56afe53c88463b6c94609f12757bd975264bd8a93b553e8ec2e2c5daL30-R30))
