### PR TITLE
Enable completion of indented hash directives

### DIFF
--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -590,7 +590,7 @@ type AdaptiveFSharpLspServer
 
             let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.lineLookupErr
 
-            if lineStr.StartsWith("#", StringComparison.Ordinal) then
+            if lineStr.TrimStart().StartsWith("#", StringComparison.Ordinal) then
               let completionList =
                 { IsIncomplete = false
                   Items = KeywordList.hashSymbolCompletionItems

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -499,6 +499,26 @@ let tests state =
               "first member should be List.Empty, since properties are preferred over functions"
           | Ok None -> failtest "Should have gotten some completion items"
           | Error e -> failtestf "Got an error while retrieving completions: %A" e
+        })
+
+      testCaseAsync
+        "completion in indented hash directive"
+        (async {
+          let! server, path = server
+
+          let completionParams: CompletionParams = completion path (pos 26u 4u) Invoked
+          let! response = server.TextDocumentCompletion completionParams
+
+          match response with
+          | Ok(Some(CompletionItems completions)) ->
+            Expect.isGreaterThanOrEqual completions.Length 2 "endif and else should be listed"
+
+            let labels = completions |> Array.map _.Label
+            Expect.contains labels "#else" "#else is a possible directive"
+            Expect.contains labels "#endif" "#endif is another possible directive"
+
+          | Ok None -> failtest "Should have gotten some completion items"
+          | Error e -> failtestf "Got an error while retrieving completions: %A" e
         }) ]
 
 ///Tests for getting autocomplete

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/Completion/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/Completion/Script.fsx
@@ -23,3 +23,5 @@ Path.GetDirectoryName("foo")
 
 $"{List.}"
 $"{ List. }"
+
+  #e


### PR DESCRIPTION
The compiler allows preceding whitespace for all hash directives.
FSAC, however, auto-completes hash directives only at the beginning of a line.
This PR enables completion also for indented hash directives.