### PR TITLE
render optional args as `?name: type` instead of `name: option<type>`

### DIFF
--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -294,7 +294,7 @@ module SignatureFormatter =
         if p.Type.IsFunctionType then
           $"({formatted})"
         else if p.IsOptionalArg && formatted.StartsWith("option<", StringComparison.Ordinal) then // render optional args as "?ident: type"
-          formatted.Substring(7).TrimEnd('>')
+          formatted.AsSpan(7, formatted.Length - 8).ToString()
         else
           formatted
       with :? InvalidOperationException ->

--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -263,7 +263,9 @@ module SignatureFormatter =
     let safeParameterName (p: FSharpParameter) =
       match Option.defaultValue p.DisplayNameCore p.Name with
       | "" -> ""
-      | name -> FSharpKeywords.NormalizeIdentifierBackticks name
+      | name ->
+        let n = FSharpKeywords.NormalizeIdentifierBackticks name
+        if p.IsOptionalArg then "?" + n else n // render optional args as "?ident: type"
 
     let padLength =
       let allLengths =
@@ -291,6 +293,8 @@ module SignatureFormatter =
 
         if p.Type.IsFunctionType then
           $"({formatted})"
+        else if p.IsOptionalArg && formatted.StartsWith("option<", StringComparison.Ordinal) then // render optional args as "?ident: type"
+          formatted.Substring(7).TrimEnd('>')
         else
           formatted
       with :? InvalidOperationException ->

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -377,9 +377,9 @@ let tooltipTests state =
             28
             (concatLines
               [ "static member Start:"
-                "   body             : (MailboxProcessor<string> -> Async<unit>) *"
-                "   cancellationToken: option<System.Threading.CancellationToken>"
-                "                   -> MailboxProcessor<string>" ])
+                "   body              : (MailboxProcessor<string> -> Async<unit>) *"
+                "   ?cancellationToken: System.Threading.CancellationToken"
+                "                    -> MailboxProcessor<string>" ])
           verifySignature 54 9 "Case2 of string * newlineBefore: bool * newlineAfter: bool"
           verifySignature
             60


### PR DESCRIPTION
before:
![Screenshot from 2024-05-17 21-42-57](https://github.com/ionide/FsAutoComplete/assets/3221269/478ac1bd-205c-4e74-9151-153834e91765)
after:
![Screenshot from 2024-05-17 21-48-09](https://github.com/ionide/FsAutoComplete/assets/3221269/5fa59366-85e4-49f1-abd4-576d46ec7ca9)

We already do this in the status bar of VsCode/Ionide.
The line lens is still wrong, but one thing at a time :)