### PR TITLE
Remove unused Debug settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,17 +214,6 @@ Options that should be send as `initializationOptions` as part of `initialize` r
         "FSharp.fsiExtraInteractiveParameters": ["--readline-"]
     ```
 
-#### Debug Settings
-Settings to change internal behavior. Intended for debugging purposes and not for normal use.
-* `FSharp.Debug.DontCheckRelatedFiles` - usually checking a file involves checking related files too. This prevents this and limits file checking to just the current file.  
-  Default: `false`
-* `FSharp.Debug.CheckFileDebouncerTimeout` - Duration (in ms) of no user write activity (in practice: no LSP `textDocument/didChange` notification) before file checking gets triggered.  
-  Default: `250`
-* `FSharp.Debug.LogDurationBetweenCheckFiles`: Logs duration between the start of to consecutive file checks.  
-  Default: `false`  
-* `FSharp.Debug.LogCheckFileDuration`: Logs duration of file checking operation.  
-  Default: `false`
-
 ## Troubleshooting
 
 ### FileWatcher exceptions

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -684,13 +684,6 @@ type NotificationsDto =
   { Trace: bool option
     TraceNamespaces: string array option }
 
-type DebugDto =
-  { DontCheckRelatedFiles: bool option
-    CheckFileDebouncerTimeout: int option
-    LogDurationBetweenCheckFiles: bool option
-    LogCheckFileDuration: bool option }
-
-
 type FSACDto =
   {
     /// <summary>The <see cref='F:Microsoft.Extensions.Caching.Memory.MemoryCacheOptions.SizeLimit '/> for typecheck cache. </summary>
@@ -747,8 +740,7 @@ type FSharpConfigDto =
     PipelineHints: InlineValueDto option
     InlayHints: InlayHintDto option
     Fsac: FSACDto option
-    Notifications: NotificationsDto option
-    Debug: DebugDto option }
+    Notifications: NotificationsDto option }
 
 type FSharpConfigRequest = { FSharp: FSharpConfigDto option }
 
@@ -819,18 +811,6 @@ type FSACConfig =
     { CachedTypeCheckCount = defaultArg dto.CachedTypeCheckCount this.CachedTypeCheckCount
       ParallelReferenceResolution = defaultArg dto.ParallelReferenceResolution this.ParallelReferenceResolution }
 
-type DebugConfig =
-  { DontCheckRelatedFiles: bool
-    CheckFileDebouncerTimeout: int
-    LogDurationBetweenCheckFiles: bool
-    LogCheckFileDuration: bool }
-
-  static member Default =
-    { DontCheckRelatedFiles = false
-      CheckFileDebouncerTimeout = 250
-      LogDurationBetweenCheckFiles = false
-      LogCheckFileDuration = false }
-
 let logger = lazy (LogProvider.getLoggerByName "LspHelpers")
 
 let tryCreateRegex (pattern: string) =
@@ -893,8 +873,7 @@ type FSharpConfig =
     InlayHints: InlayHintsConfig
     InlineValues: InlineValuesConfig
     Notifications: NotificationsConfig
-    Fsac: FSACConfig
-    Debug: DebugConfig }
+    Fsac: FSACConfig }
 
   static member Default: FSharpConfig =
     { AutomaticWorkspaceInit = false
@@ -945,8 +924,7 @@ type FSharpConfig =
       InlayHints = InlayHintsConfig.Default
       InlineValues = InlineValuesConfig.Default
       Notifications = NotificationsConfig.Default
-      Fsac = FSACConfig.Default
-      Debug = DebugConfig.Default }
+      Fsac = FSACConfig.Default }
 
   static member FromDto(dto: FSharpConfigDto) : FSharpConfig =
     { AutomaticWorkspaceInit = defaultArg dto.AutomaticWorkspaceInit false
@@ -1035,17 +1013,7 @@ type FSharpConfig =
       Fsac =
         dto.Fsac
         |> Option.map FSACConfig.FromDto
-        |> Option.defaultValue FSACConfig.Default
-      Debug =
-        match dto.Debug with
-        | None -> DebugConfig.Default
-        | Some dDto ->
-          { DontCheckRelatedFiles = defaultArg dDto.DontCheckRelatedFiles DebugConfig.Default.DontCheckRelatedFiles
-            CheckFileDebouncerTimeout =
-              defaultArg dDto.CheckFileDebouncerTimeout DebugConfig.Default.CheckFileDebouncerTimeout
-            LogDurationBetweenCheckFiles =
-              defaultArg dDto.LogDurationBetweenCheckFiles DebugConfig.Default.LogDurationBetweenCheckFiles
-            LogCheckFileDuration = defaultArg dDto.LogCheckFileDuration DebugConfig.Default.LogCheckFileDuration } }
+        |> Option.defaultValue FSACConfig.Default }
 
 
   /// called when a configuration change takes effect, so None-valued members here should revert options
@@ -1148,16 +1116,7 @@ type FSharpConfig =
         dto.Notifications
         |> Option.map x.Notifications.AddDto
         |> Option.defaultValue NotificationsConfig.Default
-      Fsac = dto.Fsac |> Option.map x.Fsac.AddDto |> Option.defaultValue FSACConfig.Default
-      Debug =
-        match dto.Debug with
-        | None -> DebugConfig.Default
-        | Some dDto ->
-          { DontCheckRelatedFiles = defaultArg dDto.DontCheckRelatedFiles x.Debug.DontCheckRelatedFiles
-            CheckFileDebouncerTimeout = defaultArg dDto.CheckFileDebouncerTimeout x.Debug.CheckFileDebouncerTimeout
-            LogDurationBetweenCheckFiles =
-              defaultArg dDto.LogDurationBetweenCheckFiles x.Debug.LogDurationBetweenCheckFiles
-            LogCheckFileDuration = defaultArg dDto.LogCheckFileDuration x.Debug.LogCheckFileDuration } }
+      Fsac = dto.Fsac |> Option.map x.Fsac.AddDto |> Option.defaultValue FSACConfig.Default }
 
   member x.ScriptTFM =
     match x.UseSdkScripts with

--- a/src/FsAutoComplete/LspHelpers.fsi
+++ b/src/FsAutoComplete/LspHelpers.fsi
@@ -268,12 +268,6 @@ type NotificationsDto =
   { Trace: bool option
     TraceNamespaces: string array option }
 
-type DebugDto =
-  { DontCheckRelatedFiles: bool option
-    CheckFileDebouncerTimeout: int option
-    LogDurationBetweenCheckFiles: bool option
-    LogCheckFileDuration: bool option }
-
 type FSACDto =
   {
     /// <summary>The <see cref='F:Microsoft.Extensions.Caching.Memory.MemoryCacheOptions.SizeLimit '/> for typecheck cache. </summary>
@@ -330,8 +324,7 @@ type FSharpConfigDto =
     PipelineHints: InlineValueDto option
     InlayHints: InlayHintDto option
     Fsac: FSACDto option
-    Notifications: NotificationsDto option
-    Debug: DebugDto option }
+    Notifications: NotificationsDto option }
 
 type FSharpConfigRequest = { FSharp: FSharpConfigDto option }
 
@@ -373,14 +366,6 @@ type FSACConfig =
   static member Default: FSACConfig
   static member FromDto: dto: FSACDto -> FSACConfig
   member AddDto: dto: FSACDto -> FSACConfig
-
-type DebugConfig =
-  { DontCheckRelatedFiles: bool
-    CheckFileDebouncerTimeout: int
-    LogDurationBetweenCheckFiles: bool
-    LogCheckFileDuration: bool }
-
-  static member Default: DebugConfig
 
 type FSharpConfig =
   { AutomaticWorkspaceInit: bool
@@ -431,8 +416,7 @@ type FSharpConfig =
     InlayHints: InlayHintsConfig
     InlineValues: InlineValuesConfig
     Notifications: NotificationsConfig
-    Fsac: FSACConfig
-    Debug: DebugConfig }
+    Fsac: FSACConfig }
 
   static member Default: FSharpConfig
   static member FromDto: dto: FSharpConfigDto -> FSharpConfig

--- a/test/FsAutoComplete.Tests.Lsp/Helpers.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Helpers.fs
@@ -293,8 +293,7 @@ let defaultConfigDto: FSharpConfigDto =
         { Enabled = Some true
           Prefix = Some "//" }
     Notifications = None
-    Fsac = None
-    Debug = None }
+    Fsac = None }
 
 let clientCaps: ClientCapabilities =
 


### PR DESCRIPTION
The last references to these settings were removed in #1174, so they currently don't do anything.