### PR TITLE
Updated IcedTasks to 0.11.7

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -38,7 +38,7 @@ nuget Destructurama.FSharp
 nuget FSharp.UMX >= 1.1
 nuget FSharp.Formatting >= 14.0
 nuget FsToolkit.ErrorHandling.TaskResult >= 4.4 framework: netstandard2.1 ,net6.0, net7.0, net8.0
-nuget IcedTasks >= 0.11.5
+nuget IcedTasks >= 0.11.7
 nuget FSharpx.Async >= 1.14
 nuget CliWrap >= 3.0
 nuget System.CommandLine prerelease

--- a/paket.lock
+++ b/paket.lock
@@ -125,7 +125,7 @@ NUGET
       Grpc.Core.Api (>= 2.51)
     Humanizer.Core (2.14.1)
     Iced (1.17)
-    IcedTasks (0.11.5)
+    IcedTasks (0.11.7)
       FSharp.Core (>= 6.0.1)
       Microsoft.Bcl.AsyncInterfaces (>= 6.0) - restriction: || (&& (== net6.0) (< netstandard2.1)) (&& (== net7.0) (< netstandard2.1)) (&& (== net8.0) (< netstandard2.1)) (== netstandard2.0)
     ICSharpCode.Decompiler (7.2.1.6856)
@@ -134,7 +134,7 @@ NUGET
       System.Reflection.Metadata (>= 5.0)
     Ionide.Analyzers (0.11)
     Ionide.KeepAChangelog.Tasks (0.1.8) - copy_local: true
-    Ionide.LanguageServerProtocol (0.6.0)
+    Ionide.LanguageServerProtocol (0.6)
       FSharp.Core (>= 6.0)
       Newtonsoft.Json (>= 13.0.1)
       StreamJsonRpc (>= 2.16.36)


### PR DESCRIPTION
Fixed [dispose issues](https://github.com/TheAngryByrd/IcedTasks/releases/tag/v0.11.7) which could cause the notification window to stay open forever.