### PR TITLE
Add signature files for FSharpLspClient, Parser and UnionPatternMatch…

### DIFF
--- a/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
+++ b/src/FsAutoComplete.Core/FsAutoComplete.Core.fsproj
@@ -50,6 +50,7 @@
     <Compile Include="State.fs" />
     <Compile Include="CodeGeneration.fsi" />
     <Compile Include="CodeGeneration.fs" />
+    <Compile Include="UnionPatternMatchCaseGenerator.fsi" />
     <Compile Include="UnionPatternMatchCaseGenerator.fs" />
     <Compile Include="RecordStubGenerator.fs" />
     <Compile Include="AbstractClassStubGenerator.fs" />

--- a/src/FsAutoComplete.Core/UnionPatternMatchCaseGenerator.fsi
+++ b/src/FsAutoComplete.Core/UnionPatternMatchCaseGenerator.fsi
@@ -1,0 +1,36 @@
+/// Original code from VisualFSharpPowerTools project: https://github.com/fsprojects/VisualFSharpPowerTools/blob/master/src/FSharp.Editing/CodeGeneration/UnionPatternMatchCaseGenerator.fs
+module FsAutoComplete.UnionPatternMatchCaseGenerator
+
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text
+open FSharp.Compiler.Symbols
+
+[<NoEquality; NoComparison>]
+type PatternMatchExpr =
+  {
+    /// Range of 'match x with' or 'function'
+    MatchWithOrFunctionRange: Range
+    /// The whole pattern match expression
+    Expr: SynExpr
+    Clauses: SynMatchClause list
+  }
+
+[<NoComparison>]
+type UnionMatchCasesInsertionParams =
+  { InsertionPos: Position
+    IndentColumn: int }
+
+val shouldGenerateUnionPatternMatchCases: patMatchExpr: PatternMatchExpr -> entity: FSharpEntity -> bool
+
+val tryFindUnionDefinitionFromPos:
+  codeGenService: ICodeGenerationService ->
+  pos: Position ->
+  document: Document ->
+    Async<(PatternMatchExpr * FSharpEntity * UnionMatchCasesInsertionParams) option>
+
+val formatMatchExpr:
+  insertionParams: UnionMatchCasesInsertionParams ->
+  caseDefaultValue: string ->
+  patMatchExpr: PatternMatchExpr ->
+  entity: FSharpEntity ->
+    string

--- a/src/FsAutoComplete/FsAutoComplete.fsproj
+++ b/src/FsAutoComplete/FsAutoComplete.fsproj
@@ -29,12 +29,14 @@
     <Compile Include="CodeFixes/*.fsi" />
     <Compile Include="CodeFixes/*.fs" />
     <Compile Include="LspServers/IFSharpLspServer.fs" />
+    <Compile Include="LspServers/FSharpLspClient.fsi" />
     <Compile Include="LspServers/FSharpLspClient.fs" />
     <Compile Include="LspServers/Common.fs" />
     <Compile Include="LspServers/AdaptiveServerState.fsi" />
     <Compile Include="LspServers/AdaptiveServerState.fs" />
     <Compile Include="LspServers/AdaptiveFSharpLspServer.fsi" />
     <Compile Include="LspServers/AdaptiveFSharpLspServer.fs" />
+    <Compile Include="Parser.fsi" />
     <Compile Include="Parser.fs" />
     <Compile Include="Program.fs" />
     <None Include="FsAutoComplete.fsproj.paket.references" />

