### PR TITLE
Resolve cref links in hover and documentation

### DIFF
--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -503,32 +503,33 @@ type ParseAndCheckResults
   member x.TryGetFormattedDocumentationForSymbol (xmlSig: string) (assembly: string) =
     let entities = x.GetAllEntities false
 
+    let matchesSymbol includeAssembly (symbol: FSharpSymbol) =
+      try
+        symbol.XmlDocSig = xmlSig
+        && (not includeAssembly || symbol.Assembly.SimpleName = assembly)
+      with _ ->
+        false
+
+    let matchesAbbreviatedEntity includeAssembly (symbol: FSharpSymbol) =
+      match symbol with
+      | FSharpEntity(_, abrvEnt, _) ->
+        try
+          abrvEnt.XmlDocSig = xmlSig
+          && (not includeAssembly || abrvEnt.Assembly.SimpleName = assembly)
+        with _ ->
+          false
+      | _ -> false
+
     let ent =
       entities
-      |> List.tryFind (fun e ->
-        let check = (e.Symbol.XmlDocSig = xmlSig && e.Symbol.Assembly.SimpleName = assembly)
-
-        if not check then
-          match e.Symbol with
-          | FSharpEntity(_, abrvEnt, _) -> abrvEnt.XmlDocSig = xmlSig && abrvEnt.Assembly.SimpleName = assembly
-          | _ -> false
-        else
-          true)
+      |> List.tryFind (fun e -> matchesSymbol true e.Symbol || matchesAbbreviatedEntity true e.Symbol)
 
     let ent =
       match ent with
       | Some ent -> Some ent
       | None ->
         entities
-        |> List.tryFind (fun e ->
-          let check = (e.Symbol.XmlDocSig = xmlSig)
-
-          if not check then
-            match e.Symbol with
-            | FSharpEntity(_, abrvEnt, _) -> abrvEnt.XmlDocSig = xmlSig
-            | _ -> false
-          else
-            true)
+        |> List.tryFind (fun e -> matchesSymbol false e.Symbol || matchesAbbreviatedEntity false e.Symbol)
 
     let symbol =
       match ent with
@@ -538,13 +539,47 @@ type ParseAndCheckResults
         |> List.tryPick (fun e ->
           match e.Symbol with
           | FSharpEntity(ent, _, _) ->
-            match ent.MembersFunctionsAndValues |> Seq.tryFind (fun f -> f.XmlDocSig = xmlSig) with
-            | Some e -> Some(e :> FSharpSymbol)
+            match
+              ent.MembersFunctionsAndValues
+              |> Seq.tryPick (fun f ->
+                try
+                  if f.XmlDocSig = xmlSig then
+                    Some(f :> FSharpSymbol)
+                  else
+                    None
+                with _ ->
+                  None)
+            with
+            | Some e -> Some e
             | None ->
-              match ent.FSharpFields |> Seq.tryFind (fun f -> f.XmlDocSig = xmlSig) with
-              | Some e -> Some(e :> FSharpSymbol)
-              | None -> None
+              match
+                ent.FSharpFields
+                |> Seq.tryPick (fun f ->
+                  try
+                    if f.XmlDocSig = xmlSig then
+                      Some(f :> FSharpSymbol)
+                    else
+                      None
+                  with _ ->
+                    None)
+              with
+              | Some e -> Some e
+              | None ->
+                ent.UnionCases
+                |> Seq.tryPick (fun f ->
+                  try
+                    if f.XmlDocSig = xmlSig then
+                      Some(f :> FSharpSymbol)
+                    else
+                      None
+                  with _ ->
+                    None)
           | _ -> None)
+
+    let symbol =
+      match symbol with
+      | Some symbol when matchesSymbol false symbol -> Some symbol
+      | _ -> None
 
     match symbol with
     | None -> Error "No matching symbol information"

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -42,6 +42,38 @@ type ParseAndCheckResults
 
   let logger = LogProvider.getLoggerByName "ParseAndCheckResults"
 
+  let getAllEntitiesUncached (publicOnly: bool) : AssemblySymbol list =
+    try
+      [ yield!
+          AssemblyContent.GetAssemblySignatureContent AssemblyContentType.Full checkResults.PartialAssemblySignature
+        let ctx = checkResults.ProjectContext
+
+        let assembliesByFileName =
+          ctx.GetReferencedAssemblies()
+          |> List.groupBy (fun asm -> asm.FileName)
+          |> List.rev // if mscorlib.dll is the first then FSC raises exception when we try to
+        // get Content.Entities from it.
+
+        for fileName, signatures in assembliesByFileName do
+          let contentType =
+            if publicOnly then
+              AssemblyContentType.Public
+            else
+              AssemblyContentType.Full
+
+          let content =
+            AssemblyContent.GetAssemblyContent entityCache.Locking contentType fileName signatures
+
+          yield! content ]
+    with _ ->
+      []
+
+  let cachedPublicEntities = lazy (getAllEntitiesUncached true)
+  let cachedFullEntities = lazy (getAllEntitiesUncached false)
+
+  let cachedCrefResolver =
+    lazy (cachedFullEntities.Force() |> TipFormatter.createCrefResolver)
+
   let getFileName (loc: range) =
     // Keep the full FCS path, just normalize backslashes to forward slashes.
     // FCS may prepend a workspace prefix if the PDB path isn't absolute on this platform.
@@ -765,33 +797,12 @@ type ParseAndCheckResults
     }
 
   member __.GetAllEntities(publicOnly: bool) : AssemblySymbol list =
-    try
-      let res =
-        [ yield!
-            AssemblyContent.GetAssemblySignatureContent AssemblyContentType.Full checkResults.PartialAssemblySignature
-          let ctx = checkResults.ProjectContext
+    if publicOnly then
+      cachedPublicEntities.Force()
+    else
+      cachedFullEntities.Force()
 
-          let assembliesByFileName =
-            ctx.GetReferencedAssemblies()
-            |> List.groupBy (fun asm -> asm.FileName)
-            |> List.rev // if mscorlib.dll is the first then FSC raises exception when we try to
-          // get Content.Entities from it.
-
-          for fileName, signatures in assembliesByFileName do
-            let contentType =
-              if publicOnly then
-                AssemblyContentType.Public
-              else
-                AssemblyContentType.Full
-
-            let content =
-              AssemblyContent.GetAssemblyContent entityCache.Locking contentType fileName signatures
-
-            yield! content ]
-
-      res
-    with _ ->
-      []
+  member __.GetCrefResolver() = cachedCrefResolver.Force()
 
   member __.GetAllSymbolUsesInFile() = checkResults.GetAllUsesOfAllSymbolsInFile()
 

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -54,6 +54,38 @@ type ParseAndCheckResults
 
   let logger = LogProvider.getLoggerByName "ParseAndCheckResults"
 
+  let getAllEntitiesUncached (publicOnly: bool) : AssemblySymbol list =
+    try
+      [ yield!
+          AssemblyContent.GetAssemblySignatureContent AssemblyContentType.Full checkResults.PartialAssemblySignature
+        let ctx = checkResults.ProjectContext
+
+        let assembliesByFileName =
+          ctx.GetReferencedAssemblies()
+          |> List.groupBy (fun asm -> asm.FileName)
+          |> List.rev // if mscorlib.dll is the first then FSC raises exception when we try to
+        // get Content.Entities from it.
+
+        for fileName, signatures in assembliesByFileName do
+          let contentType =
+            if publicOnly then
+              AssemblyContentType.Public
+            else
+              AssemblyContentType.Full
+
+          let content =
+            AssemblyContent.GetAssemblyContent entityCache.Locking contentType fileName signatures
+
+          yield! content ]
+    with _ ->
+      []
+
+  let cachedPublicEntities = lazy (getAllEntitiesUncached true)
+  let cachedFullEntities = lazy (getAllEntitiesUncached false)
+
+  let cachedCrefResolver =
+    lazy (cachedFullEntities.Force() |> TipFormatter.createCrefResolver)
+
   let getFileName (loc: range) =
     // Keep the full FCS path, just normalize backslashes to forward slashes.
     // FCS may prepend a workspace prefix if the PDB path isn't absolute on this platform.
@@ -791,33 +823,12 @@ type ParseAndCheckResults
     }
 
   member __.GetAllEntities(publicOnly: bool) : AssemblySymbol list =
-    try
-      let res =
-        [ yield!
-            AssemblyContent.GetAssemblySignatureContent AssemblyContentType.Full checkResults.PartialAssemblySignature
-          let ctx = checkResults.ProjectContext
+    if publicOnly then
+      cachedPublicEntities.Force()
+    else
+      cachedFullEntities.Force()
 
-          let assembliesByFileName =
-            ctx.GetReferencedAssemblies()
-            |> List.groupBy (fun asm -> asm.FileName)
-            |> List.rev // if mscorlib.dll is the first then FSC raises exception when we try to
-          // get Content.Entities from it.
-
-          for fileName, signatures in assembliesByFileName do
-            let contentType =
-              if publicOnly then
-                AssemblyContentType.Public
-              else
-                AssemblyContentType.Full
-
-            let content =
-              AssemblyContent.GetAssemblyContent entityCache.Locking contentType fileName signatures
-
-            yield! content ]
-
-      res
-    with _ ->
-      []
+  member __.GetCrefResolver() = cachedCrefResolver.Force()
 
   member __.GetAllSymbolUsesInFile() = checkResults.GetAllUsesOfAllSymbolsInFile()
 

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -529,32 +529,33 @@ type ParseAndCheckResults
   member x.TryGetFormattedDocumentationForSymbol (xmlSig: string) (assembly: string) =
     let entities = x.GetAllEntities false
 
+    let matchesSymbol includeAssembly (symbol: FSharpSymbol) =
+      try
+        symbol.XmlDocSig = xmlSig
+        && (not includeAssembly || symbol.Assembly.SimpleName = assembly)
+      with _ ->
+        false
+
+    let matchesAbbreviatedEntity includeAssembly (symbol: FSharpSymbol) =
+      match symbol with
+      | FSharpEntity(_, abrvEnt, _) ->
+        try
+          abrvEnt.XmlDocSig = xmlSig
+          && (not includeAssembly || abrvEnt.Assembly.SimpleName = assembly)
+        with _ ->
+          false
+      | _ -> false
+
     let ent =
       entities
-      |> List.tryFind (fun e ->
-        let check = (e.Symbol.XmlDocSig = xmlSig && e.Symbol.Assembly.SimpleName = assembly)
-
-        if not check then
-          match e.Symbol with
-          | FSharpEntity(_, abrvEnt, _) -> abrvEnt.XmlDocSig = xmlSig && abrvEnt.Assembly.SimpleName = assembly
-          | _ -> false
-        else
-          true)
+      |> List.tryFind (fun e -> matchesSymbol true e.Symbol || matchesAbbreviatedEntity true e.Symbol)
 
     let ent =
       match ent with
       | Some ent -> Some ent
       | None ->
         entities
-        |> List.tryFind (fun e ->
-          let check = (e.Symbol.XmlDocSig = xmlSig)
-
-          if not check then
-            match e.Symbol with
-            | FSharpEntity(_, abrvEnt, _) -> abrvEnt.XmlDocSig = xmlSig
-            | _ -> false
-          else
-            true)
+        |> List.tryFind (fun e -> matchesSymbol false e.Symbol || matchesAbbreviatedEntity false e.Symbol)
 
     let symbol =
       match ent with
@@ -564,13 +565,47 @@ type ParseAndCheckResults
         |> List.tryPick (fun e ->
           match e.Symbol with
           | FSharpEntity(ent, _, _) ->
-            match ent.MembersFunctionsAndValues |> Seq.tryFind (fun f -> f.XmlDocSig = xmlSig) with
-            | Some e -> Some(e :> FSharpSymbol)
+            match
+              ent.MembersFunctionsAndValues
+              |> Seq.tryPick (fun f ->
+                try
+                  if f.XmlDocSig = xmlSig then
+                    Some(f :> FSharpSymbol)
+                  else
+                    None
+                with _ ->
+                  None)
+            with
+            | Some e -> Some e
             | None ->
-              match ent.FSharpFields |> Seq.tryFind (fun f -> f.XmlDocSig = xmlSig) with
-              | Some e -> Some(e :> FSharpSymbol)
-              | None -> None
+              match
+                ent.FSharpFields
+                |> Seq.tryPick (fun f ->
+                  try
+                    if f.XmlDocSig = xmlSig then
+                      Some(f :> FSharpSymbol)
+                    else
+                      None
+                  with _ ->
+                    None)
+              with
+              | Some e -> Some e
+              | None ->
+                ent.UnionCases
+                |> Seq.tryPick (fun f ->
+                  try
+                    if f.XmlDocSig = xmlSig then
+                      Some(f :> FSharpSymbol)
+                    else
+                      None
+                  with _ ->
+                    None)
           | _ -> None)
