### PR TITLE
#r "paket: ...." ought to be shipped as part of FSAC, to easily enabl…

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -14,6 +14,7 @@ lowest_matching: true
 nuget BenchmarkDotNet 0.13.5
 nuget Fantomas.Client >= 0.9
 nuget FSharp.Compiler.Service >= 43.7.400
+nuget FSharp.DependencyManager.Paket
 nuget Ionide.ProjInfo >= 0.62.0
 nuget Ionide.ProjInfo.FCS >= 0.62.0
 nuget Ionide.ProjInfo.ProjectSystem >= 0.62.0

--- a/paket.lock
+++ b/paket.lock
@@ -78,6 +78,8 @@ NUGET
     FSharp.Data.Adaptive (1.2.13)
       FSharp.Core (>= 4.7)
       System.Reflection.Emit.Lightweight (>= 4.6)
+    FSharp.DependencyManager.Paket (6.0)
+      FSharp.Core (>= 5.0)
     FSharp.Formatting (14.0.1)
       FSharp.Compiler.Service (>= 40.0) - restriction: || (== net6.0) (== net7.0) (== net8.0) (&& (== netstandard2.0) (>= netstandard2.1)) (== netstandard2.1)
     FSharp.UMX (1.1)

--- a/src/FsAutoComplete/FsAutoComplete.fsproj
+++ b/src/FsAutoComplete/FsAutoComplete.fsproj
@@ -41,6 +41,7 @@
     <Content Include="default.win32manifest">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FsAutoComplete.Core\FsAutoComplete.Core.fsproj" />

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -112,7 +112,7 @@ type AdaptiveState(lspClient: FSharpLspClient, sourceTextFactory: ISourceTextFac
     else
       traceNotifications <- None
 
-  /// <summary>Sets tje FSI arguments on the FSharpCompilerServiceChecker</summary>
+  /// <summary>Sets the FSI arguments on the <see cref="FSharpCompilerServiceChecker"/></summary>
   /// <param name="checker"></param>
   /// <param name="fsiCompilerToolLocations">Compiler tool locations</param>
   /// <param name="fsiExtraParameters">Any extra parameters to pass to FSI</param>

--- a/src/FsAutoComplete/paket.references
+++ b/src/FsAutoComplete/paket.references
@@ -4,6 +4,7 @@ Destructurama.FSharp
 Fantomas.Client
 FSharp.Analyzers.SDK
 FSharp.Compiler.Service
+FSharp.DependencyManager.Paket
 FSharp.Core
 FSharp.UMX
 FsToolkit.ErrorHandling


### PR DESCRIPTION
#r "paket: ...." ought to be shipped as part of FSAC, to easily enable tools that integrate it, to refer to the folder with --compilertool: in the arguments for FSI.

related: https://github.com/dotnet/fsharp/issues/8880

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6774439</samp>

This pull request adds support for Paket as a dependency manager for F# scripts, and fixes a minor typo in the documentation. It modifies the `paket.dependencies`, `FsAutoComplete.fsproj`, and `paket.references` files, and the `AdaptiveServerState.fs` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6774439</samp>

> _`Paket` for scripts_
> _A feature users wanted_
> _Fixed typo too `//`_

<!--
copilot:emoji
-->

📦📝📚

<!--
1.  📦 - This emoji represents the addition of a package or dependency to a project, and can be used for the first and fourth changes.
2.  📝 - This emoji represents the editing or updating of a file or document, and can be used for the second change.
3.  📚 - This emoji represents the improvement or enhancement of documentation or code comments, and can be used for the third change.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6774439</samp>

*  Add `FSharp.DependencyManager.Paket` package to enable Paket dependency management for F# scripts ([link](https://github.com/fsharp/FsAutoComplete/pull/1198/files?diff=unified&w=0#diff-377fe73bf860b37e7d9a8ca5be27762668b3a08aac581b435d4c31b737d905cdR17), [link](https://github.com/fsharp/FsAutoComplete/pull/1198/files?diff=unified&w=0#diff-fbfdf221e61d9ee5995990c90109910b3a1578733a6635662df3f6185b343384R44), [link](https://github.com/fsharp/FsAutoComplete/pull/1198/files?diff=unified&w=0#diff-7dc88a38add764cb15d590cb39026dab8141460a98b2e3858fd223efc2d3212fR7))
*  Fix typo and add reference tag in XML documentation of `AdaptiveState` type in `AdaptiveServerState.fs` ([link](https://github.com/fsharp/FsAutoComplete/pull/1198/files?diff=unified&w=0#diff-e4d3fcc93b04f2113e7b1b0bb4bdbd5697dcc28b5f3111d2ffa1029479c706ebL115-R115))
