### PR TITLE
Added ability to search workspace by symbol name

### DIFF
--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -214,23 +214,19 @@ module Conversions =
     [| yield! inner None topLevel.Declaration |> Option.toArray
        yield! topLevel.Nested |> Array.choose (inner (Some topLevel.Declaration.LogicalName)) |]
 
-  let inline (|Name|) name = (^Name: (member Name: string) name)
-  let inline (|ContainerName|) name = (^ContainerName: (member ContainerName: string option) name)
-  let inline (|SymbolInfo|) (Name name & ContainerName cName) = name, cName
-
-  let inline applyQuery (query: string) (SymbolInfo(name, containerName)) =
+  let inline applyQuery (query: string) (info: #IBaseSymbolInformation) =
     match query.Split([| '.' |], StringSplitOptions.RemoveEmptyEntries) with
     | [||] -> false
-    | [| fullName |] -> name.StartsWith(fullName, StringComparison.Ordinal)
+    | [| fullName |] -> info.Name.StartsWith(fullName, StringComparison.Ordinal)
     | [| moduleName; fieldName |] ->
-      name.StartsWith(fieldName, StringComparison.Ordinal)
-      && containerName = Some moduleName
+      info.Name.StartsWith(fieldName, StringComparison.Ordinal)
+      && info.ContainerName = Some moduleName
     | parts ->
       let cName = parts.[0 .. (parts.Length - 2)] |> String.concat "."
       let fieldName = Array.last parts
 
-      name.StartsWith(fieldName, StringComparison.Ordinal)
-      && containerName = Some cName
+      info.Name.StartsWith(fieldName, StringComparison.Ordinal)
+      && info.ContainerName = Some cName
 
   let getCodeLensInformation (uri: DocumentUri) (typ: string) (topLevel: NavigationTopLevelDeclaration) : CodeLens[] =
     let map (decl: NavigationItem) : CodeLens =

--- a/src/FsAutoComplete/LspHelpers.fsi
+++ b/src/FsAutoComplete/LspHelpers.fsi
@@ -86,8 +86,7 @@ module Conversions =
       WorkspaceSymbol array
 
 
-  val inline applyQuery :
-    query: string -> info: #IBaseSymbolInformation -> bool
+  val inline applyQuery: query: string -> info: #IBaseSymbolInformation -> bool
 
   val getCodeLensInformation:
     uri: DocumentUri -> typ: string -> topLevel: NavigationTopLevelDeclaration -> CodeLens array

--- a/src/FsAutoComplete/LspHelpers.fsi
+++ b/src/FsAutoComplete/LspHelpers.fsi
@@ -71,10 +71,23 @@ module Conversions =
     uri: DocumentUri ->
     glyphToSymbolKind: (FSharpGlyph -> SymbolKind option) ->
     topLevel: NavigationTopLevelDeclaration ->
-    symbolFilter: (SymbolInformation -> bool) ->
       SymbolInformation array
 
-  val applyQuery: query: string -> info: SymbolInformation -> bool
+  val getDocumentSymbols:
+    glyphToSymbolKind: (FSharpGlyph -> SymbolKind option) ->
+    topLevel: NavigationTopLevelDeclaration ->
+      DocumentSymbol array
+
+  val getWorkspaceSymbols:
+    uri: DocumentUri ->
+    glyphToSymbolKind: (FSharpGlyph -> SymbolKind option) ->
+    topLevel: NavigationTopLevelDeclaration ->
+    symbolFilter: (WorkspaceSymbol -> bool) ->
+      WorkspaceSymbol array
+
+
+  val inline applyQuery< ^info when ^info: (member Name: string) and ^info: (member ContainerName: string option)> :
+    query: string -> 'info -> bool
 
   val getCodeLensInformation:
     uri: DocumentUri -> typ: string -> topLevel: NavigationTopLevelDeclaration -> CodeLens array

--- a/src/FsAutoComplete/LspHelpers.fsi
+++ b/src/FsAutoComplete/LspHelpers.fsi
@@ -86,8 +86,8 @@ module Conversions =
       WorkspaceSymbol array
 
 
-  val inline applyQuery< ^info when ^info: (member Name: string) and ^info: (member ContainerName: string option)> :
-    query: string -> 'info -> bool
+  val inline applyQuery :
+    query: string -> info: #IBaseSymbolInformation -> bool
 
   val getCodeLensInformation:
     uri: DocumentUri -> typ: string -> topLevel: NavigationTopLevelDeclaration -> CodeLens array

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1304,9 +1304,8 @@ type AdaptiveFSharpLspServer
 
           return
             decls
-            |> Array.collect (fun top ->
-              getSymbolInformations p.TextDocument.Uri state.GlyphToSymbolKind top (fun _s -> true))
-            |> U2.C1
+            |> Array.collect (getDocumentSymbols state.GlyphToSymbolKind)
+            |> U2.C2
             |> Some
         with e ->
           trace |> Tracing.recordException e
@@ -1341,9 +1340,8 @@ type AdaptiveFSharpLspServer
               let uri = Path.LocalPathToUri p
 
               ns
-              |> Array.collect (fun n ->
-                getSymbolInformations uri glyphToSymbolKind n (applyQuery symbolRequest.Query)))
-            |> U2.C1
+              |> Array.collect (fun n -> getWorkspaceSymbols uri glyphToSymbolKind n (applyQuery symbolRequest.Query)))
+            |> U2.C2
             |> Some
 
           return res
