### PR TITLE
Show script option project diagnostics

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -211,24 +211,10 @@ type FSharpCompilerServiceChecker(hasAnalyzers, typecheckCacheSize, parallelRefe
     }
 
   member self.GetProjectOptionsFromScript(file: string<LocalPath>, source, tfm) =
-    async {
-      let! (projOptions, errors) =
-        match tfm with
-        | FSIRefs.TFM.NetFx -> self.GetNetFxScriptOptions(file, source)
-        | FSIRefs.TFM.NetCore -> self.GetNetCoreScriptOptions(file, source)
+    match tfm with
+    | FSIRefs.TFM.NetFx -> self.GetNetFxScriptOptions(file, source)
+    | FSIRefs.TFM.NetCore -> self.GetNetCoreScriptOptions(file, source)
 
-      match errors with
-      | [] -> ()
-      | errs ->
-        optsLogger.info (
-          Log.setLogLevel LogLevel.Error
-          >> Log.setMessage "Resolved {opts} with {errors}"
-          >> Log.addContextDestructured "opts" projOptions
-          >> Log.addContextDestructured "errors" errs
-        )
-
-      return projOptions
-    }
 
   member __.ScriptTypecheckRequirementsChanged =
     scriptTypecheckRequirementsChanged.Publish

--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fsi
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fsi
@@ -4,14 +4,11 @@ open System.IO
 open FSharp.Compiler.CodeAnalysis
 open Utils
 open FSharp.Compiler.Text
-open FsAutoComplete.Logging
 open Ionide.ProjInfo.ProjectSystem
 open FSharp.UMX
 open FSharp.Compiler.EditorServices
 open FSharp.Compiler.Symbols
-open Microsoft.Extensions.Caching.Memory
-open System
-open FsToolkit.ErrorHandling
+open FSharp.Compiler.Diagnostics
 
 type Version = int
 
@@ -27,7 +24,8 @@ type FSharpCompilerServiceChecker =
       (FSharpProjectOptions * FSharpProjectOptions list) option
 
   member GetProjectOptionsFromScript:
-    file: string<LocalPath> * source: ISourceText * tfm: FSIRefs.TFM -> Async<FSharpProjectOptions>
+    file: string<LocalPath> * source: ISourceText * tfm: FSIRefs.TFM ->
+      Async<FSharpProjectOptions * FSharpDiagnostic list>
 
   member ScriptTypecheckRequirementsChanged: IEvent<unit>
 

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -21,7 +21,7 @@ let tests state =
       do! server.TextDocumentDidOpen tdop
 
       let! _diagnostics =
-        waitForParseResultsForFile "Script.fsx" events
+        waitForDiagnosticErrorForFile "Script.fsx" events
         |> AsyncResult.bimap (fun _ -> failtest "Should have had errors") (fun e -> e)
 
       return (server, path)
@@ -743,7 +743,7 @@ let autoOpenTests state =
       do! server.TextDocumentDidOpen tdop
 
       do!
-        waitForParseResultsForFile scriptName events
+        waitForDiagnosticErrorForFile scriptName events
         |> AsyncResult.bimap (fun _ -> failtest "Should have had errors") id
         |> Async.Ignore
 

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -689,6 +689,8 @@ let diagnosticsToResult =
 
 let waitForParseResultsForFile file = fileDiagnostics file >> diagnosticsToResult >> Async.AwaitObservable
 
+let waitForDiagnosticErrorForFile file = fileDiagnostics file >> Observable.choose (function | [||] -> None | diags -> Some diags) >> diagnosticsToResult >> Async.AwaitObservable
+
 let waitForFsacDiagnosticsForFile file = fsacDiagnostics file >> diagnosticsToResult >> Async.AwaitObservable
 
 let waitForCompilerDiagnosticsForFile file = compilerDiagnostics file >> diagnosticsToResult >> Async.AwaitObservable

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fsi
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fsi
@@ -111,6 +111,7 @@ val fsacDiagnostics: file: string -> (IObservable<string * obj> -> IObservable<D
 val compilerDiagnostics: file: string -> (IObservable<string * obj> -> IObservable<Diagnostic array>)
 val diagnosticsToResult: (IObservable<Diagnostic array> -> IObservable<Result<unit, Diagnostic array>>)
 val waitForParseResultsForFile: file: string -> (IObservable<string * obj> -> Async<Result<unit, Diagnostic array>>)
+val waitForDiagnosticErrorForFile: file: string -> (IObservable<string * obj> -> Async<Result<unit, Diagnostic array>>)
 val waitForFsacDiagnosticsForFile: file: string -> (IObservable<string * obj> -> Async<Result<unit, Diagnostic array>>)
 
 val waitForCompilerDiagnosticsForFile:


### PR DESCRIPTION
Makes sure to pass along script file project option diagnostics.

<img width="1575" alt="image" src="https://github.com/fsharp/FsAutoComplete/assets/1490044/ac91ed61-c06f-4b42-a36f-e4758ed445dd">

Should give additional info for people having issues with the restore functionality in fsx scripts.