### PR TITLE
fix: wrong "open" completion position with namespace

### DIFF
--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -699,7 +699,7 @@ module Commands =
             // this only happens when there are no other `open`
 
             // from insert position go up until first open OR namespace
-            ic.Pos.LinesToBeginning()
+            ic.Pos.IncLine().LinesToBeginning()
             |> Seq.tryFind (fun l ->
               let lineStr = getLine l
               // namespace MUST be top level -> no indentation

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -717,10 +717,16 @@ type AdaptiveFSharpLspServer
                 { (fcsPos |> fcsPosToLsp) with
                     Character = 0 }
 
+              let displayText =
+                match config.ExternalAutocomplete, ci.Label.Split(" (open ") with
+                | true, [| label; _ |] -> label
+                | true, [| label |] -> label
+                | _, _ -> ci.Label
+
               Some
                 [| { TextEdit.NewText = text
                      TextEdit.Range = { Start = insertPos; End = insertPos } } |],
-              $"{ci.Label} (open {ns})"
+              $"{displayText} (open {ns})"
 
           let d = Documentation.Markup(markdown comment)
 

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -835,7 +835,8 @@ let autoOpenTests state =
       | Ok None -> failtest "Request none"
       | Ok(Some res) ->
         Expect.isFalse res.IsIncomplete "Result is incomplete"
-        let ci = res.Items |> Array.tryFind (fun c -> c.Label = word)
+        // with ExternalAutoComplete, completions are like "Regex (open System.Text.RegularExpressions)"
+        let ci = res.Items |> Array.tryFind (fun c -> c.Label.StartsWith word)
 
         if ci = None then
           failwithf
@@ -934,7 +935,7 @@ let autoOpenTests state =
 
         yield! tests ]
 
-  let ptestScript name scriptName =
+  let _ptestScript name scriptName =
     testList
       name
       [ let scriptPath = Path.Combine(dirPath, scriptName)
@@ -947,7 +948,7 @@ let autoOpenTests state =
 
         yield! tests ]
 
-  ptestList
+  testList
     "Completion.AutoOpen"
     [
       // NOTE: Positions are ZERO-based!: { Line = 3; Character = 9 } -> Line 4, Column 10 in editor display
@@ -955,8 +956,8 @@ let autoOpenTests state =
       testScript "with root module" "Module.fsx"
       testScript "with root module with open" "ModuleWithOpen.fsx"
       testScript "with root module with open and new line" "ModuleWithOpenAndNewLine.fsx"
-      ptestScript "with namespace with new line" "NamespaceWithNewLine.fsx"
-      ptestScript "with namespace" "Namespace.fsx"
+      testScript "with namespace with new line" "NamespaceWithNewLine.fsx"
+      testScript "with namespace" "Namespace.fsx"
       testScript "with namespace with open" "NamespaceWithOpen.fsx"
       testScript "with namespace with open and new line" "NamespaceWithOpenAndNewLine.fsx"
       testScript "with implicit top level module with new line" "ImplicitTopLevelModuleWithNewLine.fsx"

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/CompletionAutoOpenTests/Namespace.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/CompletionAutoOpenTests/Namespace.fsx
@@ -12,8 +12,8 @@ module Nested1 =
 
 namespace OpenNamespace.OtherNamespace
   type T = {
-    Value: Regex(*-1,|-2*)
+    Value: Regex(*-1,|-4*)
   }
   with
     member _.Foo () =
-      Regex(*-5,|-4*)
+      Regex(*-5,|-6*)

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/CompletionAutoOpenTests/NamespaceWithNewLine.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/CompletionAutoOpenTests/NamespaceWithNewLine.fsx
@@ -15,8 +15,8 @@ module Nested1 =
 namespace OpenNamespace.OtherNamespace
 
   type T = {
-    Value: Regex(*-2,|-2*)
+    Value: Regex(*-2,|-4*)
   }
   with
     member _.Foo () =
-      Regex(*-6,|-4*)
+      Regex(*-6,|-6*)


### PR DESCRIPTION
Fix code completion for external namespace being inserted before `namespace` and bring back `Completion.AutoOpen` tests

before : 
![fix-open-namespace-before](https://github.com/ionide/FsAutoComplete/assets/632075/d04478bd-053b-4c1a-b34e-695075ccfef9)

after :
![fix-open-namespace-after](https://github.com/ionide/FsAutoComplete/assets/632075/cbcb3d3e-548e-4dc7-b4af-605ff455172d)

NB: I changed the position for `Namespace.fsx` & `NamespaceWithNewLine.fsx` to match the actual behavior, it is correct F# syntax but I would have expected it to be aligned with the code below instead of the `namespace` (at least we get coverage for the inserted line part)
![fix-open-namespace-nested](https://github.com/ionide/FsAutoComplete/assets/632075/7ec0cab5-01d8-4fff-8b73-aa0e398cebaa)

NB2: Since I added back `Completion.AutoOpen` tests, I can't get the full test suite to run locally, the test adapter is crashing with OOM. Maybe the dedicated `createServer` function missed some "recent" optimisations applied to others `createServer` since it was not running until now ?