### PR TITLE
add `warnon` to the list of hash directives

### DIFF
--- a/src/FsAutoComplete.Core/KeywordList.fs
+++ b/src/FsAutoComplete.Core/KeywordList.fs
@@ -36,6 +36,7 @@ module KeywordList =
       "else", "Supports conditional compilation"
       "endif", "Supports conditional compilation"
       "nowarn", "Disables a compiler warning or warnings"
+      "warnon", "Enables a compiler warning or warnings"
       "quit", "exits the interactive session"
       "time", "toggles whether to display performance information"
       "line", "Indicates the original source code line" ]


### PR DESCRIPTION
Provide code completion for the new `#warnon` directive.