### PR TITLE
Fix AP signatures for APs with names which are substrings of other APs

### DIFF
--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -552,10 +552,12 @@ module SignatureFormatter =
 
   let getAPCaseSignature displayContext (apc: FSharpActivePatternCase) =
     let findVal =
+      let apcSearchString = $"|{apc.DisplayName}|"
+
       apc.Group.DeclaringEntity
       |> Option.bind (fun ent ->
         ent.MembersFunctionsAndValues
-        |> Seq.tryFind (fun func -> func.DisplayName.Contains apc.DisplayName)
+        |> Seq.tryFind (fun func -> func.DisplayName.Contains(apcSearchString, StringComparison.OrdinalIgnoreCase))
         |> Option.map (getFuncSignature displayContext))
       |> Option.bind (fun n ->
         try

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -379,7 +379,28 @@ let tooltipTests state =
                 "   body             : (MailboxProcessor<string> -> Async<unit>) *"
                 "   cancellationToken: option<System.Threading.CancellationToken>"
                 "                   -> MailboxProcessor<string>" ])
-          verifySignature 54 9 "Case2 of string * newlineBefore: bool * newlineAfter: bool" ] ]
+          verifySignature 54 9 "Case2 of string * newlineBefore: bool * newlineAfter: bool"
+          verifySignature
+            60
+            7
+            (concatLines
+              [ "active pattern Value: "
+                "   input: Expr"
+                "       -> option<obj * System.Type>" ])
+          verifySignature
+            65
+            7
+            (concatLines
+              [ "active pattern DefaultValue: "
+                "   input: Expr"
+                "       -> option<System.Type>" ])
+          verifySignature
+            70
+            7
+            (concatLines
+              [ "active pattern ValueWithName: "
+                "   input: Expr"
+                "       -> option<obj * System.Type * string>" ]) ] ]
 
 let closeTests state =
   // Note: clear diagnostics also implies clear caches (-> remove file & project options from State).

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -53,3 +53,20 @@ let mailbox =
 type DiscUnionWithCaseOfLabeledTuple =
     | Case1
     | Case2 of string * newlineBefore: bool * newlineAfter: bool
+
+open FSharp.Quotations.Patterns
+
+let testActivePatternSignatureWithSubStringName (expr: Quotations.Expr) =
+  match expr with
+  | Value (o, t) -> (o, t)
+  | _ -> failwith "no value match"
+  |> ignore
+
+  match expr with
+  | DefaultValue t -> t
+  | _ -> failwith "no value match"
+  |> ignore
+
+  match expr with
+  | ValueWithName t -> t
+  | _ -> failwith "no value match"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2080072</samp>

Fix signature formatting for active pattern cases in `SignatureFormatter.fs`. Use the case name instead of the function name and ignore casing differences.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2080072</samp>

> _`apcSearchString`_
> _Finds the right function to show_
> _Autumn bug is fixed_

<!--
copilot:emoji
-->

🐛🔎📝

<!--
1.  🐛 - This emoji represents a bug fix, which is the main goal of the change.
2.  🔎 - This emoji represents a search or a filter, which is what the `apcSearchString` variable and the `Contains` method are doing.
3.  📝 - This emoji represents a text or a document, which is what the signature of an active pattern case is.
-->

### WHY
To reproduce the issue:
```fsharp
open Microsoft.FSharp.Quotations.Patterns

let rec exprNames expr =
    match expr with
    | Value(_o, t) -> ()
    | _ -> ()
```

The signature for `Value` was taken from other APs, for example `DefaultValue` `ValueWithName` etc. because the Displayname is a substring of these other APs DisplayNames. So let's make the search string specific enough to only match on the one we actually want.


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2080072</samp>

* Fix a bug where the signature of an active pattern case was not shown correctly ([link](https://github.com/fsharp/FsAutoComplete/pull/1211/files?diff=unified&w=0#diff-d0d96a9f3cc99fcf052d3e39bdbee9c9ac7c988eecfa53076779088f1f5c86b9L555-R560))
