### PR TITLE
Add unnecessary parentheses analyzer & code fix

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -80,6 +80,7 @@ type NotificationEvent =
   // | Lint of file: string<LocalPath> * warningsWithCodes: Lint.EnrichedLintWarning list
   | UnusedDeclarations of file: string<LocalPath> * decls: range[] * version: int
   | SimplifyNames of file: string<LocalPath> * names: SimplifyNames.SimplifiableRange[] * version: int
+  | UnnecessaryParentheses of file: string<LocalPath> * ranges: range[] * version: int
   | Canceled of errorMessage: string
   | FileParsed of string<LocalPath>
   | TestDetected of file: string<LocalPath> * tests: TestAdapter.TestAdapterEntry<range>[]

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -499,6 +499,38 @@ type ReadOnlySpanExtensions =
 
     line
 
+  #if !NET7_0_OR_GREATER
+  [<Extension>]
+  static member IndexOfAnyExcept(span: ReadOnlySpan<char>, value0: char, value1: char) =
+      let mutable i = 0
+      let mutable found = false
+
+      while not found && i < span.Length do
+          let c = span[i]
+
+          if c <> value0 && c <> value1 then
+              found <- true
+          else
+              i <- i + 1
+
+      if found then i else -1
+
+  [<Extension>]
+  static member LastIndexOfAnyExcept(span: ReadOnlySpan<char>, value0: char, value1: char) =
+      let mutable i = span.Length - 1
+      let mutable found = false
+
+      while not found && i >= 0 do
+          let c = span[i]
+
+          if c <> value0 && c <> value1 then
+              found <- true
+          else
+              i <- i - 1
+
+      if found then i else -1
+#endif
+
 type ConcurrentDictionary<'key, 'value> with
 
   member x.TryFind key =

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -499,36 +499,36 @@ type ReadOnlySpanExtensions =
 
     line
 
-  #if !NET7_0_OR_GREATER
+#if !NET7_0_OR_GREATER
   [<Extension>]
   static member IndexOfAnyExcept(span: ReadOnlySpan<char>, value0: char, value1: char) =
-      let mutable i = 0
-      let mutable found = false
+    let mutable i = 0
+    let mutable found = false
 
-      while not found && i < span.Length do
-          let c = span[i]
+    while not found && i < span.Length do
+      let c = span[i]
 
-          if c <> value0 && c <> value1 then
-              found <- true
-          else
-              i <- i + 1
+      if c <> value0 && c <> value1 then
+        found <- true
+      else
+        i <- i + 1
 
-      if found then i else -1
+    if found then i else -1
 
   [<Extension>]
   static member LastIndexOfAnyExcept(span: ReadOnlySpan<char>, value0: char, value1: char) =
-      let mutable i = span.Length - 1
-      let mutable found = false
+    let mutable i = span.Length - 1
+    let mutable found = false
 
-      while not found && i >= 0 do
-          let c = span[i]
+    while not found && i >= 0 do
+      let c = span[i]
 
-          if c <> value0 && c <> value1 then
-              found <- true
-          else
-              i <- i - 1
+      if c <> value0 && c <> value1 then
+        found <- true
+      else
+        i <- i - 1
 
-      if found then i else -1
+    if found then i else -1
 #endif
 
 type ConcurrentDictionary<'key, 'value> with

--- a/src/FsAutoComplete.Core/Utils.fsi
+++ b/src/FsAutoComplete.Core/Utils.fsi
@@ -181,6 +181,14 @@ type ReadOnlySpanExtensions =
   [<Extension>]
   static member LastLine: text: ReadOnlySpan<char> -> ReadOnlySpan<char>
 
+#if !NET7_0_OR_GREATER
+  [<Extension>]
+  static member IndexOfAnyExcept: span: ReadOnlySpan<char> * value0: char * value1: char -> int
+
+  [<Extension>]
+  static member LastIndexOfAnyExcept: span: ReadOnlySpan<char> * value0: char * value1: char -> int
+#endif
+
 type ConcurrentDictionary<'key, 'value> with
 
   member TryFind: key: 'key -> 'value option

--- a/src/FsAutoComplete/CodeFixes/RemoveUnnecessaryParentheses.fs
+++ b/src/FsAutoComplete/CodeFixes/RemoveUnnecessaryParentheses.fs
@@ -112,8 +112,8 @@ let fix (getFileLines: GetFileLines) : CodeFix =
 
         let newText =
           let (|ShouldPutSpaceBefore|_|) (s: string) =
