### PR TITLE
Add support for Cancel a Work Done Progress 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
     <NoWarn>$(NoWarn);3186,0042</NoWarn><!-- circumvent an error with the fake dependencymanager for
     paket: https://github.com/dotnet/fsharp/issues/8678 -->
     <NoWarn>$(NoWarn);NU1902</NoWarn><!-- NU1902 - package vulnerability detected -->
-    <WarnOn>$(WarnOn);1182</WarnOn> <!-- Unused
-    variables,https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-options#opt-in-warnings -->
+    <WarnOn>$(WarnOn);1182</WarnOn> <!-- Unused variables,https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-options#opt-in-warnings -->
+    <NoWarn>$(NoWarn);FS0044</NoWarn>       <!-- Ignore deprecations -->
     <WarnOn>$(WarnOn);3390</WarnOn><!-- Malformed XML doc comments -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ChangelogFile>$(MSBuildThisFileDirectory)CHANGELOG.md</ChangelogFile>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -52,7 +52,7 @@ nuget Expecto.Diff
 nuget YoloDev.Expecto.TestSdk
 nuget AltCover
 nuget GitHubActionsTestLogger
-nuget Ionide.LanguageServerProtocol >= 0.4.20
+nuget Ionide.LanguageServerProtocol >= 0.4.23
 nuget Microsoft.Extensions.Caching.Memory
 nuget OpenTelemetry.Api >= 1.3.2
 nuget OpenTelemetry.Exporter.OpenTelemetryProtocol >= 1.3.2 # 1.4 bumps to 7.0 versions of System.Diagnostics libs, so can't use it

--- a/paket.lock
+++ b/paket.lock
@@ -133,7 +133,7 @@ NUGET
       System.Reflection.Metadata (>= 5.0)
     Ionide.Analyzers (0.10)
     Ionide.KeepAChangelog.Tasks (0.1.8) - copy_local: true
-    Ionide.LanguageServerProtocol (0.4.20)
+    Ionide.LanguageServerProtocol (0.4.23)
       FSharp.Core (>= 6.0)
       Newtonsoft.Json (>= 13.0.1)
       StreamJsonRpc (>= 2.16.36)

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -578,8 +578,8 @@ type AdaptiveFSharpLspServer
                   // Otherwise we'll fail here and our retry logic will come into place
                   do!
                     match p.Context with
-                    | Some({ triggerKind = CompletionTriggerKind.TriggerCharacter } as context) ->
-                      volatileFile.Source.TryGetChar pos = context.triggerCharacter
+                    | Some({ TriggerKind = CompletionTriggerKind.TriggerCharacter } as context) ->
+                      volatileFile.Source.TryGetChar pos = context.TriggerCharacter
                     | _ -> true
                     |> Result.requireTrue $"TextDocumentCompletion was sent before TextDocumentDidChange"
 
@@ -2960,17 +2960,19 @@ type AdaptiveFSharpLspServer
 
     override x.Dispose() = disposables.Dispose()
 
-    member this.WorkDoneProgressCancel(token: ProgressToken) : Async<unit> =
+    member this.WorkDoneProgressCancel(param: WorkDoneProgressCancelParams) : Async<unit> =
       async {
 
-        let tags = [ "ProgressToken", box token ]
+        let tags = [ "WorkDoneProgressCancelParams", box param ]
         use trace = fsacActivitySource.StartActivityForType(thisType, tags = tags)
 
         try
           logger.info (
             Log.setMessage "WorkDoneProgressCancel Request: {params}"
-            >> Log.addContextDestructured "params" token
+            >> Log.addContextDestructured "params" param.token
           )
+
+          state.CancelServerProgress param.token
 
         with e ->
           trace |> Tracing.recordException e
@@ -2978,7 +2980,7 @@ type AdaptiveFSharpLspServer
           logException
             e
             (Log.setMessage "WorkDoneProgressCancel Request Errored {p}"
-             >> Log.addContextDestructured "token" token)
+             >> Log.addContextDestructured "token" param.token)
 
         return ()
       }

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fsi
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fsi
@@ -118,4 +118,12 @@ type AdaptiveState =
   member GetDeclarations: filename: string<LocalPath> -> Async<Result<NavigationTopLevelDeclaration array, string>>
   member GetAllDeclarations: unit -> Async<(string<LocalPath> * NavigationTopLevelDeclaration array) array>
   member GlyphToSymbolKind: (FSharpGlyph -> SymbolKind option)
