### PR TITLE
Update analyzers used in this repo

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -21,7 +21,7 @@
       ]
     },
     "fsharp-analyzers": {
-      "version": "0.21.0",
+      "version": "0.22.0",
       "commands": [
         "fsharp-analyzers"
       ]

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,7 +11,7 @@
 <PropertyGroup>
     <SarifOutput Condition="$(SarifOutput) == ''">./</SarifOutput>
     <CodeRoot Condition="$(CodeRoot) == ''">.</CodeRoot>
-    <FSharpAnalyzersOtherFlags>--analyzers-path &quot;$(PkgIonide_Analyzers)/analyzers/dotnet/fs&quot; --code-root $(CodeRoot) --report &quot;$(SarifOutput)/$(MSBuildProjectName)-$(TargetFramework).sarif&quot; --verbose</FSharpAnalyzersOtherFlags>
+    <FSharpAnalyzersOtherFlags>--analyzers-path &quot;$(PkgIonide_Analyzers)/analyzers/dotnet/fs&quot; --code-root $(CodeRoot) --report &quot;$(SarifOutput)/$(MSBuildProjectName)-$(TargetFramework).sarif&quot; --verbosity d</FSharpAnalyzersOtherFlags>
 </PropertyGroup>
 
 </Project>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -14,7 +14,7 @@ lowest_matching: true
 nuget BenchmarkDotNet 0.13.5
 nuget Fantomas.Client >= 0.9
 nuget FSharp.Compiler.Service >= 43.8.100
-nuget Ionide.Analyzers 0.5.1
+nuget Ionide.Analyzers 0.6.0
 nuget FSharp.Analyzers.Build 0.2.0
 nuget Ionide.ProjInfo >= 0.62.0
 nuget Ionide.ProjInfo.FCS >= 0.62.0

--- a/paket.lock
+++ b/paket.lock
@@ -131,7 +131,7 @@ NUGET
       Microsoft.Win32.Registry (>= 5.0)
       System.Collections.Immutable (>= 5.0)
       System.Reflection.Metadata (>= 5.0)
-    Ionide.Analyzers (0.5.1)
+    Ionide.Analyzers (0.6)
     Ionide.KeepAChangelog.Tasks (0.1.8) - copy_local: true
     Ionide.LanguageServerProtocol (0.4.20)
       FSharp.Core (>= 6.0)


### PR DESCRIPTION
- bumps the fsharp-analyzers tool to 0.22.0
- bumps Ionide.Analyzers to 0.6.0