### PR TITLE
use new nuget trusted auth to always get a fresh token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,5 +44,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: ${{ steps.changelog_reader.outputs.log_entry }}
 
+          # Get a short-lived NuGet API key
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{secrets.NUGET_USER}}
+
       - name: Push packages
-        run: dotnet nuget push bin/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_KEY }}
+        run: dotnet nuget push bin/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{steps.login.outputs.NUGET_API_KEY}}


### PR DESCRIPTION
Instead of using a hard-coded NuGet key with a timeout, this has us use delegated auth. I've configured a workflow for this repo/workflow specifically:

<img width="1147" height="255" alt="image" src="https://github.com/user-attachments/assets/c707713f-46f2-4d49-9d1c-dfb49b618da6" />

So the newly-added call to auth to get a short-lived NuGet API key should just work.