### PR TITLE
Slightly better project loading error messages

### DIFF
--- a/src/FsAutoComplete.Core/AdaptiveExtensions.fs
+++ b/src/FsAutoComplete.Core/AdaptiveExtensions.fs
@@ -8,7 +8,6 @@ open IcedTasks
 open System.Threading
 
 
-
 [<AutoOpen>]
 module AdaptiveExtensions =
 
@@ -286,6 +285,12 @@ module AMap =
       HashMap.union removeOps changes |> HashMapDelta
 
 
+  let tryFindR (reason: 'a) (key: 'Key) (map: amap<'Key, 'Value>) : aval<Result<'Value,'a>> = aval {
+    match! AMap.tryFind key map with
+    | Some x -> return Ok x
+    | None -> return Error reason
+  }
+
   /// Adaptively looks up the given key in the map and flattens the value to be easily worked with. Note that this operation should not be used extensively since its resulting aval will be re-evaluated upon every change of the map.
   let tryFindAndFlatten (key: 'Key) (map: amap<'Key, aval<option<'Value>>>) =
     aval {
@@ -293,6 +298,7 @@ module AMap =
       | Some x -> return! x
       | None -> return None
     }
+
 
   /// Adaptively looks up the given key in the map and binds the value to be easily worked with. Note that this operation should not be used extensively since its resulting aval will be re-evaluated upon every change of the map.
   let tryFindA (key: 'Key) (map: amap<'Key, #aval<'Value>>) =
@@ -741,6 +747,12 @@ module AsyncAVal =
   let mapOption (f: 'a -> CancellationToken -> 'b) (value: asyncaval<'a option>) : asyncaval<'b option> =
     mapSync (fun data ctok -> data |> Option.map (fun d -> f d ctok)) value
 
+
+  /// Returns a new async adaptive value that adaptively applies the mapping function to the given
+  /// optional adaptive inputs.
+  let mapResult (f: 'a -> CancellationToken -> 'b) (value: asyncaval<Result<'a, 'Error>>) : asyncaval<Result<'b, 'Error>> =
+    mapSync (fun data ctok -> data |> Result.map (fun d -> f d ctok)) value
+
 type AsyncAValBuilder() =
   member inline x.MergeSources(v1: asyncaval<'T1>, v2: asyncaval<'T2>) =
     (v1, v2)
@@ -828,4 +840,13 @@ module AMapAsync =
       match! AMap.tryFind key map with
       | Some x -> return! x
       | None -> return None
+    }
+
+
+  /// Adaptively looks up the given key in the map and flattens the value to be easily worked with. Note that this operation should not be used extensively since its resulting aval will be re-evaluated upon every change of the map.
+  let tryFindAndFlattenR reason (key: 'Key) (map: amap<'Key, asyncaval<Result<'Value, 'Error>>>) =
+    asyncAVal {
+      match! AMap.tryFind key map with
+      | Some x -> return! x
+      | None -> return Error reason
     }

--- a/src/FsAutoComplete.Core/AdaptiveExtensions.fs
+++ b/src/FsAutoComplete.Core/AdaptiveExtensions.fs
@@ -285,11 +285,12 @@ module AMap =
       HashMap.union removeOps changes |> HashMapDelta
 
 
-  let tryFindR (reason: 'a) (key: 'Key) (map: amap<'Key, 'Value>) : aval<Result<'Value,'a>> = aval {
-    match! AMap.tryFind key map with
-    | Some x -> return Ok x
-    | None -> return Error reason
-  }
+  let tryFindR (reason: 'a) (key: 'Key) (map: amap<'Key, 'Value>) : aval<Result<'Value, 'a>> =
+    aval {
+      match! AMap.tryFind key map with
+      | Some x -> return Ok x
+      | None -> return Error reason
+    }
 
   /// Adaptively looks up the given key in the map and flattens the value to be easily worked with. Note that this operation should not be used extensively since its resulting aval will be re-evaluated upon every change of the map.
   let tryFindAndFlatten (key: 'Key) (map: amap<'Key, aval<option<'Value>>>) =
@@ -750,7 +751,10 @@ module AsyncAVal =
 
   /// Returns a new async adaptive value that adaptively applies the mapping function to the given
   /// optional adaptive inputs.
-  let mapResult (f: 'a -> CancellationToken -> 'b) (value: asyncaval<Result<'a, 'Error>>) : asyncaval<Result<'b, 'Error>> =
+  let mapResult
+    (f: 'a -> CancellationToken -> 'b)
+    (value: asyncaval<Result<'a, 'Error>>)
+    : asyncaval<Result<'b, 'Error>> =
     mapSync (fun data ctok -> data |> Result.map (fun d -> f d ctok)) value
 
 type AsyncAValBuilder() =

--- a/src/FsAutoComplete.Core/AdaptiveExtensions.fsi
+++ b/src/FsAutoComplete.Core/AdaptiveExtensions.fsi
@@ -79,6 +79,7 @@ module ASet =
       FSharp.Data.Adaptive.amap<'a, 'b>
 
 module AMap =
+  open FSharp.Data.Adaptive
 
   /// A simple multi-map implementation.
   type internal MultiSetMap<'k, 'v> = FSharp.Data.Adaptive.HashMap<'k, FSharp.Data.Adaptive.HashSet<'v>>
@@ -108,6 +109,12 @@ module AMap =
     override Compute: t: FSharp.Data.Adaptive.AdaptiveToken -> FSharp.Data.Adaptive.HashMapDelta<'k, 'b>
 
     override InputChangedObject: t: obj * o: FSharp.Data.Adaptive.IAdaptiveObject -> unit
+
+  val tryFindR:
+    reason: 'a ->
+    key   : 'Key ->
+    map   : amap<'Key,'Value>
+          -> aval<Result<'Value,'a>>
 
   /// Adaptively looks up the given key in the map and flattens the value to be easily worked with. Note that this operation should not be used extensively since its resulting aval will be re-evaluated upon every change of the map.
   val tryFindAndFlatten:
@@ -199,6 +206,7 @@ module Extensions =
         (System.Threading.CancellationToken -> System.Runtime.CompilerServices.TaskAwaiter<'a>)
 
 module AsyncAVal =
+  open System.Threading
 
   /// <summary>
   /// Evaluates the given adaptive value and returns a Task containing the value.
@@ -314,6 +322,11 @@ module AsyncAVal =
   val mapOption:
     f: ('a -> System.Threading.CancellationToken -> 'b) -> value: asyncaval<'a option> -> asyncaval<'b option>
 
+  val mapResult:
+    f    : ('a -> CancellationToken -> 'b) ->
+    value: asyncaval<Result<'a,'Error>>
+        -> asyncaval<Result<'b,'Error>>
+
 type AsyncAValBuilder =
 
   new: unit -> AsyncAValBuilder
@@ -355,7 +368,7 @@ module AsyncAValBuilderExtensions =
     member inline BindReturn: value: asyncaval<'T1> * mapping: ('T1 -> 'T2) -> asyncaval<'T2>
 
 module AMapAsync =
-
+  open FSharp.Data.Adaptive
   /// <summary>
   /// Adaptively maps over the given map lifting the value in the map to be an asyncaval.
   /// </summary>
@@ -380,3 +393,9 @@ module AMapAsync =
   /// Adaptively looks up the given key in the map and flattens the value to be easily worked with. Note that this operation should not be used extensively since its resulting aval will be re-evaluated upon every change of the map.
   val tryFindAndFlatten:
     key: 'Key -> map: FSharp.Data.Adaptive.amap<'Key, asyncaval<'Value option>> -> asyncaval<'Value option>
+
+  val tryFindAndFlattenR:
+    reason: 'Error ->
+    key   : 'Key ->
+    map   : amap<'Key,asyncaval<Result<'Value,'Error>>>
+          -> asyncaval<Result<'Value,'Error>>

--- a/src/FsAutoComplete.Core/AdaptiveExtensions.fsi
+++ b/src/FsAutoComplete.Core/AdaptiveExtensions.fsi
@@ -110,11 +110,7 @@ module AMap =
 
     override InputChangedObject: t: obj * o: FSharp.Data.Adaptive.IAdaptiveObject -> unit
 
-  val tryFindR:
-    reason: 'a ->
-    key   : 'Key ->
-    map   : amap<'Key,'Value>
-          -> aval<Result<'Value,'a>>
+  val tryFindR: reason: 'a -> key: 'Key -> map: amap<'Key, 'Value> -> aval<Result<'Value, 'a>>
 
   /// Adaptively looks up the given key in the map and flattens the value to be easily worked with. Note that this operation should not be used extensively since its resulting aval will be re-evaluated upon every change of the map.
   val tryFindAndFlatten:
@@ -323,9 +319,7 @@ module AsyncAVal =
     f: ('a -> System.Threading.CancellationToken -> 'b) -> value: asyncaval<'a option> -> asyncaval<'b option>
 
   val mapResult:
-    f    : ('a -> CancellationToken -> 'b) ->
-    value: asyncaval<Result<'a,'Error>>
-        -> asyncaval<Result<'b,'Error>>
+    f: ('a -> CancellationToken -> 'b) -> value: asyncaval<Result<'a, 'Error>> -> asyncaval<Result<'b, 'Error>>
 
 type AsyncAValBuilder =
 
@@ -369,6 +363,7 @@ module AsyncAValBuilderExtensions =
 
 module AMapAsync =
   open FSharp.Data.Adaptive
+
   /// <summary>
   /// Adaptively maps over the given map lifting the value in the map to be an asyncaval.
   /// </summary>
@@ -396,6 +391,6 @@ module AMapAsync =
 
   val tryFindAndFlattenR:
     reason: 'Error ->
-    key   : 'Key ->
-    map   : amap<'Key,asyncaval<Result<'Value,'Error>>>
-          -> asyncaval<Result<'Value,'Error>>
+    key: 'Key ->
+    map: amap<'Key, asyncaval<Result<'Value, 'Error>>> ->
+      asyncaval<Result<'Value, 'Error>>

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -80,11 +80,10 @@ type AdaptiveFSharpLspServer
 
   let returnException e logCfg =
     logException e logCfg
+
     match e with
-    | Cancelled _ ->
-      LspResult.requestCancelled
-    | e ->
-      LspResult.internalError (string e)
+    | Cancelled _ -> LspResult.requestCancelled
+    | e -> LspResult.internalError (string e)
 
 
   let getFilePathAndPosition (p: ITextDocumentPositionParams) =
@@ -453,9 +452,11 @@ type AdaptiveFSharpLspServer
         with e ->
           trace |> Tracing.recordException e
 
-          logException e
+          logException
+            e
             (Log.setMessage "TextDocumentDidClose Request Errored {p}"
-            >> Log.addContextDestructured "p" p)
+             >> Log.addContextDestructured "p" p)
+
           return ()
       }
 
@@ -478,10 +479,10 @@ type AdaptiveFSharpLspServer
         with e ->
           trace |> Tracing.recordException e
 
-          logException e (
-            Log.setMessage "TextDocumentDidChange Request Errored {p}"
-            >> Log.addContextDestructured "p" p
-          )
+          logException
+            e
+            (Log.setMessage "TextDocumentDidChange Request Errored {p}"
+             >> Log.addContextDestructured "p" p)
 
           return ()
       }
@@ -514,10 +515,10 @@ type AdaptiveFSharpLspServer
         with e ->
           trace |> Tracing.recordException e
 
-          logException e (
-            Log.setMessage "TextDocumentDidSave Request Errored {p}"
-            >> Log.addContextDestructured "p" p
-          )
+          logException
+            e
+            (Log.setMessage "TextDocumentDidSave Request Errored {p}"
+             >> Log.addContextDestructured "p" p)
 
         return ()
       }
