### PR TITLE
Fix the format issue in the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
       run: dotnet tool restore
 
     - name: Check format
-      run: dotnet fantomas src
+      run: dotnet fantomas --check src
       env:
         DOTNET_ROLL_FORWARD: LatestMajor
         DOTNET_ROLL_FORWARD_TO_PRERELEASE: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
       run: dotnet tool restore
 
     - name: Check format
-      run: dotnet build -t:CheckFormat
+      run: dotnet fantomas src
       env:
         DOTNET_ROLL_FORWARD: LatestMajor
         DOTNET_ROLL_FORWARD_TO_PRERELEASE: 1

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -1,14 +1,10 @@
 <Project>
-  <ItemGroup>
-    <FormatInputs Include="src/**/*.fs;src/**/*.fsi" Exclude="src/**/obj/**/*.fs" />
-  </ItemGroup>
-
   <Target Name="Format">
-    <Exec Command="dotnet fantomas @(FormatInputs, ' ') " />
+    <Exec Command="dotnet fantomas src" />
   </Target>
 
   <Target Name="CheckFormat">
-    <Exec Command="dotnet fantomas --check @(FormatInputs, ' ') " />
+    <Exec Command="dotnet fantomas --check src" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
Given 3 pipeline runs without the formatting issue we see so often, I think this fixes it.
Although, maybe not in a very satisfying way. But it seems that calling fantomas via a build target is flaky in GH actions 🤷 

Also, no need to explicitely exclude the `obj` folder. If we just pass in a folder to fantomas, it ignores files in `obj` by default.