-            // "……(……)"
-            //  ↑↑ ↑
+            // ……(……)
+            // ↑↑ ↑
             (sourceText.TryGetChar((protocolPosToPos d.Range.Start).IncColumn -1),
              sourceText.TryGetChar((protocolPosToPos d.Range.Start)))
             ||> Option.map2 (fun twoBefore oneBefore ->
@@ -133,8 +133,8 @@ let fix (getFileLines: GetFileLines) : CodeFix =
             |> Option.flatten
 
           let (|ShouldPutSpaceAfter|_|) (s: string) =
-            // "(……)…"
-            //    ↑ ↑
+            // (……)…
+            //   ↑ ↑
             sourceText.TryGetChar((protocolPosToPos d.Range.End).IncColumn 1)
             |> Option.bind (fun endChar ->
               match s[s.Length - 1], endChar with

--- a/src/FsAutoComplete/CodeFixes/RemoveUnnecessaryParentheses.fs
+++ b/src/FsAutoComplete/CodeFixes/RemoveUnnecessaryParentheses.fs
@@ -1,0 +1,163 @@
+module FsAutoComplete.CodeFix.RemoveUnnecessaryParentheses
+
+open System
+open Ionide.LanguageServerProtocol.Types
+open FsAutoComplete.CodeFix
+open FsAutoComplete.CodeFix.Types
+open FsToolkit.ErrorHandling
+open FsAutoComplete
+open FsAutoComplete.LspHelpers
+
+let title = "Remove unnecessary parentheses"
+
+[<AutoOpen>]
+module private Patterns =
+  let inline toPat f x = if f x then ValueSome() else ValueNone
+
+  [<AutoOpen>]
+  module Char =
+    [<return: Struct>]
+    let inline (|LetterOrDigit|_|) c = toPat Char.IsLetterOrDigit c
+
+    [<return: Struct>]
+    let inline (|Punctuation|_|) c = toPat Char.IsPunctuation c
+
+    [<return: Struct>]
+    let inline (|Symbol|_|) c = toPat Char.IsSymbol c
+
+  [<AutoOpen>]
+  module SourceText =
+    /// E.g., something like:
+    ///
+    ///     let … = (␤
+    ///     …
+    ///     )
+    [<return: Struct>]
+    let (|TrailingOpen|_|) (range: Range) (sourceText: IFSACSourceText) =
+      let line = sourceText.Lines[range.Start.Line]
+
+      if
+        line.AsSpan(0, range.Start.Character).LastIndexOfAnyExcept(' ', '(') >= 0
+        && line.AsSpan(range.Start.Character).IndexOfAnyExcept('(', ' ') < 0
+      then
+        ValueSome TrailingOpen
+      else
+        ValueNone
+
+    /// Trim only spaces from the start if there is something else
+    /// before the open paren on the same line (or else we could move
+    /// the whole inner expression up a line); otherwise trim all whitespace
+    // from start and end.
+    let (|Trim|) (range: Range) (sourceText: IFSACSourceText) =
+      let line = sourceText.Lines[range.Start.Line]
+
+      if line.AsSpan(0, range.Start.Character).LastIndexOfAnyExcept(' ', '(') >= 0 then
+        fun (s: string) -> s.TrimEnd().TrimStart ' '
+      else
+        fun (s: string) -> s.Trim()
+
+    /// Returns the offsides diff if the given span contains an expression
+    /// whose indentation would be made invalid if the open paren
+    /// were removed (because the offside line would be shifted).
+    [<return: Struct>]
+    let (|OffsidesDiff|_|) (range: Range) (sourceText: IFSACSourceText) =
+      let startLineNo = range.Start.Line
+      let endLineNo = range.End.Line
+
+      if startLineNo = endLineNo then
+        ValueNone
+      else
+        let rec loop innerOffsides lineNo startCol =
+          if lineNo <= endLineNo then
+            let line = sourceText.Lines[lineNo]
+
+            match line.AsSpan(startCol).IndexOfAnyExcept(' ', ')') with
+            | -1 -> loop innerOffsides (lineNo + 1) 0
+            | i -> loop (i + startCol) (lineNo + 1) 0
+          else
+            ValueSome(range.Start.Character - innerOffsides)
+
+        loop range.Start.Character startLineNo (range.Start.Character + 1)
+
+    let (|ShiftLeft|NoShift|ShiftRight|) n =
+      if n < 0 then ShiftLeft -n
+      elif n = 0 then NoShift
+      else ShiftRight n
+
+/// A codefix that removes unnecessary parentheses from the source.
+let fix (getFileLines: GetFileLines) : CodeFix =
+  Run.ifDiagnosticByCode (Set.singleton "FSAC0004") (fun d codeActionParams ->
+    asyncResult {
+      let fileName = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
+
+      let! sourceText = getFileLines fileName
+      let! txt = sourceText.GetText(protocolRangeToRange (string fileName) d.Range)
+
+      let firstChar = txt[0]
+      let lastChar = txt[txt.Length - 1]
+
+      match firstChar, lastChar with
+      | '(', ')' ->
+        let adjusted =
+          match sourceText with
+          | TrailingOpen d.Range -> txt[1 .. txt.Length - 2].TrimEnd()
+
+          | Trim d.Range trim & OffsidesDiff d.Range spaces ->
+            match spaces with
+            | NoShift -> trim txt[1 .. txt.Length - 2]
+            | ShiftLeft spaces -> trim (txt[1 .. txt.Length - 2].Replace("\n" + String(' ', spaces), "\n"))
+            | ShiftRight spaces -> trim (txt[1 .. txt.Length - 2].Replace("\n", "\n" + String(' ', spaces)))
+
+          | _ -> txt[1 .. txt.Length - 2].Trim()
+
+        let newText =
+          let (|ShouldPutSpaceBefore|_|) (s: string) =
+            // "……(……)"
+            //  ↑↑ ↑
+            (sourceText.TryGetChar((protocolPosToPos d.Range.Start).IncColumn -1),
+             sourceText.TryGetChar((protocolPosToPos d.Range.Start)))
+            ||> Option.map2 (fun twoBefore oneBefore ->
+              match twoBefore, oneBefore, s[0] with
+              | _, _, ('\n' | '\r') -> None
+              | '[', '|', (Punctuation | LetterOrDigit) -> None
+              | _, '[', '<' -> Some ShouldPutSpaceBefore
+              | _, ('(' | '[' | '{'), _ -> None
+              | _, '>', _ -> Some ShouldPutSpaceBefore
+              | ' ', '=', _ -> Some ShouldPutSpaceBefore
+              | _, '=', ('(' | '[' | '{') -> None
+              | _, '=', (Punctuation | Symbol) -> Some ShouldPutSpaceBefore
+              | _, LetterOrDigit, '(' -> None
+              | _, (LetterOrDigit | '`'), _ -> Some ShouldPutSpaceBefore
+              | _, (Punctuation | Symbol), (Punctuation | Symbol) -> Some ShouldPutSpaceBefore
+              | _ -> None)
+            |> Option.flatten
+
+          let (|ShouldPutSpaceAfter|_|) (s: string) =
+            // "(……)…"
+            //    ↑ ↑
+            sourceText.TryGetChar((protocolPosToPos d.Range.End).IncColumn 1)
+            |> Option.bind (fun endChar ->
+              match s[s.Length - 1], endChar with
+              | '>', ('|' | ']') -> Some ShouldPutSpaceAfter
+              | _, (')' | ']' | '[' | '}' | '.' | ';' | ',' | '|') -> None
+              | (Punctuation | Symbol), (Punctuation | Symbol | LetterOrDigit) -> Some ShouldPutSpaceAfter
+              | LetterOrDigit, LetterOrDigit -> Some ShouldPutSpaceAfter
+              | _ -> None)
+
+          match adjusted with
+          | ShouldPutSpaceBefore & ShouldPutSpaceAfter -> " " + adjusted + " "
+          | ShouldPutSpaceBefore -> " " + adjusted
+          | ShouldPutSpaceAfter -> adjusted + " "
+          | adjusted -> adjusted
+
+        return
+          [ { Edits = [| { Range = d.Range; NewText = newText } |]
+              File = codeActionParams.TextDocument
+              Title = title
+              SourceDiagnostic = Some d
+              Kind = FixKind.Fix } ]
+
+      | notParens ->
+        System.Diagnostics.Debug.Fail $"%A{notParens} <> ('(', ')')"
+        return []
+    })

--- a/src/FsAutoComplete/CodeFixes/RemoveUnnecessaryParentheses.fs
+++ b/src/FsAutoComplete/CodeFixes/RemoveUnnecessaryParentheses.fs
@@ -71,7 +71,7 @@ module private Patterns =
       if startLineNo = endLineNo then
         ValueNone
       else
-        let rec loop innerOffsides (pos: FcsPos) startCol =
+        let rec loop innerOffsides (pos: FcsPos) (startCol: int) =
           if pos.Line <= endLineNo then
             match sourceText.GetLine pos with
             | None -> ValueNone

--- a/src/FsAutoComplete/CodeFixes/RemoveUnnecessaryParentheses.fs
+++ b/src/FsAutoComplete/CodeFixes/RemoveUnnecessaryParentheses.fs
@@ -162,7 +162,5 @@ let fix (getFileLines: GetFileLines) : CodeFix =
               SourceDiagnostic = Some d
               Kind = FixKind.Fix } ]
 