--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fsi
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fsi
@@ -1,0 +1,50 @@
+namespace FsAutoComplete.Lsp
+
+open Ionide.LanguageServerProtocol
+open Ionide.LanguageServerProtocol.Server
+open Ionide.LanguageServerProtocol.Types
+open FsAutoComplete.LspHelpers
+open System
+open IcedTasks
+
+type FSharpLspClient =
+  new: sendServerNotification: ClientNotificationSender * sendServerRequest: ClientRequestSender -> FSharpLspClient
+  inherit LspClient
+  member ClientCapabilities: ClientCapabilities option with get, set
+  override WindowShowMessage: ShowMessageParams -> Async<unit>
+  override WindowShowMessageRequest: ShowMessageRequestParams -> AsyncLspResult<MessageActionItem option>
+  override WindowLogMessage: LogMessageParams -> Async<unit>
+  override TelemetryEvent: Newtonsoft.Json.Linq.JToken -> Async<unit>
+  override ClientRegisterCapability: RegistrationParams -> AsyncLspResult<unit>
+  override ClientUnregisterCapability: UnregistrationParams -> AsyncLspResult<unit>
+  override WorkspaceWorkspaceFolders: unit -> AsyncLspResult<WorkspaceFolder array option>
+  override WorkspaceConfiguration: ConfigurationParams -> AsyncLspResult<Newtonsoft.Json.Linq.JToken array>
+  override WorkspaceApplyEdit: ApplyWorkspaceEditParams -> AsyncLspResult<ApplyWorkspaceEditResponse>
+  override WorkspaceSemanticTokensRefresh: unit -> Async<unit>
+  override TextDocumentPublishDiagnostics: PublishDiagnosticsParams -> Async<unit>
+  ///Custom notification for workspace/solution/project loading events
+  member NotifyWorkspace: p: PlainNotification -> Async<unit>
+  ///Custom notification for initial workspace peek
+  member NotifyWorkspacePeek: p: PlainNotification -> Async<unit>
+  member NotifyCancelledRequest: p: PlainNotification -> Async<unit>
+  member NotifyFileParsed: p: PlainNotification -> Async<unit>
+  member NotifyDocumentAnalyzed: p: DocumentAnalyzedNotification -> Async<unit>
+  member NotifyTestDetected: p: TestDetectedNotification -> Async<unit>
+  member CodeLensRefresh: unit -> Async<unit>
+  override WorkDoneProgressCreate: ProgressToken -> AsyncLspResult<unit>
+  override Progress: ProgressToken * 'Progress -> Async<unit>
+
+type ServerProgressReport =
+  new: lspClient: FSharpLspClient * ?token: ProgressToken -> ServerProgressReport
+  member Token: ProgressToken
+  member Begin: title: string * ?cancellable: bool * ?message: string * ?percentage: uint -> CancellableTask<unit>
+  member Report: ?cancellable: bool * ?message: string * ?percentage: uint -> CancellableTask<unit>
+  member End: ?message: string -> CancellableTask<unit>
+  interface IAsyncDisposable
+  interface IDisposable
+
+/// <summary>listener for the the events generated from the fsc ActivitySource</summary>
+type ProgressListener =
+  new: lspClient: FSharpLspClient * traceNamespace: string array -> ProgressListener
+  interface IDisposable
+  interface IAsyncDisposable

--- a/src/FsAutoComplete/Parser.fs
+++ b/src/FsAutoComplete/Parser.fs
@@ -30,24 +30,18 @@ module Parser =
       Start: FSharp.Compiler.Text.pos
       End: FSharp.Compiler.Text.pos }
 
