### PR TITLE
[WIP] Lazy Load Projects

### DIFF
--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -261,6 +261,8 @@ module CommandResponse =
       Parameters: Parameter list list
       Generics: string list }
 
+  type FsprojPeek = { Path: string; CompileItems: string list }
+
   type WorkspacePeekResponse = { Found: WorkspacePeekFound list }
 
   and WorkspacePeekFound =
@@ -269,7 +271,7 @@ module CommandResponse =
 
   and WorkspacePeekFoundDirectory =
     { Directory: string
-      Fsprojs: string list }
+      Fsprojs: FsprojPeek list }
 
   and WorkspacePeekFoundSolution =
     { Path: string
@@ -453,7 +455,7 @@ module CommandResponse =
       | WorkspacePeek.Interesting.Directory(p, fsprojs) ->
         WorkspacePeekFound.Directory
           { WorkspacePeekFoundDirectory.Directory = p
-            Fsprojs = fsprojs }
+            Fsprojs = fsprojs |> List.map (fun f -> { Path = f.Path; CompileItems = f.CompileItems })}
       | WorkspacePeek.Interesting.Solution(p, sd) ->
         let rec item (x: Ionide.ProjInfo.InspectSln.SolutionItem) =
           let kind =

--- a/src/FsAutoComplete/CommandResponse.fsi
+++ b/src/FsAutoComplete/CommandResponse.fsi
@@ -148,6 +148,8 @@ module CommandResponse =
       Parameters: Parameter list list
       Generics: string list }
 
+  type FsprojPeek = { Path: string; CompileItems: string list }
+
   type WorkspacePeekResponse = { Found: WorkspacePeekFound list }
 
   and WorkspacePeekFound =
@@ -156,7 +158,7 @@ module CommandResponse =
 
   and WorkspacePeekFoundDirectory =
     { Directory: string
-      Fsprojs: string list }
+      Fsprojs: FsprojPeek list }
 
   and WorkspacePeekFoundSolution =
     { Path: string

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -295,7 +295,7 @@ module Workspace =
     | Interesting.Directory(p, fsprojs) ->
       WorkspacePeekFound.Directory
         { WorkspacePeekFoundDirectory.Directory = p
-          Fsprojs = fsprojs }
+          Fsprojs = fsprojs |> List.map (fun x -> { Path = x.Path; CompileItems = x.CompileItems}) }
     | Interesting.Solution(p, sd) ->
       let rec item (x: Ionide.ProjInfo.InspectSln.SolutionItem) =
         let kind =
@@ -338,7 +338,7 @@ module Workspace =
         | Folder folder -> folder.Items |> List.collect getProjs
 
       sln.Items |> List.collect getProjs
-    | WorkspacePeekFound.Directory dir -> dir.Fsprojs
+    | WorkspacePeekFound.Directory dir -> dir.Fsprojs |> List.map (fun x -> x.Path)
 
   let rec foldFsproj (item: WorkspacePeekFoundSolutionItem) =
     match item.Kind with

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -333,7 +333,7 @@ type AdaptiveFSharpLspServer
 
               match peeks with
               | [] -> []
-              | [ CommandResponse.WorkspacePeekFound.Directory projs ] -> projs.Fsprojs
+              | [ CommandResponse.WorkspacePeekFound.Directory projs ] -> projs.Fsprojs |> List.map (fun p -> p.Path)
               | CommandResponse.WorkspacePeekFound.Solution sln :: _ ->
                 sln.Items |> List.collect Workspace.foldFsproj |> List.map fst
               | _ -> []


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aeb6c8c</samp>

This pull request enhances the `workspacePeek` command and its response types to provide more information about F# projects in the workspace. It also improves the integration of the `Ionide.ProjInfo.WorkspacePeek` library with the `Workspace` module and the `AdaptiveFSharpLspServer` type.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aeb6c8c</samp>

> _To peek at the projects in F#_
> _We use `FsprojPeek` to fetch_
> _The compile items and paths_
> _From the `workspacePeek` graphs_
> _And handle them in `AdaptiveFSharpLspServer`'s catch_

<!--
copilot:emoji
-->

📂🛠️🧹

<!--
1.  📂 - This emoji represents the extraction of the `Path` field from the `FsprojPeek` type, as it indicates working with files and folders.
2.  🛠️ - This emoji represents the enhancement of the `workspacePeek` command to return project files with their compile items, as it indicates improving the functionality and usefulness of the command.
3.  🧹 - This emoji represents the introduction of the `FsprojPeek` type and the improvement of the `Workspace` module integration, as it indicates cleaning up and refactoring the code.
-->

### WHY
This is WIP of trying to lazy load projects. See: https://github.com/ionide/ionide-vscode-fsharp/pull/1957

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aeb6c8c</samp>

*  Add a new record type `FsprojPeek` to represent a project file with its path and compile items ([link](https://github.com/fsharp/FsAutoComplete/pull/1191/files?diff=unified&w=0#diff-f94dd4967b2b6d03ae945d3563f727b8e866040e70313aafed4470ed178fe1b9R264-R265), [link](https://github.com/fsharp/FsAutoComplete/pull/1191/files?diff=unified&w=0#diff-fc47104e7a64114883092d942482fb5b1d93a8f21e62e127dfd9f40350f7eed4R151-R152))
*  Use the `FsprojPeek` type instead of a string list for the `Fsprojs` field of the `WorkspacePeekFoundDirectory` type, which represents a directory with F# projects ([link](https://github.com/fsharp/FsAutoComplete/pull/1191/files?diff=unified&w=0#diff-f94dd4967b2b6d03ae945d3563f727b8e866040e70313aafed4470ed178fe1b9L272-R274), [link](https://github.com/fsharp/FsAutoComplete/pull/1191/files?diff=unified&w=0#diff-fc47104e7a64114883092d942482fb5b1d93a8f21e62e127dfd9f40350f7eed4L159-R161))
*  Map the `fsprojs` list returned by the `Ionide.ProjInfo.WorkspacePeek` function to the `FsprojPeek` type using the `Path` and `CompileItems` fields in the `CommandResponse` and `LspHelpers` modules, which handle the `workspacePeek` command and request ([link](https://github.com/fsharp/FsAutoComplete/pull/1191/files?diff=unified&w=0#diff-f94dd4967b2b6d03ae945d3563f727b8e866040e70313aafed4470ed178fe1b9L456-R458), [link](https://github.com/fsharp/FsAutoComplete/pull/1191/files?diff=unified&w=0#diff-a0cc27b1398830cb3ce332015ecbd44c9649503474a0bfe34a6330dc04e99c55L298-R298))
*  Extract the `Path` field from the `FsprojPeek` type when returning or matching on the list of projects from a `WorkspacePeekFoundDirectory` value in the `LspHelpers` and `AdaptiveFSharpLspServer` modules, which use the `workspacePeek` command and request to get the list of project paths from the current workspace ([link](https://github.com/fsharp/FsAutoComplete/pull/1191/files?diff=unified&w=0#diff-a0cc27b1398830cb3ce332015ecbd44c9649503474a0bfe34a6330dc04e99c55L341-R341), [link](https://github.com/fsharp/FsAutoComplete/pull/1191/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L336-R336))
