### PR TITLE
Do ordinal string comparisons

### DIFF
--- a/src/FsAutoComplete.Core/CodeGeneration.fs
+++ b/src/FsAutoComplete.Core/CodeGeneration.fs
@@ -302,8 +302,10 @@ module CodeGenerationUtils =
     let displayName = v.DisplayName
 
     if
-      (v.IsPropertyGetterMethod && displayName.StartsWith("get_"))
-      || (v.IsPropertySetterMethod && displayName.StartsWith("set_"))
+      (v.IsPropertyGetterMethod
+       && displayName.StartsWith("get_", StringComparison.Ordinal))
+      || (v.IsPropertySetterMethod
+          && displayName.StartsWith("set_", StringComparison.Ordinal))
     then
       displayName.[4..]
     else
@@ -328,7 +330,7 @@ module CodeGenerationUtils =
 
       (if String.IsNullOrWhiteSpace(args) then
          ""
-       elif args.StartsWith("(") then
+       elif args.StartsWith("(", StringComparison.Ordinal) then
          args
        elif v.CurriedParameterGroups.Count > 1 && (not verboseMode) then
          " " + args
@@ -345,7 +347,10 @@ module CodeGenerationUtils =
         | _, _, ".ctor", _ -> "new" + parArgs
         // Properties (skipping arguments)
         | _, true, _, name when v.IsPropertyGetterMethod || v.IsPropertySetterMethod ->
-          if name.StartsWith("get_") || name.StartsWith("set_") then
+          if
+            name.StartsWith("get_", StringComparison.Ordinal)
+            || name.StartsWith("set_", StringComparison.Ordinal)
+          then
             name.[4..]
           else
             name
@@ -576,14 +581,14 @@ module CodeGenerationUtils =
     | SynBinding(valData = SynValData(Some mf, _, _); headPat = LongIdentPattern(name, range); trivia = trivia) when
       mf.MemberKind = SynMemberKind.PropertyGet
       ->
-      if name.StartsWith("get_") then
+      if name.StartsWith("get_", StringComparison.Ordinal) then
         Some(name, range, trivia.LeadingKeyword.Range)
       else
         Some("get_" + name, range, trivia.LeadingKeyword.Range)
     | SynBinding(valData = SynValData(Some mf, _, _); headPat = LongIdentPattern(name, range); trivia = trivia) when
       mf.MemberKind = SynMemberKind.PropertySet
       ->
-      if name.StartsWith("set_") then
+      if name.StartsWith("set_", StringComparison.Ordinal) then
         Some(name, range, trivia.LeadingKeyword.Range)
       else
         Some("set_" + name, range, trivia.LeadingKeyword.Range)
@@ -594,9 +599,12 @@ module CodeGenerationUtils =
   let normalizeEventName (m: FSharpMemberOrFunctionOrValue) =
     let name = m.DisplayName
 
-    if name.StartsWith("add_") then name.[4..]
-    elif name.StartsWith("remove_") then name.[7..]
-    else name
+    if name.StartsWith("add_", StringComparison.Ordinal) then
+      name.[4..]
+    elif name.StartsWith("remove_", StringComparison.Ordinal) then
+      name.[7..]
+    else
+      name
 
   /// Ideally this info should be returned in error symbols from FCS.
   /// Because it isn't, we implement a crude way of getting member signatures:

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -309,7 +309,7 @@ module Commands =
 
                     if
                       (e.Kind LookupType.Fuzzy) = EntityKind.Attribute
-                      && lastIdent.EndsWith "Attribute"
+                      && lastIdent.EndsWith("Attribute", StringComparison.Ordinal)
                     then
                       yield
                         e.TopRequireQualifiedAccessParent,
@@ -706,7 +706,7 @@ module Commands =
             |> Seq.tryFind (fun l ->
               let lineStr = getLine l
               // namespace MUST be top level -> no indentation
-              lineStr.StartsWith "namespace ")
+              lineStr.StartsWith("namespace ", StringComparison.Ordinal))
             |> function
               // move to the next line below "namespace"
               | Some l -> l.IncLine()
@@ -1000,7 +1000,10 @@ module Commands =
         // -> only check if no backticks
         let newBacktickedName = newName |> PrettyNaming.NormalizeIdentifierBackticks
 
-        if newBacktickedName.StartsWith "``" && newBacktickedName.EndsWith "``" then
+        if
+          newBacktickedName.StartsWith("``", StringComparison.Ordinal)
+          && newBacktickedName.EndsWith("``", StringComparison.Ordinal)
+        then
           return newBacktickedName
         elif PrettyNaming.IsIdentifierName newName then
           return newName

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -68,14 +68,14 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize, parallelRefe
       let toReplace, otherOpts =
         p.OtherOptions
         |> Array.partition (fun opt ->
-          opt.EndsWith "FSharp.Core.dll"
-          || opt.EndsWith "FSharp.Compiler.Interactive.Settings.dll")
+          opt.EndsWith("FSharp.Core.dll", StringComparison.Ordinal)
+          || opt.EndsWith("FSharp.Compiler.Interactive.Settings.dll", StringComparison.Ordinal))
 
       { p with
           OtherOptions = Array.append otherOpts [| $"-r:%s{fsc.FullName}"; $"-r:%s{fsi.FullName}" |] }
 
   let (|StartsWith|_|) (prefix: string) (s: string) =
-    if s.StartsWith(prefix) then
+    if s.StartsWith(prefix, StringComparison.Ordinal) then
       Some(s.[prefix.Length ..])
     else
       None
@@ -102,7 +102,7 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize, parallelRefe
         "mscorlib" ]
       |> List.map (fun p -> p + ".dll")
 