+
+    let symbol =
+      match symbol with
+      | Some symbol when matchesSymbol false symbol -> Some symbol
+      | _ -> None
 
     match symbol with
     | None -> Error "No matching symbol information"

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fsi
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fsi
@@ -85,6 +85,7 @@ type ParseAndCheckResults =
       Async<(DeclarationListItem array * string * bool) option>
 
   member GetAllEntities: publicOnly: bool -> AssemblySymbol list
+  member GetCrefResolver: unit -> (string -> (string * string * string) option)
   member GetAllSymbolUsesInFile: unit -> seq<FSharpSymbolUse>
   member GetSemanticClassification: SemanticClassificationItem array
   member GetAST: ParsedInput

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fsi
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fsi
@@ -103,6 +103,7 @@ type ParseAndCheckResults =
       Async<(DeclarationListItem array * string * bool) option>
 
   member GetAllEntities: publicOnly: bool -> AssemblySymbol list
+  member GetCrefResolver: unit -> (string -> (string * string * string) option)
   member GetAllSymbolUsesInFile: unit -> seq<FSharpSymbolUse>
   member GetSemanticClassification: SemanticClassificationItem array
   member GetAST: ParsedInput

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -18,6 +18,247 @@ let inline nl<'T> = Environment.NewLine
 
 let logger = LogProvider.getLoggerByName "TipFormatter"
 
+type private CrefCandidateKind =
+  | Type
+  | Method
+  | Property
+  | Field
+  | UnionCase
+
+type private CrefCandidate =
+  { XmlDocSig: string
+    AssemblyName: string
+    DisplayName: string
+    FullName: string option
+    GenericArity: int option
+    Kind: CrefCandidateKind }
+
+let private stripGenericArity (name: string) =
+  let idx = name.LastIndexOf('`')
+
+  if idx > 0 then
+    name.Substring(0, idx)
+  else
+    name
+
+let private tryGetGenericArity (name: string) =
+  let idx = name.LastIndexOf('`')
+
+  if idx > 0 && idx < name.Length - 1 then
+    match Int32.TryParse(name.Substring(idx + 1)) with
+    | true, value -> Some value
+    | _ -> None
+  else
+    None
+
+let private getCrefKindAndTarget (cref: string) =
+  let separatorIndex = cref.IndexOf(':')
+
+  if separatorIndex > 0 && separatorIndex < cref.Length - 1 then
+    Some(cref.Substring(0, separatorIndex)), cref.Substring(separatorIndex + 1)
+  else
+    None, cref
+
+let private lastQualifiedSegment (name: string) =
+  let separatorIndex = name.LastIndexOfAny([| '.'; '+' |])
+
+  if separatorIndex >= 0 && separatorIndex < name.Length - 1 then
+    name.Substring(separatorIndex + 1)
+  else
+    name
+
+let private renderDocumentationCommandLink (text: string) (xmlDocSig: string) (assemblyName: string) =
+  let content =
+    Uri.EscapeDataString(sprintf """[{ "XmlDocSig": "%s", "AssemblyName": "%s" }]""" xmlDocSig assemblyName)
+
+  let encodedText = System.Security.SecurityElement.Escape text
+  $"<a href='command:fsharp.showDocumentation?%s{content}'><code>%s{encodedText}</code></a>"
+
+let createCrefResolver (symbols: AssemblySymbol list) =
+  let addCandidate kind xmlDocSig assemblyName displayName fullName genericArity acc =
+    if
+      String.IsNullOrWhiteSpace xmlDocSig
+      || String.IsNullOrWhiteSpace assemblyName
+      || String.IsNullOrWhiteSpace displayName
+    then
+      acc
+    else
+      { XmlDocSig = xmlDocSig
+        AssemblyName = assemblyName
+        DisplayName = displayName
+        FullName = fullName
+        GenericArity = genericArity
+        Kind = kind }
+      :: acc
+
+  let tryAddCandidate kind getCandidate acc =
+    try
+      let xmlDocSig, assemblyName, displayName, fullName, genericArity = getCandidate ()
+      addCandidate kind xmlDocSig assemblyName displayName fullName genericArity acc
+    with _ ->
+      acc
+
+  let candidates =
+    (([], symbols)
+     ||> List.fold (fun acc assemblySymbol ->
+       match assemblySymbol.Symbol with
+       | FSharpEntity(entity, abbreviatedEntity, _) ->
+         let acc =
+           addCandidate
+             Type
+             entity.XmlDocSig
+             entity.Assembly.SimpleName
+             entity.DisplayName
+             entity.TryFullName
+             (Some entity.GenericParameters.Count)
+             acc
+
+         let acc =
+           if abbreviatedEntity.XmlDocSig <> entity.XmlDocSig then
+             addCandidate
+               Type
+               abbreviatedEntity.XmlDocSig
+               abbreviatedEntity.Assembly.SimpleName
+               abbreviatedEntity.DisplayName
+               abbreviatedEntity.TryFullName
+               (Some abbreviatedEntity.GenericParameters.Count)
+               acc
+           else
+             acc
+
+         let acc =
+          ((acc, entity.MembersFunctionsAndValues)
+           ||> Seq.fold (fun acc memberOrFunction ->
+             let kind =
+               if
+                 memberOrFunction.IsProperty
+                 || memberOrFunction.IsPropertyGetterMethod
+                 || memberOrFunction.IsPropertySetterMethod
+               then
+                 Property
+               else
+                 Method
+
+             tryAddCandidate
+               kind
+               (fun () ->
+                 memberOrFunction.XmlDocSig,
+                 memberOrFunction.Assembly.SimpleName,
+                 memberOrFunction.DisplayName,
+                 Some memberOrFunction.FullName,
+                 None)
+               acc))
+
+         let acc =
+          ((acc, entity.FSharpFields)
+           ||> Seq.fold (fun acc field ->
+             tryAddCandidate
+               Field
+               (fun () ->
+                 field.XmlDocSig,
+                 field.Assembly.SimpleName,
+                 field.DisplayName,
+                 Some field.FullName,
+                 None)
+               acc))
+
+         ((acc, entity.UnionCases)
+          ||> Seq.fold (fun acc unionCase ->
+            tryAddCandidate
+              UnionCase
+              (fun () ->
+                unionCase.XmlDocSig,
+                unionCase.Assembly.SimpleName,
+                unionCase.DisplayName,
+                Some unionCase.FullName,
+                None)
+              acc))
+       | _ -> acc))
+    |> List.rev
+
+  let distinctCandidates =
+    candidates
+    |> List.distinctBy (fun candidate -> candidate.XmlDocSig, candidate.AssemblyName)
+
+  let expectedKinds kind =
+    match kind with
+    | Some "T" -> Set.singleton Type
+    | Some "M" -> Set.singleton Method
+    | Some "P" -> Set.singleton Property
+    | Some "F" -> Set.singleton Field
+    | Some "U" -> Set.singleton UnionCase
+    | _ -> Set.empty
+
+  let tryResolveExactXmlDocSig cref =
+    distinctCandidates
+    |> List.filter (fun candidate -> candidate.XmlDocSig = cref)
+    |> function
+      | [ candidate ] -> Some(candidate.XmlDocSig, candidate.AssemblyName, candidate.DisplayName)
+      | _ -> None
+
+  let tryResolveHeuristically cref =
+    let kind, target = getCrefKindAndTarget cref
+    let targetSimpleName = target |> lastQualifiedSegment
+    let targetDisplayName = targetSimpleName |> stripGenericArity
+    let targetGenericArity = targetSimpleName |> tryGetGenericArity
+    let allowedKinds = expectedKinds kind
+
+    let scoreCandidate (candidate: CrefCandidate) =
+      let kindScore =
+        if allowedKinds.IsEmpty || allowedKinds.Contains candidate.Kind then
+          0
+        else
+          -100
+
+      let fullNameScore =
+        candidate.FullName
+        |> Option.map (fun fullName ->
+          if String.Equals(fullName, target, StringComparison.Ordinal) then
+            50
+          elif
+            fullName.EndsWith("." + target, StringComparison.Ordinal)
+            || fullName.EndsWith("+" + target, StringComparison.Ordinal)
+          then
+            40
+          else
+            0)
+        |> Option.defaultValue 0
+
+      let displayNameScore =
+        let arityScore =
+          match targetGenericArity, candidate.GenericArity with
+          | Some expected, Some actual when expected = actual -> 5
+          | Some _, Some _ -> -50
+          | _ -> 0
+
+        if String.Equals(candidate.DisplayName, targetDisplayName, StringComparison.Ordinal) then
+          30 + arityScore
+        elif String.Equals(stripGenericArity candidate.DisplayName, targetDisplayName, StringComparison.Ordinal) then
+          20 + arityScore
+        else
+          0
+
+      kindScore + fullNameScore + displayNameScore
+
+    let bestScore =
+      distinctCandidates
+      |> List.map scoreCandidate
+      |> List.filter (fun score -> score > 0)
+      |> List.sortDescending
+      |> List.tryHead
+
+    bestScore
+    |> Option.bind (fun score ->
+      distinctCandidates
+      |> List.filter (fun candidate -> scoreCandidate candidate = score)
+      |> function
+        | [ candidate ] -> Some(candidate.XmlDocSig, candidate.AssemblyName, candidate.DisplayName)
+        | _ -> None)
+
+  fun cref ->
+    tryResolveExactXmlDocSig cref
+    |> Option.orElseWith (fun () -> tryResolveHeuristically cref)
+
 module private Section =
 
   let inline addSection (name: string) (content: string) =
@@ -102,6 +343,26 @@ module private Format =
   let private href: AttrLookup = Map.tryFind "href"
   let private lang: AttrLookup = Map.tryFind "lang"
   let private name: AttrLookup = Map.tryFind "name"
+
+  let tryResolveCrefLink
+    (showDocumentationLinks: bool)
+    (tryResolveCref: string -> (string * string * string) option)
+    (crefValue: string)
+    (linkText: string option)
+    =
+    if showDocumentationLinks then
+      match tryResolveCref crefValue with
+      | Some(xmlDocSig, assemblyName, displayName) ->
+        let text =
+          match linkText with
+          | Some text when not (String.IsNullOrWhiteSpace text) -> text
+          | _ when not (String.IsNullOrWhiteSpace displayName) -> displayName
+          | _ -> extractMemberText crefValue
+
+        renderDocumentationCommandLink text xmlDocSig assemblyName |> Some
+      | None -> None
+    else
+      None
 
   let rec private applyFormatter (info: FormatterInfo) text =
     let pattern = tagPattern info.TagName
@@ -256,12 +517,15 @@ module private Format =
         | NonVoidElement(innerText, _) -> nl + innerText + nl |> Some }
     |> applyFormatter
 
-  let private see =
+  let private see (showDocumentationLinks: bool) (tryResolveCref: string -> (string * string * string) option) =
     let formatFromAttributes (attrs: Map<string, string>) =
       match cref attrs with
-      // crefs can have backticks in them, which mess with formatting.
-      // for safety we can just double-backtick and markdown is ok with that.
-      | Some cref -> Some $"``{extractMemberText cref}``"
+      | Some cref ->
+        match tryResolveCrefLink showDocumentationLinks tryResolveCref cref None with
+        | Some link -> Some link
+        // crefs can have backticks in them, which mess with formatting.
+        // for safety we can just double-backtick and markdown is ok with that.
+        | None -> Some $"``{extractMemberText cref}``"
       | None ->
         match langword attrs with
         | Some langword -> Some(code langword)
@@ -275,9 +539,15 @@ module private Format =
           if String.IsNullOrWhiteSpace innerText then
             formatFromAttributes attributes
           else
