### PR TITLE
Fix tooltip errorhandling

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -534,8 +534,7 @@ module Commands =
       | Error e -> return CoreResponse.ErrorRes e
     }
 
-  let typesig (tyRes: ParseAndCheckResults) (pos: Position) lineStr =
-    tyRes.TryGetToolTip pos lineStr
+  let typesig (tyRes: ParseAndCheckResults) (pos: Position) lineStr = tyRes.TryGetToolTip pos lineStr
 
   // Calculates pipeline hints for now as in fSharp/pipelineHint with a bit of formatting on the hints
   let inlineValues (contents: IFSACSourceText) (tyRes: ParseAndCheckResults) : Async<(pos * String)[]> =

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -536,7 +536,6 @@ module Commands =
 
   let typesig (tyRes: ParseAndCheckResults) (pos: Position) lineStr =
     tyRes.TryGetToolTip pos lineStr
-    |> Result.bimap CoreResponse.Res CoreResponse.ErrorRes
 
   // Calculates pipeline hints for now as in fSharp/pipelineHint with a bit of formatting on the hints
   let inlineValues (contents: IFSACSourceText) (tyRes: ParseAndCheckResults) : Async<(pos * String)[]> =
@@ -546,7 +545,7 @@ module Commands =
         option {
           let! lineStr = contents.GetLine pos
 
-          let! tip = tyRes.TryGetToolTip pos lineStr |> Option.ofResult
+          let! tip = tyRes.TryGetToolTip pos lineStr
 
           return TipFormatter.extractGenericParameters tip
         }
@@ -618,7 +617,7 @@ module Commands =
         option {
           let! lineStr = contents.GetLine pos
 
-          let! tip = tyRes.TryGetToolTip pos lineStr |> Option.ofResult
+          let! tip = tyRes.TryGetToolTip pos lineStr
 
           return TipFormatter.extractGenericParameters tip
         }

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -319,9 +319,7 @@ type ParseAndCheckResults
   member __.TryGetToolTip (pos: Position) (lineStr: LineStr) =
     match Lexer.findLongIdents (pos.Column, lineStr) with
     | None ->
-      logger.info (
-          Log.setMessageI $"Cannot find ident for tooltip: {pos.Column:column} in {lineStr:lineString}"
-        )
+      logger.info (Log.setMessageI $"Cannot find ident for tooltip: {pos.Column:column} in {lineStr:lineString}")
       None
     | Some(col, identIsland) ->
       let identIsland = Array.toList identIsland
@@ -336,21 +334,14 @@ type ParseAndCheckResults
           match KeywordList.keywordTooltips.TryGetValue ident with
           | true, tip -> Some tip
           | _ ->
-            logger.info (
-                Log.setMessageI $"Cannot find ident for tooltip: {pos.Column:column} in {lineStr:lineString}"
-              )
+            logger.info (Log.setMessageI $"Cannot find ident for tooltip: {pos.Column:column} in {lineStr:lineString}")
             None
         | _ ->
-          logger.info (
-              Log.setMessageI $"Cannot find ident for tooltip: {pos.Column:column} in {lineStr:lineString}"
-            )
+          logger.info (Log.setMessageI $"Cannot find ident for tooltip: {pos.Column:column} in {lineStr:lineString}")
           None
       | _ -> Some tip
 
-  member x.TryGetToolTipEnhanced
-    (pos: Position)
-    (lineStr: LineStr)
-    : option<TryGetToolTipEnhancedResult> =
+  member x.TryGetToolTipEnhanced (pos: Position) (lineStr: LineStr) : option<TryGetToolTipEnhancedResult> =
     let (|EmptyTooltip|_|) (ToolTipText elems) =
       match elems with
       | [] -> Some()
@@ -363,9 +354,7 @@ type ParseAndCheckResults
     | Completion.Context.Unknown ->
       match Lexer.findLongIdents (pos.Column, lineStr) with
       | None ->
