### PR TITLE
Make FSAC initialization assume workspacePaths[0] instead of RootPath

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,7 +52,7 @@
       "args": [
         "--debug",
         "--filter",
-        "FSAC.lsp.${input:loader}.${input:lsp-server}.${input:testName}"
+        "FSAC.lsp.${input:loader}.${input:testName}"
       ]
     }
   ],
@@ -75,17 +75,6 @@
         "MSBuild Project Graph WorkspaceLoader"
       ],
       "default": "WorkspaceLoader",
-      "type": "pickString"
-    },
-
-    {
-      "id": "lsp-server",
-      "description": "The lsp serrver",
-      "options": [
-        "FSharpLspServer",
-        "AdaptiveLspServer"
-      ],
-      "default": "AdaptiveLspServer",
       "type": "pickString"
     },
     {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,19 +1,31 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
-    "version": "2.0.0",
-    "tasks": [
-      {
-        "label": "format codebase",
-        "command": "dotnet",
-        "args": [
-          "build",
-          "-t",
-          "Format"
-        ],
-        "detail": "Format all source code using Fantomas",
-        "type": "shell",
-        "problemMatcher": []
-      }
-    ]
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "format codebase",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "-t",
+        "Format"
+      ],
+      "detail": "Format all source code using Fantomas",
+      "type": "shell",
+      "problemMatcher": []
+    },
+    {
+      "type": "msbuild",
+      "problemMatcher": [
+        "$msCompile"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "label": "Build: FsAutoComplete.fsproj",
+      "detail": "Build the FsAutoComplete.fsproj project using dotnet build"
+    }
+  ]
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "7.0.400",
-    "allowPrerelease": true
-  }
-}

--- a/paket.lock
+++ b/paket.lock
@@ -133,7 +133,7 @@ NUGET
       System.Reflection.Metadata (>= 5.0)
     Ionide.Analyzers (0.7)
     Ionide.KeepAChangelog.Tasks (0.1.8) - copy_local: true
-    Ionide.LanguageServerProtocol (0.4.20)
+    Ionide.LanguageServerProtocol (0.4.22)
       FSharp.Core (>= 6.0)
       Newtonsoft.Json (>= 13.0.1)
       StreamJsonRpc (>= 2.16.36)

--- a/src/FsAutoComplete.Logging/FsAutoComplete.Logging.fsproj
+++ b/src/FsAutoComplete.Logging/FsAutoComplete.Logging.fsproj
@@ -11,4 +11,8 @@
     <Compile Include="FsOpenTelemetry.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
+
+  <Target Name="Blah" AfterTargets="AfterBuild">
+    <Warning Message="farts" />
+  </Target>
 </Project>

--- a/src/FsAutoComplete/LspHelpers.fsi
+++ b/src/FsAutoComplete/LspHelpers.fsi
@@ -57,14 +57,19 @@ module Conversions =
   val urlForCompilerCode: number: int -> string
   val fcsErrorToDiagnostic: error: FSharpDiagnostic -> Diagnostic
 
-  val getSymbolInformations:
+  val getWorkspaceSymbols:
     uri: DocumentUri ->
     glyphToSymbolKind: (FSharpGlyph -> SymbolKind option) ->
     topLevel: NavigationTopLevelDeclaration ->
-    symbolFilter: (SymbolInformation -> bool) ->
-      SymbolInformation array
+    symbolFilter: (WorkspaceSymbol -> bool) ->
+      WorkspaceSymbol array
 
-  val applyQuery: query: string -> info: SymbolInformation -> bool
+  val getDocumentSymbol:
+    glyphToSymbolKind: (FSharpGlyph -> SymbolKind option) ->
+    topLevelItem: NavigationTopLevelDeclaration ->
+      DocumentSymbol
+
+  val applyQuery: query: string -> info: WorkspaceSymbol -> bool
 
   val getCodeLensInformation:
     uri: DocumentUri -> typ: string -> topLevel: NavigationTopLevelDeclaration -> CodeLens array

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1266,6 +1266,7 @@ type AdaptiveFSharpLspServer
           return! returnException e
       }
 
+    /// This is mostly used to power the per-document @-based searching in VSCode. Open the Command Palette, type a query starting with @SOME_MEMBER_NAME, and quickly go to that member in the current file
     override __.TextDocumentDocumentSymbol(p: DocumentSymbolParams) =
       asyncResult {
         let tags = [ "DocumentSymbolParams", box p ]
@@ -1299,6 +1300,8 @@ type AdaptiveFSharpLspServer
           return! returnException e
       }
 