-      | notParens ->
-        System.Diagnostics.Debug.Fail $"%A{notParens} <> ('(', ')')"
-        return []
+      | _notParens -> return []
     })

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -657,6 +657,7 @@ type FSharpConfigDto =
     UnusedDeclarationsAnalyzerExclusions: string array option
     SimplifyNameAnalyzer: bool option
     SimplifyNameAnalyzerExclusions: string array option
+    UnnecessaryParenthesesAnalyzer: bool option
     ResolveNamespaces: bool option
     EnableReferenceCodeLens: bool option
     EnableAnalyzers: bool option
@@ -798,6 +799,7 @@ type FSharpConfig =
     UnusedDeclarationsAnalyzerExclusions: Regex array
     SimplifyNameAnalyzer: bool
     SimplifyNameAnalyzerExclusions: Regex array
+    UnnecessaryParenthesesAnalyzer: bool
     ResolveNamespaces: bool
     EnableReferenceCodeLens: bool
     EnableAnalyzers: bool
@@ -846,6 +848,7 @@ type FSharpConfig =
       UnusedDeclarationsAnalyzerExclusions = [||]
       SimplifyNameAnalyzer = false
       SimplifyNameAnalyzerExclusions = [||]
+      UnnecessaryParenthesesAnalyzer = false
       ResolveNamespaces = false
       EnableReferenceCodeLens = false
       EnableAnalyzers = false
