### PR TITLE
Don't generate params for explicit getters/setters

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1397,7 +1397,7 @@ type Commands() =
                                     headPat = SynPat.LongIdent(longDotId = longDotId)))) when
                                 rangeContainsPos longDotId.Range pos && xmlDoc.IsEmpty
                                 ->
-                                Some(false, tryGetFirstAttributeLine attributes)
+                                Some(true, tryGetFirstAttributeLine attributes)
                               | SynMemberDefn.GetSetMember(
                                   memberDefnForGet = Some(SynBinding(
                                     attributes = attributes
@@ -1405,7 +1405,7 @@ type Commands() =
                                     headPat = SynPat.LongIdent(longDotId = longDotId)))) when
                                 rangeContainsPos longDotId.Range pos && xmlDoc.IsEmpty
                                 ->
-                                Some(false, tryGetFirstAttributeLine attributes)
+                                Some(true, tryGetFirstAttributeLine attributes)
                               | _ -> None)
                           | _ -> None)
                       | _ -> None)

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -1752,7 +1752,6 @@ let private generateXmlDocumentationTests state =
         type MyClass() =
           let mutable someField = ""
           /// <summary></summary>
-          /// <param name="x"></param>
           /// <returns></returns>
           member _.Name
             with get () = "foo"
@@ -1794,7 +1793,6 @@ let private generateXmlDocumentationTests state =
         type MyClass() =
           let mutable someField = ""
           /// <summary></summary>
-          /// <param name="x"></param>
           /// <returns></returns>
           member _.Name
             with set (x: string) = someField <- x


### PR DESCRIPTION
Params for explicit getters/setters are flagged as invalid xml comments by the compiler when 3390 is turned on.
While this might be a compiler bug, we shouldn't produce things that have the potential to fail builds.
