### PR TITLE
Fix `textDocument/hover` for function, generic and tuple alias types

### DIFF
--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -771,21 +771,21 @@ module SignatureFormatter =
 
           basicName ++ "=" ++ typeNames
         else if fse.AbbreviatedType.IsGenericParameter then
-          basicName ++ "=" ++ "'" + fse.AbbreviatedType.GenericParameter.DisplayName
+          basicName ++ "=" ++ $"'{fse.AbbreviatedType.GenericParameter.DisplayName}"
         else if fse.AbbreviatedType.IsStructTupleType then
           let typeNames =
             getUnAnnotatedParameterNames fse.AbbreviatedType
             |> List.map ParameterType.displayName
             |> String.join " * "
 
-          basicName ++ "=" ++ "struct (" + typeNames + ")"
+          basicName ++ "=" ++ $"struct ({typeNames})"
         else if fse.AbbreviatedType.IsTupleType then
           let typeNames =
             getUnAnnotatedParameterNames fse.AbbreviatedType
             |> List.map ParameterType.displayName
             |> String.join " * "
 
-          basicName ++ "=" ++ "(" + typeNames + ")"
+          basicName ++ "=" ++ $"({typeNames})"
         else
           let unannotatedType = fse.UnAnnotate()
           basicName ++ "=" ++ (unannotatedType.DisplayName)

--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -106,9 +106,9 @@ module SignatureFormatter =
           refTupleStr
       elif typ.IsAbbreviation && typ.AbbreviatedType.IsFunctionType then
         typ.AbbreviatedType
-          |> getGenericArgumentTypes
-          |> List.map ParameterType.displayName
-          |> String.join " -> "
+        |> getGenericArgumentTypes
+        |> List.map ParameterType.displayName
+        |> String.join " -> "
       elif typ.IsGenericParameter then // no longer need to differentiate between SRTP and normal generic parameter types
         "'" + typ.GenericParameter.Name
       elif typ.HasTypeDefinition && typ.GenericArguments.Count > 0 then
@@ -808,14 +808,19 @@ module SignatureFormatter =
       else
         basicName
 
-    if fse.IsFSharpUnion then typeDisplay + unionTip ()
-    elif fse.IsEnum then typeDisplay + enumTip ()
-    elif fse.IsDelegate then typeDisplay + delegateTip ()
+    if fse.IsFSharpUnion then
+      typeDisplay + unionTip ()
+    elif fse.IsEnum then
+      typeDisplay + enumTip ()
+    elif fse.IsDelegate then
+      typeDisplay + delegateTip ()
     elif
       fse.IsFSharpAbbreviation
       && (fse.AbbreviatedType.IsTupleType || fse.AbbreviatedType.IsStructTupleType)
-    then typeDisplay
-    else typeDisplay + typeTip ()
+    then
+      typeDisplay
+    else
+      typeDisplay + typeTip ()
 
   let footerForType (entity: FSharpSymbolUse) =
     let formatFooter (fullName, asmName) = $"Full name: %s{fullName}{nl}Assembly: %s{asmName}"

--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -618,10 +618,10 @@ module SignatureFormatter =
         Generic x.GenericParameter
       else if x.IsFunctionType then
         Function(getUnAnnotatedParameterNames x)
-      else if x.IsTupleType then
-        Tuple(getUnAnnotatedParameterNames x)
       else if x.IsStructTupleType then
         StructTuple(getUnAnnotatedParameterNames x)
+      else if x.IsTupleType then
+        Tuple(getUnAnnotatedParameterNames x)
       else
         x.TypeDefinition.UnAnnotate() |> Concrete)
     |> Seq.toList
@@ -772,6 +772,13 @@ module SignatureFormatter =
           basicName ++ "=" ++ typeNames
         else if fse.AbbreviatedType.IsGenericParameter then
           basicName ++ "=" ++ "'" + fse.AbbreviatedType.GenericParameter.DisplayName
+        else if fse.AbbreviatedType.IsStructTupleType then
+          let typeNames =
+            getUnAnnotatedParameterNames fse.AbbreviatedType
+            |> List.map ParameterType.displayName
+            |> String.join " * "
+
+          basicName ++ "=" ++ "struct (" + typeNames + ")"
         else if fse.AbbreviatedType.IsTupleType then
           let typeNames =
             getUnAnnotatedParameterNames fse.AbbreviatedType

--- a/src/FsAutoComplete.Core/TypedAstUtils.fs
+++ b/src/FsAutoComplete.Core/TypedAstUtils.fs
@@ -238,7 +238,7 @@ module TypedAstExtensionHelpers =
     member this.GetAbbreviatedParent() =
       match this with
       | Entity e ->
-        if e.IsFSharpAbbreviation then
+        if e.IsFSharpAbbreviation && e.AbbreviatedType.HasTypeDefinition then
           e.AbbreviatedType.TypeDefinition.GetAbbreviatedParent()
         else
           this

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -645,7 +645,12 @@ let tooltipTests state =
           verifySignature
             108u
             7u
-            "type StructFunctionTupleAlias = Int32 -> struct (Int32 * String)" ] ]
+            "type StructFunctionTupleAlias = Int32 -> struct (Int32 * String)"
+
+          verifySignature
+            109u
+            7u
+            "val functionAliasValue: int -> int" ] ]
 
 let closeTests state =
   // Note: clear diagnostics also implies clear caches (-> remove file & project options from State).

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -635,7 +635,17 @@ let tooltipTests state =
           verifySignature
             106u
             7u