+  /// <summary>
+  /// Signals the server to cancel an operation that is associated with the given progress token.
+  /// </summary>
+  ///
+  /// <remarks>
+  /// See <see href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_workDoneProgress_cancel">LSP Spec on WorkDoneProgress Cancel</see> for more information.
+  /// </remarks>
+  member CancelServerProgress: progressToken: ProgressToken -> unit
   interface IDisposable

--- a/src/FsAutoComplete/LspServers/Common.fs
+++ b/src/FsAutoComplete/LspServers/Common.fs
@@ -158,7 +158,7 @@ module Async =
       let! ct2 = Async.CancellationToken
       use cts = CancellationTokenSource.CreateLinkedTokenSource(ct, ct2)
       let tcs = new TaskCompletionSource<'a>()
-      use _reg = cts.Token.Register(fun () -> tcs.TrySetCanceled() |> ignore)
+      use _reg = cts.Token.Register(fun () -> tcs.TrySetCanceled(cts.Token) |> ignore)
 
       let a =
         async {

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -41,8 +41,8 @@ let tests state =
               Position = { Line = 3; Character = 9 } // the '.' in 'Async.'
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.TriggerCharacter
-                    triggerCharacter = Some '.' } }
+                  { TriggerKind = CompletionTriggerKind.TriggerCharacter
+                    TriggerCharacter = Some '.' } }
 
           let! response = server.TextDocumentCompletion completionParams
 
@@ -94,8 +94,8 @@ let tests state =
                   Character = character + 1 }
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.TriggerCharacter
-                    triggerCharacter = Some '.' } }
+                  { TriggerKind = CompletionTriggerKind.TriggerCharacter
+                    TriggerCharacter = Some '.' } }
 
           let! response = server.TextDocumentCompletion completionParams
           do! c
@@ -131,8 +131,8 @@ let tests state =
               Position = { Line = line; Character = character } // the '.' in 'GetDirectoryName().'
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.TriggerCharacter
-                    triggerCharacter = Some '.' } }
+                  { TriggerKind = CompletionTriggerKind.TriggerCharacter
+                    TriggerCharacter = Some '.' } }
 
           let! response = server.TextDocumentCompletion completionParams
 
@@ -183,8 +183,8 @@ let tests state =
                   Character = character + 1 }
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.TriggerCharacter
-                    triggerCharacter = Some '.' } }
+                  { TriggerKind = CompletionTriggerKind.TriggerCharacter
+                    TriggerCharacter = Some '.' } }
 
           let! response = server.TextDocumentCompletion completionParams
           do! c
@@ -220,8 +220,8 @@ let tests state =
               Position = { Line = line; Character = character }
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.TriggerCharacter
-                    triggerCharacter = Some '.' } }
+                  { TriggerKind = CompletionTriggerKind.TriggerCharacter
+                    TriggerCharacter = Some '.' } }
 
           let! response = server.TextDocumentCompletion completionParams
 
@@ -272,8 +272,8 @@ let tests state =
                   Character = character + 1 }
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.TriggerCharacter
-                    triggerCharacter = Some '.' } }
+                  { TriggerKind = CompletionTriggerKind.TriggerCharacter
+                    TriggerCharacter = Some '.' } }
 
           let! response = server.TextDocumentCompletion completionParams
           do! c
@@ -309,8 +309,8 @@ let tests state =
               Position = { Line = line; Character = character }
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.TriggerCharacter
-                    triggerCharacter = Some '.' } }
+                  { TriggerKind = CompletionTriggerKind.TriggerCharacter
+                    TriggerCharacter = Some '.' } }
 
           let! response = server.TextDocumentCompletion completionParams
 
@@ -341,8 +341,8 @@ let tests state =
               Position = { Line = 6; Character = 5 } // the '.' in 'List.'
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.TriggerCharacter
-                    triggerCharacter = Some '.' } }
+                  { TriggerKind = CompletionTriggerKind.TriggerCharacter
+                    TriggerCharacter = Some '.' } }
 
           let! response = server.TextDocumentCompletion completionParams
 
@@ -369,8 +369,8 @@ let tests state =
               Position = { Line = 8; Character = 16 } // the '.' in 'List.'
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.TriggerCharacter
-                    triggerCharacter = Some '.' } }
+                  { TriggerKind = CompletionTriggerKind.TriggerCharacter
+                    TriggerCharacter = Some '.' } }
 
           let! response = server.TextDocumentCompletion completionParams
 