-    let containsBadRef (s: string) = badRefs |> List.exists (fun r -> s.EndsWith r)
+    let containsBadRef (s: string) = badRefs |> List.exists (fun r -> s.EndsWith(r, StringComparison.Ordinal))
 
     fun (projOptions: FSharpProjectOptions) ->
       { projOptions with
@@ -120,7 +120,11 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize, parallelRefe
     { projectOptions with
         SourceFiles = files }
 
-  let (|Reference|_|) (opt: string) = if opt.StartsWith "-r:" then Some(opt.[3..]) else None
+  let (|Reference|_|) (opt: string) =
+    if opt.StartsWith("-r:", StringComparison.Ordinal) then
+      Some(opt.[3..])
+    else
+      None
 
   /// ensures that all file paths are absolute before being sent to the compiler, because compilation of scripts fails with relative paths
   let resolveRelativeFilePaths (projectOptions: FSharpProjectOptions) =

--- a/src/FsAutoComplete.Core/DocumentationFormatter.fs
+++ b/src/FsAutoComplete.Core/DocumentationFormatter.fs
@@ -104,7 +104,7 @@ module DocumentationFormatter =
       let t = Regex.Replace(org, """<.*>""", "<")
 
       [ yield formatShowDocumentationLink t xmlDocSig assemblyName
-        if t.EndsWith "<" then
+        if t.EndsWith("<", StringComparison.Ordinal) then
           yield! renderedGenericArgumentTypes |> Seq.intersperse (", ", 2)
 
           yield formatShowDocumentationLink ">" xmlDocSig assemblyName ]
@@ -217,7 +217,7 @@ module DocumentationFormatter =
       let typeList =
         unionCase.Fields
         |> Seq.map (fun unionField ->
-          if unionField.Name.StartsWith "Item" then //TODO: Some better way of detecting default names for the union cases' fields
+          if unionField.Name.StartsWith("Item", StringComparison.Ordinal) then //TODO: Some better way of detecting default names for the union cases' fields
             unionField.FieldType |> format displayContext |> fst
 
           else
@@ -231,7 +231,7 @@ module DocumentationFormatter =
       unionCase.DisplayName
 
   let getFuncSignatureWithIdent displayContext (func: FSharpMemberOrFunctionOrValue) (ident: int) =
-    let maybeGetter = func.LogicalName.StartsWith "get_"
+    let maybeGetter = func.LogicalName.StartsWith("get_", StringComparison.Ordinal)
     let indent = String.replicate ident " "
 
     let functionName =
@@ -243,7 +243,7 @@ module DocumentationFormatter =
           |> FSharpKeywords.NormalizeIdentifierBackticks
         elif func.IsOperatorOrActivePattern then
           func.DisplayName
-        elif func.DisplayName.StartsWith "( " then
+        elif func.DisplayName.StartsWith("( ", StringComparison.Ordinal) then
           FSharpKeywords.NormalizeIdentifierBackticks func.LogicalName
         else
           FSharpKeywords.NormalizeIdentifierBackticks func.DisplayName
@@ -416,9 +416,12 @@ module DocumentationFormatter =
           "new"
         elif func.IsOperatorOrActivePattern then
           func.DisplayName
-        elif func.DisplayName.StartsWith "( " then
+        elif func.DisplayName.StartsWith("( ", StringComparison.Ordinal) then
           FSharpKeywords.NormalizeIdentifierBackticks func.LogicalName
-        elif func.LogicalName.StartsWith "get_" || func.LogicalName.StartsWith "set_" then
+        elif
+          func.LogicalName.StartsWith("get_", StringComparison.Ordinal)
+          || func.LogicalName.StartsWith("set_", StringComparison.Ordinal)
+        then
           PrettyNaming.TryChopPropertyName func.DisplayName
           |> Option.defaultValue func.DisplayName
         else
@@ -536,7 +539,7 @@ module DocumentationFormatter =
     let prefix = if v.IsMutable then "val mutable" else "val"
 
     let name =
-      (if v.DisplayName.StartsWith "( " then
+      (if v.DisplayName.StartsWith("( ", StringComparison.Ordinal) then
          v.LogicalName
        else
          v.DisplayName)
@@ -782,7 +785,10 @@ module DocumentationFormatter =
 
     /// trims the leading 'Microsoft.' from the full name of the symbol
     member m.SafeFullName =
-      if m.FullName.StartsWith "Microsoft." && m.Assembly.SimpleName = "FSharp.Core" then
+      if
+        m.FullName.StartsWith("Microsoft.", StringComparison.Ordinal)
+        && m.Assembly.SimpleName = "FSharp.Core"
+      then
         m.FullName.Substring "Microsoft.".Length
       else
         m.FullName

--- a/src/FsAutoComplete.Core/DotnetNewTemplate.fs
+++ b/src/FsAutoComplete.Core/DotnetNewTemplate.fs
@@ -61,12 +61,12 @@ module DotnetNewTemplate =
     let parseTemplateOutput (x: string) =
       let xs =
         x.Split(Environment.NewLine)
-        |> Array.skipWhile (fun n -> not (n.StartsWith "Template"))
+        |> Array.skipWhile (fun n -> not (n.StartsWith("Template", StringComparison.Ordinal)))
         |> Array.filter (fun n -> not (n.StartsWith ' ' || String.IsNullOrWhiteSpace n))
 
       let header = xs.[0]
       let body = xs.[2..]
-      let nameLength = header.IndexOf("Short")
+      let nameLength = header.IndexOf("Short", StringComparison.Ordinal)
 
       let body =
         body

--- a/src/FsAutoComplete.Core/FCSPatches.fs
+++ b/src/FsAutoComplete.Core/FCSPatches.fs
@@ -657,7 +657,7 @@ module LanguageVersionShim =
   /// <returns>A LanguageVersionShim from the parsed "--langversion:" or defaultLanguageVersion </returns>
   let fromFSharpProjectOptions (fpo: FSharpProjectOptions) =
     fpo.OtherOptions
-    |> Array.tryFind (fun x -> x.StartsWith("--langversion:"))
+    |> Array.tryFind (fun x -> x.StartsWith("--langversion:", StringComparison.Ordinal))
     |> Option.map (fun x -> x.Split(":")[1])
     |> Option.map (fun x -> LanguageVersionShim(x))
     |> Option.defaultWith (fun () -> defaultLanguageVersion.Value)

--- a/src/FsAutoComplete.Core/FileSystem.fs
+++ b/src/FsAutoComplete.Core/FileSystem.fs
@@ -589,7 +589,7 @@ module Tokenizer =
     ) : Range voption =
     match text[range] with
     | Error _ -> ValueNone
-    | Ok rangeText when rangeText.EndsWith "``" ->
+    | Ok rangeText when rangeText.EndsWith("``", StringComparison.Ordinal) ->
       // find matching opening backticks
 
       // backticks cannot contain linebreaks -- even for Active Pattern:

--- a/src/FsAutoComplete.Core/InlayHints.fs
+++ b/src/FsAutoComplete.Core/InlayHints.fs
@@ -148,7 +148,11 @@ module private ShouldCreate =
 
 
   [<return: Struct>]
-  let private (|StartsWith|_|) (v: string) (fullName: string) = if fullName.StartsWith v then ValueSome() else ValueNone
+  let private (|StartsWith|_|) (v: string) (fullName: string) =
+    if fullName.StartsWith(v, StringComparison.Ordinal) then
+      ValueSome()
+    else
+      ValueNone
   // doesn't differentiate between modules, types, namespaces
   // -> is just for documentation in code
   [<return: Struct>]
@@ -206,7 +210,8 @@ module private ShouldCreate =
 
   let inline private isMeaningfulName (p: FSharpParameter) = p.DisplayName.Length > 2
 
-  let inline private isOperator (func: FSharpMemberOrFunctionOrValue) = func.CompiledName.StartsWith "op_"
+  let inline private isOperator (func: FSharpMemberOrFunctionOrValue) =
+    func.CompiledName.StartsWith("op_", StringComparison.Ordinal)
 
   /// Doesn't consider lower/upper cases:
   /// * `areSame "foo" "FOO" = true`
@@ -303,7 +308,7 @@ module private ShouldCreate =
 
   let inline private doesNotMatchArgumentText (parameterName: string) (userArgumentText: string) =
     parameterName <> userArgumentText
-    && not (userArgumentText.StartsWith parameterName)
+    && not (userArgumentText.StartsWith(parameterName, StringComparison.Ordinal))
 
   let private isParamNamePostfixOfFuncName (func: FSharpMemberOrFunctionOrValue) (paramName: string) =
     let funcName = func.DisplayName.AsSpan()
@@ -374,7 +379,7 @@ type MissingExplicitType with
       if x.SpecialRules |> List.contains RemoveOptionFromType then
         // Optional parameter:
         // `static member F(?a) =` -> `: int`, NOT `: int option`
-        if typeName.EndsWith " option" then
+        if typeName.EndsWith(" option", StringComparison.Ordinal) then
           typeName.Substring(0, typeName.Length - " option".Length)
         else
           typeName

--- a/src/FsAutoComplete.Core/Lexer.fs
+++ b/src/FsAutoComplete.Core/Lexer.fs
@@ -1,5 +1,6 @@
 namespace FsAutoComplete
 
+open System
 open FSharp.Compiler.Tokenization
 open FsAutoComplete.Logging
 open FsAutoComplete.Logging.Types
@@ -43,14 +44,14 @@ module Lexer =
 
   [<return: Struct>]
   let (|Define|_|) (a: string) =
-    if a.StartsWith "--define:" then
+    if a.StartsWith("--define:", StringComparison.Ordinal) then
       ValueSome(a.[9..])
     else
       ValueNone
 
   [<return: Struct>]
   let (|LangVersion|_|) (a: string) =
-    if a.StartsWith "--langversion:" then
+    if a.StartsWith("--langversion:", StringComparison.Ordinal) then
       ValueSome(a.[14..])
     else
       ValueNone

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -163,7 +163,9 @@ type ParseAndCheckResults
             | FindDeclFailureReason.Unknown r -> r
 
           return ResultOrString.Error(sprintf "Could not find declaration. %s" elaboration)
-        | FindDeclResult.DeclFound range when range.FileName.EndsWith(Range.rangeStartup.FileName) ->
+        | FindDeclResult.DeclFound range when
+          range.FileName.EndsWith(Range.rangeStartup.FileName, StringComparison.Ordinal)
+          ->
           return ResultOrString.Error "Could not find declaration"
         | FindDeclResult.DeclFound range when range.FileName = UMX.untag x.FileName ->
           // decl in same file

--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -167,7 +167,7 @@ module SignatureFormatter =
       let typeList =
         unionCase.Fields
         |> Seq.map (fun unionField ->
-          if unionField.Name.StartsWith "Item" then //TODO: Some better way of detecting default names for the union cases' fields
+          if unionField.Name.StartsWith("Item", StringComparison.Ordinal) then //TODO: Some better way of detecting default names for the union cases' fields
             formatFSharpType displayContext unionField.FieldType
           else
             unionField.Name + ":" ++ (formatFSharpType displayContext unionField.FieldType))
@@ -178,7 +178,7 @@ module SignatureFormatter =
       unionCase.DisplayName
 
   let getFuncSignatureWithIdent displayContext (func: FSharpMemberOrFunctionOrValue) (ident: int) =
-    let maybeGetter = func.LogicalName.StartsWith "get_"
+    let maybeGetter = func.LogicalName.StartsWith("get_", StringComparison.Ordinal)
     let indent = String.replicate ident " "
 
     let functionName =
@@ -190,7 +190,7 @@ module SignatureFormatter =
           |> FSharpKeywords.NormalizeIdentifierBackticks
         elif func.IsOperatorOrActivePattern then
           $"( {func.DisplayNameCore} )"
-        elif func.DisplayName.StartsWith "( " then
+        elif func.DisplayName.StartsWith("( ", StringComparison.Ordinal) then
           FSharpKeywords.NormalizeIdentifierBackticks func.LogicalName
         else
           FSharpKeywords.NormalizeIdentifierBackticks func.DisplayName
@@ -377,9 +377,12 @@ module SignatureFormatter =
           "new"
         elif func.IsOperatorOrActivePattern then
           func.DisplayName
-        elif func.DisplayName.StartsWith "( " then
+        elif func.DisplayName.StartsWith("( ", StringComparison.Ordinal) then
           FSharpKeywords.NormalizeIdentifierBackticks func.LogicalName
-        elif func.LogicalName.StartsWith "get_" || func.LogicalName.StartsWith "set_" then
+        elif
+          func.LogicalName.StartsWith("get_", StringComparison.Ordinal)
+          || func.LogicalName.StartsWith("set_", StringComparison.Ordinal)
+        then
           PrettyNaming.TryChopPropertyName func.DisplayName
           |> Option.defaultValue func.DisplayName
         else
@@ -515,7 +518,7 @@ module SignatureFormatter =
     let prefix = if v.IsMutable then "val mutable" else "val"
 
     let name =
-      (if v.DisplayName.StartsWith "( " then
+      (if v.DisplayName.StartsWith("( ", StringComparison.Ordinal) then
          v.LogicalName
        else
          v.DisplayName)

--- a/src/FsAutoComplete.Core/SignatureHelp.fs
+++ b/src/FsAutoComplete.Core/SignatureHelp.fs
@@ -141,7 +141,11 @@ let private getSignatureHelpForMethod
 
     let methods = methodGroup.Methods
 
-    do! Option.guard (methods.Length > 0 && not (methodGroup.MethodName.EndsWith("> )")))
+    do!
+      Option.guard (
+        methods.Length > 0
+        && not (methodGroup.MethodName.EndsWith("> )", StringComparison.Ordinal))
+      )
 
     let isStaticArgTip = lines.TryGetChar paramLocations.OpenParenLocation = Some '<'
 

--- a/src/FsAutoComplete.Core/State.fs
+++ b/src/FsAutoComplete.Core/State.fs
@@ -71,7 +71,9 @@ module ProjInfoExtensions =
   type FSharpProjectOptions with
 
     member x.OutputDll =
-      x.OtherOptions |> Array.find (fun o -> o.StartsWith("-o:")) |> (fun s -> s[3..])
+      x.OtherOptions
+      |> Array.find (fun o -> o.StartsWith("-o:", StringComparison.Ordinal))
+      |> (fun s -> s[3..])
 
     member x.SourceFilesThatThisFileDependsOn(file: string<LocalPath>) =
       let untagged = UMX.untag file

--- a/src/FsAutoComplete.Core/TestAdapter.fs
+++ b/src/FsAutoComplete.Core/TestAdapter.fs
@@ -1,6 +1,6 @@
 module FsAutoComplete.TestAdapter
 
-
+open System
 open FSharp.Compiler.Text
 open FSharp.Compiler.Syntax
 
@@ -44,46 +44,50 @@ let getExpectoTests (ast: ParsedInput) : TestAdapterEntry<range> list =
   let mutable ident = 0
 
   let isExpectoName (str: string) =
-    str.EndsWith "testCase"
-    || str.EndsWith "ftestCase"
-    || str.EndsWith "ptestCase"
-    || str.EndsWith "testCaseAsync"
-    || str.EndsWith "ftestCaseAsync"
-    || str.EndsWith "ptestCaseAsync"
-    || str.EndsWith "testCaseTask"
-    || str.EndsWith "ftestCaseTask"
-    || str.EndsWith "ptestCaseTask"
-    || (str.EndsWith "test"
-        && not (str.EndsWith "failtest")
-        && not (str.EndsWith "skiptest"))
-    || str.EndsWith "ftest"
-    || (str.EndsWith "ptest" && not (str.EndsWith "skiptest"))
-    || str.EndsWith "testAsync"
-    || str.EndsWith "ftestAsync"
-    || str.EndsWith "ptestAsync"
-    || str.EndsWith "testTask"
-    || str.EndsWith "ftestTask"
-    || str.EndsWith "ptestTask"
-    || str.EndsWith "testProperty"
-    || str.EndsWith "ptestProperty"
-    || str.EndsWith "ftestProperty"
-    || str.EndsWith "testPropertyWithConfig"
-    || str.EndsWith "ptestPropertyWithConfig"
-    || str.EndsWith "ftestPropertyWithConfig"
-    || str.EndsWith "testPropertyWithConfigs"
-    || str.EndsWith "ptestPropertyWithConfigs"
-    || str.EndsWith "ftestPropertyWithConfigs"
-    || str.EndsWith "testTheory"
-    || str.EndsWith "ftestTheory"
-    || str.EndsWith "ptestTheory"
-    || str.EndsWith "testTheoryAsync"
-    || str.EndsWith "ftestTheoryAsync"
-    || str.EndsWith "ptestTheoryAsync"
-    || str.EndsWith "testTheoryTask"
-    || str.EndsWith "ftestTheoryTask"
-    || str.EndsWith "ptestTheoryTask"
+    str.EndsWith("testCase", StringComparison.Ordinal)
+    || str.EndsWith("ftestCase", StringComparison.Ordinal)
+    || str.EndsWith("ptestCase", StringComparison.Ordinal)
+    || str.EndsWith("testCaseAsync", StringComparison.Ordinal)
+    || str.EndsWith("ftestCaseAsync", StringComparison.Ordinal)
+    || str.EndsWith("ptestCaseAsync", StringComparison.Ordinal)
+    || str.EndsWith("testCaseTask", StringComparison.Ordinal)
+    || str.EndsWith("ftestCaseTask", StringComparison.Ordinal)
+    || str.EndsWith("ptestCaseTask", StringComparison.Ordinal)
+    || (str.EndsWith("test", StringComparison.Ordinal)
+        && not (str.EndsWith("failtest", StringComparison.Ordinal))
+        && not (str.EndsWith("skiptest", StringComparison.Ordinal)))
+    || str.EndsWith("ftest", StringComparison.Ordinal)
+    || (str.EndsWith("ptest", StringComparison.Ordinal)
+        && not (str.EndsWith("skiptest", StringComparison.Ordinal)))
+    || str.EndsWith("testAsync", StringComparison.Ordinal)
+    || str.EndsWith("ftestAsync", StringComparison.Ordinal)
+    || str.EndsWith("ptestAsync", StringComparison.Ordinal)
+    || str.EndsWith("testTask", StringComparison.Ordinal)
+    || str.EndsWith("ftestTask", StringComparison.Ordinal)
+    || str.EndsWith("ptestTask", StringComparison.Ordinal)
+    || str.EndsWith("testProperty", StringComparison.Ordinal)
+    || str.EndsWith("ptestProperty", StringComparison.Ordinal)
+    || str.EndsWith("ftestProperty", StringComparison.Ordinal)
+    || str.EndsWith("testPropertyWithConfig", StringComparison.Ordinal)
+    || str.EndsWith("ptestPropertyWithConfig", StringComparison.Ordinal)
+    || str.EndsWith("ftestPropertyWithConfig", StringComparison.Ordinal)
+    || str.EndsWith("testPropertyWithConfigs", StringComparison.Ordinal)
+    || str.EndsWith("ptestPropertyWithConfigs", StringComparison.Ordinal)
+    || str.EndsWith("ftestPropertyWithConfigs", StringComparison.Ordinal)
+    || str.EndsWith("testTheory", StringComparison.Ordinal)
+    || str.EndsWith("ftestTheory", StringComparison.Ordinal)
+    || str.EndsWith("ptestTheory", StringComparison.Ordinal)
+    || str.EndsWith("testTheoryAsync", StringComparison.Ordinal)
+    || str.EndsWith("ftestTheoryAsync", StringComparison.Ordinal)
+    || str.EndsWith("ptestTheoryAsync", StringComparison.Ordinal)
+    || str.EndsWith("testTheoryTask", StringComparison.Ordinal)
+    || str.EndsWith("ftestTheoryTask", StringComparison.Ordinal)
+    || str.EndsWith("ptestTheoryTask", StringComparison.Ordinal)
 
-  let isExpectoListName (str: string) = str.EndsWith "testList" || str.EndsWith "ftestList" || str.EndsWith "ptestList"
+  let isExpectoListName (str: string) =
+    str.EndsWith("testList", StringComparison.Ordinal)
+    || str.EndsWith("ftestList", StringComparison.Ordinal)
+    || str.EndsWith("ptestList", StringComparison.Ordinal)
 
   let (|Case|List|NotExpecto|) =
     function
@@ -266,16 +270,16 @@ let getNUnitTest (ast: ParsedInput) : TestAdapterEntry<range> list =
     |> List.exists (fun a ->
       let str = a.TypeName.LongIdent |> List.last
 
-      str.idText.EndsWith "Test"
-      || str.idText.EndsWith "TestAttribute"
-      || str.idText.EndsWith "TestCase"
-      || str.idText.EndsWith "TestCaseAttribute"
-      || str.idText.EndsWith "TestCaseSource"
-      || str.idText.EndsWith "TestCaseSourceAttribute"
-      || str.idText.EndsWith "Theory"
-      || str.idText.EndsWith "TheoryAttribute"
-      || str.idText.EndsWith "Property"
-      || str.idText.EndsWith "PropertyAttribute")
+      str.idText.EndsWith("Test", StringComparison.Ordinal)
+      || str.idText.EndsWith("TestAttribute", StringComparison.Ordinal)
+      || str.idText.EndsWith("TestCase", StringComparison.Ordinal)
+      || str.idText.EndsWith("TestCaseAttribute", StringComparison.Ordinal)
+      || str.idText.EndsWith("TestCaseSource", StringComparison.Ordinal)
+      || str.idText.EndsWith("TestCaseSourceAttribute", StringComparison.Ordinal)
+      || str.idText.EndsWith("Theory", StringComparison.Ordinal)
+      || str.idText.EndsWith("TheoryAttribute", StringComparison.Ordinal)
+      || str.idText.EndsWith("Property", StringComparison.Ordinal)
+      || str.idText.EndsWith("PropertyAttribute", StringComparison.Ordinal))
 
   let getName =
     function
@@ -444,12 +448,12 @@ let getXUnitTest ast : TestAdapterEntry<range> list =
     |> List.exists (fun a ->
       let str = a.TypeName.LongIdent |> List.last
 
-      str.idText.EndsWith "Fact"
-      || str.idText.EndsWith "FactAttribute"
-      || str.idText.EndsWith "Theory"
-      || str.idText.EndsWith "TheoryAttribute"
-      || str.idText.EndsWith "Property"
-      || str.idText.EndsWith "PropertyAttribute")
+      str.idText.EndsWith("Fact", StringComparison.Ordinal)
+      || str.idText.EndsWith("FactAttribute", StringComparison.Ordinal)
+      || str.idText.EndsWith("Theory", StringComparison.Ordinal)
+      || str.idText.EndsWith("TheoryAttribute", StringComparison.Ordinal)
+      || str.idText.EndsWith("Property", StringComparison.Ordinal)
+      || str.idText.EndsWith("PropertyAttribute", StringComparison.Ordinal))
 
   let getName =
     function

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -177,7 +177,9 @@ module private Format =
           // so render the markdown code block the best way
           // by avoid empty lines at the beginning or the end
           let formattedText =
-            match innerText.StartsWith("\n"), innerText.EndsWith("\n") with
+            match
+              innerText.StartsWith("\n", StringComparison.Ordinal), innerText.EndsWith("\n", StringComparison.Ordinal)
+            with
             | true, true -> sprintf "```%s%s```" lang innerText
             | true, false -> sprintf "```%s%s\n```" lang innerText
             | false, true -> sprintf "```%s\n%s```" lang innerText
@@ -733,7 +735,10 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
 
       content.Split('\n')
       |> Array.map (fun line ->
-        if not (String.IsNullOrWhiteSpace line) && line.StartsWith(tabsOffset) then
+        if
+          not (String.IsNullOrWhiteSpace line)
+          && line.StartsWith(tabsOffset, StringComparison.Ordinal)
+        then
           line.Substring(columnOffset + indentationSize)
         else
           line)
@@ -973,7 +978,7 @@ let private tryGetXmlDocMember (xmlDoc: FSharpXmlDoc) =
       let rec findIndentationSize (lines: string list) =
         match lines with
         | head :: tail ->
-          let lesserThanIndex = head.IndexOf("<")
+          let lesserThanIndex = head.IndexOf("<", StringComparison.Ordinal)
 
           if lesserThanIndex <> -1 then
             lesserThanIndex

--- a/src/FsAutoComplete.Core/TypedAstUtils.fs
+++ b/src/FsAutoComplete.Core/TypedAstUtils.fs
@@ -57,8 +57,8 @@ module TypedAstUtils =
     |> Option.isSome
 
   let isOperator (name: string) =
-    name.StartsWith "( "
-    && name.EndsWith " )"
+    name.StartsWith("( ", StringComparison.Ordinal)
+    && name.EndsWith(" )", StringComparison.Ordinal)
     && name.Length > 4
     && name.Substring(2, name.Length - 4)
        |> String.forall (fun c -> c <> ' ' && not (Char.IsLetter c))
@@ -190,10 +190,14 @@ module TypedAstExtensionHelpers =
     member x.IsConstructor = x.CompiledName = ".ctor"
 
     member x.IsOperatorOrActivePattern =
-      x.CompiledName.StartsWith "op_"
+      x.CompiledName.StartsWith("op_", StringComparison.Ordinal)
       || let name = x.DisplayName in
 
-         if name.StartsWith "( " && name.EndsWith " )" && name.Length > 4 then
+         if
+           name.StartsWith("( ", StringComparison.Ordinal)
+           && name.EndsWith(" )", StringComparison.Ordinal)
+           && name.Length > 4
+         then
            name.Substring(2, name.Length - 4) |> String.forall (fun c -> c <> ' ')
          else
            false

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -445,9 +445,12 @@ module String =
 
 
   let (|StartsWith|_|) (pattern: string) (value: string) =
-    if String.IsNullOrWhiteSpace value then None
-    elif value.StartsWith pattern then Some()
-    else None
+    if String.IsNullOrWhiteSpace value then
+      None
+    elif value.StartsWith(pattern, StringComparison.Ordinal) then
+      Some()
+    else
+      None
 
   let split (splitter: char) (s: string) =
     s.Split([| splitter |], StringSplitOptions.RemoveEmptyEntries) |> List.ofArray
@@ -461,7 +464,7 @@ module String =
          yield line.Value
          line.Value <- reader.ReadLine()
 
-       if str.EndsWith("\n") then
+       if str.EndsWith("\n", StringComparison.Ordinal) then
          // last trailing space not returned
          // http://stackoverflow.com/questions/19365404/stringreader-omits-trailing-linebreak
          yield String.Empty |]