+
+    /// This is used to power the "Go to symbol in workspace" feature in VSCode. Open the Command Palette, type a query starting with #SOME_MEMBER_NAME, and quickly go to that member in the entire workspace
     override __.WorkspaceSymbol(symbolRequest: WorkspaceSymbolParams) =
       asyncResult {
         let tags = [ "WorkspaceSymbolParams", box symbolRequest ]

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -10,6 +10,8 @@ open FsAutoComplete.Lsp
 open FsToolkit.ErrorHandling
 open Helpers.Expecto.ShadowedTimeouts
 
+#nowarn "44" //we're testing so need to be able to use deprecated fields
+
 let tests state =
   let server =
     async {
@@ -781,7 +783,9 @@ let autoOpenTests state =
 
       let (|ContainsOpenAction|_|) (codeActions: CodeAction[]) =
         codeActions
-        |> Array.tryFind (fun ca -> ca.Kind = Some "quickfix" && ca.Title.StartsWith("open ", StringComparison.Ordinal))
+        |> Array.tryFind (fun ca ->
+          ca.Kind = Some "quickfix"
+          && ca.Title.StartsWith("open ", StringComparison.Ordinal))
 
       match! server.TextDocumentCodeAction p with
       | Error e -> return failtestf "Quick fix Request failed: %A" e

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -144,10 +144,17 @@ let documentSymbolTest state =
           | Result.Ok(Some(U2.First _)) -> raise (NotImplementedException("DocumentSymbol isn't used in FSAC yet"))
 
           | Result.Ok(Some(U2.Second res)) ->
-            Expect.equal res.Length 15 "Document Symbol has all symbols"
-
-            Expect.exists
+            // have to unroll the document symbols since they are properly heirarchical now
+            Expect.equal res.Length 4 "Document Symbol has all parent symbols"
+            let allSymbols = 
               res
+              |> Array.collect (fun s -> 
+                match s.Children with
+                | None -> [| s |]
+                | Some children -> Array.append [| s |] children)
+              |> Array.sort
+            Expect.exists
+              allSymbols
               (fun n -> n.Name = "MyDateTime" && n.Kind = SymbolKind.Class)
               "Document symbol contains given symbol"
         }) ]

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -24,6 +24,8 @@ open FSharpx.Control
 open Utils.Tests
 open Helpers.Expecto.ShadowedTimeouts
 
+#nowarn "44" //we're testing so need to be able to use deprecated fields
+
 ///Test for initialization of the server
 let initTests createServer =
   testCaseAsync

--- a/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
@@ -10,8 +10,10 @@ open FsToolkit.ErrorHandling
 open Utils.Server
 open Helpers.Expecto.ShadowedTimeouts
 
+#nowarn "44" //we're testing so need to be able to use deprecated fields
+
 let tests state =
-  let createServer() =
+  let createServer () =
     async {
       let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "EmptyFileTests")
 
@@ -23,87 +25,94 @@ let tests state =
       return server, events, scriptPath
     }
     |> Async.Cache
