### PR TITLE
fix func signature for empty param names

### DIFF
--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -505,7 +505,13 @@ module SignatureFormatter =
           many
           |> List.map (fun (paramTypes) ->
             paramTypes
-            |> List.map (fun p -> formatName p + ":" ++ (formatParameter p))
+            |> List.map (fun p ->
+              let paramName = formatName p
+
+              if String.IsNullOrWhiteSpace(paramName) then
+                formatParameter p
+              else
+                paramName + ":" ++ (formatParameter p))
             |> String.concat (" * "))
           |> String.concat (" -> ")
 

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -461,12 +461,19 @@ let tooltipTests state =
 #if NET8_0
               [ "active pattern ValueWithName: "
                 "   input: Expr"
-                "       -> option<obj * System.Type * string>" ]) ] ]
+                "       -> option<obj * System.Type * string>" ])
 #else
               [ "active pattern ValueWithName: "
                 "   input: Expr"
-                "       -> option<objnull * System.Type * string>" ]) ] ]
+                "       -> option<objnull * System.Type * string>" ])
 #endif
+          verifySignature
+            96u
+            7u
+            (concatLines
+              [ "interface IWithAndWithoutParamNames"
+                "  abstract member WithParamNames: arg1: int * arg2: float -> string"
+                "  abstract member WithoutParamNames: int * string -> int" ]) ] ]
 
 let closeTests state =
   // Note: clear diagnostics also implies clear caches (-> remove file & project options from State).

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -93,3 +93,7 @@ type Awaitable =
       (awaitable: 'Awaitable)
       =
       awaitable.GetAwaiter()
+
+type IWithAndWithoutParamNames =
+    abstract member WithParamNames : arg1: int * arg2: float -> string
+    abstract member WithoutParamNames : int * string -> int


### PR DESCRIPTION
In case of a function type without parameter names we were showing colons without anything in front of them.

before:
![2025-01-24-110731_hyprshot](https://github.com/user-attachments/assets/834f69b2-15b5-4f2b-bf38-61803631b3da)

after:
![2025-01-24-110635_hyprshot](https://github.com/user-attachments/assets/fd528e72-c1df-4381-be52-6deddf021b1f)