@@ -896,6 +899,7 @@ type FSharpConfig =
       SimplifyNameAnalyzerExclusions =
         defaultArg dto.SimplifyNameAnalyzerExclusions [||]
         |> Array.choose tryCreateRegex
+      UnnecessaryParenthesesAnalyzer = defaultArg dto.UnnecessaryParenthesesAnalyzer false
       ResolveNamespaces = defaultArg dto.ResolveNamespaces false
       EnableReferenceCodeLens = defaultArg dto.EnableReferenceCodeLens false
       EnableAnalyzers = defaultArg dto.EnableAnalyzers false
@@ -1003,6 +1007,7 @@ type FSharpConfig =
         defaultArg
           (dto.SimplifyNameAnalyzerExclusions |> Option.map (Array.choose tryCreateRegex))
           x.SimplifyNameAnalyzerExclusions
+      UnnecessaryParenthesesAnalyzer = defaultArg dto.UnnecessaryParenthesesAnalyzer x.UnnecessaryParenthesesAnalyzer
       ResolveNamespaces = defaultArg dto.ResolveNamespaces x.ResolveNamespaces
       EnableReferenceCodeLens = defaultArg dto.EnableReferenceCodeLens x.EnableReferenceCodeLens
       EnableAnalyzers = defaultArg dto.EnableAnalyzers x.EnableAnalyzers

--- a/src/FsAutoComplete/LspHelpers.fsi
+++ b/src/FsAutoComplete/LspHelpers.fsi
@@ -287,6 +287,7 @@ type FSharpConfigDto =
     UnusedDeclarationsAnalyzerExclusions: string array option
     SimplifyNameAnalyzer: bool option
     SimplifyNameAnalyzerExclusions: string array option
+    UnnecessaryParenthesesAnalyzer: bool option
     ResolveNamespaces: bool option
     EnableReferenceCodeLens: bool option
     EnableAnalyzers: bool option
@@ -387,6 +388,7 @@ type FSharpConfig =
     UnusedDeclarationsAnalyzerExclusions: System.Text.RegularExpressions.Regex array
     SimplifyNameAnalyzer: bool
     SimplifyNameAnalyzerExclusions: System.Text.RegularExpressions.Regex array