-            match href attributes with
-            | Some externalUrl -> Some(link innerText externalUrl)
-            | None -> Some $"`{innerText}`" }
+            match cref attributes with
+            | Some cref ->
+              match tryResolveCrefLink showDocumentationLinks tryResolveCref cref (Some innerText) with
+              | Some link -> Some link
+              | None -> Some $"`{innerText}`"
+            | None ->
+              match href attributes with
+              | Some externalUrl -> Some(link innerText externalUrl)
+              | None -> Some $"`{innerText}`" }
     |> applyFormatter
 
   let private xref =
@@ -693,7 +963,11 @@ module private Format =
   let private unescapeSpecialCharacters (text: string) =
     text.Replace("&lt;", "<").Replace("&gt;", ">").Replace("&quot;", "\"").Replace("&apos;", "'").Replace("&amp;", "&")
 
-  let applyAll (text: string) =
+  let applyAll
+    (showDocumentationLinks: bool)
+    (tryResolveCref: string -> (string * string * string) option)
+    (text: string)
+    =
     text
     // Remove invalid syntax first
     // It's easier to identify invalid patterns when no transformation has been done yet
@@ -704,7 +978,7 @@ module private Format =
     |> block
     |> codeInline
     |> codeBlock
-    |> see
+    |> see showDocumentationLinks tryResolveCref
     |> xref
     |> paramRef
     |> typeParamRef
@@ -727,14 +1001,19 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
   /// References used to detect if we should remove meaningless spaces
   let tabsOffset = String.replicate (columnOffset + indentationSize) " "
 
-  let readContentForTooltip (node: XmlNode) =
+  let readContentForTooltip
+    (showDocumentationLinks: bool)
+    (tryResolveCref: string -> (string * string * string) option)
+    (node: XmlNode)
+    =
     match node with
     | null -> null
     | _ ->
       let content =
         // Normale the EOL
         // This make it easier to work with line splitting
-        node.InnerXml.Replace("\r\n", "\n") |> Format.applyAll
+        node.InnerXml.Replace("\r\n", "\n")
+        |> Format.applyAll showDocumentationLinks tryResolveCref
 
       content.Split('\n')
       |> Array.map (fun line ->
@@ -779,16 +1058,8 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
       |> List.contains node.ParentNode.Name
       |> not)
 
-  let readNamedContentAsKvPair (key, content) = KeyValuePair(key, readContentForTooltip content)
-
-  let summary = readContentForTooltip rawSummary
-
-  let parameters = rawParameters |> List.map readNamedContentAsKvPair
-  let remarks = rawRemarks |> Seq.map readContentForTooltip
-  let exceptions = rawExceptions |> List.map readNamedContentAsKvPair
-  let typeParams = rawTypeParams |> List.map readNamedContentAsKvPair
-  let examples = rawExamples |> Seq.map readContentForTooltip
-  let returns = rawReturns |> Option.map readContentForTooltip
+  let readNamedContentAsKvPair showDocumentationLinks tryResolveCref (key, content) =
+    KeyValuePair(key, readContentForTooltip showDocumentationLinks tryResolveCref content)
 
   /// The cref target of an <inheritdoc cref="..."/> element, if present.
   let inheritDocCref =
@@ -801,7 +1072,7 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
       else
         None)
 
-  let seeAlso =
+  let getSeeAlso showDocumentationLinks tryResolveCref =
     doc.DocumentElement.GetElementsByTagName "seealso"
     |> Seq.cast<XmlNode>
     |> Seq.choose (fun node ->
@@ -814,7 +1085,10 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
           Map.empty
 
       match Map.tryFind "cref" attrs with
-      | Some cref -> Some("* `" + Format.extractMemberText cref + "`")
+      | Some cref ->
+        match Format.tryResolveCrefLink showDocumentationLinks tryResolveCref cref None with
+        | Some link -> Some("* " + link)
+        | None -> Some("* `" + Format.extractMemberText cref + "`")
       | None ->
         match Map.tryFind "href" attrs with
         | Some href ->
@@ -830,6 +1104,10 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
           | None -> None)
 
   override x.ToString() =
+    let summary = readContentForTooltip false (fun _ -> None) rawSummary
+    let parameters = rawParameters |> List.map (readNamedContentAsKvPair false (fun _ -> None))
+    let exceptions = rawExceptions |> List.map (readNamedContentAsKvPair false (fun _ -> None))
+
     summary
     + nl
     + nl
@@ -848,6 +1126,8 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
             |> String.concat nl))
 
   member __.ToSummaryOnlyString() =
+    let summary = readContentForTooltip false (fun _ -> None) rawSummary
+
     // If we where unable to process the doc comment, then just output it as it is
     // For example, this cover the keywords' tooltips
     if String.IsNullOrEmpty summary then
@@ -855,12 +1135,23 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
     else
       "**Description**" + nl + nl + summary
 
-  member __.HasTruncatedExamples = examples |> Seq.isEmpty |> not
+  member __.HasTruncatedExamples = rawExamples |> Seq.isEmpty |> not
 
   /// Returns the cref value of an <inheritdoc cref="..."/> element, if present in this doc member.
   member __.InheritDocCref = inheritDocCref
 
-  member __.ToFullEnhancedString() =
+  member __.ToFullEnhancedString
+    (showDocumentationLinks: bool)
+    (tryResolveCref: string -> (string * string * string) option)
+    =
+    let summary = readContentForTooltip showDocumentationLinks tryResolveCref rawSummary
+    let parameters = rawParameters |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
+    let remarks = rawRemarks |> Seq.map (readContentForTooltip showDocumentationLinks tryResolveCref)
+    let exceptions = rawExceptions |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
+    let typeParams = rawTypeParams |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
+    let returns = rawReturns |> Option.map (readContentForTooltip showDocumentationLinks tryResolveCref)
+    let seeAlso = getSeeAlso showDocumentationLinks tryResolveCref
+
     let content =
       summary
       + Section.fromList "Remarks" remarks
@@ -877,7 +1168,19 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
     else
       "**Description**" + nl + nl + content
 
-  member __.ToDocumentationString() =
+  member __.ToDocumentationString
+    (showDocumentationLinks: bool)
+    (tryResolveCref: string -> (string * string * string) option)
+    =
+    let summary = readContentForTooltip showDocumentationLinks tryResolveCref rawSummary
+    let remarks = rawRemarks |> Seq.map (readContentForTooltip showDocumentationLinks tryResolveCref)
+    let typeParams = rawTypeParams |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
+    let parameters = rawParameters |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
+    let returns = rawReturns |> Option.map (readContentForTooltip showDocumentationLinks tryResolveCref)
+    let exceptions = rawExceptions |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
+    let examples = rawExamples |> Seq.map (readContentForTooltip showDocumentationLinks tryResolveCref)
+    let seeAlso = getSeeAlso showDocumentationLinks tryResolveCref
+
     "**Description**"
     + nl
     + nl
@@ -890,12 +1193,16 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
     + Section.fromList "Examples" examples
     + Section.fromList "See also" seeAlso
 
-  member this.FormatComment(formatStyle: FormatCommentStyle) =
+  member this.FormatComment
+    (formatStyle: FormatCommentStyle)
+    (showDocumentationLinks: bool)
+    (tryResolveCref: string -> (string * string * string) option)
+    =
     match formatStyle with
     | FormatCommentStyle.Legacy -> this.ToString()
     | FormatCommentStyle.SummaryOnly -> this.ToSummaryOnlyString()
-    | FormatCommentStyle.FullEnhanced -> this.ToFullEnhancedString()
-    | FormatCommentStyle.Documentation -> this.ToDocumentationString()
+    | FormatCommentStyle.FullEnhanced -> this.ToFullEnhancedString showDocumentationLinks tryResolveCref
+    | FormatCommentStyle.Documentation -> this.ToDocumentationString showDocumentationLinks tryResolveCref
 
 
 let rec private readXmlDoc (reader: XmlReader) (indentationSize: int) (acc: Map<string, XmlDocMember>) =
@@ -1165,7 +1472,7 @@ let formatCompletionItemTip (ToolTipText tips) : (string * string) =
 
         let body =
           match tryGetXmlDocMember tipElement.XmlDoc with
-          | TryGetXmlDocMemberResult.Some xmlDoc -> xmlDoc.FormatComment(FormatCommentStyle.Legacy)
+          | TryGetXmlDocMemberResult.Some xmlDoc -> xmlDoc.FormatComment FormatCommentStyle.Legacy false (fun _ -> None)
           | TryGetXmlDocMemberResult.None -> ""
           | TryGetXmlDocMemberResult.Error -> ERROR_WHILE_PARSING_DOC_COMMENT
 
@@ -1187,7 +1494,7 @@ let formatPlainTip (ToolTipText tips) : (string * string) =
 
       let description =
         match tryGetXmlDocMember t.XmlDoc with
-        | TryGetXmlDocMemberResult.Some xmlDoc -> xmlDoc.FormatComment(FormatCommentStyle.Legacy)
+        | TryGetXmlDocMemberResult.Some xmlDoc -> xmlDoc.FormatComment FormatCommentStyle.Legacy false (fun _ -> None)
         | TryGetXmlDocMemberResult.None -> ""
         | TryGetXmlDocMemberResult.Error -> ERROR_WHILE_PARSING_DOC_COMMENT
 
@@ -1235,7 +1542,12 @@ let prepareFooterLines (footerText: string) =
   |> Array.map (fun n -> "*" + n + "*")
 
 
-let private tryComputeTooltipInfo (ToolTipText tips) (formatCommentStyle: FormatCommentStyle) =
+let private tryComputeTooltipInfo
+  (ToolTipText tips)
+  (formatCommentStyle: FormatCommentStyle)
+  (showDocumentationLinks: bool)
+  (tryResolveCref: string -> (string * string * string) option)
+  =
 
   // Note: In the previous code, we were returning a `(string * string * string) list list`
   // but always discarding the tooltip later if the list had more than one element
