### PR TITLE
Wrap arg in parens when needed when adding `new` keyword

### DIFF
--- a/src/FsAutoComplete/CodeFixes/AddNewKeywordToDisposableConstructorInvocation.fs
+++ b/src/FsAutoComplete/CodeFixes/AddNewKeywordToDisposableConstructorInvocation.fs
@@ -6,19 +6,112 @@ open FsAutoComplete.CodeFix.Types
 open Ionide.LanguageServerProtocol.Types
 open FsAutoComplete
 open FsAutoComplete.LspHelpers
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text
 
 let title = "Add 'new'"
 
 /// a codefix that suggests using the 'new' keyword on IDisposables
-let fix =
+let fix (getParseResultsForFile: GetParseResultsForFile) =
   Run.ifDiagnosticByCode (Set.ofList [ "760" ]) (fun diagnostic codeActionParams ->
-    AsyncResult.retn
-      [ { SourceDiagnostic = Some diagnostic
-          File = codeActionParams.TextDocument
-          Title = title
-          Edits =
-            [| { Range =
-                   { Start = diagnostic.Range.Start
-                     End = diagnostic.Range.Start }
-                 NewText = $"new " } |]
-          Kind = FixKind.Refactor } ])
+    asyncResult {
+      let fileName = codeActionParams.TextDocument.GetFilePath() |> normalizePath
+      let fcsRange = protocolRangeToRange (string fileName) diagnostic.Range
+      let fcsPos = protocolPosToPos diagnostic.Range.Start
+      let! parseResults, _, sourceText = getParseResultsForFile fileName fcsPos
+
+      // Constructor arg
+      // Qualified.Constructor arg
+      let matchingApp path node =
+        let (|TargetTy|_|) expr =
+          match expr with
+          | SynExpr.Ident id -> Some(SynType.LongIdent(SynLongIdent([ id ], [], [])))
+          | SynExpr.LongIdent(longDotId = longDotId) -> Some(SynType.LongIdent longDotId)
+          | SynExpr.TypeApp(SynExpr.Ident id, lessRange, typeArgs, commaRanges, greaterRange, _, range) ->
+            Some(
+              SynType.App(
+                SynType.LongIdent(SynLongIdent([ id ], [], [])),
+                Some lessRange,
+                typeArgs,
+                commaRanges,
+                greaterRange,
+                false,
+                range
+              )
+            )
+          | SynExpr.TypeApp(SynExpr.LongIdent(longDotId = longDotId),
+                            lessRange,
+                            typeArgs,
+                            commaRanges,
+                            greaterRange,
+                            _,
+                            range) ->
+            Some(
+              SynType.App(
+                SynType.LongIdent longDotId,
+                Some lessRange,
+                typeArgs,
+                commaRanges,
+                greaterRange,
+                false,
+                range
+              )
+            )
+          | _ -> None
+
+        match node with
+        | SyntaxNode.SynExpr(SynExpr.App(funcExpr = TargetTy targetTy; argExpr = argExpr; range = m)) when
+          m |> Range.equals fcsRange
+          ->
+          Some(targetTy, argExpr, path)
+        | _ -> None
+
+      return
+        (fcsRange.Start, parseResults.GetAST)
+        ||> ParsedInput.tryPick matchingApp
+        |> Option.toList
+        |> List.map (fun (targetTy, argExpr, path) ->
+          // Adding `new` may require additional parentheses: https://github.com/dotnet/fsharp/issues/15622
+          let needsParens =
+            let newExpr = SynExpr.New(false, targetTy, argExpr, fcsRange)
+
+            argExpr
+            |> SynExpr.shouldBeParenthesizedInContext sourceText.GetLineString (SyntaxNode.SynExpr newExpr :: path)
+
+          let newText =
+            let targetTyText = sourceText.GetSubTextFromRange targetTy.Range
+
+            // Constructor namedArg  → new Constructor(namedArg)
+            // Constructor "literal" → new Constructor "literal"
+            // Constructor ()        → new Constructor ()
+            // Constructor()         → new Constructor()
+            // Constructor           → new Constructor
+            // ····indentedArg         ····(indentedArg)
+            let textBetween =
+              let range = Range.mkRange (string fileName) targetTy.Range.End argExpr.Range.Start
+
+              if needsParens && range.StartLine = range.EndLine then
+                ""
+              else
+                sourceText.GetSubTextFromRange range
+
+            let argExprText =
+              let originalArgText = sourceText.GetSubTextFromRange argExpr.Range
+
+              if needsParens then
+                $"(%s{originalArgText})"
+              else
+                originalArgText
+
+            $"new %s{targetTyText}%s{textBetween}%s{argExprText}"
+
+          { SourceDiagnostic = Some diagnostic
+            File = codeActionParams.TextDocument
+            Title = title
+            Edits =
+              [| { Range =
+                     { Start = diagnostic.Range.Start
+                       End = diagnostic.Range.End }
+                   NewText = newText } |]
+            Kind = FixKind.Refactor })
+    })