@@ -1670,10 +1671,10 @@ type AdaptiveFSharpLspServer
         with e ->
           trace |> Tracing.recordException e
 
-          logException e (
-            Log.setMessage "WorkspaceDidChangeWatchedFiles Request Errored {p}"
-            >> Log.addContextDestructured "p" p
-          )
+          logException
+            e
+            (Log.setMessage "WorkspaceDidChangeWatchedFiles Request Errored {p}"
+             >> Log.addContextDestructured "p" p)
       }
 
     override __.WorkspaceDidChangeConfiguration(p: DidChangeConfigurationParams) =
@@ -1698,10 +1699,10 @@ type AdaptiveFSharpLspServer
         with e ->
           trace |> Tracing.recordException e
 
-          logException e (
-            Log.setMessage "WorkspaceDidChangeConfiguration Request Errored {p}"
-            >> Log.addContextDestructured "p" p
-          )
+          logException
+            e
+            (Log.setMessage "WorkspaceDidChangeConfiguration Request Errored {p}"
+             >> Log.addContextDestructured "p" p)
       }
 
     override __.TextDocumentFoldingRange(rangeP: FoldingRangeParams) =
@@ -2980,10 +2981,10 @@ type AdaptiveFSharpLspServer
         with e ->
           trace |> Tracing.recordException e
 