@@ -1270,7 +1582,7 @@ let private tryComputeTooltipInfo (ToolTipText tips) (formatCommentStyle: Format
         match tryGetXmlDocMember tooltipData.XmlDoc with
         | TryGetXmlDocMemberResult.Some xmlDoc ->
           // Format the doc comment
-          let docCommentText = xmlDoc.FormatComment formatCommentStyle
+          let docCommentText = xmlDoc.FormatComment formatCommentStyle showDocumentationLinks tryResolveCref
 
           // Concatenate the doc comment and the generic parameters section
           let consolidatedDocCommentText =
@@ -1305,6 +1617,8 @@ let private tryComputeTooltipInfo (ToolTipText tips) (formatCommentStyle: Format
 /// </summary>
 /// <param name="toolTipText">Tooltip documentation to render in the middle</param>
 /// <param name="formatCommentStyle">Style of tooltip</param>
+/// <param name="showDocumentationLinks">Whether resolved cref targets should be rendered as documentation command links.</param>
+/// <param name="tryResolveCref">Resolves a cref string to XmlDocSig, assembly name, and display name.</param>
 /// <returns>
 /// - <c>TipFormatterResult.Success {| DocComment; HasTruncatedExamples |}</c> if the doc comment has been formatted
 ///
@@ -1313,9 +1627,14 @@ let private tryComputeTooltipInfo (ToolTipText tips) (formatCommentStyle: Format
 /// - <c>TipFormatterResult.None</c> if the doc comment has not been found
 /// - <c>TipFormatterResult.Error string</c> if an error occurred while parsing the doc comment
 /// </returns>
-let tryFormatTipEnhanced toolTipText (formatCommentStyle: FormatCommentStyle) =
+let tryFormatTipEnhanced
+  toolTipText
+  (formatCommentStyle: FormatCommentStyle)
+  (showDocumentationLinks: bool)
+  (tryResolveCref: string -> (string * string * string) option)
+  =
 
-  match tryComputeTooltipInfo toolTipText formatCommentStyle with
+  match tryComputeTooltipInfo toolTipText formatCommentStyle showDocumentationLinks tryResolveCref with
   | Some(Ok tooltipResult) -> TipFormatterResult.Success tooltipResult
 
   | Some(Error error) -> TipFormatterResult.Error error
@@ -1350,14 +1669,20 @@ let renderShowDocumentationLink (hasTruncatedExamples: bool) (xmlDocSig: string)
 /// Try format the given tooltip as documentation.
 /// </summary>
 /// <param name="toolTipText">Tooltip to format</param>
+/// <param name="showDocumentationLinks">Whether resolved cref targets should be rendered as documentation command links.</param>
+/// <param name="tryResolveCref">Resolves a cref string to XmlDocSig, assembly name, and display name.</param>
 /// <returns>
 /// - <c>TipFormatterResult.Success string</c> if the doc comment has been formatted
 /// - <c>TipFormatterResult.None</c> if the doc comment has not been found
 /// - <c>TipFormatterResult.Error string</c> if an error occurred while parsing the doc comment
 /// </returns>
-let tryFormatDocumentationFromTooltip toolTipText =
+let tryFormatDocumentationFromTooltip
+  toolTipText
+  (showDocumentationLinks: bool)
+  (tryResolveCref: string -> (string * string * string) option)
+  =
 
-  match tryComputeTooltipInfo toolTipText FormatCommentStyle.Documentation with
+  match tryComputeTooltipInfo toolTipText FormatCommentStyle.Documentation showDocumentationLinks tryResolveCref with
   | Some(Ok tooltipResult) -> TipFormatterResult.Success tooltipResult.DocComment
 
   | Some(Error error) -> TipFormatterResult.Error error
@@ -1377,27 +1702,38 @@ let tryFormatDocumentationFromTooltip toolTipText =
 ///
 /// Example: <c>FSharp.Core</c>
 /// </param>
+/// <param name="showDocumentationLinks">Whether resolved cref targets should be rendered as documentation command links.</param>
+/// <param name="tryResolveCref">Resolves a cref string to XmlDocSig, assembly name, and display name.</param>
 /// <returns>
 /// - <c>TipFormatterResult.Success string</c> if the doc comment has been formatted
 /// - <c>TipFormatterResult.None</c> if the doc comment has not been found
 /// - <c>TipFormatterResult.Error string</c> if an error occurred while parsing the doc comment
 /// </returns>
-let tryFormatDocumentationFromXmlSig (xmlSig: string) (assembly: string) =
+let tryFormatDocumentationFromXmlSig
+  (xmlSig: string)
+  (assembly: string)
+  (showDocumentationLinks: bool)
+  (tryResolveCref: string -> (string * string * string) option)
+  =
   let xmlDoc = FSharpXmlDoc.FromXmlFile(assembly, xmlSig)
 
   match tryGetXmlDocMember xmlDoc with
   | TryGetXmlDocMemberResult.Some xmlDoc ->
-    let formattedComment = xmlDoc.FormatComment(FormatCommentStyle.Documentation)
+    let formattedComment = xmlDoc.FormatComment FormatCommentStyle.Documentation showDocumentationLinks tryResolveCref
 
     TipFormatterResult.Success formattedComment
 
   | TryGetXmlDocMemberResult.None -> TipFormatterResult.None
   | TryGetXmlDocMemberResult.Error -> TipFormatterResult.Error ERROR_WHILE_PARSING_DOC_COMMENT
 
-let formatDocumentationFromXmlDoc xmlDoc =
+let formatDocumentationFromXmlDoc
+  xmlDoc
+  (showDocumentationLinks: bool)
+  (tryResolveCref: string -> (string * string * string) option)
+  =
   match tryGetXmlDocMember xmlDoc with
   | TryGetXmlDocMemberResult.Some xmlDoc ->
-    let formattedComment = xmlDoc.FormatComment(FormatCommentStyle.Documentation)
+    let formattedComment = xmlDoc.FormatComment FormatCommentStyle.Documentation showDocumentationLinks tryResolveCref
 
     TipFormatterResult.Success formattedComment
 

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -69,7 +69,7 @@ let private renderDocumentationCommandLink (text: string) (xmlDocSig: string) (a
     Uri.EscapeDataString(sprintf """[{ "XmlDocSig": "%s", "AssemblyName": "%s" }]""" xmlDocSig assemblyName)
 
   let encodedText = System.Security.SecurityElement.Escape text
-  $"<a href='command:fsharp.showDocumentation?%s{content}'><code>%s{encodedText}</code></a>"
+  $"<a href='command:fsharp.showDocumentation?%s{content}'>%s{encodedText}</a>"
 
 let createCrefResolver (symbols: AssemblySymbol list) =
   let addCandidate kind xmlDocSig assemblyName displayName fullName genericArity acc =

--- a/src/FsAutoComplete.Core/TipFormatter.fs
+++ b/src/FsAutoComplete.Core/TipFormatter.fs
@@ -36,10 +36,7 @@ type private CrefCandidate =
 let private stripGenericArity (name: string) =
   let idx = name.LastIndexOf('`')
 
-  if idx > 0 then
-    name.Substring(0, idx)
-  else
-    name
+  if idx > 0 then name.Substring(0, idx) else name
 
 let private tryGetGenericArity (name: string) =
   let idx = name.LastIndexOf('`')
@@ -127,40 +124,35 @@ let createCrefResolver (symbols: AssemblySymbol list) =
              acc
 
          let acc =
-          ((acc, entity.MembersFunctionsAndValues)
-           ||> Seq.fold (fun acc memberOrFunction ->
-             let kind =
-               if
-                 memberOrFunction.IsProperty
-                 || memberOrFunction.IsPropertyGetterMethod
-                 || memberOrFunction.IsPropertySetterMethod
-               then
-                 Property
-               else
-                 Method
+           ((acc, entity.MembersFunctionsAndValues)
+            ||> Seq.fold (fun acc memberOrFunction ->
+              let kind =
+                if
+                  memberOrFunction.IsProperty
+                  || memberOrFunction.IsPropertyGetterMethod
+                  || memberOrFunction.IsPropertySetterMethod
+                then
+                  Property
+                else
+                  Method
 
-             tryAddCandidate
-               kind
-               (fun () ->
-                 memberOrFunction.XmlDocSig,
-                 memberOrFunction.Assembly.SimpleName,
-                 memberOrFunction.DisplayName,
-                 Some memberOrFunction.FullName,
-                 None)
-               acc))
+              tryAddCandidate
+                kind
+                (fun () ->
+                  memberOrFunction.XmlDocSig,
+                  memberOrFunction.Assembly.SimpleName,
+                  memberOrFunction.DisplayName,
+                  Some memberOrFunction.FullName,
+                  None)
+                acc))
 
          let acc =
-          ((acc, entity.FSharpFields)
-           ||> Seq.fold (fun acc field ->
-             tryAddCandidate
-               Field
-               (fun () ->
-                 field.XmlDocSig,
-                 field.Assembly.SimpleName,
-                 field.DisplayName,
-                 Some field.FullName,
-                 None)
-               acc))
+           ((acc, entity.FSharpFields)
+            ||> Seq.fold (fun acc field ->
+              tryAddCandidate
+                Field
+                (fun () -> field.XmlDocSig, field.Assembly.SimpleName, field.DisplayName, Some field.FullName, None)
+                acc))
 
          ((acc, entity.UnionCases)
           ||> Seq.fold (fun acc unionCase ->
@@ -1105,8 +1097,12 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
 
   override x.ToString() =
     let summary = readContentForTooltip false (fun _ -> None) rawSummary
-    let parameters = rawParameters |> List.map (readNamedContentAsKvPair false (fun _ -> None))
-    let exceptions = rawExceptions |> List.map (readNamedContentAsKvPair false (fun _ -> None))
+
+    let parameters =
+      rawParameters |> List.map (readNamedContentAsKvPair false (fun _ -> None))
+
+    let exceptions =
+      rawExceptions |> List.map (readNamedContentAsKvPair false (fun _ -> None))
 
     summary
     + nl
@@ -1145,11 +1141,27 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
     (tryResolveCref: string -> (string * string * string) option)
     =
     let summary = readContentForTooltip showDocumentationLinks tryResolveCref rawSummary
-    let parameters = rawParameters |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
-    let remarks = rawRemarks |> Seq.map (readContentForTooltip showDocumentationLinks tryResolveCref)
-    let exceptions = rawExceptions |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
-    let typeParams = rawTypeParams |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
-    let returns = rawReturns |> Option.map (readContentForTooltip showDocumentationLinks tryResolveCref)
+
+    let parameters =
+      rawParameters
+      |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
+
+    let remarks =
+      rawRemarks
+      |> Seq.map (readContentForTooltip showDocumentationLinks tryResolveCref)
+
+    let exceptions =
+      rawExceptions
+      |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
+
+    let typeParams =
+      rawTypeParams
+      |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
+
+    let returns =
+      rawReturns
+      |> Option.map (readContentForTooltip showDocumentationLinks tryResolveCref)
+
     let seeAlso = getSeeAlso showDocumentationLinks tryResolveCref
 
     let content =
@@ -1173,12 +1185,31 @@ type private XmlDocMember(doc: XmlDocument, indentationSize: int, columnOffset: 
     (tryResolveCref: string -> (string * string * string) option)
     =
     let summary = readContentForTooltip showDocumentationLinks tryResolveCref rawSummary
-    let remarks = rawRemarks |> Seq.map (readContentForTooltip showDocumentationLinks tryResolveCref)
-    let typeParams = rawTypeParams |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
-    let parameters = rawParameters |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
-    let returns = rawReturns |> Option.map (readContentForTooltip showDocumentationLinks tryResolveCref)
-    let exceptions = rawExceptions |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
-    let examples = rawExamples |> Seq.map (readContentForTooltip showDocumentationLinks tryResolveCref)
+
+    let remarks =
+      rawRemarks
+      |> Seq.map (readContentForTooltip showDocumentationLinks tryResolveCref)
+
+    let typeParams =
+      rawTypeParams
+      |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
+
+    let parameters =
+      rawParameters
+      |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
+
+    let returns =
+      rawReturns
+      |> Option.map (readContentForTooltip showDocumentationLinks tryResolveCref)
+
+    let exceptions =
+      rawExceptions
+      |> List.map (readNamedContentAsKvPair showDocumentationLinks tryResolveCref)
+
+    let examples =
+      rawExamples
+      |> Seq.map (readContentForTooltip showDocumentationLinks tryResolveCref)
+
     let seeAlso = getSeeAlso showDocumentationLinks tryResolveCref
 
     "**Description**"
@@ -1582,7 +1613,8 @@ let private tryComputeTooltipInfo
         match tryGetXmlDocMember tooltipData.XmlDoc with
         | TryGetXmlDocMemberResult.Some xmlDoc ->
           // Format the doc comment
-          let docCommentText = xmlDoc.FormatComment formatCommentStyle showDocumentationLinks tryResolveCref
+          let docCommentText =
+            xmlDoc.FormatComment formatCommentStyle showDocumentationLinks tryResolveCref
 
           // Concatenate the doc comment and the generic parameters section
           let consolidatedDocCommentText =
@@ -1719,7 +1751,8 @@ let tryFormatDocumentationFromXmlSig
 
   match tryGetXmlDocMember xmlDoc with
   | TryGetXmlDocMemberResult.Some xmlDoc ->
-    let formattedComment = xmlDoc.FormatComment FormatCommentStyle.Documentation showDocumentationLinks tryResolveCref
+    let formattedComment =
+      xmlDoc.FormatComment FormatCommentStyle.Documentation showDocumentationLinks tryResolveCref
 
     TipFormatterResult.Success formattedComment
 
@@ -1733,7 +1766,8 @@ let formatDocumentationFromXmlDoc
   =
   match tryGetXmlDocMember xmlDoc with
   | TryGetXmlDocMemberResult.Some xmlDoc ->
-    let formattedComment = xmlDoc.FormatComment FormatCommentStyle.Documentation showDocumentationLinks tryResolveCref
+    let formattedComment =
+      xmlDoc.FormatComment FormatCommentStyle.Documentation showDocumentationLinks tryResolveCref
 
     TipFormatterResult.Success formattedComment
 

--- a/src/FsAutoComplete.Core/TipFormatter.fsi
+++ b/src/FsAutoComplete.Core/TipFormatter.fsi
@@ -74,14 +74,13 @@ type private XmlDocMember =
   override ToString: unit -> string
   member ToSummaryOnlyString: unit -> string
   member HasTruncatedExamples: bool
+
   member ToFullEnhancedString:
-    showDocumentationLinks: bool ->
-    tryResolveCref: (string -> (string * string * string) option) ->
-      string
+    showDocumentationLinks: bool -> tryResolveCref: (string -> (string * string * string) option) -> string
+
   member ToDocumentationString:
-    showDocumentationLinks: bool ->
-    tryResolveCref: (string -> (string * string * string) option) ->
-      string
+    showDocumentationLinks: bool -> tryResolveCref: (string -> (string * string * string) option) -> string
+
   member FormatComment:
     formatStyle: FormatCommentStyle ->
     showDocumentationLinks: bool ->
@@ -149,6 +148,7 @@ val tryFormatTipEnhanced:
 /// <param name="assemblyName">Assembly name, example <c>FSharp.Core</c></param>
 /// <returns>Returns a string which represent the show documentation link</returns>
 val renderShowDocumentationLink: hasTruncatedExamples: bool -> xmlDocSig: string -> assemblyName: string -> string
+
 /// <summary>
 /// Try format the given tooltip as documentation.
 /// </summary>
@@ -165,6 +165,7 @@ val tryFormatDocumentationFromTooltip:
   showDocumentationLinks: bool ->
   tryResolveCref: (string -> (string * string * string) option) ->
     TipFormatterResult<string>
+
 /// <summary>
 /// Try format the doc comment based on the XmlSignature and the assembly name.
 /// </summary>
@@ -197,6 +198,7 @@ val formatDocumentationFromXmlDoc:
   showDocumentationLinks: bool ->
   tryResolveCref: (string -> (string * string * string) option) ->
     TipFormatterResult<string>
+
 val extractSignature: ToolTipText -> string
 /// extracts any generic parameters present in this tooltip, rendering them as plain text
 val extractGenericParameters: ToolTipText -> string list

--- a/src/FsAutoComplete.Core/TipFormatter.fsi
+++ b/src/FsAutoComplete.Core/TipFormatter.fsi
@@ -54,7 +54,11 @@ module private Format =
     /// A list where the items are a term followed by a definition (ie in markdown: * <TERM> - <DEFINITION>)
     | Definitions of Term * Definition
 
-  val applyAll: text: string -> string
+  val applyAll:
+    showDocumentationLinks: bool ->
+    tryResolveCref: (string -> (string * string * string) option) ->
+    text: string ->
+      string
 
 [<RequireQualifiedAccess; Struct>]
 type FormatCommentStyle =
@@ -63,14 +67,26 @@ type FormatCommentStyle =
   | SummaryOnly
   | Documentation
 
+val createCrefResolver: symbols: AssemblySymbol list -> (string -> (string * string * string) option)
+
 type private XmlDocMember =
   new: doc: XmlDocument * indentationSize: int * columnOffset: int -> XmlDocMember
   override ToString: unit -> string
   member ToSummaryOnlyString: unit -> string
   member HasTruncatedExamples: bool
-  member ToFullEnhancedString: unit -> string
-  member ToDocumentationString: unit -> string
-  member FormatComment: formatStyle: FormatCommentStyle -> string
+  member ToFullEnhancedString:
+    showDocumentationLinks: bool ->
+    tryResolveCref: (string -> (string * string * string) option) ->
+      string
+  member ToDocumentationString:
+    showDocumentationLinks: bool ->
+    tryResolveCref: (string -> (string * string * string) option) ->
+      string
+  member FormatComment:
+    formatStyle: FormatCommentStyle ->
+    showDocumentationLinks: bool ->
+    tryResolveCref: (string -> (string * string * string) option) ->
+      string
 
 [<RequireQualifiedAccess>]
 type private TryGetXmlDocMemberResult =
@@ -102,6 +118,8 @@ val cleanParameterDisplay: display: TaggedText[] -> string
 /// </summary>
 /// <param name="toolTipText">Tooltip documentation to render in the middle</param>
 /// <param name="formatCommentStyle">Style of tooltip</param>
+/// <param name="showDocumentationLinks">Whether resolved cref targets should be rendered as documentation command links.</param>
+/// <param name="tryResolveCref">Resolves a cref string to XmlDocSig, assembly name, and display name.</param>
 /// <returns>
 /// - <c>TipFormatterResult.Success {| DocComment; HasTruncatedExamples |}</c> if the doc comment has been formatted
 ///
@@ -113,6 +131,8 @@ val cleanParameterDisplay: display: TaggedText[] -> string
 val tryFormatTipEnhanced:
   toolTipText: ToolTipText ->
   formatCommentStyle: FormatCommentStyle ->
+  showDocumentationLinks: bool ->
+  tryResolveCref: (string -> (string * string * string) option) ->
     TipFormatterResult<
       {| DocComment: string
          HasTruncatedExamples: bool |}
@@ -133,12 +153,18 @@ val renderShowDocumentationLink: hasTruncatedExamples: bool -> xmlDocSig: string
 /// Try format the given tooltip as documentation.
 /// </summary>
 /// <param name="toolTipText">Tooltip to format</param>
+/// <param name="showDocumentationLinks">Whether resolved cref targets should be rendered as documentation command links.</param>
+/// <param name="tryResolveCref">Resolves a cref string to XmlDocSig, assembly name, and display name.</param>
 /// <returns>
 /// - <c>TipFormatterResult.Success string</c> if the doc comment has been formatted
 /// - <c>TipFormatterResult.None</c> if the doc comment has not been found
 /// - <c>TipFormatterResult.Error string</c> if an error occurred while parsing the doc comment
 /// </returns>
-val tryFormatDocumentationFromTooltip: toolTipText: ToolTipText -> TipFormatterResult<string>
+val tryFormatDocumentationFromTooltip:
+  toolTipText: ToolTipText ->
+  showDocumentationLinks: bool ->
+  tryResolveCref: (string -> (string * string * string) option) ->
+    TipFormatterResult<string>
 /// <summary>
 /// Try format the doc comment based on the XmlSignature and the assembly name.
 /// </summary>
@@ -152,13 +178,25 @@ val tryFormatDocumentationFromTooltip: toolTipText: ToolTipText -> TipFormatterR
 ///
 /// Example: <c>FSharp.Core</c>
 /// </param>
+/// <param name="showDocumentationLinks">Whether resolved cref targets should be rendered as documentation command links.</param>
+/// <param name="tryResolveCref">Resolves a cref string to XmlDocSig, assembly name, and display name.</param>
 /// <returns>
 /// - <c>TipFormatterResult.Success string</c> if the doc comment has been formatted
 /// - <c>TipFormatterResult.None</c> if the doc comment has not been found
 /// - <c>TipFormatterResult.Error string</c> if an error occurred while parsing the doc comment
 /// </returns>
-val tryFormatDocumentationFromXmlSig: xmlSig: string -> assembly: string -> TipFormatterResult<string>
-val formatDocumentationFromXmlDoc: xmlDoc: FSharpXmlDoc -> TipFormatterResult<string>
+val tryFormatDocumentationFromXmlSig:
+  xmlSig: string ->
+  assembly: string ->
+  showDocumentationLinks: bool ->
+  tryResolveCref: (string -> (string * string * string) option) ->
+    TipFormatterResult<string>
+
+val formatDocumentationFromXmlDoc:
+  xmlDoc: FSharpXmlDoc ->
+  showDocumentationLinks: bool ->
+  tryResolveCref: (string -> (string * string * string) option) ->
+    TipFormatterResult<string>
 val extractSignature: ToolTipText -> string
 /// extracts any generic parameters present in this tooltip, rendering them as plain text
 val extractGenericParameters: ToolTipText -> string list

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -568,6 +568,8 @@ module CommandResponse =
 
   let formattedDocumentation
     (serialize: Serializer)
+    (showDocumentationLinks: bool)
+    (tryResolveCref: string -> (string * string * string) option)
     (param:
       {| Tip: ToolTipText option
          XmlSig: (string * string) option
@@ -593,7 +595,7 @@ module CommandResponse =
     let data: DocumentationDescription =
       match param.Tip, param.XmlSig with
       | Some tip, _ ->
-        match TipFormatter.tryFormatDocumentationFromTooltip tip with
+        match TipFormatter.tryFormatDocumentationFromTooltip tip showDocumentationLinks tryResolveCref with
         | TipFormatter.TipFormatterResult.Success formattedDocComment ->
           createDocumentationDescription formattedDocComment
 
@@ -605,7 +607,9 @@ module CommandResponse =
         | TipFormatter.TipFormatterResult.Error error -> DocumentationDescription.CreateFromError error
 
       | _, Some(xml, assembly) ->
-        match TipFormatter.tryFormatDocumentationFromXmlSig xml assembly with
+        match
+          TipFormatter.tryFormatDocumentationFromXmlSig xml assembly showDocumentationLinks tryResolveCref
+        with
         | TipFormatter.TipFormatterResult.Success formattedDocComment ->
           createDocumentationDescription formattedDocComment
 
@@ -624,6 +628,8 @@ module CommandResponse =
 
   let formattedDocumentationForSymbol
     (serialize: Serializer)
+    (showDocumentationLinks: bool)
+    (tryResolveCref: string -> (string * string * string) option)
     (param:
       {| Xml: string
          Assembly: string
@@ -647,12 +653,18 @@ module CommandResponse =
         Comment = formattedDocComment }
 
     let data: DocumentationDescription =
-      match TipFormatter.tryFormatDocumentationFromXmlSig param.Xml param.Assembly with
+      match
+        TipFormatter.tryFormatDocumentationFromXmlSig
+          param.Xml
+          param.Assembly
+          showDocumentationLinks
+          tryResolveCref
+      with
       | TipFormatter.TipFormatterResult.Success formattedDocComment ->
         createDocumentationDescription formattedDocComment
 
       | TipFormatter.TipFormatterResult.None ->
-        match TipFormatter.formatDocumentationFromXmlDoc param.XmlDoc with
+        match TipFormatter.formatDocumentationFromXmlDoc param.XmlDoc showDocumentationLinks tryResolveCref with
         | TipFormatter.TipFormatterResult.Success formattedDocComment ->
           createDocumentationDescription formattedDocComment
 

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -1,6 +1,9 @@
 namespace FsAutoComplete
 
 open System
+open System.Text.RegularExpressions
+open Newtonsoft.Json
+open Newtonsoft.Json.Linq
 
 open FSharp.Compiler
 open Ionide.ProjInfo.ProjectSystem
@@ -97,6 +100,39 @@ module CommandResponse =
   open FSharp.Compiler.Text
 
   type ResponseMsg<'T> = { Kind: string; Data: 'T }
+
+  type DocumentationLinkContext =
+    { FileName: string
+      Line: int
+      Character: int }
+
+  let private documentationCommandPattern =
+    Regex(@"command:fsharp\.showDocumentation\?(?<payload>[^'""\)\s]+)", RegexOptions.Compiled)
+
+  let addDocumentationLinkContext (context: DocumentationLinkContext option) (content: string) =
+    match context with
+    | None -> content
+    | Some _ when String.IsNullOrWhiteSpace content -> content
+    | Some context ->
+      documentationCommandPattern.Replace(
+        content,
+        MatchEvaluator(fun m ->
+          try
+            let payload = m.Groups.["payload"].Value |> Uri.UnescapeDataString
+
+            let links = JArray.Parse payload
+
+            for link in links.Children<JObject>() do
+              link["FileName"] <- JValue(context.FileName)
+              link["Line"] <- JValue(context.Line)
+              link["Character"] <- JValue(context.Character)
+
+            let encodedPayload = links.ToString(Formatting.None) |> Uri.EscapeDataString
+
+            $"command:fsharp.showDocumentation?{encodedPayload}"
+          with _ ->
+            m.Value)
+      )
 
   type ResponseError<'T> =
     { Code: int
@@ -575,22 +611,24 @@ module CommandResponse =
          XmlSig: (string * string) option
          Signature: (string * DocumentationFormatter.EntityInfo)
          Footer: string
-         XmlKey: string |})
+         XmlKey: string
+         LinkContext: DocumentationLinkContext option |})
     =
 
     let (signature, entity) = param.Signature
+    let addContext = addDocumentationLinkContext param.LinkContext
 
     let createDocumentationDescription formattedDocComment =
       { XmlKey = param.XmlKey
-        Constructors = entity.Constructors
-        Fields = entity.Fields
-        Functions = entity.Functions
-        Interfaces = entity.Interfaces
-        Attributes = entity.Attributes
-        DeclaredTypes = entity.DeclaredTypes
-        FooterLines = TipFormatter.prepareFooterLines param.Footer
-        Signature = TipFormatter.prepareSignature signature
-        Comment = formattedDocComment }
+        Constructors = entity.Constructors |> Array.map addContext
+        Fields = entity.Fields |> Array.map addContext
+        Functions = entity.Functions |> Array.map addContext
+        Interfaces = entity.Interfaces |> Array.map addContext
+        Attributes = entity.Attributes |> Array.map addContext
+        DeclaredTypes = entity.DeclaredTypes |> Array.map addContext
+        FooterLines = TipFormatter.prepareFooterLines param.Footer |> Array.map addContext
+        Signature = TipFormatter.prepareSignature signature |> addContext
+        Comment = formattedDocComment |> addContext }
 
     let data: DocumentationDescription =
       match param.Tip, param.XmlSig with
@@ -634,21 +672,23 @@ module CommandResponse =
          XmlDoc: FSharpXmlDoc
          Signature: (string * DocumentationFormatter.EntityInfo)
          Footer: string
-         XmlKey: string |})
+         XmlKey: string
+         LinkContext: DocumentationLinkContext option |})
     =
     let (signature, entity) = param.Signature
+    let addContext = addDocumentationLinkContext param.LinkContext
 
     let createDocumentationDescription formattedDocComment =
       { XmlKey = param.XmlKey
-        Constructors = entity.Constructors
-        Fields = entity.Fields
-        Functions = entity.Functions
-        Interfaces = entity.Interfaces
-        Attributes = entity.Attributes
-        DeclaredTypes = entity.DeclaredTypes
-        FooterLines = TipFormatter.prepareFooterLines param.Footer
-        Signature = TipFormatter.prepareSignature signature
-        Comment = formattedDocComment }
+        Constructors = entity.Constructors |> Array.map addContext
+        Fields = entity.Fields |> Array.map addContext
+        Functions = entity.Functions |> Array.map addContext
+        Interfaces = entity.Interfaces |> Array.map addContext
+        Attributes = entity.Attributes |> Array.map addContext
+        DeclaredTypes = entity.DeclaredTypes |> Array.map addContext
+        FooterLines = TipFormatter.prepareFooterLines param.Footer |> Array.map addContext
+        Signature = TipFormatter.prepareSignature signature |> addContext
+        Comment = formattedDocComment |> addContext }
 
     let data: DocumentationDescription =
       match