+    UnnecessaryParenthesesAnalyzer: bool
     ResolveNamespaces: bool
     EnableReferenceCodeLens: bool
     EnableAnalyzers: bool

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -3306,7 +3306,11 @@ let private removePatternArgumentTests state =
         """ ])
 
 let private removeUnnecessaryParenthesesTests state =
-  serverTestList (nameof RemoveUnnecessaryParentheses) state defaultConfigDto None (fun server ->
+  let config =
+    { defaultConfigDto with
+        UnnecessaryParenthesesAnalyzer = Some true }
+
+  serverTestList (nameof RemoveUnnecessaryParentheses) state config None (fun server ->
     [ let selector =
         CodeFix.ofKind "quickfix"
         >> CodeFix.withTitle RemoveUnnecessaryParentheses.title
@@ -3357,6 +3361,26 @@ let private removeUnnecessaryParenthesesTests state =
         selector
         """
         [| <@ 1 @> |]
+        """
+
+      testCaseAsync "Handles multiline expr well"
+      <| CodeFix.check
+        server
+        """
+        let _ =
+          let x = 3
+          (
+              let y = 99
+              y - x
+        $0)
+        """
+        (Diagnostics.expectCode "FSAC0004")
+        selector
+        """
+        let _ =
+          let x = 3
+          let y = 99
+          y - x
         """ ])
 
 let tests textFactory state =

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -2794,7 +2794,8 @@ let private resolveNamespaceTests state =
         ResolveNamespaces = Some true }
 
   serverTestList (nameof ResolveNamespace) state config None (fun server ->
-    [ let selectCodeFix = CodeFix.matching (fun ca -> ca.Title.StartsWith("open", StringComparison.Ordinal))
+    [ let selectCodeFix =
+        CodeFix.matching (fun ca -> ca.Title.StartsWith("open", StringComparison.Ordinal))
 
       testCaseAsync "doesn't fail when target not in last line"
       <| CodeFix.checkApplicable
@@ -3304,6 +3305,60 @@ let private removePatternArgumentTests state =
         let (None) = None
         """ ])
 
+let private removeUnnecessaryParenthesesTests state =
+  serverTestList (nameof RemoveUnnecessaryParentheses) state defaultConfigDto None (fun server ->
+    [ let selector =
+        CodeFix.ofKind "quickfix"
+        >> CodeFix.withTitle RemoveUnnecessaryParentheses.title
+
+      testCaseAsync "Can remove unnecessary parentheses"
+      <| CodeFix.check
+        server
+        """
+        let x = $0(3)
+        """
+        (Diagnostics.expectCode "FSAC0004")
+        selector
+        """
+        let x = 3
+        """
+
+      testCaseAsync "Adds space after"
+      <| CodeFix.check
+        server
+        """
+        $0(int)3.14
+        """
+        (Diagnostics.expectCode "FSAC0004")
+        selector
+        """
+        int 3.14
+        """
+
+      testCaseAsync "Adds space before"
+      <| CodeFix.check
+        server
+        """
+        int$0(3.14)
+        """
+        (Diagnostics.expectCode "FSAC0004")
+        selector
+        """
+        int 3.14
+        """
+
+      testCaseAsync "Adds space before and after"
+      <| CodeFix.check
+        server
+        """
+        [|$0(<@ 1 @>)|]
+        """
+        (Diagnostics.expectCode "FSAC0004")
+        selector
+        """
+        [| <@ 1 @> |]
+        """ ])
+
 let tests textFactory state =
   testList
     "CodeFix-tests"
@@ -3352,4 +3407,5 @@ let tests textFactory state =
       wrapExpressionInParenthesesTests state
       removeRedundantAttributeSuffixTests state
       removePatternArgumentTests state
