### PR TITLE
Update Creating a new code fix.md

### DIFF
--- a/docs/Creating a new code fix.md
+++ b/docs/Creating a new code fix.md
@@ -34,12 +34,12 @@ The unit test file contains a [single focused test](https://github.com/haf/expec
 
 1. Using the `dotnet test` command:
  ```bash
-dotnet test -f net6.0 ./test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
+dotnet test -f net8.0 ./test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
  ```
 
 2. Alternatively, using the `dotnet run` command:
  ```bash
-dotnet run -f net6.0 --project ./test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
+dotnet run -f net8.0 --project ./test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
  ```
 
 This comprehensive approach ensures that the newly introduced code fix is properly integrated, tested, and ready for seamless integration into the FSAutocomplete environment.


### PR DESCRIPTION
This pull request includes a small change to the `docs/Creating a new code fix.md` file. The change updates the .NET framework version used in the unit test commands from `net6.0` to `net8.0`.

* Updated .NET framework version in test commands from `net6.0` to `net8.0` in `docs/Creating a new code fix.md`.Update CodeFix docs