@@ -2251,7 +2249,7 @@ type AdaptiveFSharpLspServer
 
     override x.WorkspaceDiagnostic p = x.logUnimplementedRequest p
 
-    override x.WorkspaceSymbolResolve p = x.logUnimplementedRequest p
+    override x.WorkspaceSymbolResolve p = AsyncLspResult.success p
 
     //unsupported -- end
 

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -140,6 +140,21 @@ let initTests createServer =
       | Result.Error _e -> failtest "Initialization failed"
     })
 
+let validateSymbolExists msgType symbolInfos predicate =
+  Expect.exists
+      symbolInfos
+      predicate
+      $"{msgType}s do not contain the expected symbol"
+
+let allSymbolInfosExist (infos: SymbolInformation seq) predicates =
+  predicates |> List.iter (validateSymbolExists (nameof SymbolInformation) infos)
+
+let allWorkspaceSymbolsExist (infos: WorkspaceSymbol seq) predicates =
+  predicates |> List.iter (validateSymbolExists (nameof WorkspaceSymbol) infos)
+
+let allDocumentSymbolsExist (infos: DocumentSymbol seq) predicates =
+  predicates |> List.iter (validateSymbolExists (nameof DocumentSymbol) infos)
+
 ///Tests for getting document symbols
 let documentSymbolTest state =
   let server =
@@ -155,30 +170,141 @@ let documentSymbolTest state =
 
   testList
     "Document Symbols Tests"
