### PR TITLE
update icedtasks to 0.11.5

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -38,7 +38,7 @@ nuget Destructurama.FSharp
 nuget FSharp.UMX >= 1.1
 nuget FSharp.Formatting >= 14.0
 nuget FsToolkit.ErrorHandling.TaskResult >= 4.4 framework: netstandard2.1 ,net6.0, net7.0, net8.0
-nuget IcedTasks >= 0.9.2
+nuget IcedTasks >= 0.11.5
 nuget FSharpx.Async >= 1.14
 nuget CliWrap >= 3.0
 nuget System.CommandLine prerelease

--- a/paket.lock
+++ b/paket.lock
@@ -110,8 +110,9 @@ NUGET
       Grpc.Core.Api (>= 2.51)
     Humanizer.Core (2.14.1)
     Iced (1.17)
-    IcedTasks (0.9.2)
+    IcedTasks (0.11.5)
       FSharp.Core (>= 6.0.1)
+      Microsoft.Bcl.AsyncInterfaces (>= 6.0) - restriction: || (&& (== net6.0) (< netstandard2.1)) (&& (== net7.0) (< netstandard2.1)) (&& (== net8.0) (< netstandard2.1)) (== netstandard2.0)
     ICSharpCode.Decompiler (7.2.1.6856)
       Microsoft.Win32.Registry (>= 5.0)
       System.Collections.Immutable (>= 5.0)
@@ -748,7 +749,6 @@ NUGET
       Expecto (>= 10.0 < 11.0) - restriction: || (== net6.0) (== net7.0) (== net8.0) (&& (== netstandard2.0) (>= net6.0)) (&& (== netstandard2.1) (>= net6.0))
       FSharp.Core (>= 7.0.200) - restriction: || (== net6.0) (== net7.0) (== net8.0) (&& (== netstandard2.0) (>= net6.0)) (&& (== netstandard2.1) (>= net6.0))
       System.Collections.Immutable (>= 6.0) - restriction: || (== net6.0) (== net7.0) (== net8.0) (&& (== netstandard2.0) (>= net6.0)) (&& (== netstandard2.1) (>= net6.0))
-
   remote: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json
     FSharp.Compiler.Service (43.8.300-preview.24205.4)
       FSharp.Core (8.0.300-beta.24205.4)


### PR DESCRIPTION
Updates IcedTasks to 0.11.5.

The main fix is to https://github.com/TheAngryByrd/IcedTasks/pull/46 where cancellations should be handled differently when going from Task -> Async.