### PR TITLE
improve the signature of a constructor call if the symbol only gives us "unit"

### DIFF
--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -314,8 +314,11 @@ module SignatureFormatter =
         retType
       //A ctor with () parameters seems to be a list with an empty list.
       // Also abstract members and abstract member overrides with one () parameter seem to be a list with an empty list.
-      elif func.IsConstructor || (func.IsMember && (not func.IsPropertyGetterMethod)) then
-        modifiers + ": unit -> " ++ retType
+      elif func.IsConstructor then
+        let retType = if retType = "unit" then func.DisplayNameCore else retType
+        modifiers + ": unit ->" ++ retType
+      elif func.IsMember && (not func.IsPropertyGetterMethod) then
+        modifiers + ": unit ->" ++ retType
       else
         modifiers ++ functionName + ":" ++ retType //Value members seems to be a list with an empty list
     | [ [ p ] ] when maybeGetter && formatParameter p = "unit" -> //Member or property with only getter


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/24b90e76-1b89-4ef7-8416-6137ed27af54)
after:
![image](https://github.com/user-attachments/assets/205bf750-12a6-4409-b3a9-cc608d0982c5)

Also remove a superfluous space character.