@@ -396,8 +396,8 @@ let tests state =
               Position = { Line = 11; Character = 10 } // after Lis partial type name in Id record field declaration
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.Invoked
-                    triggerCharacter = None } }
+                  { TriggerKind = CompletionTriggerKind.Invoked
+                    TriggerCharacter = None } }
 
           let! response = server.TextDocumentCompletion completionParams
 
@@ -428,8 +428,8 @@ let tests state =
               Position = { Line = 8; Character = 12 } // after the 'L' in 'List.'
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.Invoked
-                    triggerCharacter = None } }
+                  { TriggerKind = CompletionTriggerKind.Invoked
+                    TriggerCharacter = None } }
 
           let! response = server.TextDocumentCompletion completionParams
 
@@ -456,8 +456,8 @@ let tests state =
               Position = { Line = 8; Character = 11 } // before the 'L' in 'List.'
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.Invoked
-                    triggerCharacter = None } }
+                  { TriggerKind = CompletionTriggerKind.Invoked
+                    TriggerCharacter = None } }
 
           let! response = server.TextDocumentCompletion completionParams
 
@@ -484,8 +484,8 @@ let tests state =
               Position = { Line = 3; Character = 9 } // the '.' in 'Async.'
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.TriggerCharacter
-                    triggerCharacter = Some '.' } }
+                  { TriggerKind = CompletionTriggerKind.TriggerCharacter
+                    TriggerCharacter = Some '.' } }
 
           let! response = server.TextDocumentCompletion completionParams |> AsyncResult.map Option.get
           let ctokMember = response.Items[0]
@@ -514,8 +514,8 @@ let tests state =
               Position = { Line = 23; Character = 8 } // the '.' in 'List.'
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.TriggerCharacter
-                    triggerCharacter = Some '.' } }
+                  { TriggerKind = CompletionTriggerKind.TriggerCharacter
+                    TriggerCharacter = Some '.' } }
 
           let! response = server.TextDocumentCompletion completionParams
 
@@ -542,8 +542,8 @@ let tests state =
               Position = { Line = 24; Character = 9 } // the '.' in 'List.'
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.TriggerCharacter
-                    triggerCharacter = Some '.' } }
+                  { TriggerKind = CompletionTriggerKind.TriggerCharacter
+                    TriggerCharacter = Some '.' } }
 
           let! response = server.TextDocumentCompletion completionParams
 
@@ -1017,8 +1017,8 @@ let fullNameExternalAutocompleteTest state =
             Position = { Line = line; Character = character }
             Context =
               Some
-                { triggerKind = CompletionTriggerKind.Invoked
-                  triggerCharacter = None } }
+                { TriggerKind = CompletionTriggerKind.Invoked
+                  TriggerCharacter = None } }
 
         let! res = server.TextDocumentCompletion p
 
@@ -1049,8 +1049,8 @@ let fullNameExternalAutocompleteTest state =
               Position = { Line = 3; Character = 4 }
               Context =
                 Some
-                  { triggerKind = CompletionTriggerKind.Invoked
-                    triggerCharacter = None } }
+                  { TriggerKind = CompletionTriggerKind.Invoked
+                    TriggerCharacter = None } }
 
           let! response = server.TextDocumentCompletion p |> AsyncResult.map Option.get
 

--- a/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
@@ -82,8 +82,8 @@ let tests state =
                       Position = { Line = 0; Character = 1 }
                       Context =
                         Some
-                          { triggerKind = CompletionTriggerKind.Invoked
-                            triggerCharacter = None }
+                          { TriggerKind = CompletionTriggerKind.Invoked
+                            TriggerCharacter = None }
                     } |> Async.StartChild
 
                   let! compilerResults = waitForCompilerDiagnosticsForFile "EmptyFile.fsx" events |> Async.StartChild

--- a/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/EmptyFileTests.fs
@@ -53,8 +53,8 @@ let tests state =
                       Position = { Line = 0; Character = 0 }
                       Context =
                           Some
-                            { triggerKind = CompletionTriggerKind.Invoked
-                              triggerCharacter = None } }
+                            { TriggerKind = CompletionTriggerKind.Invoked
+                              TriggerCharacter = None } }
 
                   match! server.TextDocumentCompletion completionParams with
                   | Ok (Some _) -> failtest "An empty file has empty completions"


### PR DESCRIPTION
Adds support for [Cancel a Work Done Progress ](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_workDoneProgress_cancel).

This will now add a Cancel button to potentially longer running operations like typechecking or type checking dependents upon save:

![image](https://github.com/ionide/FsAutoComplete/assets/1490044/f90979f4-eb24-4f9e-89ec-5260adf48f7f)

Clicking cancel will cancel that operation accordingly.