### PR TITLE
Prevent console output interference with LSP communication

### DIFF
--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -3458,6 +3458,11 @@ module AdaptiveFSharpLspServer =
     use input = Console.OpenStandardInput()
     use output = Console.OpenStandardOutput()
 
+    // Attempt to prevent any console output from interfering with the LSP communication from libraries that may use Console.WriteLine
+    // https://github.com/ionide/ionide-vscode-fsharp/issues/2102
+    // This is a best-effort mitigation; libraries that write directly to the underlying stream like (Console.OpenStandardOutput) may still interfere.
+    Console.SetOut(TextWriter.Null)
+
     let requestsHandlings =
       (defaultRequestHandlings (): Map<string, ServerRequestHandling<IFSharpLspServer>>)
       |> Map.add "fsharp/signature" (serverRequestHandling (fun s p -> s.FSharpSignature(p)))


### PR DESCRIPTION
Try to handle rogue Console.Writelines from libraries we don't control.

https://github.com/ionide/ionide-vscode-fsharp/issues/2102


Example in a f# script of this behavior:

```fsharp
open System
open System.IO

Console.SetOut(TextWriter.Null)
let cout = Console.OpenStandardOutput()
let tcout = new StreamWriter(cout)

Console.WriteLine("This will not be seen in the console.")
printfn "Neither will this."
Console.Out.WriteLine("This will also not be seen in the console.")
Console.Out.Flush()

tcout.WriteLine("This will be seen in the output stream.")
tcout.Flush()
```

---

The only other solution is to explore other transport means like sockets/pipes.