-        logger.info (
-            Log.setMessageI $"Cannot find ident for tooltip: {pos.Column:column} in {lineStr:lineString}"
-          )
+        logger.info (Log.setMessageI $"Cannot find ident for tooltip: {pos.Column:column} in {lineStr:lineString}")
         None
       | Some(col, identIsland) ->
         let identIsland = Array.toList identIsland
@@ -388,21 +377,18 @@ type ParseAndCheckResults
                 SymbolInfo = TryGetToolTipEnhancedResult.Keyword ident }
               |> Some
             | _ ->
-                logger.info (
-                    Log.setMessageI $"Cannot find ident for tooltip: {pos.Column:column} in {lineStr:lineString}"
-                  )
-                None
-          | _ ->
               logger.info (
-                  Log.setMessageI $"Cannot find ident for tooltip: {pos.Column:column} in {lineStr:lineString}"
-                )
+                Log.setMessageI $"Cannot find ident for tooltip: {pos.Column:column} in {lineStr:lineString}"
+              )
+
               None
+          | _ ->
+            logger.info (Log.setMessageI $"Cannot find ident for tooltip: {pos.Column:column} in {lineStr:lineString}")
+            None
         | _ ->
           match symbol with
           | None ->
-            logger.info (
-                Log.setMessageI $"Cannot find ident for tooltip: {pos.Column:column} in {lineStr:lineString}"
-              )
+            logger.info (Log.setMessageI $"Cannot find ident for tooltip: {pos.Column:column} in {lineStr:lineString}")
             None
           | Some symbol ->
 