-            "type GenericFunctionTupleAlias<'T> = 'T -> ('T * String)" ] ]
+            "type GenericFunctionTupleAlias<'T> = 'T -> ('T * String)"
+
+          verifySignature
+            107u
+            7u
+            "type StructTupleAlias = struct (Int32 * String)"
+
+          verifySignature
+            108u
+            7u
+            "type StructFunctionTupleAlias = Int32 -> struct (Int32 * String)" ] ]
 
 let closeTests state =
   // Note: clear diagnostics also implies clear caches (-> remove file & project options from State).

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -362,6 +362,7 @@ let tooltipTests state =
                             U2.C1 _showDocumentationLink
                             U2.C1 _fullname
                             U2.C1 _assembly |] } -> Some tooltip
+    | { Contents = U3.C3 [| U2.C2(FSharpLanguage & Value tooltip); U2.C1 ""; U2.C1 _docComment |] } -> Some tooltip
     | _ -> None
 
   let (|Description|_|) (hover: Hover) =
@@ -599,7 +600,27 @@ let tooltipTests state =
             (concatLines
               [ "interface IWithAndWithoutParamNames"
                 "  abstract member WithParamNames: arg1: int * arg2: float -> string"
-                "  abstract member WithoutParamNames: int * string -> int" ]) ] ]
+                "  abstract member WithoutParamNames: int * string -> int" ])
+
+          verifySignature
+            100u
+            7u
+            (concatLines ["type TypeAlias = Int32"])
+
+          verifySignature
+            101u
+            7u
+            (concatLines ["type FunctionAlias = Int32 -> Int32"])
+
+          verifySignature
+            102u
+            7u
+            (concatLines ["type GenericTypeAlias<'T> = T"])
+
+          verifySignature
+            103u
+            7u
+            (concatLines ["type GenericFunctionAlias<'T> = T -> T -> Int32 -> Unit"]) ] ]
 
 let closeTests state =
   // Note: clear diagnostics also implies clear caches (-> remove file & project options from State).

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -605,22 +605,37 @@ let tooltipTests state =
           verifySignature
             100u
             7u
-            (concatLines ["type TypeAlias = Int32"])
+           "type TypeAlias = Int32"
 
           verifySignature
             101u
             7u
-            (concatLines ["type FunctionAlias = Int32 -> Int32"])
+            "type FunctionAlias = Int32 -> Int32"
 
           verifySignature
             102u
             7u
-            (concatLines ["type GenericTypeAlias<'T> = T"])
+           "type GenericTypeAlias<'T> = 'T"
 
           verifySignature
             103u
             7u
-            (concatLines ["type GenericFunctionAlias<'T> = T -> T -> Int32 -> Unit"]) ] ]
+           "type GenericFunctionAlias<'T> = 'T -> 'T -> Int32 -> Unit"
+
+          verifySignature
+            104u
+            7u
+           "type TypeAliasTuple = (Int32 * String)"
+
+          verifySignature
+            105u
+            7u
+            "type GenericTypeAliasTuple<'A,'B> = ('A * 'B * Int32)"
+
+          verifySignature
+            106u
+            7u
+            "type GenericFunctionTupleAlias<'T> = 'T -> ('T * String)" ] ]
 
 let closeTests state =
   // Note: clear diagnostics also implies clear caches (-> remove file & project options from State).

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -97,3 +97,8 @@ type Awaitable =
 type IWithAndWithoutParamNames =
     abstract member WithParamNames : arg1: int * arg2: float -> string
     abstract member WithoutParamNames : int * string -> int
+
+type TypeAlias = int
+type FunctionAlias = int -> int
+type GenericTypeAlias<'T> = 'T
+type GenericFunctionAlias<'T> = 'T -> 'T -> int -> unit

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -102,3 +102,6 @@ type TypeAlias = int
 type FunctionAlias = int -> int
 type GenericTypeAlias<'T> = 'T
 type GenericFunctionAlias<'T> = 'T -> 'T -> int -> unit
+type TypeAliasTuple = (int * string)
+type GenericTypeAliasTuple<'A, 'B> = ('A * 'B * int)
+type GenericFunctionTupleAlias<'T> = 'T -> ('T * string)

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -105,3 +105,5 @@ type GenericFunctionAlias<'T> = 'T -> 'T -> int -> unit
 type TypeAliasTuple = (int * string)
 type GenericTypeAliasTuple<'A, 'B> = ('A * 'B * int)
 type GenericFunctionTupleAlias<'T> = 'T -> ('T * string)
+type StructTupleAlias = (struct (int * string))
+type StructFunctionTupleAlias = int -> (struct (int * string))

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -107,3 +107,4 @@ type GenericTypeAliasTuple<'A, 'B> = ('A * 'B * int)
 type GenericFunctionTupleAlias<'T> = 'T -> ('T * string)
 type StructTupleAlias = (struct (int * string))
 type StructFunctionTupleAlias = int -> (struct (int * string))
+let functionAliasValue: FunctionAlias = fun _ -> 2


### PR DESCRIPTION
Fixes the hover tooltip not working for certain complex type abbreviations.