### PR TITLE
[Ignore] Top level types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,3 +23,9 @@ fsharp_max_array_or_list_width=80
 fsharp_max_dot_get_expression_width=80
 fsharp_max_function_binding_width=80
 fsharp_max_value_binding_width=80
+
+[src/FsAutoComplete/CodeFixes/TopLevelTypes.fs]
+indent_size = 4
+fsharp_multiline_bracket_style = aligned
+fsharp_align_function_signature_to_indentation = true
+fsharp_experimental_keep_indent_in_branch = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -24,7 +24,7 @@ fsharp_max_dot_get_expression_width=80
 fsharp_max_function_binding_width=80
 fsharp_max_value_binding_width=80
 
-[src/FsAutoComplete/CodeFixes/TopLevelTypes.fs]
+[{src/FsAutoComplete/CodeFixes/TopLevelTypes.fs,src/FsAutoComplete/TopLevelTypeAnalysis.fs}]
 indent_size = 4
 fsharp_multiline_bracket_style = aligned
 fsharp_align_function_signature_to_indentation = true

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -472,3 +472,5 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize, parallelRefe
       fsiAdditionalArguments <- additionalArgs
       fsiAdditionalFiles <- files
       scriptTypecheckRequirementsChanged.Trigger()
+
+  member _.ParseAndCheckProject(options: FSharpProjectOptions) = checker.ParseAndCheckProject(options)

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -13,7 +13,7 @@ open Microsoft.Extensions.Caching.Memory
 open System
 open FsToolkit.ErrorHandling
 
-
+#nowarn "57"
 
 type Version = int
 
@@ -474,3 +474,6 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize, parallelRefe
       scriptTypecheckRequirementsChanged.Trigger()
 
   member _.ParseAndCheckProject(options: FSharpProjectOptions) = checker.ParseAndCheckProject(options)
+
+  member _.NotifyFileChanged(fileName: string, options: FSharpProjectOptions) =
+    checker.NotifyFileChanged(fileName, options)

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fsi
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fsi
@@ -86,3 +86,4 @@ type FSharpCompilerServiceChecker =
   member SetDotnetRoot: dotnetBinary: FileInfo * cwd: DirectoryInfo -> unit
   member GetDotnetRoot: unit -> DirectoryInfo option
   member SetFSIAdditionalArguments: args: string array -> unit
+  member ParseAndCheckProject: FSharpProjectOptions -> Async<FSharpCheckProjectResults>

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fsi
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fsi
@@ -87,3 +87,4 @@ type FSharpCompilerServiceChecker =
   member GetDotnetRoot: unit -> DirectoryInfo option
   member SetFSIAdditionalArguments: args: string array -> unit
   member ParseAndCheckProject: FSharpProjectOptions -> Async<FSharpCheckProjectResults>
+  member NotifyFileChanged: string * FSharpProjectOptions -> Async<unit>

--- a/src/FsAutoComplete/CodeFixes/TopLevelTypes.fs
+++ b/src/FsAutoComplete/CodeFixes/TopLevelTypes.fs
@@ -1,5 +1,6 @@
 ﻿module FsAutoComplete.CodeFix.TopLevelTypes
 
+open FSharp.Compiler.SyntaxTrivia
 open FSharp.Compiler.Text
 open FSharp.UMX
 open FsToolkit.ErrorHandling
@@ -8,35 +9,125 @@ open Ionide.LanguageServerProtocol.Types
 open FsAutoComplete
 open FsAutoComplete.LspHelpers
 open FSharp.Compiler.CodeAnalysis
+open TopLevelTypeAnalysis
 