@@ -638,7 +641,7 @@ let inline fail msg = Printf.kprintf Debug.Fail msg
 
 
 let chooseByPrefix (prefix: string) (s: string) =
-  if s.StartsWith(prefix) then
+  if s.StartsWith(prefix, StringComparison.Ordinal) then
     Some(s.Substring(prefix.Length))
   else
     None
@@ -646,7 +649,7 @@ let chooseByPrefix (prefix: string) (s: string) =
 let chooseByPrefix2 prefixes (s: string) = prefixes |> List.tryPick (fun prefix -> chooseByPrefix prefix s)
 
 let splitByPrefix (prefix: string) (s: string) =
-  if s.StartsWith(prefix) then
+  if s.StartsWith(prefix, StringComparison.Ordinal) then
     Some(prefix, s.Substring(prefix.Length))
   else
     None
@@ -659,7 +662,7 @@ module Patterns =
   let (|StartsWith|_|) (pat: string) (str: string) =
     match str with
     | null -> None
-    | _ when str.StartsWith pat -> Some str
+    | _ when str.StartsWith(pat, StringComparison.Ordinal) -> Some str
     | _ -> None
 
   let (|Contains|_|) (pat: string) (str: string) =

--- a/src/FsAutoComplete/CodeFixes/AdjustConstant.fs
+++ b/src/FsAutoComplete/CodeFixes/AdjustConstant.fs
@@ -698,7 +698,8 @@ module private CommonFixes =
   /// -> Prepend space if leading sign in `replacement` and operator char immediately in front (in `lineStr`)
   let prependSpaceIfNecessary (range: Range) (lineStr: string) (replacement: string) =
     if
