### PR TITLE
Add Helix, Flow and Kate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The `FsAutoComplete` project (`FSAC`) provides a backend service for rich editin
 
 It can be hosted using the Language Server Protocol.
 
-Currently it is used by:
+Currently, it is used by the following extensions:
 
 * [Emacs](https://github.com/fsharp/emacs-fsharp-mode)
 * [Neovim](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#fsautocomplete)
@@ -16,7 +16,14 @@ Currently it is used by:
 * [Sublime Text](https://lsp.sublimetext.io/language_servers/#f)
 * [Zed](https://github.com/nathanjcollins/zed-fsharp)
 
-It's based on:
+And it can be used with the following editors, by simply installing FsAutoComplete directly: 
+`dotnet tool install --global fsautocomplete`
+
+* [Kate](https://kate-editor.org/)
+* [Flow](https://flow-control.dev/)
+* [Helix](https://helix-editor.com/)
+
+It is based on:
 
 * [FSharp.Compiler.Service](https://github.com/fsharp/FSharp.Compiler.Service/) for F# language info.
 * [Ionide.ProjInfo](https://github.com/ionide/proj-info) for project/solution management.


### PR DESCRIPTION
Hello. 🙂 This adds Flow, Kate, and Helix to the list of supported editors. 
Since they require fsautocomplete to be installed separately, and there is no documentation page to link to, I decided to include the installation command. 

I also added the individual project websites as the embedded link. 

For confirmation, can you see the commits that added support here:

https://github.com/neurocyte/flow/blob/a299d27b1fbe0109903eb3b0e0fa942cb0ec18a1/src/file_type_lsp.zig#L51-L53

https://invent.kde.org/utilities/kate/-/blob/c2792fc2f988b10cf038c8d05f5d4e115a5ff899/addons/lspclient/settings.json

https://github.com/helix-editor/helix/blob/master/languages.toml#L52

I will try to get the superfluous flag in the Kate configuration removed.

Helix seems to use `AutomaticWorkspaceInit` by default.  I assume this is correct.