-let title = "Oh some stuff, y'know"
+let private collectMissingTypeInformation
+    (forceGetFSharpProjectOptions: string<LocalPath> -> Async<Result<FSharpProjectOptions, string>>)
+    (getParseResultsForFile: GetParseResultsForFile)
+    (forceChecker: unit -> FSharpCompilerServiceChecker)
+    (codeActionParams: CodeActionParams)
+    : Async<Result<MissingTypeInfo list, string>>
+    =
+    asyncResult {
+        let fileName = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
+        let! options = forceGetFSharpProjectOptions fileName
+        let checker = forceChecker ()
+        do! checker.NotifyFileChanged(UMX.untag fileName, options) // workaround for https://github.com/dotnet/fsharp/issues/15960
+        let! projectCheckResults = checker.ParseAndCheckProject options
+        let allSymbolUses = projectCheckResults.GetAllUsesOfAllSymbols()
+
+        if Array.isEmpty allSymbolUses then
+            return []
+        else
+
+        let! parseAndCheckResult, _, fsacSourceText = getParseResultsForFile fileName Position.pos0
+
+        let sourceText: ISourceText = fsacSourceText
+
+        let parsedInput, checkFileResults =
+            parseAndCheckResult.GetParseResults.ParseTree, parseAndCheckResult.GetCheckResults
+
+        return
+            TopLevelTypeAnalysis.findMissingTypeInformation sourceText parsedInput checkFileResults projectCheckResults
+    }
+
+let titleMkPrivate = "Make as much as possible private"
+let titleAddTopLevelTypes = "Add missing top level types"
+
+let private mkEditsForMissingTypes (missingTypeInfo: MissingTypeInfo) : TextEdit list =
+    [
+        // generic parameters
+
+        // parameters
+        for p in missingTypeInfo.Parameters do
+            // TODO: deal with multiline parameter patterns
+            if p.Range.StartLine = p.Range.EndLine && not p.AddParentheses then
+                {
+                    NewText = $"(%s{p.SourceText}: %s{p.TypeName})"
+                    Range = fcsRangeToLsp p.Range
+                }
+
+        // declaration specific
+        match missingTypeInfo.Declaration with
+        | Declaration.Binding(returnType = Some returnType) ->
+            {
+                NewText = $": %s{returnType.TypeName} ="
+                Range = fcsRangeToLsp returnType.Equals
+            }
+        | _ -> ()
+    ]
+
+let private mkEditToPrivate (missingTypeInfo: MissingTypeInfo) : TextEdit list =
+    match missingTypeInfo.Declaration with
+    | Declaration.Binding(leadingKeyword = leadingKeyword) ->
+        match leadingKeyword with
+        | SynLeadingKeyword.Let mLet ->
+            List.singleton
+                {
+                    NewText = "let private"
+                    Range = fcsRangeToLsp mLet
+                }
+        | _ -> List.empty
+    | _ -> List.empty
 
 let fix
-  (forceGetFSharpProjectOptions: string<LocalPath> -> Async<Result<FSharpProjectOptions, string>>)
-  (getParseResultsForFile: GetParseResultsForFile)
-  (forceChecker: unit -> FSharpCompilerServiceChecker)
-  : CodeFix =
-  fun codeActionParams ->
+    (forceGetFSharpProjectOptions: string<LocalPath> -> Async<Result<FSharpProjectOptions, string>>)
+    (getParseResultsForFile: GetParseResultsForFile)
+    (forceChecker: unit -> FSharpCompilerServiceChecker)
+    (codeActionParams: CodeActionParams)
+    : Async<Result<Fix list, string>>
+    =
     asyncResult {
-      let fileName = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
-      let! options = forceGetFSharpProjectOptions fileName
-      let checker = forceChecker ()
-      let! projectCheckResults = checker.ParseAndCheckProject options
-      let! (parseAndCheckResult, _, fsacSourceText) = getParseResultsForFile fileName FSharp.Compiler.Text.Position.pos0
-      let sourceText: ISourceText = fsacSourceText
+        let! missingTypeInformation =
+            collectMissingTypeInformation
+                forceGetFSharpProjectOptions
+                getParseResultsForFile
+                forceChecker
+                codeActionParams
 
-      let parsedInput, checkFileResults =
-        parseAndCheckResult.GetParseResults.ParseTree, parseAndCheckResult.GetCheckResults
+        ignore missingTypeInformation
 
-      let missingTypeInformation =
-        TopLevelTypeAnalysis.findMissingTypeInformation sourceText parsedInput checkFileResults projectCheckResults
+        if missingTypeInformation.IsEmpty then
+            return []
+        else
 
-      ignore missingTypeInformation
+        let editsMkPrivate =
+            missingTypeInformation
+            |> List.collect (fun missingTypeInfo ->
+                if missingTypeInfo.ValueIsUsedOutsideTheFileInTheProject then
+                    mkEditsForMissingTypes missingTypeInfo
+                else
+                    mkEditToPrivate missingTypeInfo)
+            |> List.toArray
 
-      return
-        [ { Edits = Array.empty
-            File = codeActionParams.TextDocument
-            Title = title
-            SourceDiagnostic = None
-            Kind = FixKind.Refactor } ]
+        let editsAddTopLevelTypes =
+            missingTypeInformation |> List.collect mkEditsForMissingTypes |> List.toArray
+
+        return
+            [
+                {
+                    Edits = editsMkPrivate
+                    File = codeActionParams.TextDocument
+                    Title = titleMkPrivate
+                    SourceDiagnostic = None
+                    Kind = FixKind.Refactor
+                }
+                {
+                    Edits = editsAddTopLevelTypes
+                    File = codeActionParams.TextDocument
+                    Title = titleAddTopLevelTypes
+                    SourceDiagnostic = None
+                    Kind = FixKind.Refactor
+                }
+            ]
     }

