### PR TITLE
GA fixed this

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "fantomas": {
-      "version": "6.2.2",
+      "version": "6.2.3",
       "commands": [
         "fantomas"
       ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,10 +84,7 @@ jobs:
       run: dotnet --info
 
     - name: Restore tools
-      run: |
-        # can't do a tool restore here due to an 8.0.100 rc2 bug - this is fixed in GA so can go back to
-        # dotnet tool restore then.
-        dotnet tool install paket --version 8.0.0-alpha002 && dotnet tool install fantomas --version 6.2.2 && dotnet paket restore
+      run: dotnet tool restore
 
     - name: Check format
       run: dotnet build -t:CheckFormat


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0f52b8a</samp>

Simplify the `Restore tools` step in the GitHub workflow `.github/workflows/build.yml` by using `dotnet tool restore` instead of manual installation. This change takes advantage of a bug fix in .NET 6.0.100 GA.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0f52b8a</samp>

> _`dotnet tool restore`_
> _Simplifies workflow steps_
> _Bug fixed in autumn_

<!--
copilot:emoji
-->

🐛🛠️🧹

<!--
1.  🐛 - This emoji represents the bug fix that allowed `dotnet tool restore` to work with .NET 6.0.100.
2.  🛠️ - This emoji represents the simplification of the `Restore tools` step by using a built-in command instead of manual installation.
3.  🧹 - This emoji represents the cleanup of the workflow by making it more concise and consistent.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0f52b8a</samp>

*  Simplify `Restore tools` step to use `dotnet tool restore` instead of manual installation of paket and fantomas ([link](https://github.com/fsharp/FsAutoComplete/pull/1209/files?diff=unified&w=0#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L87-R87))