--- a/src/FsAutoComplete/CommandResponse.fs
+++ b/src/FsAutoComplete/CommandResponse.fs
@@ -607,9 +607,7 @@ module CommandResponse =
         | TipFormatter.TipFormatterResult.Error error -> DocumentationDescription.CreateFromError error
 
       | _, Some(xml, assembly) ->
-        match
-          TipFormatter.tryFormatDocumentationFromXmlSig xml assembly showDocumentationLinks tryResolveCref
-        with
+        match TipFormatter.tryFormatDocumentationFromXmlSig xml assembly showDocumentationLinks tryResolveCref with
         | TipFormatter.TipFormatterResult.Success formattedDocComment ->
           createDocumentationDescription formattedDocComment
 
@@ -654,11 +652,7 @@ module CommandResponse =
 
     let data: DocumentationDescription =
       match
-        TipFormatter.tryFormatDocumentationFromXmlSig
-          param.Xml
-          param.Assembly
-          showDocumentationLinks
-          tryResolveCref
+        TipFormatter.tryFormatDocumentationFromXmlSig param.Xml param.Assembly showDocumentationLinks tryResolveCref
       with
       | TipFormatter.TipFormatterResult.Success formattedDocComment ->
         createDocumentationDescription formattedDocComment

--- a/src/FsAutoComplete/CommandResponse.fsi
+++ b/src/FsAutoComplete/CommandResponse.fsi
@@ -20,6 +20,13 @@ module CommandResponse =
   open FSharp.Compiler.Text
   type ResponseMsg<'T> = { Kind: string; Data: 'T }
 
