### PR TITLE
Use the macos-15 build agent instead of macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os:
           - windows-latest
-          - macos-13 # using 13 because it's a bigger machine, and latest is still pointing to 12
+          - macos-15
           - ubuntu-latest
         dotnet-version: ["8.0.x", "9.0.x"]
         use-transparent-compiler:


### PR DESCRIPTION
refs https://github.com/actions/runner-images/issues/13046 because the macos-13 runners are being deprecated.

~~I set it to the Intel agent because I think the existing macos builds are using the intel, but I'm not sure if it should be using Intel or ARM at this point?~~ Change to the ARM agent.