--- a/src/FsAutoComplete/CodeFixes/AddNewKeywordToDisposableConstructorInvocation.fs
+++ b/src/FsAutoComplete/CodeFixes/AddNewKeywordToDisposableConstructorInvocation.fs
@@ -22,6 +22,8 @@ let fix (getParseResultsForFile: GetParseResultsForFile) =
 
       // Constructor arg
       // Qualified.Constructor arg
+      // Constructor<TypeArg> arg
+      // Qualified.Constructor<TypeArg> arg
       let matchingApp path node =
         let (|TargetTy|_|) expr =
           match expr with

--- a/src/FsAutoComplete/CodeFixes/AddNewKeywordToDisposableConstructorInvocation.fsi
+++ b/src/FsAutoComplete/CodeFixes/AddNewKeywordToDisposableConstructorInvocation.fsi
@@ -4,5 +4,6 @@ open FsAutoComplete.CodeFix.Types
 open Ionide.LanguageServerProtocol.Types
 
 val title: string
+
 /// a codefix that suggests using the 'new' keyword on IDisposables
-val fix: (CodeActionParams -> Async<Result<Fix list, string>>)
+val fix: getParseResultsForFile: GetParseResultsForFile -> (CodeActionParams -> Async<Result<Fix list, string>>)

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -2130,7 +2130,7 @@ type AdaptiveState
          Run.ifEnabled
            (fun _ -> config.UnusedDeclarationsAnalyzer)
            (RenameUnusedValue.fix tryGetParseAndCheckResultsForFile)
-         AddNewKeywordToDisposableConstructorInvocation.fix
+         AddNewKeywordToDisposableConstructorInvocation.fix tryGetParseAndCheckResultsForFile
          Run.ifEnabled
            (fun _ -> config.UnionCaseStubGeneration)
            (GenerateUnionCases.fix


### PR DESCRIPTION
- Update the "add `new` keyword" code fix to wrap the constructor argument in parentheses when needed, so that applying the fix does not cause https://github.com/dotnet/fsharp/issues/15622.

This change incidentally also prevents the code fix from suggesting a "fix" that would be invalid in various scenarios,[^1] e.g.:

```fsharp
(Disposable) arg // Formerly suggested `(new Disposable) arg`, now suggests nothing.
```

```fsharp
xs |> List.map Disposable // Formerly suggested `xs |> List.map new Disposable`, now suggests nothing.
```

[^1]: We could in theory update the code fix to suggest `new (Disposable)(arg)` (or even `new Disposable(arg)`), `xs |> List.map (fun x -> new Disposable(x))`, etc., for such scenarios, but I considered that out of scope for this PR—and perhaps altogether, since transformations like `xs |> List.map (fun x -> new Disposable(x))` _also_ may not be valid, depending on the type of the constructor argument! For example, if `xs` is a `unit list`, then transforming `xs |> List.map Disposable` to `xs |> List.map (fun x -> new Disposable(x))` is not valid.