+  type DocumentationLinkContext =
+    { FileName: string
+      Line: int
+      Character: int }
+
+  val addDocumentationLinkContext: context: DocumentationLinkContext option -> content: string -> string
+
   type ResponseError<'T> =
     { Code: int
       Message: string
@@ -236,7 +243,8 @@ module CommandResponse =
          XmlSig: (string * string) option
          Signature: (string * DocumentationFormatter.EntityInfo)
          Footer: string
-         XmlKey: string |} ->
+         XmlKey: string
+         LinkContext: DocumentationLinkContext option |} ->
       string
 
   val formattedDocumentationForSymbol:
@@ -249,7 +257,8 @@ module CommandResponse =
          XmlDoc: FSharpXmlDoc
          Signature: (string * DocumentationFormatter.EntityInfo)
          Footer: string
-         XmlKey: string |} ->
+         XmlKey: string
+         LinkContext: DocumentationLinkContext option |} ->
       string
 
   val typeSig: serialize: Serializer -> tip: ToolTipText -> string

--- a/src/FsAutoComplete/CommandResponse.fsi
+++ b/src/FsAutoComplete/CommandResponse.fsi
@@ -229,6 +229,8 @@ module CommandResponse =
 
   val formattedDocumentation:
     serialize: Serializer ->
+    showDocumentationLinks: bool ->
+    tryResolveCref: (string -> (string * string * string) option) ->
     param:
       {| Tip: ToolTipText option
          XmlSig: (string * string) option
@@ -239,6 +241,8 @@ module CommandResponse =
 
   val formattedDocumentationForSymbol:
     serialize: Serializer ->
+    showDocumentationLinks: bool ->
+    tryResolveCref: (string -> (string * string * string) option) ->
     param:
       {| Xml: string
          Assembly: string

--- a/src/FsAutoComplete/LspHelpers.fs
+++ b/src/FsAutoComplete/LspHelpers.fs
@@ -647,7 +647,12 @@ type WorkspacePeekRequest =
     Deep: int
     ExcludedDirs: string array }
 
-type DocumentationForSymbolRequest = { XmlSig: string; Assembly: string }
+type DocumentationForSymbolRequest =
+  { XmlSig: string
+    Assembly: string
+    FileName: string option
+    Line: int option
+    Character: int option }
 
 type HighlightingRequest =
   { TextDocument: TextDocumentIdentifier }

--- a/src/FsAutoComplete/LspHelpers.fsi
+++ b/src/FsAutoComplete/LspHelpers.fsi
@@ -231,7 +231,12 @@ type WorkspacePeekRequest =
     Deep: int
     ExcludedDirs: string array }
 
-type DocumentationForSymbolRequest = { XmlSig: string; Assembly: string }
+type DocumentationForSymbolRequest =
+  { XmlSig: string
+    Assembly: string
+    FileName: string option
+    Line: int option
+    Character: int option }
 
 type HighlightingRequest =
   { TextDocument: TextDocumentIdentifier }

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1124,6 +1124,12 @@ type AdaptiveFSharpLspServer
             let showExternalDocumentation = state.Config.TooltipShowDocumentationLink
             let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
 
+            let linkContext: CommandResponse.DocumentationLinkContext option =
+              Some
+                { FileName = filePath |> UMX.untag
+                  Line = int p.Position.Line
+                  Character = int p.Position.Character }
+
             match
               TipFormatter.tryFormatTipEnhanced
                 tooltipResult.ToolTipText
@@ -1132,6 +1138,9 @@ type AdaptiveFSharpLspServer
                 tryResolveCref
             with
             | TipFormatter.TipFormatterResult.Success tooltipInfo ->
+              let formattedDocComment =
+                tooltipInfo.DocComment
+                |> CommandResponse.addDocumentationLinkContext linkContext
 
               let response =
                 { Contents =
@@ -1141,7 +1150,7 @@ type AdaptiveFSharpLspServer
                          tooltipResult.Signature
                          |> TipFormatter.prepareSignature
                          |> (fun content -> U2.C2 { Language = "fsharp"; Value = content })
-                         U2.C1 tooltipInfo.DocComment
+                         U2.C1 formattedDocComment
                          match tooltipResult.SymbolInfo with
                          | TryGetToolTipEnhancedResult.Keyword _ -> ()
                          | TryGetToolTipEnhancedResult.Symbol symbolInfo when showExternalDocumentation ->
@@ -1149,6 +1158,7 @@ type AdaptiveFSharpLspServer
                              tooltipInfo.HasTruncatedExamples
                              symbolInfo.XmlDocSig
                              symbolInfo.Assembly
+                           |> CommandResponse.addDocumentationLinkContext linkContext
                            |> U2.C1
                          | TryGetToolTipEnhancedResult.Symbol _ -> ()
                          // Display each footer line as a separate line
@@ -3045,6 +3055,12 @@ type AdaptiveFSharpLspServer
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
           lastFSharpDocumentationTypeCheck <- Some tyRes
 
+          let linkContext: CommandResponse.DocumentationLinkContext option =
+            Some
+              { FileName = filePath |> UMX.untag
+                Line = int p.Position.Line
+                Character = int p.Position.Character }
+
           match! Commands.FormattedDocumentation tyRes pos lineStr |> Result.ofCoreResponse with
           | Some(tip, xml, signature, footer, xmlKey) ->
             let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
@@ -3060,7 +3076,8 @@ type AdaptiveFSharpLspServer
                          XmlSig = xml
                          Signature = signature
                          Footer = footer
-                         XmlKey = xmlKey |} }
+                         XmlKey = xmlKey
+                         LinkContext = linkContext |} }
           | None -> return None
         with e ->
           trace |> Tracing.recordException e
@@ -3084,9 +3101,27 @@ type AdaptiveFSharpLspServer
           )
 
           let! tyRes =
-            lastFSharpDocumentationTypeCheck
-            |> Result.ofOption (fun () -> $"No typecheck results from FSharpDocumentation")
-            |> Result.ofStringErr
+            asyncResult {
+              match p.FileName with
+              | Some fileName ->
+                return!
+                  state.GetOpenFileTypeCheckResults(Utils.normalizePath fileName)
+                  |> AsyncResult.ofStringErr
+              | None ->
+                return!
+                  lastFSharpDocumentationTypeCheck
+                  |> Result.ofOption (fun () -> $"No typecheck results from FSharpDocumentation")
+                  |> Result.ofStringErr
+            }
+
+          let linkContext: CommandResponse.DocumentationLinkContext option =
+            match p.FileName, p.Line, p.Character with
+            | Some fileName, Some line, Some character ->
+              Some
+                { FileName = fileName |> Utils.normalizePath |> UMX.untag
+                  Line = line
+                  Character = character }
+            | _ -> None
 
           match!
             Commands.FormattedDocumentationForSymbol tyRes p.XmlSig p.Assembly
@@ -3107,7 +3142,8 @@ type AdaptiveFSharpLspServer
                        XmlDoc = xmlDoc
                        Signature = signature
                        Footer = footer
-                       XmlKey = xmlKey |} }
+                       XmlKey = xmlKey
+                       LinkContext = linkContext |} }
               |> Some
         with e ->
           trace |> Tracing.recordException e

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1122,7 +1122,7 @@ type AdaptiveFSharpLspServer
                 TipFormatter.FormatCommentStyle.Legacy
 
             let showExternalDocumentation = state.Config.TooltipShowDocumentationLink
-            let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
+            let tryResolveCref = tyRes.GetCrefResolver()
 
             let linkContext: CommandResponse.DocumentationLinkContext option =
               Some
@@ -3063,7 +3063,7 @@ type AdaptiveFSharpLspServer
 
           match! Commands.FormattedDocumentation tyRes pos lineStr |> Result.ofCoreResponse with
           | Some(tip, xml, signature, footer, xmlKey) ->
-            let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
+            let tryResolveCref = tyRes.GetCrefResolver()
 
             return
               Some
@@ -3129,7 +3129,7 @@ type AdaptiveFSharpLspServer
           with
           | None -> return None
           | Some(xml, assembly, xmlDoc, signature, footer, xmlKey) ->
