### PR TITLE
add codefix "replace dotLambda to lambda"

### DIFF
--- a/src/FsAutoComplete/CodeFixes/ReplaceLambdaWithDotLambda.fs
+++ b/src/FsAutoComplete/CodeFixes/ReplaceLambdaWithDotLambda.fs
@@ -67,10 +67,7 @@ let tryFindLambda (cursor: pos) (tree: ParsedInput) =
       | Some(SyntaxNode.SynExpr(SynExpr.Paren _)) ->
         DotLambdaReplaceInfo.NotNeedParen m |> FixType.ReplaceToLambda |> Some
       | _ ->
-        let (Pos(line, column)) = mLambda.End
-        let posEnd = Position.mkPos line (column + 1)
-
-        DotLambdaReplaceInfo.NeedParen(m, mkRange m.FileName posEnd posEnd)
+        DotLambdaReplaceInfo.NeedParen(m, mkRange m.FileName mLambda.End mLambda.End)
         |> FixType.ReplaceToLambda
         |> Some
     | _ -> None)

--- a/src/FsAutoComplete/CodeFixes/ReplaceLambdaWithDotLambda.fsi
+++ b/src/FsAutoComplete/CodeFixes/ReplaceLambdaWithDotLambda.fsi
@@ -2,5 +2,6 @@ module FsAutoComplete.CodeFix.ReplaceLambdaWithDotLambda
 
 open FsAutoComplete.CodeFix.Types
 
-val title: string
+val titleReplaceToDotLambda: string
+val titleReplaceToLambda: string
 val fix: getLanguageVersion: GetLanguageVersion -> getParseResultsForFile: GetParseResultsForFile -> CodeFix

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ReplaceLambdaWithDotLambdaTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ReplaceLambdaWithDotLambdaTests.fs
@@ -8,7 +8,7 @@ open FsAutoComplete.CodeFix
 
 let tests state =
   serverTestList (nameof ReplaceLambdaWithDotLambda) state defaultConfigDto None (fun server ->
-    [ let selectCodeFix = CodeFix.withTitle ReplaceLambdaWithDotLambda.title
+    [ let selectCodeFix = CodeFix.withTitle ReplaceLambdaWithDotLambda.titleReplaceToDotLambda
 
       testCaseAsync "Simple property"
       <| CodeFix.check
@@ -41,6 +41,10 @@ let tests state =
         Diagnostics.acceptAll
         selectCodeFix
         "let a6 = _.ToString()"
+
+      // -------------------- from dot lambda to lambda test ----------------------
+
+      let selectCodeFix = CodeFix.withTitle ReplaceLambdaWithDotLambda.titleReplaceToLambda
 
       testCaseAsync "Simple property (from dot lambda to lambda)"
       <| CodeFix.check

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ReplaceLambdaWithDotLambdaTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/ReplaceLambdaWithDotLambdaTests.fs
@@ -42,4 +42,35 @@ let tests state =
         selectCodeFix
         "let a6 = _.ToString()"
 
+      testCaseAsync "Simple property (from dot lambda to lambda)"
+      <| CodeFix.check
+        server
+        "let x = \"\" |> $0_.Length"
+        Diagnostics.acceptAll
+        selectCodeFix
+        "let x = \"\" |> (fun _i -> _i.Length)"
+
+      testCaseAsync "Property of application (from dot lambda to lambda)"
+      <| CodeFix.check
+        server
+        "let a5 : {| Foo : int -> {| X : string |} |} -> string = _.$0Foo(5).X"
+        Diagnostics.acceptAll
+        selectCodeFix
+        "let a5 : {| Foo : int -> {| X : string |} |} -> string = (fun _i -> _i.Foo(5).X)"
+
+      testCaseAsync "Application (from dot lambda to lambda)"
+      <| CodeFix.check
+        server
+        "let a6 = [1] |> List.map _$0.ToString()"
+        Diagnostics.acceptAll
+        selectCodeFix
+        "let a6 = [1] |> List.map (fun _i -> _i.ToString())"
+
+      testCaseAsync "fun x -> x.ToString() (from dot lambda to lambda)"
+      <| CodeFix.check
+        server
+        "let a6 = _.ToStri$0ng()"
+        Diagnostics.acceptAll
+        selectCodeFix
+        "let a6 = (fun _i -> _i.ToString())"
       ])


### PR DESCRIPTION
add codefix "replace dotLambda to lambda"

it will replace `_.` to `fun _i -> _i.`

![GIF 2024-4-14 23-16-05](https://github.com/ionide/FsAutoComplete/assets/43789618/f179af15-dba2-4913-bca5-e6138010cac7)