-  let private setArity arity (o: #Option) =
+  let setArity arity (o: #Option) =
     o.Arity <- arity
     o
 
   /// set option to expect no arguments (e.g a flag-style argument: `--verbose`)
-  let inline private zero x = setArity ArgumentArity.Zero x
+  let inline zero x = setArity ArgumentArity.Zero x
   /// set option to expect one argument (e.g a single value: `--foo bar)
-  let inline private one x = setArity ArgumentArity.ExactlyOne x
+  let inline one x = setArity ArgumentArity.ExactlyOne x
 
   /// set option to expect multiple arguments
   /// (e.g a list of values: `--foo bar baz` or `--foo bar --foo baz` depending on the style)
-  let inline private many x = setArity ArgumentArity.OneOrMore x
-
-  /// set option to allow multiple arguments per use of the option flag
-  /// (e.g. `--foo bar baz` is equivalent to `--foo bar --foo baz`)
-  let inline private multipleArgs (x: #Option) =
-    x.AllowMultipleArgumentsPerToken <- true
-    x
+  let inline many x = setArity ArgumentArity.OneOrMore x
 
   let verboseOption =
     Option<bool>([| "--verbose"; "-v"; "--debug" |], "Enable verbose logging. This is equivalent to --log-level debug.")

--- a/src/FsAutoComplete/Parser.fsi
+++ b/src/FsAutoComplete/Parser.fsi
@@ -1,0 +1,6 @@
+namespace FsAutoComplete
+
+open System.CommandLine.Parsing
+
+module Parser =
+  val parser: Parser


### PR DESCRIPTION
…CaseGenerator.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0f2b5ad</samp>

This pull request adds signature files for several modules in the FsAutoComplete and FsAutoComplete.Core projects, which define the interfaces of the LSP client, the command line parser, and the union pattern match case generator. It also removes an unused function from the Parser module and updates the project references accordingly. These changes improve the readability, maintainability, and functionality of the FsAutoComplete server.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0f2b5ad</samp>

> _The FsAutoComplete server is great_
> _It helps F# developers create_
> _But it needed some tweaks_
> _To improve its techniques_
> _So we added some files to update_

<!--
copilot:emoji
-->

:sparkles::fire::memo:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, which is the case for the code generation for union pattern match cases and the LSP client for F# language features.
2.  :fire: This emoji represents the removal of code or files, which is the case for the `multipleArgs` function that was unused and redundant.
3.  :memo: This emoji represents the addition or update of documentation, which is the case for the signature files that define the interfaces of the modules.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0f2b5ad</samp>

*  Add the signature of the module for union pattern match case generation, a feature ported from VisualFSharpPowerTools ([link](https://github.com/fsharp/FsAutoComplete/pull/1213/files?diff=unified&w=0#diff-4e1eec4f3001f859eea14f05b14bef7491267e3f1b7aab96893b57047fefe4d4R1-R36),[link](https://github.com/fsharp/FsAutoComplete/pull/1213/files?diff=unified&w=0#diff-463d13f8edd389ba6d3523e62674bcaff8884e05a4578aef11ff4f12e86bcd99R53))
* Add the signature of the type for the LSP client for F# language features, a core component of the server ([link](https://github.com/fsharp/FsAutoComplete/pull/1213/files?diff=unified&w=0#diff-a376229ff846b8658f8b516801b8b388d8a5d2bb9855623cee02ef0d1d43b8cfR1-R50),[link](https://github.com/fsharp/FsAutoComplete/pull/1213/files?diff=unified&w=0#diff-fbfdf221e61d9ee5995990c90109910b3a1578733a6635662df3f6185b343384R32))
* Add the signature of the module for the command line parser for the server, which parses the arguments and options passed to the executable ([link](https://github.com/fsharp/FsAutoComplete/pull/1213/files?diff=unified&w=0#diff-69d7249ec3564e29666009d3397f33008616a7ecce64ee1234a1268c6c96d3daR1-R6),[link](https://github.com/fsharp/FsAutoComplete/pull/1213/files?diff=unified&w=0#diff-fbfdf221e61d9ee5995990c90109910b3a1578733a6635662df3f6185b343384R39))
* Remove the unused and redundant `multipleArgs` function from the `Parser` module ([link](https://github.com/fsharp/FsAutoComplete/pull/1213/files?diff=unified&w=0#diff-83138e39ec2a1b48ab9298036c49a450021f15bbebf1085f9b1d58c2fd5ae08aL33-R45))

Played around with `--test:GraphBasedChecking` and the longest path algorithm in https://github.com/fslaborg/Graphoscope/issues/58.
As a result, these were interesting to have signatures for as well.