### PR TITLE
Remove duplicate 'Reference' active pattern

### DIFF
--- a/src/FsAutoComplete.Core/CompilerServiceInterface.fs
+++ b/src/FsAutoComplete.Core/CompilerServiceInterface.fs
@@ -226,13 +226,6 @@ type FSharpCompilerServiceChecker
 
     snapshot.Replace(files)
 
-  let (|Reference|_|) (opt: string) =
-    if opt.StartsWith("-r:", StringComparison.Ordinal) then
-      Some(opt.[3..])
-    else
-      None
-
-
   /// ensures that any user-configured include/load files are added to the typechecking context
   let addLoadedFilesToProject (projectOptions: FSharpProjectOptions) =
     let additionalSourceFiles =

--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fs
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fs
@@ -193,8 +193,6 @@ type ProgressListener(lspClient: FSharpLspClient, traceNamespace: string array) 
 
   let isOneOf list string = list |> Array.exists (fun f -> f string)
 
-  let strEquals (other: string) (this: string) = this.Equals(other, StringComparison.InvariantCultureIgnoreCase)
-
   let strContains (substring: Regex) (str: string) = substring.IsMatch str
 
   let interestingActivities = traceNamespace |> Array.map strContains


### PR DESCRIPTION
Not sure what the history is here, but when I try to do a local build I get

```
  FsAutoComplete.Core net8.0 failed with 1 error(s) (3.0s)
    G:\Dev\FsAutoComplete\src\FsAutoComplete.Core\CompilerServiceInterface.fs(229,8): error FS1182: The value '(|Reference|_|)' is unused
```

but there appears to be two copies of the same function - this one and one on line 199 - which looks wrong anyway?