### PR TITLE
Add test for #line directives

### DIFF
--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -58,6 +58,7 @@ module Conversions =
 
 
   let fcsRangeToLspLocation (range: FcsRange) : LspLocation =
+    // let range = range.ApplyLineDirectives()  // Possibly for F# 10.0 (rc1 or later)
     let fileUri = Path.FilePathToUri range.FileName
     let lspRange = fcsRangeToLsp range
     { Uri = fileUri; Range = lspRange }

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/Definition.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/Definition.fs
@@ -2,10 +2,15 @@ module Definitions
 
 let sample_value = 123
 
-type A = {x: int; y: int}
+type A = { x: int; y: int }
 
-let value_with_type = {x = 123; y = 456}
+let value_with_type = { x = 123; y = 456 }
 
 type IInterface =
-    abstract member C : int -> int
-    abstract member D : int -> int
+  abstract member C: int -> int
+  abstract member D: int -> int
+
+let generatorValue = 42
+
+#line "13"
+let generated = 42

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/Library.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/Library.fs
@@ -4,13 +4,14 @@ let z = Definitions.sample_value
 
 let x = Definitions.value_with_type
 
-let v = {
-    new Definitions.IInterface with
-        member __.C(a) = 123
-        member __.D(a) = 123
-}
+let v =
+  { new Definitions.IInterface with
+      member __.C(a) = 123
+      member __.D(a) = 123 }
 
-type Abc () =
-    interface Definitions.IInterface with
-        member __.C(a) = 123
-        member __.D(a) = 123
+type Abc() =
+  interface Definitions.IInterface with
+    member __.C(a) = 123
+    member __.D(a) = 123
+
+let s = Definitions.generated


### PR DESCRIPTION
In anticipation of a need for changes due to the F# ["Refactor #line processing" PR](https://github.com/dotnet/fsharp/pull/18699), this PR just adds a test.
The test confirms that FSAC currently doesn't respect #line directives (at least not for GOTOs), so there may not even be a need for changes. But the test might be valuable anyway.