--- a/src/FsAutoComplete/CodeFixes/TopLevelTypes.fs
+++ b/src/FsAutoComplete/CodeFixes/TopLevelTypes.fs
@@ -71,14 +71,27 @@ let private mkGenericParameterEdits (missingTypeInfo: MissingTypeInfo) : TextEdi
     | Declaration.AutoProperty _ -> []
     | Declaration.ImplicitCtor(typeName = ident)
     | Declaration.Binding(name = ident) ->
-        let text =
+        let parameters =
             missingTypeInfo.GenericParameters
             |> List.map (fun gp -> gp.Name)
             |> String.concat ", "
 
+        let constraints =
+            let allConstraintsTexts =
+                missingTypeInfo.GenericParameters
+                |> List.collect (fun gp -> gp.MissingConstraints)
+
+            if allConstraintsTexts.IsEmpty then
+                ""
+            else
+
+            allConstraintsTexts
+            |> String.concat " and "
+            |> sprintf " when %s"
+
         [
             {
-                NewText = $"%s{ident.idText}<%s{text}>"
+                NewText = $"%s{ident.idText}<%s{parameters}%s{constraints}>"
                 Range = fcsRangeToLsp ident.idRange
             }
         ]

--- a/src/FsAutoComplete/CodeFixes/TopLevelTypes.fs
+++ b/src/FsAutoComplete/CodeFixes/TopLevelTypes.fs
@@ -128,8 +128,16 @@ let private mkEditsForMissingTypes (missingTypeInfo: MissingTypeInfo) : TextEdit
 
 let private mkEditToPrivate (missingTypeInfo: MissingTypeInfo) : TextEdit list =
     match missingTypeInfo.Declaration with
