### PR TITLE
Fix missing generic argument in alias hover

### DIFF
--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -54,9 +54,7 @@ module SignatureFormatter =
       | WithGenericArguments x ->
         let parameters =
           x.GenericArguments
-          |> Seq.map ParameterType.getParameterType
-          |> Seq.toList
-          |> List.map ParameterType.displayNameUnAnnotated
+          |> Seq.map (ParameterType.getParameterType >> ParameterType.displayNameUnAnnotated)
           |> String.join ", "
 
         let displayName = x.TypeDefinition.DisplayName

--- a/src/FsAutoComplete.Core/SignatureFormatter.fs
+++ b/src/FsAutoComplete.Core/SignatureFormatter.fs
@@ -54,7 +54,7 @@ module SignatureFormatter =
       | WithGenericArguments x ->
         let parameters =
           x.GenericArguments
-          |> Seq.map (ParameterType.getParameterType >> ParameterType.displayNameUnAnnotated)
+          |> Seq.map (ParameterType.getParameterType >> ParameterType.displayName)
           |> String.join ", "
 
         let displayName = x.TypeDefinition.DisplayName
@@ -75,9 +75,7 @@ module SignatureFormatter =
       | WithGenericArguments x ->
         let parameters =
           x.GenericArguments
-          |> Seq.map ParameterType.getParameterType
-          |> Seq.toList
-          |> List.map ParameterType.displayNameUnAnnotated
+          |> Seq.map (ParameterType.getParameterType >> ParameterType.displayNameUnAnnotated)
           |> String.join ", "
 
         let displayName = x.TypeDefinition.UnAnnotate().DisplayName

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -615,40 +615,45 @@ let tooltipTests state =
           verifySignature
             102u
             7u
-           "type GenericTypeAlias<'T> = 'T"
+            "type FunctionAliasWithGenerics = Int32 -> String -> Option<Result<Int32, String>>"
 
           verifySignature
             103u
             7u
-           "type GenericFunctionAlias<'T> = 'T -> 'T -> Int32 -> Unit"
+           "type GenericTypeAlias<'T> = 'T"
 
           verifySignature
             104u
             7u
-           "type TypeAliasTuple = (Int32 * String)"
+           "type GenericFunctionAlias<'T> = 'T -> 'T -> Int32 -> Unit"
 
           verifySignature
             105u
             7u
-            "type GenericTypeAliasTuple<'A,'B> = ('A * 'B * Int32)"
+           "type TypeAliasTuple = (Int32 * String)"
 
           verifySignature
             106u
             7u
-            "type GenericFunctionTupleAlias<'T> = 'T -> ('T * String)"
+            "type GenericTypeAliasTuple<'A,'B> = ('A * 'B * Int32)"
 
           verifySignature
             107u
             7u
-            "type StructTupleAlias = struct (Int32 * String)"
+            "type GenericFunctionTupleAlias<'T> = 'T -> ('T * String)"
 
           verifySignature
             108u
             7u
-            "type StructFunctionTupleAlias = Int32 -> struct (Int32 * String)"
+            "type StructTupleAlias = struct (Int32 * String)"
 
           verifySignature
             109u
+            7u
+            "type StructFunctionTupleAlias = Int32 -> struct (Int32 * String)"
+
+          verifySignature
+            110u
             7u
             "val functionAliasValue: int -> int" ] ]
 

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Tooltips/Script.fsx
@@ -100,6 +100,7 @@ type IWithAndWithoutParamNames =
 
 type TypeAlias = int
 type FunctionAlias = int -> int
+type FunctionAliasWithGenerics = int -> string -> Result<int, string> option
 type GenericTypeAlias<'T> = 'T
 type GenericFunctionAlias<'T> = 'T -> 'T -> int -> unit
 type TypeAliasTuple = (int * string)


### PR DESCRIPTION
Fixes a bug I noticed in #1365 where generic argument types like option where not including their arguments. (e.g. `Option` instead of `Option<Int32>`)