### PR TITLE
Extend FS25 codefix to allow generating match cases from scratch

### DIFF
--- a/src/FsAutoComplete.Core/UnionPatternMatchCaseGenerator.fs
+++ b/src/FsAutoComplete.Core/UnionPatternMatchCaseGenerator.fs
@@ -511,7 +511,7 @@ let tryFindCaseInsertionParamsAtPos (codeGenService: ICodeGenerationService) pos
       return patMatchExpr, insertionParams
     else
       return patMatchExpr, {
-        InsertionPos = patMatchExpr.Expr.Range.Start.IncLine()
+        InsertionPos = patMatchExpr.Expr.Range.End
         IndentColumn = patMatchExpr.Expr.Range.Start.Column
       }
   }

--- a/src/FsAutoComplete.Core/UnionPatternMatchCaseGenerator.fs
+++ b/src/FsAutoComplete.Core/UnionPatternMatchCaseGenerator.fs
@@ -211,20 +211,19 @@ let private tryFindPatternMatchExprInParsedInput (pos: Position) (parsedInput: P
             | _ -> None
           else
             None)
-          |> Option.orElseWith (fun () ->
-            if synMatchClauseList.IsEmpty
-            then
-              match debugPoint with
-              | DebugPointAtBinding.Yes range ->
-                { MatchWithOrFunctionRange = range
-                  Expr = matchExpr
-                  Clauses = [] }
-                |> Some
-              | _ -> None
-            else
-              None
+        |> Option.orElseWith (fun () ->
+          if synMatchClauseList.IsEmpty then
+            match debugPoint with
+            | DebugPointAtBinding.Yes range ->
+              { MatchWithOrFunctionRange = range
+                Expr = matchExpr
+                Clauses = [] }
+              |> Some
+            | _ -> None
+          else
+            None
 
-          )
+        )
 
       | SynExpr.App(_exprAtomicFlag, _isInfix, synExpr1, synExpr2, _range) ->
         List.tryPick walkExpr [ synExpr1; synExpr2 ]
@@ -510,10 +509,10 @@ let tryFindCaseInsertionParamsAtPos (codeGenService: ICodeGenerationService) pos
       let! insertionParams = tryFindInsertionParams codeGenService document patMatchExpr
       return patMatchExpr, insertionParams
     else
-      return patMatchExpr, {
-        InsertionPos = patMatchExpr.Expr.Range.End
-        IndentColumn = patMatchExpr.Expr.Range.Start.Column
-      }
+      return
+        patMatchExpr,
+        { InsertionPos = patMatchExpr.Expr.Range.End
+          IndentColumn = patMatchExpr.Expr.Range.Start.Column }
   }
 
 let tryFindUnionDefinitionFromPos (codeGenService: ICodeGenerationService) pos document =

