### PR TITLE
Add a workflow that merges main to nightly whenever a push to main occurs

### DIFF
--- a/.github/workflows/auto-merge-main-to-nightly.yml
+++ b/.github/workflows/auto-merge-main-to-nightly.yml
@@ -1,0 +1,27 @@
+name: Auto Merge Main to Nightly
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+            ref: nightly
+            fetch-depth: 0 # need all history to merge main
+
+      - name: Merge main to nightly
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git merge main -m "merge main to nightly" --no-edit
+          git push origin nightly


### PR DESCRIPTION
This should help us keep infra changes in main up to date in nightly, and also make it easier for contributors like @brianrourkeboll to contribute initial features that work on the current released FCS, but have a more correct/fully-featured implementation on the next release of FCS.