-  let server1 = createServer()
-  let server2 = createServer()
+
+  let server1 = createServer ()
+  let server2 = createServer ()
 
   testList
     "empty file features"
     [ testList
         "tests"
-        [
-            testCaseAsync
-                "no parsing/checking errors"
-                (async {
-                  let! server, events, scriptPath = server1
-                  do! server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath }
+        [ testCaseAsync
+            "no parsing/checking errors"
+            (async {
+              let! server, events, scriptPath = server1
+              do! server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath }
 
-                  match! waitForParseResultsForFile "EmptyFile.fsx" events with
-                  | Ok _ -> () // all good, no parsing/checking errors
-                  | Core.Result.Error errors -> failwithf "Errors while parsing script %s: %A" scriptPath errors
-                })
+              match! waitForParseResultsForFile "EmptyFile.fsx" events with
+              | Ok _ -> () // all good, no parsing/checking errors
+              | Core.Result.Error errors -> failwithf "Errors while parsing script %s: %A" scriptPath errors
+            })
 
-            testCaseAsync
-                "auto completion does not throw and is empty"
-                (async {
-                  let! server, _, path = server1
-                  do! server.TextDocumentDidOpen { TextDocument = loadDocument path }
+          testCaseAsync
+            "auto completion does not throw and is empty"
+            (async {
+              let! server, _, path = server1
+              do! server.TextDocumentDidOpen { TextDocument = loadDocument path }
 
-                  let completionParams: CompletionParams =
-                    { TextDocument = { Uri = Path.FilePathToUri path }
-                      Position = { Line = 0; Character = 0 }
-                      Context =
-                          Some
-                            { triggerKind = CompletionTriggerKind.Invoked
-                              triggerCharacter = None } }
+              let completionParams: CompletionParams =
+                { TextDocument = { Uri = Path.FilePathToUri path }
+                  Position = { Line = 0; Character = 0 }
+                  Context =
+                    Some
+                      { triggerKind = CompletionTriggerKind.Invoked
+                        triggerCharacter = None } }
 
-                  match! server.TextDocumentCompletion completionParams with
-                  | Ok (Some _) -> failtest "An empty file has empty completions"
-                  | Ok None -> ()
-                  | Error e -> failtestf "Got an error while retrieving completions: %A" e
-                })
-            testCaseAsync
-                "type 'c' for checking error and autocompletion starts with 'async'"
-                (async {
-                  let! server, events, scriptPath = server2
-                  do! server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath }
+              match! server.TextDocumentCompletion completionParams with
+              | Ok(Some _) -> failtest "An empty file has empty completions"
+              | Ok None -> ()
+              | Error e -> failtestf "Got an error while retrieving completions: %A" e
+            })
+          testCaseAsync
+            "type 'c' for checking error and autocompletion starts with 'async'"
+            (async {
+              let! server, events, scriptPath = server2
+              do! server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath }
 
-                  do! server.TextDocumentDidChange {
-                      TextDocument = { Uri = Path.FilePathToUri scriptPath; Version = 1 }
-                      ContentChanges =  [| {
-                          Range = Some { Start = { Line = 0; Character = 0 }; End = { Line = 0; Character = 0 } }
-                          RangeLength = Some 0
-                          Text = "c"
-                      } |]
-                    }
+              do!
+                server.TextDocumentDidChange
+                  { TextDocument =
+                      { Uri = Path.FilePathToUri scriptPath
+                        Version = 1 }
+                    ContentChanges =
+                      [| { Range =
+                             Some
+                               { Start = { Line = 0; Character = 0 }
+                                 End = { Line = 0; Character = 0 } }
+                           RangeLength = Some 0
+                           Text = "c" } |] }
 
-                  let! completions =
-                    server.TextDocumentCompletion {
-                      TextDocument = { Uri = Path.FilePathToUri scriptPath }
-                      Position = { Line = 0; Character = 1 }
-                      Context =
-                        Some
-                          { triggerKind = CompletionTriggerKind.Invoked
-                            triggerCharacter = None }
-                    } |> Async.StartChild
+              let! completions =
+                server.TextDocumentCompletion
+                  { TextDocument = { Uri = Path.FilePathToUri scriptPath }
+                    Position = { Line = 0; Character = 1 }
+                    Context =
+                      Some
+                        { triggerKind = CompletionTriggerKind.Invoked
+                          triggerCharacter = None } }
+                |> Async.StartChild
 
-                  let! compilerResults = waitForCompilerDiagnosticsForFile "EmptyFile.fsx" events |> Async.StartChild
+              let! compilerResults = waitForCompilerDiagnosticsForFile "EmptyFile.fsx" events |> Async.StartChild
 
-                  match! compilerResults with
-                  | Ok () -> failtest "should get an F# compiler checking error from a 'c' by itself"
-                  | Core.Result.Error errors ->
-                    Expect.hasLength errors 1 "should have only an error FS0039: identifier not defined"
-                    Expect.exists errors (fun error -> error.Code = Some "39") "should have an error FS0039: identifier not defined"
+              match! compilerResults with
+              | Ok() -> failtest "should get an F# compiler checking error from a 'c' by itself"
+              | Core.Result.Error errors ->
+                Expect.hasLength errors 1 "should have only an error FS0039: identifier not defined"
 
-                  match! completions with
-                  | Ok (Some completions) ->
-                    Expect.isGreaterThan
-                      completions.Items.Length
-                      30
-                      "should have a complete completion list all containing c"
+                Expect.exists
+                  errors
+                  (fun error -> error.Code = Some "39")
+                  "should have an error FS0039: identifier not defined"
 
-                    let firstItem = completions.Items.[0]
-                    Expect.equal firstItem.Label "async" "first member should be async"
-                  | Ok None -> failtest "Should have gotten some completion items"
-                  | Error e -> failtestf "Got an error while retrieving completions: %A" e
-                })
-        ]]
+              match! completions with
+              | Ok(Some completions) ->
+                Expect.isGreaterThan
+                  completions.Items.Length
+                  30
+                  "should have a complete completion list all containing c"
+
+                let firstItem = completions.Items.[0]
+                Expect.equal firstItem.Label "async" "first member should be async"
+              | Ok None -> failtest "Should have gotten some completion items"
+              | Error e -> failtestf "Got an error while retrieving completions: %A" e
+            }) ] ]

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -12,6 +12,8 @@ open FSharp.Control.Reactive
 open System.Threading
 open FSharp.UMX
 
+#nowarn "44" //we're testing so need to be able to use deprecated fields
+
 module Expecto =
   open System.Threading.Tasks
 

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -553,7 +553,7 @@ let serverInitialize path (config: FSharpConfigDto) createServer =
           Some
             [| { Uri = Path.FilePathToUri path
                  Name = "Test Folder" } |]
-        trace = None
+        trace = Some "verbose"
         Locale = None }
 
     let! result = server.Initialize p

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
@@ -15,6 +15,8 @@ open Expecto
 open Utils
 open Ionide.ProjInfo.Logging
 
+#nowarn "44" //we're testing so need to be able to use deprecated fields
+
 let private logger = LogProvider.getLoggerByName "Utils.Server"
 
 type Server =
@@ -28,26 +30,22 @@ type CachedServer = Async<Server>
 
 type Document =
   { Server: Server
-    FilePath : string
+    FilePath: string
     Uri: DocumentUri
     mutable Version: int }
+
   member doc.TextDocumentIdentifier: TextDocumentIdentifier = { Uri = doc.Uri }
 
   member doc.VersionedTextDocumentIdentifier: VersionedTextDocumentIdentifier =
-    { Uri = doc.Uri
-      Version = doc.Version }
+    { Uri = doc.Uri; Version = doc.Version }
 
   member x.Diagnostics =
-    x.Server.Events
-    |> fileDiagnosticsForUri x.TextDocumentIdentifier.Uri
+    x.Server.Events |> fileDiagnosticsForUri x.TextDocumentIdentifier.Uri
 
-  member x.CompilerDiagnostics =
-    x.Diagnostics
-    |> diagnosticsFromSource "F# Compiler"
+  member x.CompilerDiagnostics = x.Diagnostics |> diagnosticsFromSource "F# Compiler"
 
   interface IDisposable with