-    | Declaration.Binding(leadingKeyword = leadingKeyword) ->
+    | Declaration.Binding(leadingKeyword = leadingKeyword; inlineKeyword = inlineKeyword) ->
         [
+            match inlineKeyword with
+            | Some inlineKeyword ->
+                {
+                    NewText = "inline private"
+                    Range = fcsRangeToLsp inlineKeyword
+                }
+            | None ->
+
             match leadingKeyword with
             | SynLeadingKeyword.Let _ ->
                 {
@@ -174,10 +182,7 @@ let fix
         let editsMkPrivate =
             missingTypeInformation
             |> List.collect (fun missingTypeInfo ->
-                if
-                    (not missingTypeInfo.ValueIsUsedOutsideTheFileInTheProject
-                     && missingTypeInfo.Declaration.IsLetBinding)
-                then
+                if missingTypeInfo.ValueCouldBeMadePrivateToFile then
                     mkEditToPrivate missingTypeInfo
                 else
                     mkEditsForMissingTypes missingTypeInfo)

--- a/src/FsAutoComplete/CodeFixes/TopLevelTypes.fs
+++ b/src/FsAutoComplete/CodeFixes/TopLevelTypes.fs
@@ -1,0 +1,42 @@
+﻿module FsAutoComplete.CodeFix.TopLevelTypes
+
+open FSharp.Compiler.Text
+open FSharp.UMX
+open FsToolkit.ErrorHandling
+open FsAutoComplete.CodeFix.Types
+open Ionide.LanguageServerProtocol.Types
+open FsAutoComplete
+open FsAutoComplete.LspHelpers
+open FSharp.Compiler.CodeAnalysis
+
+let title = "Oh some stuff, y'know"
+
+let fix
+  (forceGetFSharpProjectOptions: string<LocalPath> -> Async<Result<FSharpProjectOptions, string>>)
+  (getParseResultsForFile: GetParseResultsForFile)
+  (forceChecker: unit -> FSharpCompilerServiceChecker)
+  : CodeFix =
+  fun codeActionParams ->
+    asyncResult {
+      let fileName = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
+      let! options = forceGetFSharpProjectOptions fileName
+      let checker = forceChecker ()
+      let! projectCheckResults = checker.ParseAndCheckProject options
+      let! (parseAndCheckResult, _, fsacSourceText) = getParseResultsForFile fileName FSharp.Compiler.Text.Position.pos0
+      let sourceText: ISourceText = fsacSourceText
+
+      let parsedInput, checkFileResults =
+        parseAndCheckResult.GetParseResults.ParseTree, parseAndCheckResult.GetCheckResults
+
+      let missingTypeInformation =
+        TopLevelTypeAnalysis.findMissingTypeInformation sourceText parsedInput checkFileResults projectCheckResults
+
+      ignore missingTypeInformation
+
+      return
+        [ { Edits = Array.empty
+            File = codeActionParams.TextDocument
+            Title = title
+            SourceDiagnostic = None
+            Kind = FixKind.Refactor } ]
+    }

--- a/src/FsAutoComplete/FsAutoComplete.fsproj
+++ b/src/FsAutoComplete/FsAutoComplete.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="JsonSerializer.fs" />
     <Compile Include="LspHelpers.fsi" />
     <Compile Include="LspHelpers.fs" />
+    <Compile Include="C:\Users\nojaf\Projects\g-research-fsharp-analyzers\src\FSharp.Analyzers\TopLevelTypeAnalysis.fs" />
     <Compile Include="CodeFixes.fsi" />
     <Compile Include="CodeFixes.fs" />
     <Compile Include="CodeFixes/*.fsi" />

--- a/src/FsAutoComplete/FsAutoComplete.fsproj
+++ b/src/FsAutoComplete/FsAutoComplete.fsproj
@@ -24,7 +24,7 @@
     <Compile Include="JsonSerializer.fs" />
     <Compile Include="LspHelpers.fsi" />
     <Compile Include="LspHelpers.fs" />
-    <Compile Include="C:\Users\nojaf\Projects\g-research-fsharp-analyzers\src\FSharp.Analyzers\TopLevelTypeAnalysis.fs" />
+    <Compile Include="TopLevelTypeAnalysis.fs" />
     <Compile Include="CodeFixes.fsi" />
     <Compile Include="CodeFixes.fs" />
     <Compile Include="CodeFixes/*.fsi" />

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -98,7 +98,10 @@ module Conversions =
   let urlForCompilerCode (number: int) =
     $"https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-messages/fs%04d{number}"
 
-  let fcsErrorToDiagnostic (error: FSharpDiagnostic) =
+  let fcsErrorToDiagnostic (error: FSharpDiagnostic) : Diagnostic =
+    // Store?
+    ignore error.ExtendedData
+
     { Range =
         { Start =
             { Line = error.StartLine - 1

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -99,9 +99,6 @@ module Conversions =
     $"https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-messages/fs%04d{number}"
 
   let fcsErrorToDiagnostic (error: FSharpDiagnostic) : Diagnostic =
-    // Store?
-    ignore error.ExtendedData
-
     { Range =
         { Start =
             { Line = error.StartLine - 1

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -1768,7 +1768,8 @@ type AdaptiveState(lspClient: FSharpLspClient, sourceTextFactory: ISourceTextFac
          RenameParamToMatchSignature.fix tryGetParseResultsForFile
          RemovePatternArgument.fix tryGetParseResultsForFile
          ToInterpolatedString.fix tryGetParseResultsForFile getLanguageVersion
-         AdjustConstant.fix tryGetParseResultsForFile |])
+         AdjustConstant.fix tryGetParseResultsForFile
+         TopLevelTypes.fix forceGetFSharpProjectOptions tryGetParseResultsForFile (fun () -> AVal.force checker) |])
 
   let forgetDocument (uri: DocumentUri) =
     async {

--- a/src/FsAutoComplete/TopLevelTypeAnalysis.fs
+++ b/src/FsAutoComplete/TopLevelTypeAnalysis.fs
@@ -1,0 +1,1 @@
+C:/Users/nojaf/Projects/g-research-fsharp-analyzers/src/FSharp.Analyzers/TopLevelTypeAnalysis.fs


### PR DESCRIPTION
This PR is mostly for @dawedawe to follow along. There are no immediate intentions to ever get this merged.

It is part of the experiment in https://github.com/dotnet/fsharp/discussions/16450.
I'm reusing [TopLevelTypeAnalysis.fs](https://github.com/G-Research/fsharp-analyzers/blob/576fe88bd07b3c213f87c10f79edfaf5cd8f4942/src/FSharp.Analyzers/TopLevelTypeAnalysis.fs) from [G-Research/fsharp-analyzers#47](https://github.com/G-Research/fsharp-analyzers/pull/47).