-    [ testCaseAsync
-        "Get Document Symbols"
-        (async {
-          let! server, path = server
+    [ testCaseAsync "Get Document Symbols"
+      <| async {
+        let! server, path = server
 
-          let p: DocumentSymbolParams =
-            { TextDocument = { Uri = Path.FilePathToUri path }
-              WorkDoneToken = None
-              PartialResultToken = None }
+        let p: DocumentSymbolParams =
+          { TextDocument = { Uri = Path.FilePathToUri path }
+            WorkDoneToken = None
+            PartialResultToken = None }
 
-          let! res = server.TextDocumentDocumentSymbol p
+        let! res = server.TextDocumentDocumentSymbol p
 
-          match res with
-          | Result.Error e -> failtestf "Request failed: %A" e
-          | Result.Ok None -> failtest "Request none"
-          | Result.Ok(Some(U2.C1 res)) ->
-            Expect.equal res.Length 15 "Document Symbol has all symbols"
+        match res with
+        | Result.Error e -> failtestf "Request failed: %A" e
+        | Ok None -> failtest "Request none"
+        | Ok(Some(U2.C1 symbolInformations)) ->
+          Expect.equal symbolInformations.Length 15 "Document Symbol has all symbols"
 
-            Expect.exists
-              res
-              (fun n -> n.Name = "MyDateTime" && n.Kind = SymbolKind.Class)
-              "Document symbol contains given symbol"
-          | Result.Ok(Some(U2.C2 _res)) -> raise (NotImplementedException("DocumentSymbol isn't used in FSAC yet"))
-        }) ]
+          allSymbolInfosExist
+            symbolInformations
+            [fun n -> n.Name = "MyDateTime" && n.Kind = SymbolKind.Class]
+
+        | Ok(Some(U2.C2 documentSymbols)) ->
+          Expect.equal documentSymbols.Length 15 "Document Symbol has all symbols"
+
+          allDocumentSymbolsExist
+            documentSymbols
+            [fun n -> n.Name = "MyDateTime" && n.Kind = SymbolKind.Class]
+      } ]
+
+let workspaceSymbolTest state =
+  let server =
+    async {
+      let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "WorkspaceSymbolTest")
+      let! (server, _event) = serverInitialize path defaultConfigDto state
+      let path = Path.Combine(path, "Script.fsx")
+      let tdop: DidOpenTextDocumentParams = { TextDocument = loadDocument path }
+      do! server.TextDocumentDidOpen tdop
+      return (server, path)
+    }
+    |> Async.Cache
+
+  testList
+    "Workspace Symbols Tests"
+    [
+      testCaseAsync "Get Workspace Symbols Using Filename of Script File as Query"
+      <| async {
+        let! server, path = server
+
+        let p: WorkspaceSymbolParams =
+          { Query = "Script"
+            WorkDoneToken = None
+            PartialResultToken = None }
+
+        let! res = server.WorkspaceSymbol p
+
+        match res with
+        | Result.Error e -> failtestf "Request failed: %A" e
+        | Ok None -> failtest "Request none"
+        | Ok(Some(U2.C1 symbolInfos)) ->
+          Expect.equal symbolInfos.Length 1 "Workspace did not find all the expected symbols"
+
+          allSymbolInfosExist
+            symbolInfos
+            [fun n -> n.Name = "Script" && n.Kind = SymbolKind.Module]
+
+        | Ok(Some(U2.C2 workspaceSymbols)) ->
+          Expect.equal workspaceSymbols.Length 1 "Workspace did not find all the expected symbols"
+
+          allWorkspaceSymbolsExist
+            workspaceSymbols
+            [fun n -> n.Name = "Script" && n.Kind = SymbolKind.Module]
+      }
+
+      testCaseAsync "Get Workspace Symbols Using Query w/ Text"
+      <| async {
+        let! server, path = server
+
+        let p: WorkspaceSymbolParams =
+          { Query = "X"
+            WorkDoneToken = None
+            PartialResultToken = None }
+
+        let! res = server.WorkspaceSymbol p
+
+        match res with
+        | Result.Error e -> failtestf "Request failed: %A" e
+        | Ok None -> failtest "Request none"
+        | Ok(Some(U2.C1 symbolInfos)) ->
+          Expect.equal symbolInfos.Length 5 "Workspace did not find all the expected symbols"
+
+          allSymbolInfosExist
+            symbolInfos
+            [
+              fun n -> n.Name = "X" && n.Kind = SymbolKind.Class
+              fun n -> n.Name = "X" && n.Kind = SymbolKind.Class
+              fun n -> n.Name = "X.X" && n.Kind = SymbolKind.Module
+              fun n -> n.Name = "X.Y" && n.Kind = SymbolKind.Module
+              fun n -> n.Name = "X.Z" && n.Kind = SymbolKind.Class
+            ]
+
+        | Ok(Some(U2.C2 workspaceSymbols)) ->
+          Expect.equal workspaceSymbols.Length 5 "Workspace did not find all the expected symbols"
+
+          allWorkspaceSymbolsExist
+            workspaceSymbols
+            [
+              fun n -> n.Name = "X" && n.Kind = SymbolKind.Class
+              fun n -> n.Name = "X" && n.Kind = SymbolKind.Class
+              fun n -> n.Name = "X.X" && n.Kind = SymbolKind.Module
+              fun n -> n.Name = "X.Y" && n.Kind = SymbolKind.Module
+              fun n -> n.Name = "X.Z" && n.Kind = SymbolKind.Class
+            ]
+      }
+
+      testCaseAsync "Get Workspace Symbols Using Query w/o Text"
+      <| async {
+        let! server, path = server
+
+        let p: WorkspaceSymbolParams =
+          { Query = String.Empty
+            WorkDoneToken = None
+            PartialResultToken = None }
+
+        let! res = server.WorkspaceSymbol p
+
+        match res with
+        | Result.Error e -> failtestf "Request failed: %A" e
+        | Ok None -> failtest "Request none"
+        | Ok(Some(U2.C1 res)) ->
+          Expect.equal res.Length 0 "Workspace found symbols when we didn't expect to find any"
+        | Ok(Some(U2.C2 res)) ->
+          Expect.equal res.Length 0 "Workspace found symbols when we didn't expect to find any"
+      }
+    ]
+
 
 let foldingTests state =
   let server =

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -216,7 +216,7 @@ let workspaceSymbolTest state =
     [
       testCaseAsync "Get Workspace Symbols Using Filename of Script File as Query"
       <| async {
-        let! server, path = server
+        let! server, _path = server
 
         let p: WorkspaceSymbolParams =
           { Query = "Script"
@@ -245,7 +245,7 @@ let workspaceSymbolTest state =
 
       testCaseAsync "Get Workspace Symbols Using Query w/ Text"
       <| async {
-        let! server, path = server
+        let! server, _path = server
 
         let p: WorkspaceSymbolParams =
           { Query = "X"
@@ -286,7 +286,7 @@ let workspaceSymbolTest state =
 
       testCaseAsync "Get Workspace Symbols Using Query w/o Text"
       <| async {
-        let! server, path = server
+        let! server, _path = server
 
         let p: WorkspaceSymbolParams =
           { Query = String.Empty

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -97,6 +97,7 @@ let lspTests =
 
                   CodeLens.tests createServer
                   documentSymbolTest createServer
+                  workspaceSymbolTest createServer
                   Completion.autocompleteTest createServer
                   Completion.autoOpenTests createServer
                   Completion.fullNameExternalAutocompleteTest createServer

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/WorkspaceSymbolTest/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/WorkspaceSymbolTest/Script.fsx
@@ -1,0 +1,15 @@
+type X = { Name: string }
+
+module X =
+
+  let getName x = x.Name
+
+  module X =
+
+    let doSideEffect() = ()
+
+  module Y =
+
+    let getName x = x.Name
+
+  type Z = { Name: string }


### PR DESCRIPTION
## Summary

In this PR, I was hoping to add the ability for users to be able to search their workspace using symbols. There is currently support for searching the editor and I thought this would be a handy addition to the tooling.

## Current Behavior

![BadWorkspaceSymbolSearch](https://github.com/user-attachments/assets/74b2680c-1e27-4b80-bbd1-cbadc1778ed7)

## New Behavior

![GoodWorkspaceSymbolSearch](https://github.com/user-attachments/assets/2c070281-0216-467e-8696-5b638160d522)
