### PR TITLE
Speed up project load times.

### DIFF
--- a/src/FsAutoComplete.Core/AdaptiveExtensions.fs
+++ b/src/FsAutoComplete.Core/AdaptiveExtensions.fs
@@ -589,7 +589,7 @@ module AsyncAVal =
     else
       { new AbstractVal<'a>() with
           member x.Compute t =
-            let real = Task.FromResult(value.GetValue t)
+            let real = Task.Run(fun () -> value.GetValue t)
             AdaptiveCancellableTask(id, real) }
       :> asyncaval<_>
 


### PR DESCRIPTION
This fixes issues where long running `aval.GetValue` would cause threadpool exhaustion. In practice this speeds up project load times. 