### PR TITLE
Preserve Whitespace in fsproj file.

### DIFF
--- a/src/FsAutoComplete.Core/FsprojEdit.fs
+++ b/src/FsAutoComplete.Core/FsprojEdit.fs
@@ -48,6 +48,7 @@ module FsProjEditor =
 
   let moveFileUp (fsprojPath: string) (file: string) =
     let xDoc = System.Xml.XmlDocument()
+    xDoc.PreserveWhitespace <- true // to keep custom formatting if present 
     xDoc.Load fsprojPath
     let xpath = sprintf "//Compile[@Include='%s']/.." file
     let itemGroup = xDoc.SelectSingleNode(xpath)
@@ -64,6 +65,7 @@ module FsProjEditor =
 
   let moveFileDown (fsprojPath: string) (file: string) =
     let xDoc = System.Xml.XmlDocument()
+    xDoc.PreserveWhitespace <- true // to keep custom formatting if present 
     xDoc.Load fsprojPath
     let xpath = sprintf "//Compile[@Include='%s']/.." file
     let itemGroup = xDoc.SelectSingleNode(xpath)
@@ -96,6 +98,7 @@ module FsProjEditor =
 
   let addFileBelow (fsprojPath: string) (belowFile: string) (newFileName: string) =
     let xDoc = System.Xml.XmlDocument()
+    xDoc.PreserveWhitespace <- true // to keep custom formatting if present 
     xDoc.Load fsprojPath
 
     if fileAlreadyIncludedViaCompileTag xDoc newFileName then
@@ -112,6 +115,7 @@ module FsProjEditor =
 
   let renameFile (fsprojPath: string) (oldFileName: string) (newFileName: string) =
     let xDoc = System.Xml.XmlDocument()
+    xDoc.PreserveWhitespace <- true // to keep custom formatting if present 
     xDoc.Load fsprojPath
     let xpath = sprintf "//Compile[@Include='%s']" oldFileName
     let node = xDoc.SelectSingleNode(xpath)
@@ -120,6 +124,7 @@ module FsProjEditor =
 
   let addFile (fsprojPath: string) (newFileName: string) =
     let xDoc = System.Xml.XmlDocument()
+    xDoc.PreserveWhitespace <- true // to keep custom formatting if present 
     xDoc.Load fsprojPath
 
     if fileAlreadyIncludedViaCompileTag xDoc newFileName then
@@ -156,6 +161,7 @@ module FsProjEditor =
 
   let removeFile (fsprojPath: string) (fileToRemove: string) =
     let xDoc = System.Xml.XmlDocument()
+    xDoc.PreserveWhitespace <- true // to keep custom formatting if present 
     xDoc.Load fsprojPath
     let sanitizedFileToRemove = fileToRemove.Replace("\\", "/")
 


### PR DESCRIPTION
Sometimes I add whitespace / empty lines to my .fsproj files to structure it.
They get lost when using the ionide tools to change the fsproj file.
This PR tries to presreve this whitespace by setting: 

`xDoc.PreserveWhitespace <- true 
`

I am not sure how to test this though.

see https://learn.microsoft.com/en-us/dotnet/api/system.xml.xmldocument.preservewhitespace?view=net-9.0#system-xml-xmldocument-preservewhitespace