### PR TITLE
Use actualRootPath instead of p.RootPath when peeking workspaces.

### DIFF
--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -316,15 +316,12 @@ type AdaptiveFSharpLspServer
             | None -> p.RootPath
 
           let projs =
-            match p.RootPath, c.AutomaticWorkspaceInit with
+            match actualRootPath, c.AutomaticWorkspaceInit with
             | None, _
             | _, false -> state.WorkspacePaths
-            | Some actualRootPath, true ->
+            | Some rootPath, true ->
               let peeks =
-                WorkspacePeek.peek
-                  actualRootPath
-                  c.WorkspaceModePeekDeepLevel
-                  (c.ExcludeProjectDirectories |> List.ofArray)
+                WorkspacePeek.peek rootPath c.WorkspaceModePeekDeepLevel (c.ExcludeProjectDirectories |> List.ofArray)
                 |> List.map Workspace.mapInteresting
                 |> List.sortByDescending (fun x ->
                   match x with


### PR DESCRIPTION
This fix the issue #1277 where rootUri was ignored when using AutomaticWorkspaceInit.