### PR TITLE
Add exclusion config for parens analyzer

### DIFF
--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -723,6 +723,7 @@ type FSharpConfigDto =
     SimplifyNameAnalyzer: bool option
     SimplifyNameAnalyzerExclusions: string array option
     UnnecessaryParenthesesAnalyzer: bool option
+    UnnecessaryParenthesesAnalyzerExclusions: string array option
     ResolveNamespaces: bool option
     EnableReferenceCodeLens: bool option
     EnableAnalyzers: bool option
@@ -867,6 +868,7 @@ type FSharpConfig =
     SimplifyNameAnalyzer: bool
     SimplifyNameAnalyzerExclusions: Regex array
     UnnecessaryParenthesesAnalyzer: bool
+    UnnecessaryParenthesesAnalyzerExclusions: Regex array
     ResolveNamespaces: bool
     EnableReferenceCodeLens: bool
     EnableAnalyzers: bool
@@ -922,6 +924,7 @@ type FSharpConfig =
       SimplifyNameAnalyzer = false
       SimplifyNameAnalyzerExclusions = [||]
       UnnecessaryParenthesesAnalyzer = true
+      UnnecessaryParenthesesAnalyzerExclusions = [||]
       ResolveNamespaces = false
       EnableReferenceCodeLens = false
       EnableAnalyzers = false
@@ -975,6 +978,9 @@ type FSharpConfig =
         defaultArg dto.SimplifyNameAnalyzerExclusions [||]
         |> Array.choose tryCreateRegex
       UnnecessaryParenthesesAnalyzer = defaultArg dto.UnnecessaryParenthesesAnalyzer true
+      UnnecessaryParenthesesAnalyzerExclusions =
+        defaultArg dto.UnnecessaryParenthesesAnalyzerExclusions [||]
+        |> Array.choose tryCreateRegex
       ResolveNamespaces = defaultArg dto.ResolveNamespaces false
       EnableReferenceCodeLens = defaultArg dto.EnableReferenceCodeLens false
       EnableAnalyzers = defaultArg dto.EnableAnalyzers false
@@ -1086,6 +1092,11 @@ type FSharpConfig =
           (dto.SimplifyNameAnalyzerExclusions |> Option.map (Array.choose tryCreateRegex))
           x.SimplifyNameAnalyzerExclusions
       UnnecessaryParenthesesAnalyzer = defaultArg dto.UnnecessaryParenthesesAnalyzer x.UnnecessaryParenthesesAnalyzer
+      UnnecessaryParenthesesAnalyzerExclusions =
+        defaultArg
+          (dto.UnnecessaryParenthesesAnalyzerExclusions
+           |> Option.map (Array.choose tryCreateRegex))
+          x.UnnecessaryParenthesesAnalyzerExclusions
       ResolveNamespaces = defaultArg dto.ResolveNamespaces x.ResolveNamespaces
       EnableReferenceCodeLens = defaultArg dto.EnableReferenceCodeLens x.EnableReferenceCodeLens
       EnableAnalyzers = defaultArg dto.EnableAnalyzers x.EnableAnalyzers

--- a/src/FsAutoComplete/LspHelpers.fsi
+++ b/src/FsAutoComplete/LspHelpers.fsi
@@ -306,6 +306,7 @@ type FSharpConfigDto =
     SimplifyNameAnalyzer: bool option
     SimplifyNameAnalyzerExclusions: string array option
     UnnecessaryParenthesesAnalyzer: bool option
+    UnnecessaryParenthesesAnalyzerExclusions: string array option
     ResolveNamespaces: bool option
     EnableReferenceCodeLens: bool option
     EnableAnalyzers: bool option
@@ -409,6 +410,7 @@ type FSharpConfig =
     SimplifyNameAnalyzer: bool
     SimplifyNameAnalyzerExclusions: System.Text.RegularExpressions.Regex array
     UnnecessaryParenthesesAnalyzer: bool
+    UnnecessaryParenthesesAnalyzerExclusions: System.Text.RegularExpressions.Regex array
     ResolveNamespaces: bool
     EnableReferenceCodeLens: bool
     EnableAnalyzers: bool

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -504,7 +504,10 @@ type AdaptiveState
           && isNotExcluded config.SimplifyNameAnalyzerExclusions
         then
           checkSimplifiedNames
-        if config.UnnecessaryParenthesesAnalyzer then
+        if
+          config.UnnecessaryParenthesesAnalyzer
+          && isNotExcluded config.UnnecessaryParenthesesAnalyzerExclusions
+        then
           checkUnnecessaryParentheses ]
 
     async {

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -254,6 +254,7 @@ let defaultConfigDto: FSharpConfigDto =
     SimplifyNameAnalyzer = None
     SimplifyNameAnalyzerExclusions = None
     UnnecessaryParenthesesAnalyzer = None
+    UnnecessaryParenthesesAnalyzerExclusions = None
     ResolveNamespaces = None
     EnableReferenceCodeLens = None
     EnableAnalyzers = None


### PR DESCRIPTION
Resolves https://github.com/ionide/FsAutoComplete/discussions/1360 by applying the config technique used in https://github.com/ionide/FsAutoComplete/pull/1120 for the other FCS analyzers. Goes together with https://github.com/ionide/ionide-vscode-fsharp/pull/2070 and https://github.com/ionide/Ionide-vim/pull/94.