### PR TITLE
don't offer the XML comment codefix on namespaces or anon modules

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -1361,8 +1361,10 @@ type Commands() =
 
               member _.VisitModuleOrNamespace(_, synModuleOrNamespace) =
                 match synModuleOrNamespace with
-                | SynModuleOrNamespace(attribs = attributes; longId = longId; xmlDoc = xmlDoc) when
-                  longIdentContainsPos longId pos && xmlDoc.IsEmpty
+                | SynModuleOrNamespace(attribs = attributes; longId = longId; xmlDoc = xmlDoc; kind = kind) when
+                  kind = SynModuleOrNamespaceKind.NamedModule
+                  && longIdentContainsPos longId pos
+                  && xmlDoc.IsEmpty
                   ->
                   Some(false, tryGetFirstAttributeLine attributes)
                 | SynModuleOrNamespace(decls = decls) ->

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -1852,7 +1852,18 @@ let private generateXmlDocumentationTests state =
           /// <summary></summary>
           module MyNestedModule =
             let x = 3
-        """ ])
+        """
+
+      testCaseAsync "not applicable for namespace"
+      <| CodeFix.checkNotApplicable
+        server
+        """
+        namespace N$0
+          module MyNestedModule =
+            let x = 3
+        """
+        Diagnostics.acceptAll
+        selectCodeFix ])
 
 let private addMissingXmlDocumentationTests state =
   serverTestList (nameof AddMissingXmlDocumentation) state defaultConfigDto None (fun server ->


### PR DESCRIPTION
Fix another bunch of cases where this was offered too liberally.