-    override doc.Dispose() : unit =
-      doc |> Document.close |> Async.RunSynchronously
+    override doc.Dispose() : unit = doc |> Document.close |> Async.RunSynchronously
 
 module Server =
   let private initialize path (config: FSharpConfigDto) createServer =
@@ -65,7 +63,7 @@ module Server =
         for file in System.IO.Directory.EnumerateFiles(path, "*.fsproj", SearchOption.AllDirectories) do
           do! file |> Path.GetDirectoryName |> dotnetRestore
 
-      let (server : IFSharpLspServer, events : IObservable<_>) = createServer ()
+      let (server: IFSharpLspServer, events: IObservable<_>) = createServer ()
       events |> Observable.add logEvent
 
       let p: InitializeParams =
@@ -88,7 +86,8 @@ module Server =
 
       match! server.Initialize p with
       | Ok _ ->
-        do! server.Initialized (InitializedParams())
+        do! server.Initialized(InitializedParams())
+
         return
           { RootPath = path
             Server = server
@@ -131,9 +130,7 @@ module Server =
     async {
       let! server = server
 
-      let doc =
-        server
-        |> createDocument String.Empty (server |> nextUntitledDocUri)
+      let doc = server |> createDocument String.Empty (server |> nextUntitledDocUri)
 
       let! diags = doc |> Document.openWith initialText
 
@@ -161,17 +158,13 @@ module Server =
         server
         |> createDocument
           fullPath
-          (
-            fullPath
-            // normalize path is necessary: otherwise might be different lower/upper cases in uri for tests and LSP server:
-            // on windows `E:\...`: `file:///E%3A/...` (before normalize) vs. `file:///e%3A/..` (after normalize)
-            |> normalizePath
-            |> Path.LocalPathToUri
-          )
+          (fullPath
+           // normalize path is necessary: otherwise might be different lower/upper cases in uri for tests and LSP server:
+           // on windows `E:\...`: `file:///E%3A/...` (before normalize) vs. `file:///e%3A/..` (after normalize)
+           |> normalizePath
+           |> Path.LocalPathToUri)
 
-      let! diags =
-        doc
-        |> Document.openWith (File.ReadAllText fullPath)
+      let! diags = doc |> Document.openWith (File.ReadAllText fullPath)
 
       return (doc, diags)
     }
@@ -197,9 +190,7 @@ module Server =
       // To avoid hitting the typechecker cache, we need to update the file's timestamp
       IO.File.SetLastWriteTimeUtc(fullPath, DateTime.UtcNow)
 
-      let doc =
-        server
-        |> createDocument fullPath (Path.FilePathToUri fullPath)
+      let doc = server |> createDocument fullPath (Path.FilePathToUri fullPath)
 
       let! diags = doc |> Document.openWith initialText
 
@@ -211,11 +202,7 @@ module Document =
   open System.Threading.Tasks
 
   let private typedEvents<'t> typ : _ -> System.IObservable<'t> =
-    Observable.choose (fun (typ', _o) ->
-      if typ' = typ then
-        Some(unbox _o)
-      else
-        None)
+    Observable.choose (fun (typ', _o) -> if typ' = typ then Some(unbox _o) else None)
 
   /// `textDocument/publishDiagnostics`
   ///
@@ -225,11 +212,7 @@ module Document =
   let diagnosticsStream (doc: Document) =
     doc.Server.Events
     |> typedEvents<PublishDiagnosticsParams> "textDocument/publishDiagnostics"
-    |> Observable.choose (fun n ->
-      if n.Uri = doc.Uri then
-        Some n.Diagnostics
-      else
-        None)
+    |> Observable.choose (fun n -> if n.Uri = doc.Uri then Some n.Diagnostics else None)
 
   /// `fsharp/documentAnalyzed`
   let analyzedStream (doc: Document) =
@@ -241,21 +224,19 @@ module Document =
   /// in ms
   let private waitForLateDiagnosticsDelay =
     let envVar = "FSAC_WaitForLateDiagnosticsDelay"
+
     System.Environment.GetEnvironmentVariable envVar
     |> Option.ofObj
     |> Option.map (fun d ->
       match System.Int32.TryParse d with
       | (true, d) -> d
-      | (false, _) ->
-          failwith $"Environment Variable '%s{envVar}' exists, but is not a correct int number ('%s{d}')"
-    )
+      | (false, _) -> failwith $"Environment Variable '%s{envVar}' exists, but is not a correct int number ('%s{d}')")
     |> Option.orElseWith (fun _ ->
-        // set in Github Actions: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-        match System.Environment.GetEnvironmentVariable "CI" with
-        | null -> None
-        | _ -> Some 25
-    )
-    |> Option.defaultValue 7  // testing locally
+      // set in Github Actions: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+      match System.Environment.GetEnvironmentVariable "CI" with
+      | null -> None
+      | _ -> Some 25)
+    |> Option.defaultValue 7 // testing locally
 
   /// Waits (if necessary) and gets latest diagnostics.
   ///
@@ -298,6 +279,7 @@ module Document =
         >> Log.addContext "uri" doc.Uri
         >> Log.addContext "version" doc.Version
       )