-      (replacement.StartsWith "-" || replacement.StartsWith "+")
+      (replacement.StartsWith("-", StringComparison.Ordinal)
+       || replacement.StartsWith("+", StringComparison.Ordinal))
       && range.Start.Character > 0
       && "!$%&*+-./<=>?@^|~".Contains(lineStr[range.Start.Character - 1])
     then

--- a/src/FsAutoComplete/CodeFixes/ConvertTripleSlashCommentToXmlTaggedDoc.fs
+++ b/src/FsAutoComplete/CodeFixes/ConvertTripleSlashCommentToXmlTaggedDoc.fs
@@ -134,7 +134,7 @@ let private collectCommentContents
       match currentLine with
       | None -> acc
       | Some line ->
-        let idx = line.IndexOf("///")
+        let idx = line.IndexOf("///", StringComparison.Ordinal)
 
         if idx >= 0 then
           let existingComment = line.TrimStart().Substring(3).TrimStart()
@@ -177,7 +177,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getRangeText: GetRange
         let origCommentContents =
           collectCommentContents d.Range.Start d.Range.End sourceText
 
-        let indent = lineStr.IndexOf("///")
+        let indent = lineStr.IndexOf("///", StringComparison.Ordinal)
         let summaryXmlDoc = wrapInSummary indent origCommentContents
 
         let range =