--- a/src/FsAutoComplete/CodeFixes/GenerateUnionCases.fs
+++ b/src/FsAutoComplete/CodeFixes/GenerateUnionCases.fs
@@ -18,23 +18,40 @@ let fix
   (getTextReplacements: unit -> Map<string, string>)
   =
   Run.ifDiagnosticByCode (Set.ofList [ "25" ]) (fun diagnostic codeActionParams ->
+    let _getCasePos (lines: IFSACSourceText) (fcsRange: FcsRange) =
+      result {
+        let! nextLine = lines.NextLine fcsRange.Start |> Result.ofOption (fun _ -> "no next line")
+
+        let! caseLine = lines.GetLine(nextLine) |> Result.ofOption (fun _ -> "No case line")
+
+        let! caseCol = match caseLine.IndexOf('|') with
+                        | -1 -> Error "Invalid case line"
+                        | idx  -> Ok (uint32 idx + 3u) // Find column of first case in pattern matching
+
+        let casePos =
+          { Line = uint32 nextLine.Line - 1u;
+                  Character = caseCol }
+        return casePos
+      }
+
+    let getCasePosFromMatch (lines: IFSACSourceText) (fcsRange: FcsRange) =
+      result {
+        let! matchLine = lines.GetLine fcsRange.Start |> Result.ofOption (fun _ -> "no current line")
+        let caseCol = matchLine.IndexOf("match")
+        let casePos = { Line = uint32 fcsRange.Start.Line - 1u;
+                Character = uint32 caseCol + 7u }
+        return casePos
+      }
+
     asyncResult {
-      let fileName = codeActionParams.TextDocument.GetFilePath() |> Utils.normalizePath
+      let fileName = codeActionParams.TextDocument.GetFilePath() |> normalizePath
 
       let! lines = getFileLines fileName
       // try to find the first case already written
       let fcsRange = protocolRangeToRange (FSharp.UMX.UMX.untag fileName) diagnostic.Range
 
-      let! nextLine = lines.NextLine fcsRange.Start |> Result.ofOption (fun _ -> "no next line")
 
-      let! caseLine = lines.GetLine(nextLine) |> Result.ofOption (fun _ -> "No case line")
-
-      let caseCol = uint32 (caseLine.IndexOf('|')) + 3u // Find column of first case in pattern matching
-
-      let casePos =
-        { Line = uint32 nextLine.Line - 1u
-          Character = caseCol }
-
+      let! casePos = (_getCasePos lines fcsRange) |> Result.orElseWith (fun _ -> getCasePosFromMatch lines fcsRange)
       let casePosFCS = protocolPosToPos casePos
 
       let! tyRes, _line, lines = getParseResultsForFile fileName casePosFCS

--- a/src/FsAutoComplete/CodeFixes/GenerateUnionCases.fs
+++ b/src/FsAutoComplete/CodeFixes/GenerateUnionCases.fs
@@ -18,7 +18,7 @@ let fix
   (getTextReplacements: unit -> Map<string, string>)
   =
   Run.ifDiagnosticByCode (Set.ofList [ "25" ]) (fun diagnostic codeActionParams ->
-    let _getCasePos (lines: IFSACSourceText) (fcsRange: FcsRange) =
+    let getCasePosFromCaseLine (lines: IFSACSourceText) (fcsRange: FcsRange) =
       result {
         let! nextLine = lines.NextLine fcsRange.Start |> Result.ofOption (fun _ -> "no next line")
 
@@ -51,7 +51,7 @@ let fix
       let fcsRange = protocolRangeToRange (FSharp.UMX.UMX.untag fileName) diagnostic.Range
 
 
-      let! casePos = (_getCasePos lines fcsRange) |> Result.orElseWith (fun _ -> getCasePosFromMatch lines fcsRange)
+      let! casePos = (getCasePosFromCaseLine lines fcsRange) |> Result.orElseWith (fun _ -> getCasePosFromMatch lines fcsRange)
       let casePosFCS = protocolPosToPos casePos
 
       let! tyRes, _line, lines = getParseResultsForFile fileName casePosFCS

--- a/src/FsAutoComplete/CodeFixes/GenerateUnionCases.fs
+++ b/src/FsAutoComplete/CodeFixes/GenerateUnionCases.fs
@@ -24,13 +24,15 @@ let fix
 
         let! caseLine = lines.GetLine(nextLine) |> Result.ofOption (fun _ -> "No case line")
 
-        let! caseCol = match caseLine.IndexOf('|') with
-                        | -1 -> Error "Invalid case line"
-                        | idx  -> Ok (uint32 idx + 3u) // Find column of first case in pattern matching
+        let! caseCol =
+          match caseLine.IndexOf('|') with
+          | -1 -> Error "Invalid case line"
+          | idx -> Ok(uint32 idx + 3u) // Find column of first case in pattern matching
 
         let casePos =
-          { Line = uint32 nextLine.Line - 1u;
-                  Character = caseCol }
+          { Line = uint32 nextLine.Line - 1u
+            Character = caseCol }
+
         return casePos
       }
 
@@ -38,8 +40,11 @@ let fix
       result {
         let! matchLine = lines.GetLine fcsRange.Start |> Result.ofOption (fun _ -> "no current line")
         let caseCol = matchLine.IndexOf("match")
-        let casePos = { Line = uint32 fcsRange.Start.Line - 1u;
-                Character = uint32 caseCol + 7u }
+
+        let casePos =
+          { Line = uint32 fcsRange.Start.Line - 1u
+            Character = uint32 caseCol + 7u }
+
         return casePos
       }
 
@@ -51,7 +56,10 @@ let fix
       let fcsRange = protocolRangeToRange (FSharp.UMX.UMX.untag fileName) diagnostic.Range
 
 
-      let! casePos = (getCasePosFromCaseLine lines fcsRange) |> Result.orElseWith (fun _ -> getCasePosFromMatch lines fcsRange)
+      let! casePos =
+        (getCasePosFromCaseLine lines fcsRange)
+        |> Result.orElseWith (fun _ -> getCasePosFromMatch lines fcsRange)
+
       let casePosFCS = protocolPosToPos casePos
 
       let! tyRes, _line, lines = getParseResultsForFile fileName casePosFCS

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -3200,7 +3200,7 @@ let private removePatternArgumentTests state =
 
         do
           let (E.A x$0) = E.A
-        ()
+          ()
         """
         (Diagnostics.expectCode "3191")
         selectCodeFix

--- a/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CodeFixTests/Tests.fs
@@ -2100,7 +2100,7 @@ let private generateUnionCasesTests state =
   serverTestList (nameof GenerateUnionCases) state config None (fun server ->
     [ let _selectCodeFix = CodeFix.withTitle GenerateUnionCases.title
 
-      testCaseAsync "can generate match cases for a simple DU"
+      testCaseAsync "can generate match cases for a simple DU with one case"
       <| CodeFix.check
         server
         """
@@ -2120,6 +2120,29 @@ let private generateUnionCasesTests state =
 
         match char with
         | A -> ()
+        | B -> failwith "---"
+        | C -> failwith "---"
+        """
+
+      testCaseAsync "can generate match cases for a simple DU without cases"
+      <| CodeFix.check
+        server
+        """
+        type Letter = A | B | C
+
+        let char = A
+
+        match $0char with
+        """
+        (Diagnostics.expectCode "25")
+        (CodeFix.withTitle GenerateUnionCases.title)
+        """
+        type Letter = A | B | C
+
+        let char = A
+
+        match char with
+        | A -> failwith "---"
         | B -> failwith "---"
         | C -> failwith "---"
         """ ])
@@ -2724,6 +2747,7 @@ let private replaceWithSuggestionTests state =
       let validateDiags (diags: Diagnostic[]) =
         Diagnostics.expectCode "39" diags
         let messages = diags |> Array.map (fun d -> d.Message) |> String.concat "\n"
+
         Expect.exists
           diags
           (fun (d: Diagnostic) -> d.Message.Contains "Maybe you want one of the following:")
@@ -3175,8 +3199,8 @@ let private removePatternArgumentTests state =
           | B = 2
 
         do
-	        let (E.A x$0) = E.A
-	        ()
+          let (E.A x$0) = E.A
+        ()
         """
         (Diagnostics.expectCode "3191")
         selectCodeFix
@@ -3186,8 +3210,8 @@ let private removePatternArgumentTests state =
           | B = 2
 
         do
-	        let (E.A) = E.A
-	        ()
+          let (E.A) = E.A
+          ()
         """
 
       testCaseAsync "Local literal constant pattern qualified parameter"


### PR DESCRIPTION
Hello :wave: 

I've made an addition to existing FS25 "Generate union pattern match case". Basically, it allows applying this codefix to an empty `match ... with`, so user isn't required to write first case branch for the codefix to work. I think that this codefix might be useful in slightly different contexts. Current implementation is more suitable for cases when already existing Union type gets extended, and therefore already existing match expression becomes non-exhaustive. But in my practice, when I'm writing small programs from scratch, I usually have a different situation cause I'm writing completely new match expressions.

I tried to develop it in backward-compatible way, so that previous logic for the codefix stays intact, and the code only falls back to a new logic if the original one is unable to produce results.