+
       let tcs = TaskCompletionSource<_>()
 
       use _ =
@@ -313,7 +295,7 @@ module Document =
         )
         |> Observable.bufferSpan (timeout)
         // |> Observable.timeoutSpan timeout
-        |> Observable.subscribe(fun x -> tcs.SetResult x)
+        |> Observable.subscribe (fun x -> tcs.SetResult x)
 
       let! result = tcs.Task |> Async.AwaitTask
 
@@ -322,11 +304,10 @@ module Document =
 
 
   /// Note: Mutates passed `doc`
-  let private incrVersion (doc: Document) =
-    System.Threading.Interlocked.Increment(&doc.Version)
+  let private incrVersion (doc: Document) = System.Threading.Interlocked.Increment(&doc.Version)
 
   /// Note: Mutates passed `doc`
-  let private incrVersionedTextDocumentIdentifier (doc: Document): VersionedTextDocumentIdentifier =
+  let private incrVersionedTextDocumentIdentifier (doc: Document) : VersionedTextDocumentIdentifier =
     { Uri = doc.Uri
       Version = incrVersion doc }
 
@@ -343,8 +324,8 @@ module Document =
 
       try
         return! doc |> waitForLatestDiagnostics Helpers.defaultTimeout
-      with
-      | :? TimeoutException -> return failwith $"Timeout waiting for latest diagnostics for {doc.Uri}"
+      with :? TimeoutException ->
+        return failwith $"Timeout waiting for latest diagnostics for {doc.Uri}"
     }
 
   let close (doc: Document) =
@@ -371,12 +352,11 @@ module Document =
       return! doc |> waitForLatestDiagnostics Helpers.defaultTimeout
     }
 
-  let saveText (text : string) (doc : Document) =
+  let saveText (text: string) (doc: Document) =
     async {
-      let p : DidSaveTextDocumentParams = {
-        Text = Some text
-        TextDocument = doc.TextDocumentIdentifier
-      }
+      let p: DidSaveTextDocumentParams =
+        { Text = Some text
+          TextDocument = doc.TextDocumentIdentifier }
       // Simulate the file being written to disk so we don't hit the typechecker cache
       IO.File.SetLastWriteTimeUtc(doc.FilePath, DateTime.UtcNow)
       do! doc.Server.Server.TextDocumentDidSave p
@@ -387,8 +367,7 @@ module Document =
   let private assertOk result =
     Expect.isOk result "Expected success"
 
-    result
-    |> Result.defaultWith (fun _ -> failtest "not reachable")
+    result |> Result.defaultWith (fun _ -> failtest "not reachable")
 
   let private assertSome opt =
     Expect.isSome opt "Expected to have Some"
@@ -401,21 +380,27 @@ module Document =
       let ps: CodeActionParams =
         { TextDocument = doc.TextDocumentIdentifier
           Range = range
-          Context = { Diagnostics = diagnostics; Only = None; TriggerKind = None } }
+          Context =
+            { Diagnostics = diagnostics
+              Only = None
+              TriggerKind = None } }
 
       let! res = doc.Server.Server.TextDocumentCodeAction ps
       return res |> assertOk
     }
 