--- a/src/FsAutoComplete/CodeFixes/RemoveRedundantAttributeSuffix.fs
+++ b/src/FsAutoComplete/CodeFixes/RemoveRedundantAttributeSuffix.fs
@@ -1,5 +1,6 @@
 ﻿module FsAutoComplete.CodeFix.RemoveRedundantAttributeSuffix
 
+open System
 open FSharp.Compiler.Syntax
 open FsToolkit.ErrorHandling
 open FsAutoComplete.CodeFix.Types
@@ -26,7 +27,7 @@ let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
                   attributes.Attributes
                   |> List.choose (fun a ->
                     match List.tryLast a.TypeName.LongIdent with
-                    | Some ident when ident.idText.EndsWith("Attribute") -> Some ident
+                    | Some ident when ident.idText.EndsWith("Attribute", StringComparison.Ordinal) -> Some ident
                     | _ -> None)
 
                 if List.isEmpty attributesWithRedundantSuffix then

--- a/src/FsAutoComplete/CodeFixes/RemoveUnnecessaryReturnOrYield.fs
+++ b/src/FsAutoComplete/CodeFixes/RemoveUnnecessaryReturnOrYield.fs
@@ -1,5 +1,6 @@
 module FsAutoComplete.CodeFix.RemoveUnnecessaryReturnOrYield
 
+open System
 open FsToolkit.ErrorHandling
 open FsAutoComplete.CodeFix.Types
 open Ionide.LanguageServerProtocol.Types
