### PR TITLE
Fix SourceLink go-to-definition failure when .NET 10 is used on Linux

### DIFF
--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -43,10 +43,11 @@ type ParseAndCheckResults
   let logger = LogProvider.getLoggerByName "ParseAndCheckResults"
 
   let getFileName (loc: range) =
-    if Ionide.ProjInfo.ProjectSystem.Environment.isWindows then
-      UMX.tag<NormalizedRepoPathSegment> loc.FileName
-    else
-      UMX.tag<NormalizedRepoPathSegment> (Path.GetFileName loc.FileName)
+    // Keep the full FCS path, just normalize backslashes to forward slashes.
+    // FCS may prepend a workspace prefix if the PDB path isn't absolute on this platform.
+    // The comparison in Sourcelink.compareRepoPath will handle the prefix via suffix matching.
+    let normalized = loc.FileName.Replace('\\', '/')
+    UMX.tag<NormalizedRepoPathSegment> normalized
 
   member __.TryFindDeclaration (pos: Position) (lineStr: LineStr) =
     async {

--- a/src/FsAutoComplete.Core/Sourcelink.fs
+++ b/src/FsAutoComplete.Core/Sourcelink.fs
@@ -46,16 +46,42 @@ type private Document =
     Language: System.Guid
     IsEmbedded: bool }
 
-let private compareRepoPath (d: Document) targetFile =
-  if Environment.isWindows then
-    let s = UMX.untag d.Name
-    let s' = normalizePath s |> UMX.untag
-    let s' = UMX.tag<NormalizedRepoPathSegment> s'
-    s' = targetFile
-  else
-    let t = UMX.untag targetFile |> UMX.tag<RepoPathSegment>
-    let t' = normalizeRepoPath t
-    normalizeRepoPath d.Name = t'
+let private compareRepoPath (d: Document) fcsPath =
+  // The fcsPath is the full path from FCS (normalized, backslashes converted to forward slashes).
+  // FCS may prepend a workspace prefix if the PDB path wasn't absolute on this platform.
+  // The d.Name is a PDB document entry (the original path from when the DLL was compiled).
+  //
+  // The PDB document should be a SUFFIX of (or equal to) the FCS path:
+  // - FCS path: /workspaces/project/D:/a/_work/1/s/src/FSharp.Core/list.fs
+  // - PDB doc:                      D:/a/_work/1/s/src/FSharp.Core/list.fs
+  //   → fcsPath.EndsWith("/" + pdbDoc) = true
+  //
+  // - FCS path: /__w/1/s/src/fsharp/src/FSharp.Core/list.fs
+  // - PDB doc:  /__w/1/s/src/fsharp/src/FSharp.Core/list.fs
+  //   → fcsPath == pdbDoc = true
+
+  let docNormalized: string<NormalizedRepoPathSegment> =
+    if Environment.isWindows then
+      let s = UMX.untag d.Name
+      let normalized = normalizePath s |> UMX.untag
+      UMX.tag<NormalizedRepoPathSegment> normalized
+    else
+      normalizeRepoPath d.Name
+
+  let fcsNormalized: string<NormalizedRepoPathSegment> =
+    if Environment.isWindows then
+      fcsPath
+    else
+      let t: string = UMX.untag fcsPath
+      let tagged: string<RepoPathSegment> = UMX.tag<RepoPathSegment> t
+      normalizeRepoPath tagged
+
+  let docStr = UMX.untag docNormalized
+  let fcsStr = UMX.untag fcsNormalized
+
+  // PDB doc should be suffix of (or equal to) FCS path
+  fcsStr = docStr
+  || fcsStr.EndsWith("/" + docStr, System.StringComparison.Ordinal)
 
 let private pdbForDll (dllPath: string<LocalPath>) =
   UMX.tag<LocalPath> (Path.ChangeExtension(UMX.untag dllPath, ".pdb"))

--- a/src/FsAutoComplete.Core/Sourcelink.fs
+++ b/src/FsAutoComplete.Core/Sourcelink.fs
@@ -64,7 +64,8 @@ let private compareRepoPath (d: Document) fcsPath =
     if Environment.isWindows then
       let s = UMX.untag d.Name
       let normalized = normalizePath s |> UMX.untag
-      UMX.tag<NormalizedRepoPathSegment> normalized
+      // Convert backslashes to forward slashes for consistent comparison
+      UMX.tag<NormalizedRepoPathSegment> (normalized.Replace("\\", "/"))
     else
       normalizeRepoPath d.Name
 


### PR DESCRIPTION
## Summary
Fix SourceLink go-to-definition failure on .NET 10 for FSharp.Core symbols (e.g., `List.map`).

## Problem
Go-to-definition fails for FSharp.Core symbols on .NET 10 with error `MissingSourceFile`, while working correctly on .NET 9.

**Root cause**: FSharp.Core 10.x is built on Linux (was Windows for 9.x), so PDB paths use forward slashes. On Linux, `Path.GetFileName` correctly strips the directory, leaving just the basename (`list.fs`), which then fails to match the full PDB document path (`/__w/1/s/.../list.fs`).

## Changes
1. **ParseAndCheckResults.fs** (`getFileName`): Keep the full FCS path instead of calling `Path.GetFileName` on non-Windows. Just normalize backslashes to forward slashes.
2. **Sourcelink.fs** (`compareRepoPath`): Use suffix matching - the PDB document should be a suffix of (or equal to) the FCS path, to handle workspace prefixes FCS may add.

## Tests
- [x] .NET 10 devcontainer (`mcr.microsoft.com/dotnet/sdk:10.0.100-noble-aot`) - go-to-definition on `List.map` now works
- [x] .NET 9 devcontainer (`mcr.microsoft.com/devcontainers/dotnet:1-9.0`) - no regression

## Details

This PR aims to solve the issue described here: https://github.com/ionide/ionide-vscode-fsharp/issues/2115 

This has been a very interesting experience because I used claude code to track down the problem, then understand the root cause and implement a fix. I left the comments claude added in the code, because they clarify the context, though for the maintainers of this repo they may be just redundant. 

I also tried to track down the changes to how fsharp core libraries are built, which took place with the .NET 10 release, but it is hard to find a single document that explains it. Overall, it looks like the sourcelink document metadata in fsharp dlls have changed.  I added some debug statements to trace the document paths `FCS` returns and I can see that .net 9 and .net 10 environments have different values for the same entry: 

- **FSharp.Core 9.x**  → PDB contains paths such as `D:\a\_work\1\s\src\FSharp.Core\list.fs`
- **FSharp.Core 10.x** → PDB contains paths such as `/__w/1/s/src/fsharp/src/FSharp.Core/list.fs`

