### PR TITLE
Bump to net8 SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.400",
+    "version": "8.0.300",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
net7 is end-of-life.

I haven't touched the existing net7 tests (e.g. test/FsAutoComplete.Tests.Lsp/TestCases/DependentFileChecking/CrossProject-net7.0/App/App.fsproj or benchmarks/benchmarks.fsproj ).