-  let inlayHintsAt range (doc: Document) = async {
-    let ps: InlayHintParams = {
-      Range = range
-      TextDocument = doc.TextDocumentIdentifier
+  let inlayHintsAt range (doc: Document) =
+    async {
+      let ps: InlayHintParams =
+        { Range = range
+          TextDocument = doc.TextDocumentIdentifier }
+
+      let! res = doc.Server.Server.TextDocumentInlayHint ps
+      return res |> assertOk |> assertSome
     }
-    let! res = doc.Server.Server.TextDocumentInlayHint ps
-    return res |> assertOk |> assertSome
-  }
-  let resolveInlayHint inlayHint (doc: Document) = async {
-    let! res = doc.Server.Server.InlayHintResolve inlayHint
-    return res |> assertOk
-  }
+
+  let resolveInlayHint inlayHint (doc: Document) =
+    async {
+      let! res = doc.Server.Server.InlayHintResolve inlayHint
+      return res |> assertOk
+    }

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.fsi
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.fsi
@@ -16,111 +16,114 @@ open Utils
 open Ionide.ProjInfo.Logging
 
 type Server =
-    { RootPath: string option
-      Server: IFSharpLspServer
-      Events: ClientEvents
-      mutable UntitledCounter: int }
+  { RootPath: string
+    Server: IFSharpLspServer
+    Events: ClientEvents
+    mutable UntitledCounter: int }
 
 /// `Server` cached with `Async.Cache`
 type CachedServer = Async<Server>
 
 type Document =
-    { Server: Server
-      FilePath: string
-      Uri: DocumentUri
-      mutable Version: int }
+  { Server: Server
+    FilePath: string
+    Uri: DocumentUri
+    mutable Version: int }
 
-    member TextDocumentIdentifier: TextDocumentIdentifier
-    member VersionedTextDocumentIdentifier: VersionedTextDocumentIdentifier
-    member Diagnostics: IObservable<Diagnostic array>
-    member CompilerDiagnostics: IObservable<Diagnostic array>
-    interface IDisposable
+  member TextDocumentIdentifier: TextDocumentIdentifier
+  member VersionedTextDocumentIdentifier: VersionedTextDocumentIdentifier
+  member Diagnostics: IObservable<Diagnostic array>
+  member CompilerDiagnostics: IObservable<Diagnostic array>
+  interface IDisposable
 
 module Server =
-    val create:
-        path: string option ->
-        config: FSharpConfigDto ->
-        createServer: (unit -> IFSharpLspServer * IObservable<string * obj>) ->
-            CachedServer
+  /// <param name="path">if not specified, a temp directory will be created to anchor the LSP</param>
+  /// <param name="config" />
+  /// <param name="createServer" />
+  val create:
+    path: string option ->
+    config: FSharpConfigDto ->
+    createServer: (unit -> IFSharpLspServer * IObservable<string * obj>) ->
+      CachedServer
 
-    val shutdown: server: CachedServer -> Async<unit>
-    val createUntitledDocument: initialText: string -> server: CachedServer -> Async<Document * Diagnostic array>
-    /// `path` can be absolute or relative.
-    /// For relative path `server.RootPath` must be specified!
-    ///
-    /// Note: When `path` is relative: relative to `server.RootPath`!
-    val openDocument: path: string -> server: CachedServer -> Async<Document * Diagnostic array>
+  val shutdown: server: CachedServer -> Async<unit>
+  val createUntitledDocument: initialText: string -> server: CachedServer -> Async<Document * Diagnostic array>
+  /// `path` can be absolute or relative.
+  /// For relative path `server.RootPath` must be specified!
+  ///
+  /// Note: When `path` is relative: relative to `server.RootPath`!
+  val openDocument: path: string -> server: CachedServer -> Async<Document * Diagnostic array>
 
-    /// Like `Server.openDocument`, but instead of reading source text from `path`,
-    /// this here instead uses `initialText` (which can be different from content of `path`!).
-    ///
-    /// This way an existing file with different text can be faked.
-    /// Logically equal to `Server.openDocument`, and later changing its text via `Document.changeTextTo`.
-    /// But this here doesn't have to parse and check everything twice (once for open, once for changed)
-    /// and is WAY faster than `Server.openDocument` followed by `Document.changeTextTo` when involving multiple documents.
-    /// (For example with CodeFix tests using `fsi` file and corresponding `fs` file)
-    val openDocumentWithText:
-        path: string -> initialText: string -> server: CachedServer -> Async<Document * Diagnostic array>
+  /// Like `Server.openDocument`, but instead of reading source text from `path`,
+  /// this here instead uses `initialText` (which can be different from content of `path`!).
+  ///
+  /// This way an existing file with different text can be faked.
+  /// Logically equal to `Server.openDocument`, and later changing its text via `Document.changeTextTo`.
+  /// But this here doesn't have to parse and check everything twice (once for open, once for changed)
+  /// and is WAY faster than `Server.openDocument` followed by `Document.changeTextTo` when involving multiple documents.
+  /// (For example with CodeFix tests using `fsi` file and corresponding `fs` file)
+  val openDocumentWithText:
+    path: string -> initialText: string -> server: CachedServer -> Async<Document * Diagnostic array>
 
 module Document =
-    open System.Reactive.Linq
-    open System.Threading.Tasks
+  open System.Reactive.Linq
+  open System.Threading.Tasks
 
-    /// `textDocument/publishDiagnostics`
-    ///
-    /// Note: for each analyzing round there are might be multiple `publishDiagnostics` events (F# compiler, for each built-in Analyzer, for Custom Analyzers)
-    ///
-    /// Note: Because source `doc.Server.Events` is `ReplaySubject`, subscribing to Stream returns ALL past diagnostics too!
-    val diagnosticsStream: doc: Document -> IObservable<Diagnostic array>
-    /// `fsharp/documentAnalyzed`
-    val analyzedStream: doc: Document -> IObservable<DocumentAnalyzedNotification>
-    /// in ms
-    /// Waits (if necessary) and gets latest diagnostics.
-    ///
-    /// To detect newest diags:
-    /// * Waits for `fsharp/documentAnalyzed` for passed `doc` and its `doc.Version`.
-    /// * Then waits a but more for potential late diags.
-    /// * Then returns latest diagnostics.
-    ///
-    ///
-    /// ### Explanation: Get latest & correct diagnostics
-    /// Diagnostics aren't collected and then sent once, but instead sent after each parsing/analyzing step.
-    /// -> There are multiple `textDocument/publishDiagnostics` sent for each parsing/analyzing round:
-    /// * one when file parsed by F# compiler
-    /// * one for each built-in (enabled) Analyzers (in `src\FsAutoComplete\FsAutoComplete.Lsp.fs` > `FsAutoComplete.Lsp.FSharpLspServer.analyzeFile`),
-    /// * for linter (currently disabled)
-    /// * for custom analyzers
-    ///
-    /// -> To receive ALL diagnostics: use Diagnostics of last `textDocument/publishDiagnostics` event.
-    ///
-    /// Issue: What is the last `publishDiagnostics`? Might already be here or arrive in future.
-    /// -> `fsharp/documentAnalyzed` was introduced. Notification when a doc was completely analyzed
-    /// -> wait for `documentAnalyzed`
-    ///
-    /// But issue: last `publishDiagnostics` might be received AFTER `documentAnalyzed` (because of async notifications & sending)
-    /// -> after receiving `documentAnalyzed` wait a bit for late `publishDiagnostics`
-    ///
-    /// But issue: Wait for how long? Too long: extends test execution time. Too short: Might miss diags.
-    /// -> unresolved. Current wait based on testing on modern_ish PC. Seems to work on CI too.
-    ///
-    ///
-    /// *Inconvenience*: Only newest diags can be retrieved this way. Diags for older file versions cannot be extracted reliably:
-    /// `doc.Server.Events` is a `ReplaySubject` -> returns ALL previous events on new subscription
-    /// -> All past `documentAnalyzed` events and their diags are all received at once
-    /// -> waiting a bit after a version-specific `documentAnalyzed` always returns latest diags.
-    val waitForLatestDiagnostics: timeout: TimeSpan -> doc: Document -> Async<Diagnostic array>
-    val openWith: initialText: string -> doc: Document -> Async<Diagnostic array>
-    val close: doc: Document -> Async<unit>
-    ///<summary>
-    /// Fire a <code>textDocument/didChange</code> request for the specified document with the given text
-    /// as the entire new text of the document, then wait for diagnostics for the document.
-    /// </summary>
-    val changeTextTo: text: string -> doc: Document -> Async<Diagnostic array>
-    val saveText: text: string -> doc: Document -> Async<Diagnostic array>
+  /// `textDocument/publishDiagnostics`
+  ///
+  /// Note: for each analyzing round there are might be multiple `publishDiagnostics` events (F# compiler, for each built-in Analyzer, for Custom Analyzers)
+  ///
+  /// Note: Because source `doc.Server.Events` is `ReplaySubject`, subscribing to Stream returns ALL past diagnostics too!
+  val diagnosticsStream: doc: Document -> IObservable<Diagnostic array>
+  /// `fsharp/documentAnalyzed`
+  val analyzedStream: doc: Document -> IObservable<DocumentAnalyzedNotification>
+  /// in ms
+  /// Waits (if necessary) and gets latest diagnostics.
+  ///
+  /// To detect newest diags:
+  /// * Waits for `fsharp/documentAnalyzed` for passed `doc` and its `doc.Version`.
+  /// * Then waits a but more for potential late diags.
+  /// * Then returns latest diagnostics.
+  ///
+  ///
+  /// ### Explanation: Get latest & correct diagnostics
+  /// Diagnostics aren't collected and then sent once, but instead sent after each parsing/analyzing step.
+  /// -> There are multiple `textDocument/publishDiagnostics` sent for each parsing/analyzing round:
+  /// * one when file parsed by F# compiler
+  /// * one for each built-in (enabled) Analyzers (in `src\FsAutoComplete\FsAutoComplete.Lsp.fs` > `FsAutoComplete.Lsp.FSharpLspServer.analyzeFile`),
+  /// * for linter (currently disabled)
+  /// * for custom analyzers
+  ///
+  /// -> To receive ALL diagnostics: use Diagnostics of last `textDocument/publishDiagnostics` event.
+  ///
+  /// Issue: What is the last `publishDiagnostics`? Might already be here or arrive in future.
+  /// -> `fsharp/documentAnalyzed` was introduced. Notification when a doc was completely analyzed
+  /// -> wait for `documentAnalyzed`
+  ///
+  /// But issue: last `publishDiagnostics` might be received AFTER `documentAnalyzed` (because of async notifications & sending)
+  /// -> after receiving `documentAnalyzed` wait a bit for late `publishDiagnostics`
+  ///
+  /// But issue: Wait for how long? Too long: extends test execution time. Too short: Might miss diags.
+  /// -> unresolved. Current wait based on testing on modern_ish PC. Seems to work on CI too.
+  ///
+  ///
+  /// *Inconvenience*: Only newest diags can be retrieved this way. Diags for older file versions cannot be extracted reliably:
+  /// `doc.Server.Events` is a `ReplaySubject` -> returns ALL previous events on new subscription
+  /// -> All past `documentAnalyzed` events and their diags are all received at once
+  /// -> waiting a bit after a version-specific `documentAnalyzed` always returns latest diags.
+  val waitForLatestDiagnostics: timeout: TimeSpan -> doc: Document -> Async<Diagnostic array>
+  val openWith: initialText: string -> doc: Document -> Async<Diagnostic array>
+  val close: doc: Document -> Async<unit>
+  ///<summary>
+  /// Fire a <code>textDocument/didChange</code> request for the specified document with the given text
+  /// as the entire new text of the document, then wait for diagnostics for the document.
+  /// </summary>
+  val changeTextTo: text: string -> doc: Document -> Async<Diagnostic array>
+  val saveText: text: string -> doc: Document -> Async<Diagnostic array>
 
-    /// Note: diagnostics aren't filtered to match passed range in here
-    val codeActionAt:
-        diagnostics: Diagnostic[] -> range: Range -> doc: Document -> Async<TextDocumentCodeActionResult option>
+  /// Note: diagnostics aren't filtered to match passed range in here
+  val codeActionAt:
+    diagnostics: Diagnostic[] -> range: Range -> doc: Document -> Async<TextDocumentCodeActionResult option>
 
-    val inlayHintsAt: range: Range -> doc: Document -> Async<InlayHint array>
-    val resolveInlayHint: inlayHint: InlayHint -> doc: Document -> Async<InlayHint>
+  val inlayHintsAt: range: Range -> doc: Document -> Async<InlayHint array>
+  val resolveInlayHint: inlayHint: InlayHint -> doc: Document -> Async<InlayHint>

--- a/test/FsAutoComplete.Tests.Lsp/Utils/ServerTests.fsi
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/ServerTests.fsi
@@ -16,13 +16,13 @@ open Ionide.LanguageServerProtocol.Types
 ///       Use `false` when `initialize` returns an already cached value, otherwise `false`.
 ///       Then in here `Async.Cache` is used to cache value.
 val cleanableTestList:
-    runner: (string -> Test list -> Test) ->
-    name: string ->
-    initialize: Async<'a> ->
-    cacheValue: bool ->
-    cleanup: (Async<'a> -> Async<unit>) ->
-    tests: (Async<'a> -> Test list) ->
-        Test
+  runner: (string -> Test list -> Test) ->
+  name: string ->
+  initialize: Async<'a> ->
+  cacheValue: bool ->
+  cleanup: (Async<'a> -> Async<unit>) ->
+  tests: (Async<'a> -> Test list) ->
+    Test
 
 /// ## Example
 /// ```fsharp
@@ -35,9 +35,29 @@ val cleanableTestList:
 ///   }
 /// ])
 /// ```
-val serverTestList: (string -> (unit -> FsAutoComplete.Lsp.IFSharpLspServer * System.IObservable<string * obj>) -> FsAutoComplete.LspHelpers.FSharpConfigDto -> option<string> -> (Async<Server> -> list<Test>) -> Test)
-val fserverTestList: (string -> (unit -> FsAutoComplete.Lsp.IFSharpLspServer * System.IObservable<string * obj>) -> FsAutoComplete.LspHelpers.FSharpConfigDto -> option<string> -> (Async<Server> -> list<Test>) -> Test)
-val pserverTestList: (string -> (unit -> FsAutoComplete.Lsp.IFSharpLspServer * System.IObservable<string * obj>) -> FsAutoComplete.LspHelpers.FSharpConfigDto -> option<string> -> (Async<Server> -> list<Test>) -> Test)
+val serverTestList:
+  (string
+    -> (unit -> FsAutoComplete.Lsp.IFSharpLspServer * System.IObservable<string * obj>)
+    -> FsAutoComplete.LspHelpers.FSharpConfigDto
+    -> option<string>
+    -> (Async<Server> -> list<Test>)
+    -> Test)
+
+val fserverTestList:
+  (string
+    -> (unit -> FsAutoComplete.Lsp.IFSharpLspServer * System.IObservable<string * obj>)
+    -> FsAutoComplete.LspHelpers.FSharpConfigDto
+    -> option<string>
+    -> (Async<Server> -> list<Test>)
+    -> Test)
+
+val pserverTestList:
+  (string
+    -> (unit -> FsAutoComplete.Lsp.IFSharpLspServer * System.IObservable<string * obj>)
+    -> FsAutoComplete.LspHelpers.FSharpConfigDto
+    -> option<string>
+    -> (Async<Server> -> list<Test>)
+    -> Test)
 
 
 /// Note: Not intended for changing document: always same (initial) diags
@@ -57,6 +77,23 @@ val pserverTestList: (string -> (unit -> FsAutoComplete.Lsp.IFSharpLspServer * S
 ///   ])
 /// ])
 /// ```
-val documentTestList: (string -> CachedServer -> (CachedServer -> Async<Document * Diagnostic []>) -> (Async<Document * Diagnostic []> -> list<Test>) -> Test)
-val fdocumentTestList: (string -> CachedServer -> (CachedServer -> Async<Document * Diagnostic []>) -> (Async<Document * Diagnostic []> -> list<Test>) -> Test)
-val pdocumentTestList: (string -> CachedServer -> (CachedServer -> Async<Document * Diagnostic []>) -> (Async<Document * Diagnostic []> -> list<Test>) -> Test)
+val documentTestList:
+  (string
+    -> CachedServer
+    -> (CachedServer -> Async<Document * Diagnostic[]>)
+    -> (Async<Document * Diagnostic[]> -> list<Test>)
+    -> Test)
+
+val fdocumentTestList:
+  (string
+    -> CachedServer
+    -> (CachedServer -> Async<Document * Diagnostic[]>)
+    -> (Async<Document * Diagnostic[]> -> list<Test>)
+    -> Test)
+
+val pdocumentTestList:
+  (string
+    -> CachedServer
+    -> (CachedServer -> Async<Document * Diagnostic[]>)
+    -> (Async<Document * Diagnostic[]> -> list<Test>)
+    -> Test)


### PR DESCRIPTION
This updates the LSP lib to get deprecation notices for members, then removes the use of RootPath/RootUri in the initialization in favor of just using workspacePaths[0]. This is step one of the overall plan described in https://github.com/fsharp/FsAutoComplete/issues/733.

In addition, while removing obsolete usages, I specialized the outputs of `textDocument/documentSymbol` and `workspace/symbol`. 