-          logException e (
-            Log.setMessage "WorkDoneProgressCancel Request Errored {p}"
-            >> Log.addContextDestructured "token" token
-          )
+          logException
+            e
+            (Log.setMessage "WorkDoneProgressCancel Request Errored {p}"
+             >> Log.addContextDestructured "token" token)
 
         return ()
       }

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -75,16 +75,15 @@ type AdaptiveFSharpLspServer
 
   let logException e cfg =
     match e with
-    | Cancelled e -> logger.warn (cfg >> Log.addExn e)
+    | Cancelled e -> logger.info (cfg >> Log.addExn e)
     | e -> logger.error (cfg >> Log.addExn e)
 
   let returnException e logCfg =
+    logException e logCfg
     match e with
-    | Cancelled e ->
-      logger.warn (logCfg >> Log.addExn e)
+    | Cancelled _ ->
       LspResult.requestCancelled
     | e ->
-      logger.error (logCfg >> Log.addExn e)
       LspResult.internalError (string e)
 
 

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fsi
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fsi
@@ -115,7 +115,7 @@ type AdaptiveState =
   member GetDeclarationLocation:
     symbolUse: FSharpSymbolUse * text: IFSACSourceText -> Async<Option<SymbolLocation.SymbolDeclarationLocation>>
 
-  member GetDeclarations: filename: string<LocalPath> -> Async<NavigationTopLevelDeclaration array option>
+  member GetDeclarations: filename: string<LocalPath> -> Async<Result<NavigationTopLevelDeclaration array, string>>
   member GetAllDeclarations: unit -> Async<(string<LocalPath> * NavigationTopLevelDeclaration array) array>
   member GlyphToSymbolKind: (FSharpGlyph -> SymbolKind option)
   interface IDisposable


### PR DESCRIPTION
- Centralizes and logs Cancellation of LSP endpoints as Info messages
- Converts some types from Options to Results for better errors
- Changed messages to inform the user the projects might not be loaded (yes we still need to fix the auto restore but that's a more work)
- Refactored the `selectProject` to be an interface rather than a FSharpFunc. Makes it easier to swap later. Adaptive requires comparisons and FSharpFuncs aren't comparable. 