### PR TITLE
fix package restore on dotnet sdk 8.0.303

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <PackageLicenseExpression Condition=" '$(PackAsTool)' != 'true' ">Apache-2.0</PackageLicenseExpression>
     <NoWarn>$(NoWarn);3186,0042</NoWarn><!-- circumvent an error with the fake dependencymanager for
     paket: https://github.com/dotnet/fsharp/issues/8678 -->
-    <NoWarn>$(NoWarn);NU1902</NoWarn><!-- NU1902 - package vulnerability detected -->
+    <NoWarn>$(NoWarn);NU1901;NU1902;NU1903;NU1904</NoWarn><!-- NU1901-NU1904 - package vulnerability detected (low, moderate, high, critical) -->
     <NoWarn>$(NoWarn);57</NoWarn> <!-- Enable experimental compiler features -->
     <WarnOn Condition="'$(Configuration)' != 'Debug'">$(WarnOn);1182</WarnOn> <!-- Unused
     variables,https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-options#opt-in-warnings -->


### PR DESCRIPTION
on dotnet sdk 8.0.303 the package restore currently fails with `src/FsAutoComplete/FsAutoComplete.fsproj : error NU1903: Warning As Error: Package 'System.Text.Json' 7.0.3 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w`. currently only NU1902 (moderate security vulnerability) is ignored, this pr changes that to ignore all four warnings, NU1901-NU1904.
the proper solution would most likely be to update `System.Text.Json` but i don't know how easy that would be.