-            let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
+            let tryResolveCref = tyRes.GetCrefResolver()
 
             return
               { Content =

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1122,8 +1122,15 @@ type AdaptiveFSharpLspServer
                 TipFormatter.FormatCommentStyle.Legacy
 
             let showExternalDocumentation = state.Config.TooltipShowDocumentationLink
+            let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
 
-            match TipFormatter.tryFormatTipEnhanced tooltipResult.ToolTipText formatCommentStyle with
+            match
+              TipFormatter.tryFormatTipEnhanced
+                tooltipResult.ToolTipText
+                formatCommentStyle
+                showExternalDocumentation
+                tryResolveCref
+            with
             | TipFormatter.TipFormatterResult.Success tooltipInfo ->
 
               let response =
@@ -3040,11 +3047,15 @@ type AdaptiveFSharpLspServer
 
           match! Commands.FormattedDocumentation tyRes pos lineStr |> Result.ofCoreResponse with
           | Some(tip, xml, signature, footer, xmlKey) ->
+            let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
+
             return
               Some
                 { Content =
                     CommandResponse.formattedDocumentation
                       JsonSerializer.writeJson
+                      state.Config.TooltipShowDocumentationLink
+                      tryResolveCref
                       {| Tip = tip
                          XmlSig = xml
                          Signature = signature
@@ -3083,11 +3094,14 @@ type AdaptiveFSharpLspServer
           with
           | None -> return None
           | Some(xml, assembly, xmlDoc, signature, footer, xmlKey) ->
+            let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
 
             return
               { Content =
                   CommandResponse.formattedDocumentationForSymbol
                     JsonSerializer.writeJson
+                    state.Config.TooltipShowDocumentationLink
+                    tryResolveCref
                     {| Xml = xml
                        Assembly = assembly
                        XmlDoc = xmlDoc

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1239,6 +1239,12 @@ type AdaptiveFSharpLspServer
             let showExternalDocumentation = state.Config.TooltipShowDocumentationLink
             let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
 
+            let linkContext: CommandResponse.DocumentationLinkContext option =
+              Some
+                { FileName = filePath |> UMX.untag
+                  Line = int p.Position.Line
+                  Character = int p.Position.Character }
+
             match
               TipFormatter.tryFormatTipEnhanced
                 tooltipResult.ToolTipText
@@ -1247,6 +1253,9 @@ type AdaptiveFSharpLspServer
                 tryResolveCref
             with
             | TipFormatter.TipFormatterResult.Success tooltipInfo ->
+              let formattedDocComment =
+                tooltipInfo.DocComment
+                |> CommandResponse.addDocumentationLinkContext linkContext
 
               let response =
                 { Contents =
@@ -1256,7 +1265,7 @@ type AdaptiveFSharpLspServer
                          tooltipResult.Signature
                          |> TipFormatter.prepareSignature
                          |> (fun content -> U2.C2 { Language = "fsharp"; Value = content })
-                         U2.C1 tooltipInfo.DocComment
+                         U2.C1 formattedDocComment
                          match tooltipResult.SymbolInfo with
                          | TryGetToolTipEnhancedResult.Keyword _ -> ()
                          | TryGetToolTipEnhancedResult.Symbol symbolInfo when showExternalDocumentation ->
@@ -1264,6 +1273,7 @@ type AdaptiveFSharpLspServer
                              tooltipInfo.HasTruncatedExamples
                              symbolInfo.XmlDocSig
                              symbolInfo.Assembly
+                           |> CommandResponse.addDocumentationLinkContext linkContext
                            |> U2.C1
                          | TryGetToolTipEnhancedResult.Symbol _ -> ()
                          // Display each footer line as a separate line
@@ -3171,6 +3181,12 @@ type AdaptiveFSharpLspServer
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
           lastFSharpDocumentationTypeCheck <- Some tyRes
 
+          let linkContext: CommandResponse.DocumentationLinkContext option =
+            Some
+              { FileName = filePath |> UMX.untag
+                Line = int p.Position.Line
+                Character = int p.Position.Character }
+
           match! Commands.FormattedDocumentation tyRes pos lineStr |> Result.ofCoreResponse with
           | Some(tip, xml, signature, footer, xmlKey) ->
             let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
@@ -3186,7 +3202,8 @@ type AdaptiveFSharpLspServer
                          XmlSig = xml
                          Signature = signature
                          Footer = footer
-                         XmlKey = xmlKey |} }
+                         XmlKey = xmlKey
+                         LinkContext = linkContext |} }
           | None -> return None
         with e ->
           trace |> Tracing.recordException e
@@ -3210,9 +3227,27 @@ type AdaptiveFSharpLspServer
           )
 
           let! tyRes =
-            lastFSharpDocumentationTypeCheck
-            |> Result.ofOption (fun () -> $"No typecheck results from FSharpDocumentation")
-            |> Result.ofStringErr
+            asyncResult {
+              match p.FileName with
+              | Some fileName ->
+                return!
+                  state.GetOpenFileTypeCheckResults(Utils.normalizePath fileName)
+                  |> AsyncResult.ofStringErr
+              | None ->
+                return!
+                  lastFSharpDocumentationTypeCheck
+                  |> Result.ofOption (fun () -> $"No typecheck results from FSharpDocumentation")
+                  |> Result.ofStringErr
+            }
+
+          let linkContext: CommandResponse.DocumentationLinkContext option =
+            match p.FileName, p.Line, p.Character with
+            | Some fileName, Some line, Some character ->
+              Some
+                { FileName = fileName |> Utils.normalizePath |> UMX.untag
+                  Line = line
+                  Character = character }
+            | _ -> None
 
           match!
             Commands.FormattedDocumentationForSymbol tyRes p.XmlSig p.Assembly
@@ -3233,7 +3268,8 @@ type AdaptiveFSharpLspServer
                        XmlDoc = xmlDoc
                        Signature = signature
                        Footer = footer
-                       XmlKey = xmlKey |} }
+                       XmlKey = xmlKey
+                       LinkContext = linkContext |} }
               |> Some
         with e ->
           trace |> Tracing.recordException e

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1237,8 +1237,15 @@ type AdaptiveFSharpLspServer
                 TipFormatter.FormatCommentStyle.Legacy
 
             let showExternalDocumentation = state.Config.TooltipShowDocumentationLink
+            let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
 
-            match TipFormatter.tryFormatTipEnhanced tooltipResult.ToolTipText formatCommentStyle with
+            match
+              TipFormatter.tryFormatTipEnhanced
+                tooltipResult.ToolTipText
+                formatCommentStyle
+                showExternalDocumentation
+                tryResolveCref
+            with
             | TipFormatter.TipFormatterResult.Success tooltipInfo ->
 
               let response =
@@ -3166,11 +3173,15 @@ type AdaptiveFSharpLspServer
 
           match! Commands.FormattedDocumentation tyRes pos lineStr |> Result.ofCoreResponse with
           | Some(tip, xml, signature, footer, xmlKey) ->
+            let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
+
             return
               Some
                 { Content =
                     CommandResponse.formattedDocumentation
                       JsonSerializer.writeJson
+                      state.Config.TooltipShowDocumentationLink
+                      tryResolveCref
                       {| Tip = tip
                          XmlSig = xml
                          Signature = signature
@@ -3209,11 +3220,14 @@ type AdaptiveFSharpLspServer
           with
           | None -> return None
           | Some(xml, assembly, xmlDoc, signature, footer, xmlKey) ->
+            let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
 
             return
               { Content =
                   CommandResponse.formattedDocumentationForSymbol
                     JsonSerializer.writeJson
+                    state.Config.TooltipShowDocumentationLink
+                    tryResolveCref
                     {| Xml = xml
                        Assembly = assembly
                        XmlDoc = xmlDoc

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1237,7 +1237,7 @@ type AdaptiveFSharpLspServer
                 TipFormatter.FormatCommentStyle.Legacy
 
             let showExternalDocumentation = state.Config.TooltipShowDocumentationLink
-            let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
+            let tryResolveCref = tyRes.GetCrefResolver()
 
             let linkContext: CommandResponse.DocumentationLinkContext option =
               Some
@@ -3189,7 +3189,7 @@ type AdaptiveFSharpLspServer
 
           match! Commands.FormattedDocumentation tyRes pos lineStr |> Result.ofCoreResponse with
           | Some(tip, xml, signature, footer, xmlKey) ->
-            let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
+            let tryResolveCref = tyRes.GetCrefResolver()
 
             return
               Some
@@ -3255,7 +3255,7 @@ type AdaptiveFSharpLspServer
           with
           | None -> return None
           | Some(xml, assembly, xmlDoc, signature, footer, xmlKey) ->
-            let tryResolveCref = tyRes.GetAllEntities false |> TipFormatter.createCrefResolver
+            let tryResolveCref = tyRes.GetCrefResolver()
 
             return
               { Content =

--- a/test/FsAutoComplete.Tests.Lsp/CrefLinkDocumentationTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CrefLinkDocumentationTests.fs
@@ -1,0 +1,92 @@
+module FsAutoComplete.Tests.CrefLinkDocumentationTests
+
+open System.IO
+open Expecto
+open Ionide.LanguageServerProtocol.Types
+open FsToolkit.ErrorHandling
+open Helpers
+open Helpers.Expecto.ShadowedTimeouts
+
+let private creflinkServer state =
+  async {
+    let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "CrefLinks")
+    let scriptPath = Path.Combine(path, "Script.fsx")
+    let! (server, events) = serverInitialize path defaultConfigDto state
+    do! server.TextDocumentDidOpen { TextDocument = loadDocument scriptPath }
+
+    match! waitForParseResultsForFile "Script.fsx" events with
+    | Ok() -> ()
+    | Error errors -> failtestf "Errors while parsing script %s: %A" scriptPath errors
+
+    return server, scriptPath
+  }
+  |> Async.Cache
+
+let private hoverText (hover: Hover) =
+  match hover.Contents with
+  | U3.C3 parts ->
+    parts
+    |> Array.choose (function
+      | U2.C1 s -> Some s
+      | _ -> None)
+    |> String.concat "\n"
+  | _ -> ""
+
+let tests state =
+  let server = creflinkServer state
+
+  let hoverAt line character =
+    async {
+      let! (srv, scriptPath) = server
+
+      let pos: HoverParams =
+        { TextDocument = { Uri = sprintf "file://%s" scriptPath }
+          Position = { Line = line; Character = character }
+          WorkDoneToken = None }
+
+      return! srv.TextDocumentHover pos
+    }
+
+  let documentationAt line character =
+    async {
+      let! (srv, scriptPath) = server
+
+      return!
+        srv.FSharpDocumentation
+          { TextDocument = { Uri = sprintf "file://%s" scriptPath }
+            Position = { Line = line; Character = character } }
+    }
+
+  testSequenced
+  <| testList
+    "cref link integration tests"
+    [ testCaseAsync
+        "hover on local symbol renders resolved cref link"
+        (async {
+          match! hoverAt 5u 0u with
+          | Ok(Some hover) ->
+            let text = hoverText hover
+            Expect.stringContains text "command:fsharp.showDocumentation?" "hover should contain a documentation command link"
+            Expect.stringContains text "Async</code>" "hover should render the resolved Async display name"
+          | Ok None -> failtest "Hover returned None; expected documentation for x"
+          | Error e -> failtestf "Hover request errored: %A" e
+        })
+
+      testCaseAsync
+        "documentation endpoint on local symbol renders resolved cref link"
+        (async {
+          match! documentationAt 5u 0u with
+          | Ok(Some(As(model: FsAutoComplete.CommandResponse.DocumentationDescription))) ->
+            Expect.stringContains
+              model.Comment
+              "command:fsharp.showDocumentation?"
+              "documentation endpoint should contain a documentation command link"
+
+            Expect.stringContains
+              model.Comment
+              "Async</code>"
+              "documentation endpoint should render the resolved Async display name"
+          | Ok None -> failtest "Documentation request returned None; expected documentation for x"
+          | Ok _ -> failtest "Could not deserialize the documentation response"
+          | Error e -> failtestf "Documentation request errored: %A" e
+        }) ]

--- a/test/FsAutoComplete.Tests.Lsp/CrefLinkDocumentationTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CrefLinkDocumentationTests.fs
@@ -57,6 +57,19 @@ let tests state =
             Position = { Line = line; Character = character } }
     }
 
+  let documentationForSymbol xmlSig assembly fileName line character =
+    async {
+      let! (srv, _) = server
+
+      return!
+        srv.FSharpDocumentationSymbol
+          { XmlSig = xmlSig
+            Assembly = assembly
+            FileName = fileName
+            Line = line
+            Character = character }
+    }
+
   testSequenced
   <| testList
     "cref link integration tests"
@@ -66,8 +79,25 @@ let tests state =
           match! hoverAt 5u 0u with
           | Ok(Some hover) ->
             let text = hoverText hover
-            Expect.stringContains text "command:fsharp.showDocumentation?" "hover should contain a documentation command link"
-            Expect.stringContains text "Async</code>" "hover should render the resolved Async display name"
+
+            Expect.stringContains
+              text
+              "command:fsharp.showDocumentation?"
+              "hover should contain a documentation command link"
+
+            Expect.stringContains
+              text
+              "[`Async`](command:fsharp.showDocumentation?"
+              "hover should render the resolved Async display name as an inline-code markdown link"
+
+            Expect.stringContains
+              text
+              "%22FileName%22%3A"
+              "hover should include source context in documentation command links"
+
+            Expect.isFalse
+              (text.Contains "<code>")
+              "hover should not include literal code tags in the rendered cref link"
           | Ok None -> failtest "Hover returned None; expected documentation for x"
           | Error e -> failtestf "Hover request errored: %A" e
         })