-      UpdateValueInSignatureFileTests.tests state ]
+      UpdateValueInSignatureFileTests.tests state
+      removeUnnecessaryParenthesesTests state ]

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -3372,7 +3372,7 @@ let private removeUnnecessaryParenthesesTests state =
           (
               let y = 99
               y - x
-        $0)
+          )$0
         """
         (Diagnostics.expectCode "FSAC0004")
         selector

--- a/test/FsAutoComplete.Tests.Lsp/FindReferencesTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/FindReferencesTests.fs
@@ -378,27 +378,27 @@ let private untitledTests state =
           open System
           open System.Threading.Tasks
           let _ = task {
-            do! Task.$<De$0lay>$ (TimeSpan.MaxValue)
-            do! Task.$<``Delay``>$ (TimeSpan.MaxValue)
-            do! System.Threading.Tasks.Task.$<Delay>$ (TimeSpan.MaxValue)
+            do! Task.$<De$0lay>$ TimeSpan.MaxValue
+            do! Task.$<``Delay``>$ TimeSpan.MaxValue
+            do! System.Threading.Tasks.Task.$<Delay>$ TimeSpan.MaxValue
             do!
               System
                 .Threading
                 .Tasks
                 .Task
-                .$<Delay>$ (TimeSpan.MaxValue)
+                .$<Delay>$ TimeSpan.MaxValue
           }
           """
                """
           open System
           open System.Threading.Tasks
           let _ = task {
-            do! Task.$<Delay>$ (TimeSpan.MaxValue)
+            do! Task.$<Delay>$ TimeSpan.MaxValue
             printfn "..."
-            do! Threading.Tasks.Task.$<Delay>$ (TimeSpan.MaxValue)
+            do! Threading.Tasks.Task.$<Delay>$ TimeSpan.MaxValue
           }
           let _ = task {
-            do! Task.$<Delay>$ (TimeSpan.MaxValue)
+            do! Task.$<Delay>$ TimeSpan.MaxValue
           }
           """
                // No Task.Delay
@@ -458,8 +458,16 @@ let private rangeTests state =
     async {
       let (source, cursors) = sourceWithCursors |> extractRanges
       let! (doc, diags) = server |> Server.createUntitledDocument source
+
+      let pertinentDiags =
+        diags
+        |> Array.filter (function
+          // Ignore extra parens diagnostics here.
+          | { Code = Some "FSAC0004" } -> false
+          | _ -> true)
+
       use doc = doc
-      Expect.hasLength diags 0 "There should be no diags"
+      Expect.hasLength pertinentDiags 0 "There should be no diags"
 
       let request: ReferenceParams =
         { TextDocument = doc.TextDocumentIdentifier

--- a/test/FsAutoComplete.Tests.Lsp/FindReferencesTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/FindReferencesTests.fs
@@ -459,15 +459,8 @@ let private rangeTests state =
       let (source, cursors) = sourceWithCursors |> extractRanges
       let! (doc, diags) = server |> Server.createUntitledDocument source
 
-      let pertinentDiags =
-        diags
-        |> Array.filter (function
-          // Ignore extra parens diagnostics here.
-          | { Code = Some "FSAC0004" } -> false
-          | _ -> true)
-
       use doc = doc
-      Expect.hasLength pertinentDiags 0 "There should be no diags"
+      Expect.hasLength diags 0 "There should be no diags"
 
       let request: ReferenceParams =
         { TextDocument = doc.TextDocumentIdentifier

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -226,6 +226,7 @@ let defaultConfigDto: FSharpConfigDto =
     UnusedDeclarationsAnalyzerExclusions = None
     SimplifyNameAnalyzer = None
     SimplifyNameAnalyzerExclusions = None
+    UnnecessaryParenthesesAnalyzer = None
     ResolveNamespaces = None
     EnableReferenceCodeLens = None
     EnableAnalyzers = None

--- a/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/InlayHintTests.fs
@@ -151,8 +151,16 @@ module private LspInlayHints =
     =
     async {
       let! (doc, diags) = server |> Server.createUntitledDocument text
+
+      let pertinentDiags =
+        diags
+        |> Array.filter (function
+          // Ignore extra parens diagnostics here.
+          | { Code = Some "FSAC0004" } -> false
+          | _ -> true)
+
       use doc = doc
-      Expect.hasLength diags 0 "Should not have had check errors"
+      Expect.hasLength pertinentDiags 0 "Should not have had check errors"
 
       let! hints = doc |> Document.inlayHintsAt range
       let hints = hints |> Array.sortBy (fun h -> h.Position)


### PR DESCRIPTION
- Add unnecessary parentheses analyzer and code fix using the FSC API exposed in https://github.com/dotnet/fsharp/pull/16079.

**Note**: this will need a small update to use https://github.com/dotnet/fsharp/pull/16461 when FSC 8.0.300 is shipped.