### PR TITLE
add missing keyword list and extra information

### DIFF
--- a/src/FsAutoComplete.Core/KeywordList.fs
+++ b/src/FsAutoComplete.Core/KeywordList.fs
@@ -28,7 +28,7 @@ module KeywordList =
     |> dict
 
   let hashDirectives =
-    [ "r", "References an assembly, or a nuget: package, or a paket: reference"
+    [ "r", "References an assembly or a nuget: package"
       "load", "References a source .fsx script or .fs file, by compiling and running it."
       "I", "Specifies an assembly search path in quotation marks."
       "light", "Enables or disables lightweight syntax, for compatibility with other versions of ML"

--- a/src/FsAutoComplete.Core/KeywordList.fs
+++ b/src/FsAutoComplete.Core/KeywordList.fs
@@ -28,14 +28,16 @@ module KeywordList =
     |> dict
 
   let hashDirectives =
-    [ "r", "References an assembly"
-      "load", "Reads a source file, compiles it, and runs it."
+    [ "r", "References an assembly, or a nuget: package, or a paket: reference"
+      "load", "Reference other .fsx scripts or .fs files, by compiling and running them"
       "I", "Specifies an assembly search path in quotation marks."
       "light", "Enables or disables lightweight syntax, for compatibility with other versions of ML"
       "if", "Supports conditional compilation"
       "else", "Supports conditional compilation"
       "endif", "Supports conditional compilation"
       "nowarn", "Disables a compiler warning or warnings"
+      "quit", "exits the interactive session"
+      "time", "toggles whether to display performance information"
       "line", "Indicates the original source code line" ]
     |> dict
 

--- a/src/FsAutoComplete.Core/KeywordList.fs
+++ b/src/FsAutoComplete.Core/KeywordList.fs
@@ -29,7 +29,7 @@ module KeywordList =
 
   let hashDirectives =
     [ "r", "References an assembly, or a nuget: package, or a paket: reference"
-      "load", "Reference other .fsx scripts or .fs files, by compiling and running them"
+      "load", "References a source .fsx script or .fs file, by compiling and running it."
       "I", "Specifies an assembly search path in quotation marks."
       "light", "Enables or disables lightweight syntax, for compatibility with other versions of ML"
       "if", "Supports conditional compilation"


### PR DESCRIPTION
### WHAT
add missing keyword infos, add nuget and paket info for #r, #time, and others,

related but not fixing the display issue: https://github.com/fsharp/FsAutoComplete/issues/1225

### WHY
https://learn.microsoft.com/en-us/dotnet/fsharp/tools/fsharp-interactive/#f-interactive-directive-reference