@@ -84,9 +114,74 @@ let tests state =
 
             Expect.stringContains
               model.Comment
-              "Async</code>"
-              "documentation endpoint should render the resolved Async display name"
+              "[`Async`](command:fsharp.showDocumentation?"
+              "documentation endpoint should render the resolved Async display name as an inline-code markdown link"
+
+            Expect.stringContains
+              model.Comment
+              "%22FileName%22%3A"
+              "documentation endpoint should include source context in documentation command links"
+
+            Expect.isFalse
+              (model.Comment.Contains "<code>")
+              "documentation endpoint should not include literal code tags in the rendered cref link"
           | Ok None -> failtest "Documentation request returned None; expected documentation for x"
           | Ok _ -> failtest "Could not deserialize the documentation response"
           | Error e -> failtestf "Documentation request errored: %A" e
+        })
+
+      testCaseAsync
+        "documentationSymbol returns Async documentation after priming request"
+        (async {
+          let! _ = documentationAt 5u 0u
+
+          match! documentationForSymbol "T:Microsoft.FSharp.Control.FSharpAsync`1" "FSharp.Core" None None None with
+          | Ok(Some(As(model: FsAutoComplete.CommandResponse.DocumentationDescription))) ->
+            Expect.stringContains model.Signature "Async" "documentationSymbol should render Async docs"
+            Expect.isFalse (model.Signature.Contains "val x") "documentationSymbol should not render the local symbol"
+          | Ok None -> failtest "documentationSymbol returned None; expected documentation for Async"
+          | Ok _ -> failtest "Could not deserialize the documentationSymbol response"
+          | Error e -> failtestf "documentationSymbol request errored: %A" e
+        })
+
+      testCaseAsync
+        "documentationSymbol returns Async documentation from source context without priming request"
+        (async {
+          let! (_, scriptPath) = server
+
+          match!
+            documentationForSymbol
+              "T:Microsoft.FSharp.Control.FSharpAsync`1"
+              "FSharp.Core"
+              (Some scriptPath)
+              (Some 5)
+              (Some 0)
+          with
+          | Ok(Some(As(model: FsAutoComplete.CommandResponse.DocumentationDescription))) ->
+            Expect.stringContains model.Signature "Async" "documentationSymbol should render Async docs"
+            Expect.isFalse (model.Signature.Contains "val x") "documentationSymbol should not render the local symbol"
+
+            Expect.stringContains
+              model.Comment
+              "%22FileName%22%3A"
+              "documentationSymbol should preserve source context in returned command links"
+
+            let attributeLinks =
+              model.Attributes
+              |> Array.filter (fun attributeLine -> attributeLine.Contains "command:fsharp.showDocumentation?")
+
+            Expect.isGreaterThan
+              attributeLinks.Length
+              0
+              "documentationSymbol should include documentation command links in attributes for Async"
+
+            attributeLinks
+            |> Array.iter (fun attributeLine ->
+              Expect.stringContains
+                attributeLine
+                "%22FileName%22%3A"
+                "documentationSymbol attribute links should preserve source context")
+          | Ok None -> failtest "documentationSymbol returned None; expected documentation for Async"
+          | Ok _ -> failtest "Could not deserialize the documentationSymbol response"
+          | Error e -> failtestf "documentationSymbol request errored: %A" e
         }) ]

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -140,6 +140,7 @@ let lspTests =
                   CallHierarchy.tests createServer
                   diagnosticsTest createServer
                   InheritDocTooltipTests.tests createServer
+                  CrefLinkDocumentationTests.tests createServer
 
                   TestExplorer.tests createServer ] ] ]
 

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -153,6 +153,7 @@ let lspTests =
                   3, CallHierarchy.tests createServer
                   4, diagnosticsTest createServer
                   4, InheritDocTooltipTests.tests createServer
+                  4, CrefLinkDocumentationTests.tests createServer
 
                   3, TestExplorer.tests createServer ]
 

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/CrefLinks/Script.fsx
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/CrefLinks/Script.fsx
@@ -1,0 +1,6 @@
+/// <summary>
+/// Testing <see cref="T:Async`1" /> and some more text before <see cref="T:Async`1" />.
+/// </summary>
+let x = 1
+
+x

--- a/test/FsAutoComplete.Tests.Lsp/TipFormatterTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TipFormatterTests.fs
@@ -52,7 +52,11 @@ let seeAlsoTests =
           "command:fsharp.showDocumentation?"
           "resolved seealso cref should become a documentation command link"
 
-        Expect.stringContains content ">Async</code></a>" "resolved seealso cref should use the resolved display name"
+        Expect.stringContains content ">Async</a>" "resolved seealso cref should use the resolved display name"
+
+        Expect.isFalse
+          (content.Contains "<code>")
+          "resolved seealso cref should not emit nested code tags that VS Code displays literally"
 
       testCase "href void element renders as auto-link"
       <| fun _ ->
@@ -158,7 +162,14 @@ let seeTests =
           "command:fsharp.showDocumentation?"
           "resolved inline see cref should become a documentation command link"
 
-        Expect.stringContains content "Async</code>" "resolved inline see cref should use the resolved display name"
+        Expect.stringContains
+          content
+          "[`Async`](command:fsharp.showDocumentation?"
+          "resolved inline see cref should use the resolved display name as an inline-code markdown link"
+
+        Expect.isFalse
+          (content.Contains "<code>")
+          "resolved inline see cref should not emit nested code tags that VS Code displays literally"
 
       testCase "inline see cref falls back to code formatting when resolver fails"
       <| fun _ ->

--- a/test/FsAutoComplete.Tests.Lsp/TipFormatterTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TipFormatterTests.fs
@@ -11,11 +11,23 @@ open FsAutoComplete
 let private makeXmlDoc (lines: string[]) = FSharpXmlDoc.FromXmlText(FSharp.Compiler.Xml.XmlDoc(lines, Range.Zero))
 
 /// Call formatDocumentationFromXmlDoc and return the Success string, failing the test otherwise.
-let private getDoc (xmlDoc: FSharpXmlDoc) =
-  match TipFormatter.formatDocumentationFromXmlDoc xmlDoc with
+let private getDocWith
+  (showDocumentationLinks: bool)
+  (tryResolveCref: string -> (string * string * string) option)
+  (xmlDoc: FSharpXmlDoc)
+  =
+  match TipFormatter.formatDocumentationFromXmlDoc xmlDoc showDocumentationLinks tryResolveCref with
   | TipFormatter.TipFormatterResult.Success s -> s
   | TipFormatter.TipFormatterResult.None -> failtest "Expected doc content but got None"
   | TipFormatter.TipFormatterResult.Error e -> failtest $"Expected doc content but got Error: {e}"
+
+let private getDoc (xmlDoc: FSharpXmlDoc) = getDocWith false (fun _ -> None) xmlDoc
+
+let private tryResolveAsyncCref cref =
+  if cref = "T:Async`1" then
+    Some("T:Microsoft.FSharp.Control.FSharpAsync`1", "FSharp.Core", "Async")
+  else
+    None
 
 let seeAlsoTests =
   testList
@@ -27,6 +39,20 @@ let seeAlsoTests =
 
         let content = getDoc xml
         Expect.stringContains content "* `Foo.Bar`" "cref should render as backtick-quoted member name"
+
+      testCase "cref attribute renders documentation command link when resolver succeeds"
+      <| fun _ ->
+        let xml =
+          makeXmlDoc [| "<summary>Description</summary>"; """<seealso cref="T:Async`1"/>""" |]
+
+        let content = getDocWith true tryResolveAsyncCref xml
+
+        Expect.stringContains
+          content
+          "command:fsharp.showDocumentation?"
+          "resolved seealso cref should become a documentation command link"
+
+        Expect.stringContains content ">Async</code></a>" "resolved seealso cref should use the resolved display name"
 
       testCase "href void element renders as auto-link"
       <| fun _ ->
@@ -101,7 +127,7 @@ let inheritDocTests =
         // When inheritdoc has no cref, we can't resolve — should not throw.
         let xml = makeXmlDoc [| """<inheritdoc/>""" |]
 
-        match TipFormatter.formatDocumentationFromXmlDoc xml with
+        match TipFormatter.formatDocumentationFromXmlDoc xml false (fun _ -> None) with
         | TipFormatter.TipFormatterResult.Success _
         | TipFormatter.TipFormatterResult.None -> ()
         | TipFormatter.TipFormatterResult.Error e -> failtest $"Should not error on bare inheritdoc, got: {e}"
@@ -112,10 +138,35 @@ let inheritDocTests =
         // the cref without assembly context — should fall back without crashing.
         let xml = makeXmlDoc [| """<inheritdoc cref="P:Ns.Type.Member"/>""" |]
 
-        match TipFormatter.formatDocumentationFromXmlDoc xml with
+        match TipFormatter.formatDocumentationFromXmlDoc xml false (fun _ -> None) with
         | TipFormatter.TipFormatterResult.Success _
         | TipFormatter.TipFormatterResult.None -> ()
         | TipFormatter.TipFormatterResult.Error e -> failtest $"Should not error on inheritdoc cref, got: {e}" ]
+
+let seeTests =
+  testList
+    "see rendering"
+    [ testCase "inline see cref renders documentation command link when resolver succeeds"
+      <| fun _ ->
+        let xml =
+          makeXmlDoc [| """<summary>Testing <see cref="T:Async`1" /> before more text.</summary>""" |]
+
+        let content = getDocWith true tryResolveAsyncCref xml
+
+        Expect.stringContains
+          content
+          "command:fsharp.showDocumentation?"
+          "resolved inline see cref should become a documentation command link"
+
+        Expect.stringContains content "Async</code>" "resolved inline see cref should use the resolved display name"
+
+      testCase "inline see cref falls back to code formatting when resolver fails"
+      <| fun _ ->
+        let xml =
+          makeXmlDoc [| """<summary>Testing <see cref="T:Async`1" /> before more text.</summary>""" |]
+
+        let content = getDoc xml
+        Expect.stringContains content "``Async`1``" "unresolved inline see cref should stay as inline code" ]
 
 /// Helper: wrap a single string as a one-element TaggedText array (the type used by the compiler service).
 let private makeTaggedTexts (parts: string list) : FSharp.Compiler.Text.TaggedText[] =
@@ -177,4 +228,4 @@ let cleanParameterDisplayTests =
         Expect.equal result "flag: bool = false" "should strip attribute block and append = false" ]
 
 let allTests =
-  testList "TipFormatter" [ seeAlsoTests; inheritDocTests; cleanParameterDisplayTests ]
+  testList "TipFormatter" [ seeTests; seeAlsoTests; inheritDocTests; cleanParameterDisplayTests ]


### PR DESCRIPTION
## Summary
- render resolved `<see cref>` and `<seealso cref>` targets with clean display text
- include source file, line, and column in documentation command links returned from hover and documentation APIs
- keep `documentationSymbol` resilient when matching symbols from metadata

## Why
The original issue started in tooltip formatting, but there was a second problem in the click path. Hover links only carried the target symbol, so the VS Code side sometimes had to fall back to the current cursor position when resolving the clicked link. If the cursor had already moved, the Info Panel could open the wrong symbol or stay blank.

This change makes the link payload self-contained. The new source-context fields are optional, so existing callers still work.

## Testing
- `dotnet fantomas --check build.fsx src`
- `dotnet test test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj -f net8.0 --filter "cref link integration tests"`
- local VS Code repro through Ionide using the patched build, confirming hover `x` then click `Async` opens `Async` docs across fresh launches

## Context
- addresses ionide-vscode-fsharp#1543
- paired with ionide/ionide-vscode-fsharp#2165