### PR TITLE
Add support for partial active pattern case usage detection and testing

### DIFF
--- a/test/FsAutoComplete.Tests.Lsp/FindReferencesTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/FindReferencesTests.fs
@@ -702,15 +702,8 @@ let private activePatternProjectTests state =
         let definitionRefs = refs |> Array.filter (fun r -> r.Uri.Contains "ActivePatterns.fs")
         let usageRefs = refs |> Array.filter (fun r -> r.Uri.Contains "Program.fs")
 
-        // Note: TransparentCompiler has a known limitation where finding references
-        // from the definition position may return fewer/different results.
-        // For BackgroundCompiler, we verify all expected references are found.
-        // For TransparentCompiler, we accept that results may be empty or different.
-        if definitionRefs.Length > 0 && usageRefs.Length > 0 then
-          // BackgroundCompiler - verify all expected references are found
-          Expect.isGreaterThanOrEqual definitionRefs.Length 1 "Should find definition in ActivePatterns.fs"
-          Expect.isGreaterThanOrEqual usageRefs.Length 1 "Should find usage in Program.fs"
-        // else: TransparentCompiler limitation or no results - skip detailed assertions
+        Expect.isGreaterThanOrEqual definitionRefs.Length 1 "Should find definition in ActivePatterns.fs"
+        Expect.isGreaterThanOrEqual usageRefs.Length 1 "Should find usage in Program.fs"
       }
 
       testCaseAsync "can find partial active pattern with parameters across files (from usage)"
@@ -774,16 +767,8 @@ let private activePatternProjectTests state =
         // 2. The usage in Program.fs
         let definitionRefs = refs |> Array.filter (fun r -> r.Uri.Contains "ActivePatterns.fs")
         let usageRefs = refs |> Array.filter (fun r -> r.Uri.Contains "Program.fs")
-
-        // Note: TransparentCompiler has a known limitation where finding references
-        // from the definition position may return fewer/different results.
-        // For BackgroundCompiler, we verify all expected references are found.
-        // For TransparentCompiler, we accept that results may be empty or different.
-        if definitionRefs.Length > 0 && usageRefs.Length > 0 then
-          // BackgroundCompiler - verify all expected references are found
-          Expect.isGreaterThanOrEqual definitionRefs.Length 1 "Should find definition in ActivePatterns.fs"
-          Expect.isGreaterThanOrEqual usageRefs.Length 1 "Should find usage in Program.fs"
-        // else: TransparentCompiler limitation or no results - skip detailed assertions
+        Expect.isGreaterThanOrEqual definitionRefs.Length 1 "Should find definition in ActivePatterns.fs"
+        Expect.isGreaterThanOrEqual usageRefs.Length 1 "Should find usage in Program.fs"
       }
 
       testCaseAsync "can find struct partial active pattern (ValueOption) across files (from usage)"

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/FindReferences/ActivePatternProject/ActivePatternProject.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/FindReferences/ActivePatternProject/ActivePatternProject.fsproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="ActivePatterns.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/FindReferences/ActivePatternProject/ActivePatterns.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/FindReferences/ActivePatternProject/ActivePatterns.fs
@@ -1,0 +1,23 @@
+module ActivePatterns
+
+open System.Text.RegularExpressions
+
+let (|ParseInt|_|) (str: string) =
+//>  ^^^^^^^^^^^^^ Partial Active Pattern definition
+  let success, i = System.Int32.TryParse str
+  if success then Some i else None
+
+let (|ParseRegex|_|) regex str =
+//>  ^^^^^^^^^^^^^ Partial Active Pattern with parameters
+    let m = Regex(regex).Match(str)
+    if m.Success then
+        Some(List.tail [ for x in m.Groups -> x.Value ])
+    else
+        None
+
+/// Partial active pattern with [<return: Struct>] attribute returning ValueOption
+[<return: Struct>]
+let (|ParseIntStruct|_|) (str: string) =
+//>  ^^^^^^^^^^^^^^^^^^^ Partial Active Pattern with Struct attribute
+    let success, i = System.Int32.TryParse str
+    if success then ValueSome i else ValueNone

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/FindReferences/ActivePatternProject/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/FindReferences/ActivePatternProject/Program.fs
@@ -1,0 +1,32 @@
+open ActivePatterns
+
+let test1 =
+  match "42" with
+  | ParseInt i -> printfn $"Got int: {i}"
+//  ^^^^^^^^ Usage in test1
+  | _ -> printfn "Not an int"
+
+let test2 x =
+  async {
+    match x with
+    | ParseInt i -> return i
+//    ^^^^^^^^ Usage in test2 async
+    | _ -> return 0
+  }
+
+let findFeatNumber branch =
+    match branch with
+    | ParseRegex @"(?i)(FEAT-\d+)-.*" [num] -> num
+//    ^^^^^^^^^^ Usage of parameterized partial active pattern
+    | _ -> branch
+
+let testStructPattern input =
+    match input with
+    | ParseIntStruct i -> printfn $"Got struct int: {i}"
+//    ^^^^^^^^^^^^^^ Usage of Struct partial active pattern
+    | _ -> printfn "Not an int"
+
+[<EntryPoint>]
+let main argv =
+  test1
+  0


### PR DESCRIPTION
- Implemented functions to extract and find usages of partial active patterns in the AST.
- Enhanced the `findReferencesForSymbolInFile` function to include AST walking for partial active patterns.
- Added tests for detecting partial active patterns with parameters across multiple files.
- Created new test project structure for active pattern reference tests.