### PR TITLE
Some parens fixes

### DIFF
--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -516,6 +516,19 @@ type ReadOnlySpanExtensions =
     if found then i else -1
 
   [<Extension>]
+  static member IndexOfAnyExcept(span: ReadOnlySpan<char>, values: ReadOnlySpan<char>) =
+    let mutable i = 0
+    let mutable found = false
+
+    while not found && i < span.Length do
+      if values.IndexOf span[i] < 0 then
+        found <- true
+      else
+        i <- i + 1
+
+    if found then i else -1
+
+  [<Extension>]
   static member LastIndexOfAnyExcept(span: ReadOnlySpan<char>, value0: char, value1: char) =
     let mutable i = span.Length - 1
     let mutable found = false

--- a/src/FsAutoComplete.Core/Utils.fsi
+++ b/src/FsAutoComplete.Core/Utils.fsi
@@ -186,6 +186,9 @@ type ReadOnlySpanExtensions =
   static member IndexOfAnyExcept: span: ReadOnlySpan<char> * value0: char * value1: char -> int
 
   [<Extension>]
+  static member IndexOfAnyExcept: span: ReadOnlySpan<char> * values: ReadOnlySpan<char> -> int
+
+  [<Extension>]
   static member LastIndexOfAnyExcept: span: ReadOnlySpan<char> * value0: char * value1: char -> int
 #endif
 

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -1606,7 +1606,7 @@ let private generateXmlDocumentationTests state =
         /// <summary></summary>
         type MyRecord = { Foo: int }
         """
-      
+
       testCaseAsync "documentation for record type with multiple attribute lists"
       <| CodeFix.check
         server
@@ -3436,7 +3436,68 @@ let private removeUnnecessaryParenthesesTests state =
         longFunctionName
           longVarName1
           longVarName2
-        """ ])
+        """
+
+      testCaseAsync "Handles outlaw match exprs"
+      <| CodeFix.check
+        server
+        """
+        3 > (match x with
+            | 1
+            | _ -> 3)$0
+        """
+        (Diagnostics.expectCode "FSAC0004")
+        selector
+        """
+        3 > match x with
+            | 1
+            | _ -> 3
+        """
+
+      testCaseAsync "Handles even more outlaw match exprs"
+      <| CodeFix.check
+        server
+        """
+        3 > ( match x with
+            | 1
+            | _ -> 3)$0
+        """
+        (Diagnostics.expectCode "FSAC0004")
+        selector
+        """
+        3 > match x with
+            | 1
+            | _ -> 3
+        """
+
+      testCaseAsync "Handles single-line comments"
+      <| CodeFix.check
+        server
+        """
+        3 > (match x with
+             // Lol.
+            | 1
+            | _ -> 3)$0
+        """
+        (Diagnostics.expectCode "FSAC0004")
+        selector
+        """
+        3 > match x with
+             // Lol.
+            | 1
+            | _ -> 3
+        """
+
+      testCaseAsync "Keep parens when removal would cause reparse of infix as prefix"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        ""+(Unchecked.defaultof<string>)$0+""
+        """
+        (Diagnostics.expectCode "FSAC0004")
+        selector
+
+      ])
 
 let tests textFactory state =
   testList


### PR DESCRIPTION
This pulls in some code-fix-level fixes from https://github.com/dotnet/fsharp/pull/16901 (I meant to do this a while ago).

- Keep parens around outlaw `match` exprs (where the first `|` is leftward of the start of the `match` keyword).
- Ignore single-line comments when determining offsides lines.
- Don't add a space when removing parens when doing so would result in reparsing an infix op as a prefix op.