@@ -415,8 +401,9 @@ type ParseAndCheckResults
             match SignatureFormatter.getTooltipDetailsFromSymbolUse symbol with
             | None ->
               logger.info (
-                  Log.setMessageI $"Cannot find tooltip for {symbol:symbol} ({pos.Column:column} in {lineStr:lineString})"
-                )
+                Log.setMessageI $"Cannot find tooltip for {symbol:symbol} ({pos.Column:column} in {lineStr:lineString})"
+              )
+
               None
             | Some(signature, footer) ->
               { ToolTipText = tip

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fsi
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fsi
@@ -47,9 +47,9 @@ type ParseAndCheckResults =
   member TryFindIdentifierDeclaration: pos: Position -> lineStr: LineStr -> Async<Result<FindDeclarationResult, string>>
 
   member TryFindTypeDeclaration: pos: Position -> lineStr: LineStr -> Async<Result<FindDeclarationResult, string>>
-  member TryGetToolTip: pos: Position -> lineStr: LineStr -> Result<ToolTipText, string>
+  member TryGetToolTip: pos: Position -> lineStr: LineStr -> ToolTipText option
 
-  member TryGetToolTipEnhanced: pos: Position -> lineStr: LineStr -> Result<TryGetToolTipEnhancedResult option, string>
+  member TryGetToolTipEnhanced: pos: Position -> lineStr: LineStr -> TryGetToolTipEnhancedResult option
 
   member TryGetFormattedDocumentation:
     pos: Position ->

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -568,11 +568,12 @@ type AdaptiveFSharpLspServer
                 asyncResult {
 
                   let! volatileFile = state.GetOpenFileOrRead filePath
+
                   let! lineStr =
                     volatileFile.Source
                     |> tryGetLineStr pos
                     |> Result.mapError ErrorMsgUtils.formatLineLookErr
-                    //TODO ⮝⮝⮝ good candidate for better error model -- review!
+                  //TODO ⮝⮝⮝ good candidate for better error model -- review!
 
                   // TextDocumentCompletion will sometimes come in before TextDocumentDidChange
                   // This will require the trigger character to be at the place VSCode says it is
@@ -940,8 +941,7 @@ type AdaptiveFSharpLspServer
 
             | TipFormatter.TipFormatterResult.None -> return None
 
-          | None ->
-            return None
+          | None -> return None
 
         with e ->
           trace |> Tracing.recordException e

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -540,7 +540,7 @@ type AdaptiveFSharpLspServer
             return None // An empty file has empty completions. Otherwise we would error down there
           else
 
-            let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
+            let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.lineLookupErr
 
             if lineStr.StartsWith "#" then
               let completionList =
@@ -568,7 +568,11 @@ type AdaptiveFSharpLspServer
                 asyncResult {
 
                   let! volatileFile = state.GetOpenFileOrRead filePath
-                  let! lineStr = volatileFile.Source |> tryGetLineStr pos
+                  let! lineStr =
+                    volatileFile.Source
+                    |> tryGetLineStr pos
+                    |> Result.mapError ErrorMsgUtils.formatLineLookErr
+                    //TODO ⮝⮝⮝ good candidate for better error model -- review!
 
                   // TextDocumentCompletion will sometimes come in before TextDocumentDidChange
                   // This will require the trigger character to be at the place VSCode says it is
@@ -871,11 +875,11 @@ type AdaptiveFSharpLspServer
 
           let (filePath, pos) = getFilePathAndPosition p
           let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
-          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
+          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.lineLookupErr
           and! tyRes = state.GetOpenFileTypeCheckResultsCached filePath |> AsyncResult.ofStringErr
 
           match tyRes.TryGetToolTipEnhanced pos lineStr with
-          | Ok(Some tooltipResult) ->
+          | Some tooltipResult ->
             logger.info (
               Log.setMessage "TryGetToolTipEnhanced : {params}"
               >> Log.addContextDestructured "params" tooltipResult
@@ -936,13 +940,9 @@ type AdaptiveFSharpLspServer
 
             | TipFormatter.TipFormatterResult.None -> return None
 
-          | Ok(None) ->
+          | None ->
+            return None
 
-            return! LspResult.internalError $"No TryGetToolTipEnhanced results for {filePath}"
-          | Error e ->
-            trace.RecordError(e, "TextDocumentHover.Error") |> ignore<Activity>
-            logger.error (Log.setMessage "Failed with {error}" >> Log.addContext "error" e)
-            return! LspResult.internalError e
         with e ->
           trace |> Tracing.recordException e
 
@@ -964,7 +964,7 @@ type AdaptiveFSharpLspServer
 
         let (filePath, pos) = getFilePathAndPosition p
         let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
-        let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
+        let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.lineLookupErr
         let! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
 
         let! (_, _, range) =
@@ -987,7 +987,7 @@ type AdaptiveFSharpLspServer
 
           let (filePath, pos) = getFilePathAndPosition p
           let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
-          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
+          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.lineLookupErr
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
 
           // validate name and surround with backticks if necessary
@@ -1061,7 +1061,7 @@ type AdaptiveFSharpLspServer
           let (filePath, pos) = getFilePathAndPosition p
           let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
 
-          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
+          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.lineLookupErr
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
           let! decl = tyRes.TryFindDeclaration pos lineStr |> AsyncResult.ofStringErr
           return decl |> findDeclToLspLocation |> GotoResult.Single |> Some
@@ -1091,7 +1091,7 @@ type AdaptiveFSharpLspServer
           let (filePath, pos) = getFilePathAndPosition p
 
           let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
-          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
+          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.lineLookupErr
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
           let! decl = tyRes.TryFindTypeDeclaration pos lineStr |> AsyncResult.ofStringErr
           return decl |> findDeclToLspLocation |> GotoResult.Single |> Some
@@ -1120,7 +1120,7 @@ type AdaptiveFSharpLspServer
 
           let (filePath, pos) = getFilePathAndPosition p
           let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
-          let! lineStr = tryGetLineStr pos volatileFile.Source |> Result.ofStringErr
+          let! lineStr = tryGetLineStr pos volatileFile.Source |> Result.lineLookupErr
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
 
           let! usages =
@@ -1156,7 +1156,7 @@ type AdaptiveFSharpLspServer
 
           let (filePath, pos) = getFilePathAndPosition p
           let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
-          let! lineStr = tryGetLineStr pos volatileFile.Source |> Result.ofStringErr
+          let! lineStr = tryGetLineStr pos volatileFile.Source |> Result.lineLookupErr
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
 
           match
@@ -1198,7 +1198,7 @@ type AdaptiveFSharpLspServer
 
           let (filePath, pos) = getFilePathAndPosition p
           let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
-          let! lineStr = tryGetLineStr pos volatileFile.Source |> Result.ofStringErr
+          let! lineStr = tryGetLineStr pos volatileFile.Source |> Result.lineLookupErr
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
 
           logger.info (
@@ -1557,7 +1557,7 @@ type AdaptiveFSharpLspServer
             )
 
             let! (sourceText: IFSACSourceText) = state.GetOpenFileSource filePath |> AsyncResult.ofStringErr
-            let! lineStr = sourceText |> tryGetLineStr pos |> Result.ofStringErr
+            let! lineStr = sourceText |> tryGetLineStr pos |> Result.lineLookupErr
 
             let typ = data.[1]
             let! r = Async.Catch(f arg pos tyRes sourceText lineStr typ filePath)
@@ -2068,7 +2068,7 @@ type AdaptiveFSharpLspServer
           let filePath = Path.FileUriToLocalPath p.Item.Uri |> Utils.normalizePath
           let pos = protocolPosToPos p.Item.SelectionRange.Start
           let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
-          let! lineStr = tryGetLineStr pos volatileFile.Source |> Result.ofStringErr
+          let! lineStr = tryGetLineStr pos volatileFile.Source |> Result.lineLookupErr
           // Incoming file may not be "Opened" so we need to force a typecheck
           let! tyRes = state.GetTypeCheckResultsForFile filePath |> AsyncResult.ofStringErr
 
@@ -2155,7 +2155,7 @@ type AdaptiveFSharpLspServer
             |> getFilePathAndPosition
 
           let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
-          let! lineStr = tryGetLineStr pos volatileFile.Source |> Result.ofStringErr
+          let! lineStr = tryGetLineStr pos volatileFile.Source |> Result.lineLookupErr
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
 
           let! decl = tyRes.TryFindDeclaration pos lineStr |> AsyncResult.ofStringErr
@@ -2237,9 +2237,9 @@ type AdaptiveFSharpLspServer
           let (filePath, pos) = getFilePathAndPosition p
           let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
 
-          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
+          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.lineLookupErr
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
-          let! tip = Commands.typesig tyRes pos lineStr |> Result.ofCoreResponse
+          let tip = Commands.typesig tyRes pos lineStr
 
           return
             tip
@@ -2272,7 +2272,7 @@ type AdaptiveFSharpLspServer
 
           let filePath = p.TextDocument.GetFilePath() |> Utils.normalizePath
           let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
-          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
+          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.lineLookupErr
 
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
           let! (typ, parms, generics) = tyRes.TryGetSignatureData pos lineStr |> Result.ofStringErr
@@ -2308,7 +2308,7 @@ type AdaptiveFSharpLspServer
           let (filePath, pos) = getFilePathAndPosition p
           let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
 
-          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
+          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.lineLookupErr
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
 
           match!
@@ -2656,7 +2656,7 @@ type AdaptiveFSharpLspServer
 
           let (filePath, pos) = getFilePathAndPosition p
           let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
-          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
+          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.lineLookupErr
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
 
           match! Commands.Help tyRes pos lineStr |> Result.ofCoreResponse with
@@ -2687,7 +2687,7 @@ type AdaptiveFSharpLspServer
 
           let (filePath, pos) = getFilePathAndPosition p
           let! volatileFile = state.GetOpenFileOrRead filePath |> AsyncResult.ofStringErr
-          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.ofStringErr
+          let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.lineLookupErr
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
           lastFSharpDocumentationTypeCheck <- Some tyRes
 

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -1634,11 +1634,12 @@ type AdaptiveState(lspClient: FSharpLspClient, sourceTextFactory: ISourceTextFac
     let tryGetParseResultsForFile filePath pos =
       asyncResult {
         let! (file) = forceFindOpenFileOrRead filePath
+
         let! lineStr =
           file.Source
           |> tryGetLineStr pos
           |> Result.mapError ErrorMsgUtils.formatLineLookErr
-          //TODO ⮝⮝⮝ good candidate for better error model -- review!
+        //TODO ⮝⮝⮝ good candidate for better error model -- review!
         and! tyRes = forceGetOpenFileTypeCheckResults filePath
         return tyRes, lineStr, file.Source
       }

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -1634,7 +1634,11 @@ type AdaptiveState(lspClient: FSharpLspClient, sourceTextFactory: ISourceTextFac
     let tryGetParseResultsForFile filePath pos =
       asyncResult {
         let! (file) = forceFindOpenFileOrRead filePath
-        let! lineStr = file.Source |> tryGetLineStr pos
+        let! lineStr =
+          file.Source
+          |> tryGetLineStr pos
+          |> Result.mapError ErrorMsgUtils.formatLineLookErr
+          //TODO ⮝⮝⮝ good candidate for better error model -- review!
         and! tyRes = forceGetOpenFileTypeCheckResults filePath
         return tyRes, lineStr, file.Source
       }

--- a/src/FsAutoComplete/LspServers/Common.fs
+++ b/src/FsAutoComplete/LspServers/Common.fs
@@ -15,7 +15,11 @@ open CliWrap
 
 
 module ErrorMsgUtils =
-  let formatLineLookErr (x : {| FileName: string<LocalPath>; Position: FcsPos |}) =
+  let formatLineLookErr
+    (x:
+      {| FileName: string<LocalPath>
+         Position: FcsPos |})
+    =
     let position = fcsPosToLsp x.Position
     $"No line in {x.FileName} at position {position}"
 
@@ -23,8 +27,13 @@ module ErrorMsgUtils =
 module Result =
   let ofStringErr r = r |> Result.mapError JsonRpc.Error.InternalErrorMessage
 
-  let lineLookupErr (r : Result<'T, {| FileName: string<LocalPath>; Position: FcsPos |}>) =
-    r |> Result.mapError (ErrorMsgUtils.formatLineLookErr >> JsonRpc.Error.InternalErrorMessage)
+  let lineLookupErr
+    (r:
+      Result<'T, {| FileName: string<LocalPath>
+                    Position: FcsPos |}>)
+    =
+    r
+    |> Result.mapError (ErrorMsgUtils.formatLineLookErr >> JsonRpc.Error.InternalErrorMessage)
 
   let ofCoreResponse (r: CoreResponse<'a>) =
     match r with
@@ -196,7 +205,9 @@ module Helpers =
 
   let tryGetLineStr pos (text: IFSACSourceText) =
     text.GetLine(pos)
-    |> Result.ofOption (fun () -> {| FileName = text.FileName; Position = pos |})
+    |> Result.ofOption (fun () ->
+      {| FileName = text.FileName
+         Position = pos |})
 
 
   let fullPathNormalized = Path.GetFullPath >> Utils.normalizePath >> UMX.untag

--- a/test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
@@ -8,7 +8,6 @@
     <IsTestProject>true</IsTestProject>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
-
     <!-- enable graph-based checking. This can't go at the repo-level because when we test
          in .net 6 the TestCases projects don't know about these flags -->
     <!-- Yes we know 'times' is for test only, thanks FSC :) -->
@@ -47,27 +46,16 @@
     <Compile Include="Utils/CursorbasedTests.fs" />
     <Compile Include="Utils/CursorbasedTests.Tests.fsi" />
     <Compile Include="Utils/CursorbasedTests.Tests.fs" />
-    <Compile
-        Include="*Tests.fs"
-        Exclude="Helpers.fs;Program.fs" />
+    <Compile Include="*Tests.fs" Exclude="Helpers.fs;Program.fs" />
     <Compile Include="CodeFixTests/Utils.fs" />
-    <Compile
-        Include="CodeFixTests/*.fs"
-        Exclude="CodeFixTests/Utils.fs;CodeFixTests/Tests.fs" />
+    <Compile Include="CodeFixTests/*.fs" Exclude="CodeFixTests/Utils.fs;CodeFixTests/Tests.fs" />
     <Compile Include="CodeFixTests/Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
-
   <!-- This is a workaround for the test framework using Microsoft.Build dependencies and our
   project uses it's own set of Microsoft.Build dependencies which causes loading conflicts -->
-  <Target
-      Name="PostBuild"
-      AfterTargets="PostBuildEvent">
-    <Copy
-        SourceFiles="$([System.IO.Directory]::GetParent($(BundledRuntimeIdentifierGraphFile)))\NuGet.Frameworks.dll"
-        DestinationFolder="$(OutputPath)"
-        ContinueOnError="false" />
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Copy SourceFiles="$([System.IO.Directory]::GetParent($(BundledRuntimeIdentifierGraphFile)))\NuGet.Frameworks.dll" DestinationFolder="$(OutputPath)" ContinueOnError="false" />
   </Target>
-
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/test/FsAutoComplete.Tests.Lsp/InlineHintsTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InlineHintsTests.fs
@@ -1,0 +1,69 @@
+module FsAutoComplete.Tests.InlineHints
+
+open Expecto
+open Helpers
+open Ionide.LanguageServerProtocol.Types
+open FsAutoComplete
+open Utils.Server
+open Utils.Utils
+open Utils.TextEdit
+open Utils.ServerTests
+open Helpers.Expecto.ShadowedTimeouts
+
+let private testInlineHints (server : CachedServer) text checkResp =
+  async {
+    let range, text =
+      text
+      |> Text.trimTripleQuotation
+      |> Cursor.assertExtractRange
+
+    let! (doc, diags) = server |> Server.createUntitledDocument text
+    use doc = doc
+
+    let inlineValueRequest: InlineValueParams = {
+      Context = {
+        FrameId = 0
+        StoppedLocation = range
+      }
+      Range = range
+      TextDocument = doc.TextDocumentIdentifier
+    }
+    let! resp = doc.Server.Server.TextDocumentInlineValue inlineValueRequest
+    checkResp resp
+  }
+
+let good = """
+let test value =
+  $0
+  value
+  |> String.replicate 3
+  |> String.filter (fun c -> Char.IsAscii(c))
+  |> String.length
+  $0
+value "foo"
+"""
+
+let tests state =
+  serverTestList "inline hints" state defaultConfigDto None (fun server -> [
+    testCaseAsync
+      "Gets inline hints for simple pipeline"
+      (testInlineHints
+        server
+        good
+        (fun resp ->
+          Expect.isOk resp "should get inline hints for valid code fragment"
+          let resp = resp |> Result.defaultWith (fun _ -> failwith "Unpossible!")
+          Expect.isSome resp "should get inline hints for valid code fragment"
+          let resp = resp |> Option.get
+          Expect.hasLength resp 4 "THERE ARE FOUR LIGHTS!!"
+          let hints =
+            resp
+            |> Array.choose (
+              function
+              | InlineValue.InlineValueText hint -> Some hint.Text
+              | _ -> None
+            )
+          Expect.containsAll hints [nameof string; nameof int] "should be 3 strings and an int"
+        )
+      )
+  ])

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -96,6 +96,7 @@ let lspTests =
                 analyzerTests createServer
                 signatureTests createServer
                 SignatureHelp.tests createServer
+                InlineHints.tests createServer
                 CodeFixTests.Tests.tests sourceTextFactory createServer
                 Completion.tests createServer
                 GoTo.tests createServer


### PR DESCRIPTION
Co-authored-by: Jimmy Byrd <TheAngryByrd@users.noreply.github.com>

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 683625a</samp>

This pull request refactors and improves some parts of the FsAutoComplete core and LSP server modules, especially related to error handling, type conversions, and option types. It also adds a new test case for the inline hints feature and cleans up some whitespace in the test project file. The main files affected are `Commands.fs`, `ParseAndCheckResults.fs`, `AdaptiveFSharpLspServer.fs`, `Common.fs`, `InlineHintsTests.fs`, and `FsAutoComplete.Tests.Lsp.fsproj`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 683625a</samp>

> _The server for F# LSP_
> _Got some refactoring to see_
> _`Result` to `option`_
> _And error adoption_
> _With better formatting and speed_

<!--
copilot:emoji
-->

🛠️🚀🧹

<!--
1.  🛠️ - This emoji represents the refactoring and improvement of the existing code, such as simplifying expressions, avoiding unnecessary conversions, and adding logging.
2.  🚀 - This emoji represents the introduction of a new feature, such as the inline hints test case and the error message formatting module.
3.  🧹 - This emoji represents the cleaning up and formatting of the code, such as removing whitespace and unused functions.
-->

### WHY
Because proper modelling and handling of various program states is important (and the hack session was fun!)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 683625a</samp>

*  Simplify the return types of TryGetToolTip and TryGetToolTipEnhanced from Result to option and add logging for the cases when no tooltip is found ( [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-9fb9b45b77d929cc7b14a843f350fd52e6cd8734fc397572828c14098c31cef0L321-R325), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-9fb9b45b77d929cc7b14a843f350fd52e6cd8734fc397572828c14098c31cef0L333-R353), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-9fb9b45b77d929cc7b14a843f350fd52e6cd8734fc397572828c14098c31cef0L349-R369), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-9fb9b45b77d929cc7b14a843f350fd52e6cd8734fc397572828c14098c31cef0L374-R406), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-9fb9b45b77d929cc7b14a843f350fd52e6cd8734fc397572828c14098c31cef0L389-R420), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-9fb9b45b77d929cc7b14a843f350fd52e6cd8734fc397572828c14098c31cef0L399), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-c1290a71ddaa5837f3783645a57dd26552ef23f25c45f7930afb2d91e13113ebL50-R52), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L939-R945))
* Replace the Result.ofStringErr function with the Result.lineLookupErr function, which formats the error message using the ErrorMsgUtils.formatLineLookErr function, and add comments for the candidates for a better error model ([link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L543-R543), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L571-R575), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L874-R882), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L967-R967), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L990-R990), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L1064-R1064), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L1094-R1094), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L1123-R1123), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L1159-R1159), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L1201-R1201), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L1560-R1560), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2071-R2071), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2158-R2158), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2275-R2275), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2311-R2311), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2659-R2659), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2690-R2690), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-e4d3fcc93b04f2113e7b1b0bb4bdbd5697dcc28b5f3111d2ffa1029479c706ebL1637-R1641), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-444833594f5cf1c53d97749a712d8a6dd25b635ecea7891390e37746a66a7f6fL17-R28), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-444833594f5cf1c53d97749a712d8a6dd25b635ecea7891390e37746a66a7f6fL190-R199))
* Remove the unnecessary conversions of the result type to a CoreResponse type in `Commands.fs` and `AdaptiveServerState.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-f030ffbad83492980d57dd555322c7d8e9f26a1986413d60384e0730f8f54dd7L539), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-f030ffbad83492980d57dd555322c7d8e9f26a1986413d60384e0730f8f54dd7L621-R620), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-febb2875fef94d7a7c78c5c23943057bc820a1f6b672f7357aee2502b51806e0L2240-R2242))
* Simplify the expressions by removing the Option.ofResult function in `Commands.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-f030ffbad83492980d57dd555322c7d8e9f26a1986413d60384e0730f8f54dd7L549-R548), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-f030ffbad83492980d57dd555322c7d8e9f26a1986413d60384e0730f8f54dd7L621-R620))
* Add a new file `InlineHintsTests.fs`, which defines a test case for the inline hints feature of the server ([link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-70df40004ac6f9bc529fdc5ea974a731a125c8f4420598ba5d43bc9e60276650R1-R69), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-617db9e831fb074eb5a368b2c99f6e50f1e568cb70c7c37377ba7be3333aa17bR99))
* Remove some empty lines and line breaks from the project file `FsAutoComplete.Tests.Lsp.fsproj` ([link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-229f0ad5d8cd1f3b5c7e56c13fb1318fac8c81c202084e52e63213ba758bcaeeL11), [link](https://github.com/fsharp/FsAutoComplete/pull/1195/files?diff=unified&w=0#diff-229f0ad5d8cd1f3b5c7e56c13fb1318fac8c81c202084e52e63213ba758bcaeeL50-R59))
