### PR TITLE
In the Tooltip markdown, render generic type names with multiple segments correctly

### DIFF
--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -1058,8 +1058,8 @@ let private formatTaggedText (t: TaggedText) : string =
   | TextTag.StringLiteral
   | TextTag.Text
   | TextTag.Punctuation
-  | TextTag.UnknownType
-  | TextTag.UnknownEntity -> t.Text
+  | TextTag.UnknownType -> t.Text
+  | TextTag.UnknownEntity
   | TextTag.Enum
   | TextTag.Event
   | TextTag.ActivePatternCase
@@ -1075,7 +1075,8 @@ let private formatUntaggedText (t: TaggedText) = t.Text
 
 let private formatUntaggedTexts = Array.map formatUntaggedText >> String.concat ""
 
-let private formatTaggedTexts = Array.map formatTaggedText >> String.concat ""
+let private formatTaggedTexts =
+  Array.map formatTaggedText >> String.concat "" >> (fun s -> s.Replace("``", ""))
 
 let private formatGenericParameters (typeMappings: TaggedText[] list) =
   typeMappings

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -308,7 +308,7 @@ let tooltipTests state =
               ""
               "**Generic Parameters**"
               ""
-              "* `'T` is `string`" ] // verify fancy descriptions for external library functions
+              "* `'T` is `System.String`" ] // verify fancy descriptions for external library functions and correct backticks for multiple segments
           verifyDescription
             13
             11

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -2,7 +2,7 @@ let arrayOfTuples = [| 1, 2 |]
 let listOfTuples = [ 1, 2 ]
 let listOfStructTuples = [ struct(1, 2) ]
 let floatThatShouldHaveGenericReportedInTooltip = 1.
-sprintf "asd"
+sprintf<System.String> "asd"
 
 /// <summary>
 /// My super summary


### PR DESCRIPTION
This tries to fix https://github.com/ionide/ionide-vscode-fsharp/issues/1987
before:
<img width="278" alt="Screenshot 2024-05-19 224858" src="https://github.com/ionide/FsAutoComplete/assets/3221269/2bae319e-e905-44ef-af27-451653d1a536">
after:
<img width="230" alt="Screenshot 2024-05-19 225108" src="https://github.com/ionide/FsAutoComplete/assets/3221269/401ccacb-261d-4a9f-994e-3179890f044f">