@@ -26,13 +27,13 @@ let fix (getParseResultsForFile: GetParseResultsForFile) (getLineText: GetLineTe
         let! errorText = getLineText lines diagnostic.Range
 
         let! title =
-          if errorText.StartsWith "return!" then
+          if errorText.StartsWith("return!", StringComparison.Ordinal) then
             Ok(title "return!")
-          elif errorText.StartsWith "yield!" then
+          elif errorText.StartsWith("yield!", StringComparison.Ordinal) then
             Ok(title "yield!")
-          elif errorText.StartsWith "return" then
+          elif errorText.StartsWith("return", StringComparison.Ordinal) then
             Ok(title "return")
-          elif errorText.StartsWith "yield" then
+          elif errorText.StartsWith("yield", StringComparison.Ordinal) then
             Ok(title "yield")
           else
             Error "unknown start token for remove return or yield codefix"

--- a/src/FsAutoComplete/CodeFixes/RemoveUnusedBinding.fs
+++ b/src/FsAutoComplete/CodeFixes/RemoveUnusedBinding.fs
@@ -1,6 +1,6 @@
 module FsAutoComplete.CodeFix.RemoveUnusedBinding
 
-
+open System
 open FsToolkit.ErrorHandling
 open FsAutoComplete.CodeFix.Navigation
 open FsAutoComplete.CodeFix.Types
@@ -10,7 +10,6 @@ open FsAutoComplete.LspHelpers
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
-
 
 let posBetween (range: Range) tester =
   Position.posGeq tester range.Start // positions on this one are flipped to simulate Pos.posLte, because that doesn't exist
@@ -62,7 +61,9 @@ type FSharpParseFileResults with
                 else
                   // Check if it's an operator
                   match pat with
-                  | SynPat.LongIdent(longDotId = SynLongIdent(id = [ id ])) when id.idText.StartsWith("op_") ->
+                  | SynPat.LongIdent(longDotId = SynLongIdent(id = [ id ])) when
+                    id.idText.StartsWith("op_", StringComparison.Ordinal)
+                    ->
                     if Range.rangeContainsRange id.idRange diagnosticRange then
                       Some(FullBinding binding.RangeOfBindingWithRhs)
                     else

--- a/src/FsAutoComplete/CodeFixes/RenameParamToMatchSignature.fs
+++ b/src/FsAutoComplete/CodeFixes/RenameParamToMatchSignature.fs
@@ -1,5 +1,6 @@
 module FsAutoComplete.CodeFix.RenameParamToMatchSignature
 
+open System
 open FsToolkit.ErrorHandling
 open FsAutoComplete.CodeFix.Types
 open Ionide.LanguageServerProtocol.Types
@@ -27,8 +28,8 @@ let fix (getParseResultsForFile: GetParseResultsForFile) : CodeFix =
           let head = "The argument names in the signature '"
           let mid = "' and implementation '"
 
-          if msg.StartsWith head then
-            match msg.IndexOf mid with
+          if msg.StartsWith(head, StringComparison.Ordinal) then
+            match msg.IndexOf(mid, StringComparison.Ordinal) with
             | -1 -> None
             | i -> msg.Substring(head.Length, i - head.Length) |> Some
           else

--- a/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
+++ b/src/FsAutoComplete/CodeFixes/ResolveNamespace.fs
@@ -1,5 +1,6 @@
 module FsAutoComplete.CodeFix.ResolveNamespace
 
+open System
 open Ionide.LanguageServerProtocol.Types
 open FsAutoComplete.CodeFix
 open FsAutoComplete.CodeFix.Types
@@ -37,7 +38,10 @@ let fix
         let line = lines.GetLineString(l - 2)
 
         let isImplicitTopLevelModule =
-          not (line.StartsWith "module" && not (line.EndsWith "="))
+          not (
+            line.StartsWith("module", StringComparison.Ordinal)
+            && not (line.EndsWith("=", StringComparison.Ordinal))
+          )
 
         if isImplicitTopLevelModule then 1 else l
       | ScopeKind.TopModule -> 1
@@ -47,7 +51,11 @@ let fix
 
           lineNos
           |> List.mapi (fun i line -> i, lines.GetLineString line)
-          |> List.choose (fun (i, lineStr) -> if lineStr.StartsWith "namespace" then Some i else None)
+          |> List.choose (fun (i, lineStr) ->
+            if lineStr.StartsWith("namespace", StringComparison.Ordinal) then
+              Some i
+            else
+              None)
           |> List.tryLast
 
         match mostRecentNamespaceInScope with
@@ -78,7 +86,7 @@ let fix
     let docLine = insertPoint - 1
 
     let actualOpen =
-      if name.EndsWith word && name <> word then
+      if name.EndsWith(word, StringComparison.Ordinal) && name <> word then
         let prefix = name.Substring(0, name.Length - word.Length).TrimEnd('.')
 
         $"%s{ns}.%s{prefix}"

--- a/src/FsAutoComplete/CodeFixes/ToInterpolatedString.fs
+++ b/src/FsAutoComplete/CodeFixes/ToInterpolatedString.fs
@@ -1,5 +1,6 @@
 ﻿module FsAutoComplete.CodeFix.ToInterpolatedString
 
+open System
 open System.Text.RegularExpressions
 open FsToolkit.ErrorHandling
 open FsAutoComplete.CodeFix.Types
@@ -87,7 +88,9 @@ let tryFindSprintfApplication (parseAndCheck: ParseAndCheckResults) (sourceText:
     parseAndCheck.TryGetSymbolUse functionIdent.idRange.End lineStr
     |> Option.bind (fun symbolUse ->
       match symbolUse.Symbol with
-      | :? FSharpMemberOrFunctionOrValue as mfv when mfv.Assembly.QualifiedName.StartsWith("FSharp.Core") ->
+      | :? FSharpMemberOrFunctionOrValue as mfv when
+        mfv.Assembly.QualifiedName.StartsWith("FSharp.Core", StringComparison.Ordinal)
+        ->
         // Verify the function is from F# Core.
         Some(functionIdent, mString, xs, mLastArg)
       | _ -> None))

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -211,7 +211,7 @@ module CommandResponse =
 
     static member IsIgnored(e: FSharpDiagnostic) =
       // FST-1027 support in Fake 5
-      e.ErrorNumber = 213 && e.Message.StartsWith "'paket:"
+      e.ErrorNumber = 213 && e.Message.StartsWith("'paket:", StringComparison.Ordinal)
 
     static member OfFSharpError(e: FSharpDiagnostic) =
       { FileName = e.FileName

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -146,14 +146,17 @@ module Conversions =
   let applyQuery (query: string) (info: SymbolInformation) =
     match query.Split([| '.' |], StringSplitOptions.RemoveEmptyEntries) with
     | [||] -> false
-    | [| fullName |] -> info.Name.StartsWith fullName
-    | [| moduleName; fieldName |] -> info.Name.StartsWith fieldName && info.ContainerName = Some moduleName
+    | [| fullName |] -> info.Name.StartsWith(fullName, StringComparison.Ordinal)
+    | [| moduleName; fieldName |] ->
+      info.Name.StartsWith(fieldName, StringComparison.Ordinal)
+      && info.ContainerName = Some moduleName
     | parts ->
       let containerName = parts.[0 .. (parts.Length - 2)] |> String.concat "."
 
       let fieldName = Array.last parts
 
-      info.Name.StartsWith fieldName && info.ContainerName = Some containerName
+      info.Name.StartsWith(fieldName, StringComparison.Ordinal)
+      && info.ContainerName = Some containerName
 
   let getCodeLensInformation (uri: DocumentUri) (typ: string) (topLevel: NavigationTopLevelDeclaration) : CodeLens[] =
     let map (decl: NavigationItem) : CodeLens =

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -542,7 +542,7 @@ type AdaptiveFSharpLspServer
 
             let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
 
-            if lineStr.StartsWith "#" then
+            if lineStr.StartsWith("#", StringComparison.Ordinal) then
               let completionList =
                 { IsIncomplete = false
                   Items = KeywordList.hashSymbolCompletionItems
@@ -737,7 +737,10 @@ type AdaptiveFSharpLspServer
           | true, s -> CoreResponse.Res(HelpText.Simple(sym, s))
           | _ ->
             let sym =
-              if sym.StartsWith "``" && sym.EndsWith "``" then
+              if
+                sym.StartsWith("``", StringComparison.Ordinal)
+                && sym.EndsWith("``", StringComparison.Ordinal)
+              then
                 sym.TrimStart([| '`' |]).TrimEnd([| '`' |])
               else
                 sym

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -777,7 +777,7 @@ type AdaptiveState(lspClient: FSharpLspClient, sourceTextFactory: ISourceTextFac
                 | MSBuildAllProjects v ->
                   yield!
                     v
-                    |> Array.filter (fun x -> x.EndsWith(".props") && isWithinObjFolder x)
+                    |> Array.filter (fun x -> x.EndsWith(".props", StringComparison.Ordinal) && isWithinObjFolder x)
                     |> Array.map (UMX.tag >> projectFileChanges)
                 | _ -> () ]
 

--- a/src/FsAutoComplete/Parser.fs
+++ b/src/FsAutoComplete/Parser.fs
@@ -138,8 +138,8 @@ module Parser =
 
         let dotnetPath =
           if
-            Environment.ProcessPath.EndsWith("dotnet")
-            || Environment.ProcessPath.EndsWith("dotnet.exe")
+            Environment.ProcessPath.EndsWith("dotnet", StringComparison.Ordinal)
+            || Environment.ProcessPath.EndsWith("dotnet.exe", StringComparison.Ordinal)
           then
             // this is valid when not running as a global tool
             Some(FileInfo(Environment.ProcessPath))

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/AdjustConstantTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/AdjustConstantTests.fs
@@ -327,7 +327,7 @@ module private ConvertIntToOtherBase =
                   "0o173"
                   "0b1111011"
                   
-                if not (name.StartsWith "u") && name <> "byte" then
+                if not (name.StartsWith("u", StringComparison.Ordinal)) && name <> "byte" then
                   checkAll server $"with value -123"
                     $"let n = {{number}}{suffix}"
                     "123"
@@ -802,10 +802,10 @@ module private ConvertIntToOtherBase =
 module private ConvertCharToOtherForm =
   let private tryExtractChar (title: String) =
     let (start, fin) = "Convert to `", "`"
-    if title.StartsWith start && title.EndsWith fin then
+    if title.StartsWith(start, StringComparison.Ordinal) && title.EndsWith(fin, StringComparison.Ordinal) then
       let c = title.Substring(start.Length, title.Length - start.Length - fin.Length).ToString()
       let c =
-        if c.Length > 3 && c.StartsWith "'" && c.EndsWith "'B" then
+        if c.Length > 3 && c.StartsWith("'", StringComparison.Ordinal) && c.EndsWith("'B", StringComparison.Ordinal) then
           // byte char (only when converting from int to char representation. Otherwise no `B` suffix in title)
           c.Substring(1, c.Length - 2)
         else
@@ -815,11 +815,11 @@ module private ConvertCharToOtherForm =
     else
       None
   let private extractFormat (char: String) =
-    if char.StartsWith "\\u" then
+    if char.StartsWith("\\u", StringComparison.Ordinal) then
       CharFormat.Utf16Hexadecimal
-    elif char.StartsWith "\\U" then
+    elif char.StartsWith("\\U", StringComparison.Ordinal) then
       CharFormat.Utf32Hexadecimal
-    elif char.StartsWith "\\x" then
+    elif char.StartsWith("\\x", StringComparison.Ordinal) then
       CharFormat.Hexadecimal
     elif char.Length >= 2 && char[0] = '\\' && Char.IsDigit char[1] then
       CharFormat.Decimal

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -1,5 +1,6 @@
 module FsAutoComplete.Tests.CodeFixTests.Tests
 
+open System
 open Expecto
 open Helpers
 open Utils.ServerTests
@@ -2794,7 +2795,7 @@ let private resolveNamespaceTests state =
         ResolveNamespaces = Some true }
 
   serverTestList (nameof ResolveNamespace) state config None (fun server ->
-    [ let selectCodeFix = CodeFix.matching (fun ca -> ca.Title.StartsWith "open")
+    [ let selectCodeFix = CodeFix.matching (fun ca -> ca.Title.StartsWith("open", StringComparison.Ordinal))
 
       testCaseAsync "doesn't fail when target not in last line"
       <| CodeFix.checkApplicable

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -1,13 +1,13 @@
 module FsAutoComplete.Tests.Completion
 
-open Expecto
+open System
 open System.IO
+open Expecto
 open Helpers
 open Ionide.LanguageServerProtocol.Types
 open FsAutoComplete.Utils
 open FsAutoComplete.Lsp
 open FsToolkit.ErrorHandling
-open Utils.Server
 open Helpers.Expecto.ShadowedTimeouts
 
 let tests state =
@@ -781,7 +781,7 @@ let autoOpenTests state =
 
       let (|ContainsOpenAction|_|) (codeActions: CodeAction[]) =
         codeActions
-        |> Array.tryFind (fun ca -> ca.Kind = Some "quickfix" && ca.Title.StartsWith "open ")
+        |> Array.tryFind (fun ca -> ca.Kind = Some "quickfix" && ca.Title.StartsWith("open ", StringComparison.Ordinal))
 
       match! server.TextDocumentCodeAction p with
       | Error e -> return failtestf "Quick fix Request failed: %A" e

--- a/test/FsAutoComplete.Tests.Lsp/FindReferencesTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/FindReferencesTests.fs
@@ -1,7 +1,8 @@
 module FsAutoComplete.Tests.FindReferences
 
-open Expecto
+open System
 open System.IO
+open Expecto
 open FsAutoComplete
 open Helpers
 open Ionide.LanguageServerProtocol.Types
@@ -229,13 +230,13 @@ let private solutionTests state =
     let refs = Dictionary<string, IList<Location>>()
     for i in 0..(lines.Length-1) do
       let line = lines[i].TrimStart()
-      if line.StartsWith marker then
+      if line.StartsWith(marker, StringComparison.Ordinal) then
         let l = line.Substring(marker.Length).Trim()
         let splits = l.Split([|' '|], 2)
         let mark = splits[0]
         let ty = mark[0]
         let range =
-          let col = line.IndexOf mark
+          let col = line.IndexOf(mark, StringComparison.Ordinal)
           let length = mark.Length
           let line = i - 1  // marker is line AFTER actual range
           {

--- a/test/FsAutoComplete.Tests.Lsp/GoToTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/GoToTests.fs
@@ -1,8 +1,8 @@
 module FsAutoComplete.Tests.GoTo
 
-
-open Expecto
+open System
 open System.IO
+open Expecto
 open Helpers
 open Ionide.LanguageServerProtocol.Types
 open FsToolkit.ErrorHandling
@@ -69,7 +69,7 @@ let private gotoTest state =
              | Result.Error e -> failtestf "Request failed: %A" e
              | Result.Ok None -> failtest "Request none"
              | Result.Ok (Some (GotoResult.Multiple _)) -> failtest "Should only get one location"
-             | Result.Ok (Some (GotoResult.Single r)) when r.Uri.EndsWith("startup") ->
+             | Result.Ok (Some (GotoResult.Single r)) when r.Uri.EndsWith("startup", StringComparison.Ordinal) ->
                failtest "Should not generate the startup dummy file"
              | Result.Ok (Some (GotoResult.Single r)) ->
                Expect.stringEnds r.Uri ".cs" "should have generated a C# code file"

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -673,7 +673,7 @@ let diagnosticsFromSource (desiredSource: String) =
     match diags
           |> Array.choose (fun d ->
             match d.Source with
-            | Some s -> if s.StartsWith desiredSource then Some d else None
+            | Some s -> if s.StartsWith(desiredSource, StringComparison.Ordinal) then Some d else None
             | None -> None)
       with
     | [||] -> None

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -142,7 +142,7 @@ let main args =
     let logLevel =
       match
         args
-        |> Array.tryFind (fun arg -> arg.StartsWith logMarker)
+        |> Array.tryFind (fun arg -> arg.StartsWith(logMarker, StringComparison.Ordinal))
         |> Option.map (fun log -> log.Substring(logMarker.Length))
       with
       | Some ("warn" | "warning") -> Logging.LogLevel.Warn
@@ -155,7 +155,7 @@ let main args =
 
     let args =
       args
-      |> Array.filter (fun arg -> not <| arg.StartsWith logMarker)
+      |> Array.filter (fun arg -> not <| arg.StartsWith(logMarker, StringComparison.Ordinal))
 
     logLevel, args
 
@@ -173,10 +173,10 @@ let main args =
 
     let toExclude =
       args
-      |> Array.filter (fun arg -> arg.StartsWith excludeMarker)
+      |> Array.filter (fun arg -> arg.StartsWith(excludeMarker, StringComparison.Ordinal))
       |> Array.collect (fun arg -> arg.Substring(excludeMarker.Length).Split(','))
 
-    let args = args |> Array.filter (fun arg -> not <| arg.StartsWith excludeMarker)
+    let args = args |> Array.filter (fun arg -> not <| arg.StartsWith(excludeMarker, StringComparison.Ordinal))
 
     toExclude, args
 

--- a/test/FsAutoComplete.Tests.Lsp/Utils/TextEdit.Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/TextEdit.Tests.fs
@@ -1,4 +1,6 @@
 module Utils.Tests.TextEdit
+
+open System
 open Expecto
 open Expecto.Logging
 open Expecto.Logging.Message
@@ -512,7 +514,7 @@ printfn "$0Result$0=%i$0" b$0
   let beforeIndexTests = testList (nameof Cursor.beforeIndex) [
     let assertBeforeIndex expected textWithCursor =
       let textWithCursor = Text.trimTripleQuotation textWithCursor
-      let idx = textWithCursor.IndexOf Cursor.Marker
+      let idx = textWithCursor.IndexOf(Cursor.Marker, StringComparison.Ordinal)
       Expect.isGreaterThanOrEqual "Text has no cursor" (idx, 0)
       let text = textWithCursor.Remove(idx, Cursor.Marker.Length)
 
@@ -669,7 +671,7 @@ printfn "Result=%i" b$0"""
       let (pos, text) = assertAndGetTextAndCursor textWithCursor
       match Cursor.tryIndexOf pos text with
       | Ok actualIndex -> 
-        let idxInText = textWithCursor.IndexOf Cursor.Marker
+        let idxInText = textWithCursor.IndexOf(Cursor.Marker, StringComparison.Ordinal)
         let errorMsg = $"wrong index. Cursor at Postion={{Line={pos.Line};Char={pos.Character}}} or Index={idxInText}"
         Expect.equal errorMsg expectedIndex actualIndex
       | Result.Error msg -> failtest $"should have found index. But was error: {msg}"
@@ -868,7 +870,7 @@ printfn "Result=%i" b
 
     testList "idx |> beforeIndex |> tryIndexOf = idx" [
       let value (textWithCursor: string) = 
-        let idx = textWithCursor.IndexOf Cursor.Marker
+        let idx = textWithCursor.IndexOf(Cursor.Marker, StringComparison.Ordinal)
         if idx < 0 then
           failtest "No cursor"
         let text = textWithCursor.Replace(Cursor.Marker, "")
@@ -1259,7 +1261,7 @@ $0printfn "$0Result=%i" b$0
           |> Text.lines
           |> Seq.indexed
           |> Seq.choose (fun (l, line) ->
-              match line.IndexOf "incrementNumber" with
+              match line.IndexOf("incrementNumber", StringComparison.Ordinal) with
               | -1 -> None
               | c -> Some (pos l c)
           )

--- a/test/FsAutoComplete.Tests.Lsp/Utils/TextEdit.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/TextEdit.fs
@@ -1,4 +1,6 @@
 module Utils.TextEdit
+
+open System
 open Ionide.LanguageServerProtocol.Types
 open Utils.Utils
 open Expecto
@@ -49,7 +51,7 @@ module Cursor =
   /// Note: Cursor Position is BEFORE index.
   /// Note: Index might be `text.Length` (-> Cursor AFTER last char in text)
   let tryExtractIndex (text: string) =
-    match text.IndexOf Marker with
+    match text.IndexOf(Marker, StringComparison.Ordinal) with
     | -1 -> None
     | i ->
         (i, text.Remove(i, Marker.Length))
@@ -65,7 +67,7 @@ module Cursor =
       let markersInLine =
         markers
         |> Array.choose (fun marker ->
-            match line.IndexOf marker with
+            match line.IndexOf(marker, StringComparison.Ordinal) with
             | -1 -> None
             | column -> Some (marker, column)
         )
@@ -252,7 +254,7 @@ module Cursors =
   /// Note: doesn't trim input!
   let iter (textWithCursors: string) =
     let rec collect (textsWithSingleCursor) (textWithCursors: string) =
-      match textWithCursors.IndexOf Cursor.Marker with
+      match textWithCursors.IndexOf(Cursor.Marker, StringComparison.Ordinal) with
       | -1 -> textsWithSingleCursor |> List.rev
       | i ->
         let textWithSingleCursor =


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 15b8219</samp>

This pull request changes various string comparison operations in the `FsAutoComplete` project to use `StringComparison.Ordinal` instead of the default culture-sensitive option. This improves the performance, consistency, and correctness of the code, as it avoids unnecessary allocations and potential bugs related to different cultures. The changes affect several modules and files, such as `CodeGeneration.fs`, `Commands.fs`, `CompilerServiceInterface.fs`, `DocumentationFormatter.fs`, `InlayHints.fs`, `Lexer.fs`, `SignatureFormatter.fs`, `TestAdapter.fs`, `TipFormatter.fs`, `TypedAstUtils.fs`, `Utils.fs`, and some code fixes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 15b8219</samp>

> _`StringComparison.Ordinal` is the way to go_
> _No culture can stop us, we're in control_
> _We generate the code with speed and precision_
> _We fix the bugs with ruthless decision_

<!--
copilot:emoji
-->

🚀🛠️📝

<!--
1.  🚀 - This emoji represents the performance improvement aspect of the changes, as using ordinal string comparisons is faster and more efficient than culture-sensitive ones.
2.  🛠️ - This emoji represents the bug fixing and reliability aspect of the changes, as using ordinal string comparisons avoids potential issues with different cultures and case sensitivity.
3.  📝 - This emoji represents the documentation and code formatting aspect of the changes, as using ordinal string comparisons improves the accuracy and consistency of the generated code and documentation.
-->

### WHY
Using Ordinal is both faster and more correct as our intent is to do symbolic compares.
See https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings for the full story.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 15b8219</samp>

*  Use `StringComparison.Ordinal` for `StartsWith`, `EndsWith`, and `IndexOf` methods to avoid culture-sensitive comparisons and improve performance ([link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-542241253f952a50c96405c20d8c10c40f23bf3d330bc8ea0310e0dc80179fe2L305-R308), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-542241253f952a50c96405c20d8c10c40f23bf3d330bc8ea0310e0dc80179fe2L331-R333), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-542241253f952a50c96405c20d8c10c40f23bf3d330bc8ea0310e0dc80179fe2L348-R353), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-542241253f952a50c96405c20d8c10c40f23bf3d330bc8ea0310e0dc80179fe2L579-R584), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-542241253f952a50c96405c20d8c10c40f23bf3d330bc8ea0310e0dc80179fe2L586-R591), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-542241253f952a50c96405c20d8c10c40f23bf3d330bc8ea0310e0dc80179fe2L597-R607), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-f030ffbad83492980d57dd555322c7d8e9f26a1986413d60384e0730f8f54dd7L312-R312), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-f030ffbad83492980d57dd555322c7d8e9f26a1986413d60384e0730f8f54dd7L709-R709), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-f030ffbad83492980d57dd555322c7d8e9f26a1986413d60384e0730f8f54dd7L1003-R1006), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-d3a131711af73b7dfc9dad588cea6f40c3d483f43d8a0f4f0d02ef4ac339a916L71-R72), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-d3a131711af73b7dfc9dad588cea6f40c3d483f43d8a0f4f0d02ef4ac339a916L78-R78), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-d3a131711af73b7dfc9dad588cea6f40c3d483f43d8a0f4f0d02ef4ac339a916L105-R105), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-d3a131711af73b7dfc9dad588cea6f40c3d483f43d8a0f4f0d02ef4ac339a916L123-R127), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L107-R107), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L220-R220), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L234-R234), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L246-R246), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L419-R424), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L539-R542), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-380a12b20380174b9e8048f53f185ab984345b1ccc4902fcd607ad5d98cc6312L785-R791), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-ba7903f7d5e1c31845a616c8df980f47dba3460d699b1e516b131e18e1f1e37aL64-R69), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-60438e5f9f940ce4f32d73eb8c6e2fdeac9a0724b229f403080c0f2b15e7b99fL660-R660), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-7c1d3328baa270a7e1450113731e5f1fe55cce453db26186a346965e4b66e981L592-R592), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-b6395f63a994db1807e01fe8b1bb75322e6f998630ff9db0539d5a0c7c486604L151-R155), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-b6395f63a994db1807e01fe8b1bb75322e6f998630ff9db0539d5a0c7c486604L209-R214), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-b6395f63a994db1807e01fe8b1bb75322e6f998630ff9db0539d5a0c7c486604L306-R311), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-b6395f63a994db1807e01fe8b1bb75322e6f998630ff9db0539d5a0c7c486604L377-R382), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-4766d788a219fa323cb26cfeaf32a81a171c3cf20fb1165fc197bd4c315497dcL46-R47), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-4766d788a219fa323cb26cfeaf32a81a171c3cf20fb1165fc197bd4c315497dcL53-R54), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-9fb9b45b77d929cc7b14a843f350fd52e6cd8734fc397572828c14098c31cef0L166-R168), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-d0d96a9f3cc99fcf052d3e39bdbee9c9ac7c988eecfa53076779088f1f5c86b9L170-R170), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-d0d96a9f3cc99fcf052d3e39bdbee9c9ac7c988eecfa53076779088f1f5c86b9L181-R181), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-d0d96a9f3cc99fcf052d3e39bdbee9c9ac7c988eecfa53076779088f1f5c86b9L193-R193), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-d0d96a9f3cc99fcf052d3e39bdbee9c9ac7c988eecfa53076779088f1f5c86b9L380-R385), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-d0d96a9f3cc99fcf052d3e39bdbee9c9ac7c988eecfa53076779088f1f5c86b9L518-R521), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-eba3b23ba360ad506d15e56d3bf96a0f2e88a1686c7d64e7416535eccc7481b8L144-R148), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-f792615916bec36e13bc13527dcad3dd26a45063c44f41dbacebb068b6dfb3e5L74-R76), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-f5d394e50d0e258dd596259bcae454c18522de64df5e5aafceac736b7aa2106bL47-R90), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-f5d394e50d0e258dd596259bcae454c18522de64df5e5aafceac736b7aa2106bL269-R282), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-f5d394e50d0e258dd596259bcae454c18522de64df5e5aafceac736b7aa2106bL447-R456), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-feb3e5048685e57aced3b12771a9533041ef007bcd34232b317aa6a245308f6aL180-R182), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-feb3e5048685e57aced3b12771a9533041ef007bcd34232b317aa6a245308f6aL736-R741), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-feb3e5048685e57aced3b12771a9533041ef007bcd34232b317aa6a245308f6aL976-R981), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-ac5915f0196a8e2c547c5bc5d0f4c0143007a45aeab3c6b04b4985ca52638b7dL60-R61), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-ac5915f0196a8e2c547c5bc5d0f4c0143007a45aeab3c6b04b4985ca52638b7dL193-R200), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-9af59b386f0d6d11954514dbf9d61c88cb09fbed23c39b4412f5e7c5a63b32a6L448-R453), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-9af59b386f0d6d11954514dbf9d61c88cb09fbed23c39b4412f5e7c5a63b32a6L464-R467), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-9af59b386f0d6d11954514dbf9d61c88cb09fbed23c39b4412f5e7c5a63b32a6L641-R644), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-9af59b386f0d6d11954514dbf9d61c88cb09fbed23c39b4412f5e7c5a63b32a6L649-R652), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-9af59b386f0d6d11954514dbf9d61c88cb09fbed23c39b4412f5e7c5a63b32a6L662-R665), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-878812da0f46374fdbb119460dee1cdf58e063ac2f534b9d8b5f9f55784afa8dL701-R702), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-75db7c1b6de95a6957e56bb04bbbd3071099722cf5e26c56b0291b4cef2e3891L137-R137), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-75db7c1b6de95a6957e56bb04bbbd3071099722cf5e26c56b0291b4cef2e3891L180-R180), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-fd6b9d9451b19ceb3508e84206446a254af0347d5ef42bb39ad6460daa8ed7aaL29-R30))
* Add `open System` directive to `Lexer` and `TestAdapter` modules to make `StringComparison` enum available ([link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-4766d788a219fa323cb26cfeaf32a81a171c3cf20fb1165fc197bd4c315497dcR3), [link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-f5d394e50d0e258dd596259bcae454c18522de64df5e5aafceac736b7aa2106bL3-R3))
* Add `open System` directive to `RemoveRedundantAttributeSuffix` module to make `StringComparison` enum available ([link](https://github.com/fsharp/FsAutoComplete/pull/1193/files?diff=unified&w=0#diff-fd6b9d9451b19ceb3508e84206446a254af0347d5ef42bb39ad6460daa8ed7aaR3))
