### PR TITLE
fix unicode characters in F# compiler diagnostic messages

### DIFF
--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -100,8 +100,8 @@ module Conversions =
 
   [<Literal>]
   let unicodeParagraphCharacter: string = "\u001d"
-  let private handleUnicodeParagraph (message: string) =
-    message.Replace(unicodeParagraphCharacter, Environment.NewLine)
+
+  let private handleUnicodeParagraph (message: string) = message.Replace(unicodeParagraphCharacter, Environment.NewLine)
 
   let fcsErrorToDiagnostic (error: FSharpDiagnostic) =
     { Range =

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -98,6 +98,11 @@ module Conversions =
   let urlForCompilerCode (number: int) =
     $"https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-messages/fs%04d{number}"
 
+  [<Literal>]
+  let unicodeParagraphCharacter: string = "\u001d"
+  let private handleUnicodeParagraph (message: string) =
+    message.Replace(unicodeParagraphCharacter, Environment.NewLine)
+
   let fcsErrorToDiagnostic (error: FSharpDiagnostic) =
     { Range =
         { Start =
@@ -108,7 +113,7 @@ module Conversions =
               Character = error.EndColumn } }
       Severity = fcsSeverityToDiagnostic error.Severity
       Source = Some "F# Compiler"
-      Message = error.Message
+      Message = handleUnicodeParagraph error.Message
       Code = Some(string error.ErrorNumber)
       RelatedInformation = Some [||]
       Tags = None

--- a/src/FsAutoComplete/LspHelpers.fsi
+++ b/src/FsAutoComplete/LspHelpers.fsi
@@ -35,6 +35,7 @@ module Conversions =
   val fcsPosToProtocolRange: pos: FcsPos -> Range
   val fcsRangeToLspLocation: range: FcsRange -> Location
   val findDeclToLspLocation: decl: FsAutoComplete.FindDeclarationResult -> Location
+
   [<Literal>]
   val unicodeParagraphCharacter: string = "\u001d"
 

--- a/src/FsAutoComplete/LspHelpers.fsi
+++ b/src/FsAutoComplete/LspHelpers.fsi
@@ -35,6 +35,8 @@ module Conversions =
   val fcsPosToProtocolRange: pos: FcsPos -> Range
   val fcsRangeToLspLocation: range: FcsRange -> Location
   val findDeclToLspLocation: decl: FsAutoComplete.FindDeclarationResult -> Location
+  [<Literal>]
+  val unicodeParagraphCharacter: string = "\u001d"
 
   type TextDocumentIdentifier with
 

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -471,7 +471,6 @@ let closeTests state =
 let diagnosticsTest state =
   let server =
     async {
-      printfn "starting..."
       let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "DiagnosticFormatting")
       let! (server, events) = serverInitialize path defaultConfigDto state
       let path = Path.Combine(path, "Program.fs")
@@ -490,7 +489,6 @@ let diagnosticsTest state =
           let tdop: DidOpenTextDocumentParams = { TextDocument = loadDocument path }
           do! server.TextDocumentDidOpen tdop
 
-          printfn "waiting for compiler..."
           let! compilerResults = waitForCompilerDiagnosticsForFile "Program.fs" events |> Async.StartChild
 
           match! compilerResults with

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -480,13 +480,13 @@ let diagnosticsTest state =
     }
     |> Async.Cache
 
-  ftestList
+  testList
     "Diagnostics formatting Tests"
     [ testCaseAsync
         "replacing unicode paragraph by newline"
         (async {
           let! (server, events, path) = server
-          
+
           let tdop: DidOpenTextDocumentParams = { TextDocument = loadDocument path }
           do! server.TextDocumentDidOpen tdop
 
@@ -494,8 +494,15 @@ let diagnosticsTest state =
           let! compilerResults = waitForCompilerDiagnosticsForFile "Program.fs" events |> Async.StartChild
 
           match! compilerResults with
-          | Ok () -> failtest "should get an F# compiler checking error"
+          | Ok() -> failtest "should get an F# compiler checking error"
           | Core.Result.Error errors ->
-            Expect.exists errors (fun error -> error.Code = Some "39" || error.Code = Some "41") "should have an error FS0039(identifier not defined) or FS0041(a unique overload for method 'TryParse' could not be determined based on type information prior to this program point)"
-            Expect.all errors (fun error -> not <| error.Message.Contains(unicodeParagraphCharacter)) "message should not contains unicode paragraph characters"
+            Expect.exists
+              errors
+              (fun error -> error.Code = Some "39" || error.Code = Some "41")
+              "should have an error FS0039(identifier not defined) or FS0041(a unique overload for method 'TryParse' could not be determined based on type information prior to this program point)"
+
+            Expect.all
+              errors
+              (fun error -> not <| error.Message.Contains(unicodeParagraphCharacter))
+              "message should not contains unicode paragraph characters"
         }) ]

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -51,11 +51,11 @@ module Expecto =
 
     let testCase = testCaseWithTimeout DEFAULT_TIMEOUT
     let ptestCase = ptestCaseWithTimeout DEFAULT_TIMEOUT
-    let ftestCase = ptestCaseWithTimeout DEFAULT_TIMEOUT
+    let ftestCase = ftestCaseWithTimeout DEFAULT_TIMEOUT
 
     let testCaseAsync = testCaseAsyncWithTimeout DEFAULT_TIMEOUT
     let ptestCaseAsync = ptestCaseAsyncWithTimeout DEFAULT_TIMEOUT
-    let ftestCaseAsync = ptestCaseAsyncWithTimeout DEFAULT_TIMEOUT
+    let ftestCaseAsync = ftestCaseAsyncWithTimeout DEFAULT_TIMEOUT
 
 let rec private copyDirectory sourceDir destDir =
   // Get the subdirectories for the specified directory.

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -103,6 +103,7 @@ let lspTests =
             UnusedDeclarationsTests.tests createServer
             EmptyFileTests.tests createServer
             CallHierarchy.tests createServer
+            diagnosticsTest createServer
             ] ]
 
 /// Tests that do not require a LSP server

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/DiagnosticFormatting/DiagnosticFormatting.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/DiagnosticFormatting/DiagnosticFormatting.fsproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Test.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/DiagnosticFormatting/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/DiagnosticFormatting/Program.fs
@@ -1,0 +1,9 @@
+﻿// Learn more about F# at http://fsharp.org
+
+open System
+
+[<EntryPoint>]
+let main argv =
+    let isOk, integer = System.Int32.TryParse nope
+    printfn "Hello World from F#!"
+    0 // return an integer exit code


### PR DESCRIPTION
Fixes https://github.com/ionide/ionide-vscode-fsharp/issues/1939

(and I spent way too much time wondering why `ftestCaseAsync` tests didn't run... 😅)