### PR TITLE
Make semantic token mapping more accurate

### DIFF
--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -593,8 +593,8 @@ module ClassificationUtils =
     | SemanticClassificationType.Exception
     | SemanticClassificationType.Field
     | SemanticClassificationType.Event
-    | SemanticClassificationType.Delegate -> SemanticTokenTypes.Member, []
-    | SemanticClassificationType.NamedArgument -> SemanticTokenTypes.Modifier, []
+    | SemanticClassificationType.Delegate
+    | SemanticClassificationType.NamedArgument -> SemanticTokenTypes.Member, []
     | SemanticClassificationType.Value
     | SemanticClassificationType.LocalValue -> SemanticTokenTypes.Variable, []
     | SemanticClassificationType.Plaintext -> SemanticTokenTypes.Text, []

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -553,6 +553,7 @@ module ClassificationUtils =
     (* custom modifiers *)
     | Mutable = 0b100_0000_0000
     | Disposable = 0b1000_0000_0000
+    | Extension = 0b1_0000_0000_0000
 
 
   let map (t: SemanticClassificationType) : SemanticTokenTypes * SemanticTokenModifier list =
@@ -561,22 +562,22 @@ module ClassificationUtils =
     | SemanticClassificationType.ReferenceType
     | SemanticClassificationType.Type
     | SemanticClassificationType.TypeDef
-    | SemanticClassificationType.ConstructorForReferenceType -> SemanticTokenTypes.Type, []
+    | SemanticClassificationType.ConstructorForReferenceType -> SemanticTokenTypes.Class, []
     | SemanticClassificationType.ValueType
     | SemanticClassificationType.ConstructorForValueType -> SemanticTokenTypes.Struct, []
-    | SemanticClassificationType.UnionCase
-    | SemanticClassificationType.UnionCaseField -> SemanticTokenTypes.EnumMember, []
+    | SemanticClassificationType.UnionCase -> SemanticTokenTypes.EnumMember, []
+    | SemanticClassificationType.UnionCaseField -> SemanticTokenTypes.Parameter, []
     | SemanticClassificationType.Function
-    | SemanticClassificationType.Method
-    | SemanticClassificationType.ExtensionMethod -> SemanticTokenTypes.Function, []
+    | SemanticClassificationType.IntrinsicFunction -> SemanticTokenTypes.Function, []
+    | SemanticClassificationType.Method -> SemanticTokenTypes.Method, []
+    | SemanticClassificationType.ExtensionMethod -> SemanticTokenTypes.Method, [ SemanticTokenModifier.Extension ]
     | SemanticClassificationType.Property -> SemanticTokenTypes.Property, []
-    | SemanticClassificationType.MutableVar
-    | SemanticClassificationType.MutableRecordField -> SemanticTokenTypes.Member, [ SemanticTokenModifier.Mutable ]
+    | SemanticClassificationType.MutableVar -> SemanticTokenTypes.Variable, [ SemanticTokenModifier.Mutable ]
+    | SemanticClassificationType.MutableRecordField -> SemanticTokenTypes.Property, [ SemanticTokenModifier.Mutable ]
     | SemanticClassificationType.Module -> SemanticTokenTypes.Module, []
     | SemanticClassificationType.Namespace -> SemanticTokenTypes.Namespace, []
     | SemanticClassificationType.Printf -> SemanticTokenTypes.Regexp, []
     | SemanticClassificationType.ComputationExpression -> SemanticTokenTypes.Cexpr, []
-    | SemanticClassificationType.IntrinsicFunction -> SemanticTokenTypes.Function, []
     | SemanticClassificationType.Enumeration -> SemanticTokenTypes.Enum, []
     | SemanticClassificationType.Interface -> SemanticTokenTypes.Interface, []
     | SemanticClassificationType.TypeArgument -> SemanticTokenTypes.TypeParameter, []
@@ -592,8 +593,8 @@ module ClassificationUtils =
     | SemanticClassificationType.Exception
     | SemanticClassificationType.Field
     | SemanticClassificationType.Event
-    | SemanticClassificationType.Delegate
-    | SemanticClassificationType.NamedArgument -> SemanticTokenTypes.Member, []
+    | SemanticClassificationType.Delegate -> SemanticTokenTypes.Member, []
+    | SemanticClassificationType.NamedArgument -> SemanticTokenTypes.Modifier, []
     | SemanticClassificationType.Value
     | SemanticClassificationType.LocalValue -> SemanticTokenTypes.Variable, []
     | SemanticClassificationType.Plaintext -> SemanticTokenTypes.Text, []

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -560,9 +560,9 @@ module ClassificationUtils =
     match t with
     | SemanticClassificationType.Operator -> SemanticTokenTypes.Operator, []
     | SemanticClassificationType.ReferenceType
-    | SemanticClassificationType.Type
-    | SemanticClassificationType.TypeDef
     | SemanticClassificationType.ConstructorForReferenceType -> SemanticTokenTypes.Class, []
+    | SemanticClassificationType.Type
+    | SemanticClassificationType.TypeDef -> SemanticTokenTypes.Type, []
     | SemanticClassificationType.ValueType
     | SemanticClassificationType.ConstructorForValueType -> SemanticTokenTypes.Struct, []
     | SemanticClassificationType.UnionCase -> SemanticTokenTypes.EnumMember, []

--- a/test/FsAutoComplete.Tests.Lsp/HighlightingTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/HighlightingTests.fs
@@ -148,7 +148,7 @@ let tests state =
         "tests"
         [ tokenIsOfType (0u, 29u) ClassificationUtils.SemanticTokenTypes.TypeParameter fullHighlights // the `^a` type parameter in the SRTP constraint
           tokenIsOfType (0u, 44u) ClassificationUtils.SemanticTokenTypes.Member fullHighlights // the `PeePee` member in the SRTP constraint
-          tokenIsOfType (3u, 52u) ClassificationUtils.SemanticTokenTypes.Type fullHighlights // the `string` type annotation in the PooPoo srtp member
+          tokenIsOfType (3u, 52u) ClassificationUtils.SemanticTokenTypes.Class fullHighlights // the `string` type annotation in the PooPoo srtp member
           tokenIsOfType (6u, 21u) ClassificationUtils.SemanticTokenTypes.EnumMember fullHighlights // the `PeePee` AP application in the `yeet` function definition
-          tokenIsOfType (9u, 10u) ClassificationUtils.SemanticTokenTypes.Type fullHighlights //the `SomeJson` type alias should be a type
+          tokenIsOfType (9u, 10u) ClassificationUtils.SemanticTokenTypes.Class fullHighlights //the `SomeJson` type alias should be a type
           tokenIsOfType (15u, 2u) ClassificationUtils.SemanticTokenTypes.Module fullHighlights ] ] // tests that module coloration isn't overwritten by function coloration when a module function is used, so Foo in Foo.x should be module-colored


### PR DESCRIPTION
Make semantic token mapping more accurate. And add a new modifier "Extension" to make user can make themes that can distinguish extension methods out from intrinsic methods.
See ionide/ionide-vscode-fsharp#2114

Basically, changes are:

1. ReferenceType → Class
2. MutableVar → Variable + Mutable
3. MutableRecordField → Property + Mutable
4. UnionCaseField → Parameter
5. Method → Method (not Function)
6. ExtensionMethod → Method + Extension

