### PR TITLE
feat: go to definition navigates between sig and impl

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -241,8 +241,9 @@
 				<OmitContent Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 7">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[6])</OmitContent>
 				<ImportTargets Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 8">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[7])</ImportTargets>
 				<Aliases Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 9">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[8])</Aliases>
+				<ReferenceCondition Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 10">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[9])</ReferenceCondition>
 			</PaketReferencesFileLinesInfo>
-			<PackageReference Condition=" '$(ManagePackageVersionsCentrally)' != 'true' Or '%(PaketReferencesFileLinesInfo.Reference)' == 'Direct' " Include="%(PaketReferencesFileLinesInfo.PackageName)">
+			<PackageReference Condition=" ('$(ManagePackageVersionsCentrally)' != 'true' Or '%(PaketReferencesFileLinesInfo.Reference)' == 'Direct') AND ('%(PaketReferencesFileLinesInfo.ReferenceCondition)' == 'true' Or $(%(PaketReferencesFileLinesInfo.ReferenceCondition)) == 'true')" Include="%(PaketReferencesFileLinesInfo.PackageName)">
 				<Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
 				<PrivateAssets Condition=" ('%(PaketReferencesFileLinesInfo.AllPrivateAssets)' == 'true') Or ('$(PackAsTool)' == 'true') ">All</PrivateAssets>
 				<ExcludeAssets Condition=" %(PaketReferencesFileLinesInfo.CopyLocal) == 'false' or %(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
@@ -251,10 +252,8 @@
 				<Aliases Condition=" %(PaketReferencesFileLinesInfo.Aliases) != ''">%(PaketReferencesFileLinesInfo.Aliases)</Aliases>
 				<Publish Condition=" '$(PackAsTool)' == 'true' ">true</Publish>
 				<AllowExplicitVersion>true</AllowExplicitVersion>
-
 			</PackageReference>
-
-			<PackageVersion Include="%(PaketReferencesFileLinesInfo.PackageName)">
+			<PackageVersion Condition="('$(ManagePackageVersionsCentrally)' != 'true' Or '%(PaketReferencesFileLinesInfo.Reference)' == 'Direct') AND ('%(PaketReferencesFileLinesInfo.ReferenceCondition)' == 'true' Or $(%(PaketReferencesFileLinesInfo.ReferenceCondition)) == 'true')" Include="%(PaketReferencesFileLinesInfo.PackageName)">
 				<Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
 			</PackageVersion>
 		</ItemGroup>
@@ -319,7 +318,17 @@
 		</ItemGroup>
 
 		<Error Text="Error Because of PAKET_ERROR_ON_MSBUILD_EXEC (not calling fix-nuspecs)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' " />
-		<Exec Condition="@(_NuspecFiles) != ''" Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" ' />
+		<Exec Condition="@(_NuspecFiles) != ''" Command='$(PaketCommand) show-conditions -s' ConsoleToMSBuild="true" StandardOutputImportance="low">
+			<Output TaskParameter="ConsoleOutput" ItemName="_ConditionProperties"/>
+		</Exec>
+		<ItemGroup>
+			<_DefinedConditionProperties Include="@(_ConditionProperties)" Condition="$(%(Identity)) == 'true'"/>
+		</ItemGroup>
+		<PropertyGroup>
+			<_ConditionsParameter></_ConditionsParameter>
+			<_ConditionsParameter Condition="@(_DefinedConditionProperties) != ''">--conditions @(_DefinedConditionProperties)</_ConditionsParameter>
+		</PropertyGroup>
+		<Exec Condition="@(_NuspecFiles) != ''" Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" $(_ConditionsParameter)' />
 		<Error Condition="@(_NuspecFiles) == ''" Text='Could not find nuspec files in "$(AdjustedNuspecOutputPath)" (Version: "$(PackageVersion)"), therefore we cannot call "paket fix-nuspecs" and have to error out!' />
 
 		<ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- [Go to definition navigates between signature and implementation files](https://github.com/ionide/FsAutoComplete/pull/1544) - Go to definition resolves to the declaration in the signature file when a symbol has one, and to the matching definition in the implementation file when the cursor is already on that signature declaration
+
 ### Fixed
 
 - [Disable inline values by default to restore pipeline hints](https://github.com/ionide/FsAutoComplete/pull/1456) - `InlineValueProvider` is no longer advertised by default, restoring pipeline hints during normal editing (closes [#1214](https://github.com/ionide/FsAutoComplete/issues/1214))

--- a/src/FsAutoComplete.Core/Commands.fs
+++ b/src/FsAutoComplete.Core/Commands.fs
@@ -538,6 +538,94 @@ module Commands =
       | Error e -> return CoreResponse.ErrorRes e
     }
 
+  /// The implementation file paired with `signatureFile`, when the project contains both.
+  let private tryFindPairedImplementationFile
+    (getProjectOptions: string<LocalPath> -> Async<Result<CompilerProjectOption, string>>)
+    (signatureFile: string<LocalPath>)
+    =
+    async {
+      match! getProjectOptions signatureFile with
+      | Error _ -> return None
+      | Ok opts ->
+        // `Foo.fsi` is implemented by `Foo.fs`, but only trust it when the project actually compiles that file.
+        let untagged = UMX.untag signatureFile
+
+        if not (isSignatureFile untagged) then
+          return None
+        else
+          let implementationFile = normalizePath (untagged.Substring(0, untagged.Length - 1))
+          return opts.SourceFilesTagged |> List.tryFind (fun f -> f = implementationFile)
+    }
+
+  /// Is `signatureLocation` the declaration found at `declRange` in `signatureFile`?
+  let private matchesSignatureDeclaration
+    (signatureFile: string<LocalPath>)
+    (declRange: Range)
+    (signatureLocation: Range)
+    =
+    normalizePath signatureLocation.FileName = signatureFile
+    && (Position.posEq signatureLocation.Start declRange.Start
+        || rangeContainsPos signatureLocation declRange.Start)
+
+  /// Find the definition in the implementation file that implements the signature declaration at `declRange`.
+  ///
+  /// FCS cannot answer this from the signature file's own check results: the signature is checked before the
+  /// implementation, so at that point the implementation does not exist yet as far as the compiler is concerned.
+  /// The implementation file's symbols do carry a `SignatureLocation` pointing back into the signature file
+  /// though, so we check the paired file and match on that. Matching on the range rather than on the name means
+  /// overloads and shadowed names resolve to exactly the definition the compiler paired them with.
+  let private tryFindImplementationOfSignatureDeclaration
+    getProjectOptions
+    (getTypeCheckResults: string<LocalPath> -> Async<Result<ParseAndCheckResults, string>>)
+    (declRange: Range)
+    =
+    async {
+      let signatureFile = normalizePath declRange.FileName
+
+      match! tryFindPairedImplementationFile getProjectOptions signatureFile with
+      | None -> return None
+      | Some implementationFile ->
+        match! getTypeCheckResults implementationFile with
+        | Error _ -> return None
+        | Ok implementationTyRes ->
+          return
+            implementationTyRes.GetAllSymbolUsesInFile()
+            |> Seq.tryFind (fun su ->
+              su.IsFromDefinition
+              && (match su.Symbol.SignatureLocation with
+                  | Some signatureLocation -> matchesSignatureDeclaration signatureFile declRange signatureLocation
+                  | None -> false))
+            |> Option.map (fun su -> su.Range)
+    }
+
+  /// Go-to-definition across signature/implementation pairs.
+  ///
+  /// Resolves to the declaration in the signature file when the symbol has one, because that is the public
+  /// access point. When the cursor is already on that signature declaration, resolves to the matching
+  /// definition in the implementation file instead, so that repeated invocations move between the two.
+  let findDeclaration
+    getProjectOptions
+    getTypeCheckResults
+    (tyRes: ParseAndCheckResults)
+    (pos: Position)
+    (lineStr: LineStr)
+    =
+    async {
+      match! tyRes.TryFindDeclaration pos lineStr FindDeclarationPreference.Signature with
+      | Error e -> return Error e
+      | Ok decl ->
+        match decl with
+        | FindDeclarationResult.Range declRange when
+          isSignatureFile declRange.FileName
+          && normalizePath declRange.FileName = tyRes.FileName
+          && rangeContainsPos declRange pos
+          ->
+          match! tryFindImplementationOfSignatureDeclaration getProjectOptions getTypeCheckResults declRange with
+          | Some implementationRange -> return Ok(FindDeclarationResult.Range implementationRange)
+          | None -> return Ok decl
+        | _ -> return Ok decl
+    }
+
   let typesig (tyRes: ParseAndCheckResults) (pos: Position) lineStr = tyRes.TryGetToolTip pos lineStr
 
   // Calculates pipeline hints for now as in fSharp/pipelineHint with a bit of formatting on the hints

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -104,14 +104,22 @@ type ParseAndCheckResults
     | Some(col, identIsland) ->
       let identIsland = Array.toList identIsland
 
+      let getDeclarations preferSignature =
+        checkResults.GetDeclarationLocation(pos.Line, int col, lineStr, identIsland, preferFlag = preferSignature)
+
       let declarations =
-        checkResults.GetDeclarationLocation(
-          pos.Line,
-          int col,
-          lineStr,
-          identIsland,
-          preferFlag = preference.PreferSignature
-        )
+        let preferred = getDeclarations preference.PreferSignature
+
+        match preferred with
+        // A signature file of another assembly is of no use to us: signature files carry no IL, so they never end
+        // up as a document in the pdb and sourcelink cannot fetch them. Take the implementation for those.
+        | FindDeclResult.DeclFound range when
+          preference.PreferSignature
+          && range.FileName <> UMX.untag x.FileName
+          && not (System.IO.File.Exists range.FileName)
+          ->
+          getDeclarations false
+        | _ -> preferred
 
       let decompile assembly externalSym =
         match Decompiler.tryFindExternalDeclaration checkResults (assembly, externalSym) with

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fs
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fs
@@ -22,6 +22,18 @@ type FindDeclarationResult =
   /// The declaration refers to a file.
   | File of string
 
+/// Which side to favour when a symbol is declared in both a signature and an implementation file.
+/// Has no effect on symbols that are declared in only one of the two.
+[<RequireQualifiedAccess>]
+type FindDeclarationPreference =
+  | Implementation
+  | Signature
+
+  member x.PreferSignature =
+    match x with
+    | Implementation -> false
+    | Signature -> true
+
 [<RequireQualifiedAccess>]
 module TryGetToolTipEnhancedResult =
 
@@ -49,10 +61,10 @@ type ParseAndCheckResults
     let normalized = loc.FileName.Replace('\\', '/')
     UMX.tag<NormalizedRepoPathSegment> normalized
 
-  member __.TryFindDeclaration (pos: Position) (lineStr: LineStr) =
+  member __.TryFindDeclaration (pos: Position) (lineStr: LineStr) (preference: FindDeclarationPreference) =
     async {
       // try find identifier first
-      let! identResult = __.TryFindIdentifierDeclaration pos lineStr
+      let! identResult = __.TryFindIdentifierDeclaration pos lineStr preference
 
       match identResult with
       | Ok r -> return Ok r
@@ -86,14 +98,20 @@ type ParseAndCheckResults
       | None -> return Error "load directive not recognized"
     }
 
-  member x.TryFindIdentifierDeclaration (pos: Position) (lineStr: LineStr) =
+  member x.TryFindIdentifierDeclaration (pos: Position) (lineStr: LineStr) (preference: FindDeclarationPreference) =
     match Lexer.findLongIdents (uint32 pos.Column, lineStr) with
     | None -> async.Return(ResultOrString.Error "Could not find ident at this location")
     | Some(col, identIsland) ->
       let identIsland = Array.toList identIsland
 
       let declarations =
-        checkResults.GetDeclarationLocation(pos.Line, int col, lineStr, identIsland, preferFlag = false)
+        checkResults.GetDeclarationLocation(
+          pos.Line,
+          int col,
+          lineStr,
+          identIsland,
+          preferFlag = preference.PreferSignature
+        )
 
       let decompile assembly externalSym =
         match Decompiler.tryFindExternalDeclaration checkResults (assembly, externalSym) with

--- a/src/FsAutoComplete.Core/ParseAndCheckResults.fsi
+++ b/src/FsAutoComplete.Core/ParseAndCheckResults.fsi
@@ -22,6 +22,15 @@ type FindDeclarationResult =
   /// The declaration refers to a file.
   | File of string
 
+/// Which side to favour when a symbol is declared in both a signature and an implementation file.
+/// Has no effect on symbols that are declared in only one of the two.
+[<RequireQualifiedAccess>]
+type FindDeclarationPreference =
+  | Implementation
+  | Signature
+
+  member PreferSignature: bool
+
 [<RequireQualifiedAccess>]
 module TryGetToolTipEnhancedResult =
   type SymbolInfo =
@@ -41,10 +50,19 @@ type ParseAndCheckResults =
     parseResults: FSharpParseFileResults * checkResults: FSharpCheckFileResults * entityCache: EntityCache ->
       ParseAndCheckResults
 
-  member TryFindDeclaration: pos: Position -> lineStr: LineStr -> Async<Result<FindDeclarationResult, string>>
+  member TryFindDeclaration:
+    pos: Position ->
+    lineStr: LineStr ->
+    preference: FindDeclarationPreference ->
+      Async<Result<FindDeclarationResult, string>>
+
   member TryFindLoadDirectiveSource: pos: Position -> lineStr: LineStr -> Async<Result<FindDeclarationResult, string>>
 
-  member TryFindIdentifierDeclaration: pos: Position -> lineStr: LineStr -> Async<Result<FindDeclarationResult, string>>
+  member TryFindIdentifierDeclaration:
+    pos: Position ->
+    lineStr: LineStr ->
+    preference: FindDeclarationPreference ->
+      Async<Result<FindDeclarationResult, string>>
 
   member TryFindTypeDeclaration: pos: Position -> lineStr: LineStr -> Async<Result<FindDeclarationResult, string>>
   member TryGetToolTip: pos: Position -> lineStr: LineStr -> ToolTipText option

--- a/src/FsAutoComplete/CodeFixes/MakeDeclarationMutable.fs
+++ b/src/FsAutoComplete/CodeFixes/MakeDeclarationMutable.fs
@@ -31,7 +31,7 @@ let fix
           (Array.ofList opts.OtherOptions)
       with
       | Some _symbol ->
-        match! tyRes.TryFindDeclaration fcsPos line with
+        match! tyRes.TryFindDeclaration fcsPos line FindDeclarationPreference.Implementation with
         | FindDeclarationResult.Range declRange when declRange.FileName = (UMX.untag fileName) ->
           let lspRange = fcsRangeToLsp declRange
 

--- a/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveFSharpLspServer.fs
@@ -1298,7 +1298,16 @@ type AdaptiveFSharpLspServer
 
           let! lineStr = volatileFile.Source |> tryGetLineStr pos |> Result.lineLookupErr
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
-          let! decl = tyRes.TryFindDeclaration pos lineStr |> AsyncResult.ofStringErr
+
+          let! decl =
+            Commands.findDeclaration
+              (fun file -> state.GetProjectOptionsForFile file)
+              (fun file -> state.GetTypeCheckResultsForFile file)
+              tyRes
+              pos
+              lineStr
+            |> AsyncResult.ofStringErr
+
           return decl |> findDeclToLspLocation |> U2.C1 |> U2.C1 |> Some
         with e ->
           trace |> Tracing.recordException e
@@ -2531,7 +2540,9 @@ type AdaptiveFSharpLspServer
           let! lineStr = tryGetLineStr pos volatileFile.Source |> Result.lineLookupErr
           and! tyRes = state.GetOpenFileTypeCheckResults filePath |> AsyncResult.ofStringErr
 
-          let! decl = tyRes.TryFindDeclaration pos lineStr |> AsyncResult.ofStringErr
+          let! decl =
+            tyRes.TryFindDeclaration pos lineStr FindDeclarationPreference.Implementation
+            |> AsyncResult.ofStringErr
 
           let! lexedResult =
             Lexer.getSymbol (uint32 pos.Line) (uint32 pos.Column) lineStr SymbolLookupKind.Fuzzy [||]

--- a/test/FsAutoComplete.Tests.Lsp/GoToTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/GoToTests.fs
@@ -725,10 +725,145 @@ let private untitledGotoTests state =
         | Ok(_resultValue) -> failwith "Not Implemented"
       } ])
 
+/// GoTo tests between a signature file and its implementation file
+let private signatureGotoTests state =
+  let server =
+    async {
+      let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "GoToTests")
+
+      let csharpPath = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "GoToCSharp")
+      let _buildInfo = DotnetCli.build csharpPath
+
+      let! (server, event) = serverInitialize path defaultConfigDto state
+      do! waitForWorkspaceFinishedParsing event
+
+      let signaturePath = Path.Combine(path, "Signature.fsi")
+      let implementationPath = Path.Combine(path, "Signature.fs")
+      let usagePath = Path.Combine(path, "SignatureUsage.fs")
+
+      for file in [ signaturePath; implementationPath; usagePath ] do
+        let tdop: DidOpenTextDocumentParams = { TextDocument = loadDocument file }
+        do! server.TextDocumentDidOpen tdop
+
+      do!
+        waitForParseResultsForFile "Signature.fs" event
+        |> AsyncResult.foldResult id (failtestf "%A")
+
+      do!
+        waitForParseResultsForFile "SignatureUsage.fs" event
+        |> AsyncResult.foldResult id (failtestf "%A")
+
+      return (server, signaturePath, implementationPath, usagePath)
+    }
+    |> Async.Cache
+
+  let expectGotoDefinition
+    (server: FsAutoComplete.Lsp.IFSharpLspServer)
+    fromFile
+    (line, character)
+    expectedFile
+    expectedRange
+    =
+    async {
+      let p: DefinitionParams =
+        { TextDocument = { Uri = Path.FilePathToUri fromFile }
+          Position = { Line = line; Character = character }
+          WorkDoneToken = None
+          PartialResultToken = None }
+
+      let! res = server.TextDocumentDefinition p
+
+      match res with
+      | Result.Error e -> failtestf "Request failed: %A" e
+      | Result.Ok None -> failtest "Request none"
+      | Result.Ok(Some(U2.C1(U2.C1 r))) ->
+        Expect.stringEnds r.Uri expectedFile $"Should navigate to {expectedFile}"
+        Expect.equal r.Range expectedRange $"Should point at the declaration in {expectedFile}"
+      | Result.Ok other -> failtestf "Should get a single location, instead got %A" other
+    }
+
+  // `val add` in Signature.fsi
+  let addInSignature =
+    { Start = { Line = 6u; Character = 4u }
+      End = { Line = 6u; Character = 7u } }
+
+  testSequenced
+  <| testList
+    "Signature File GoTo Tests"
+    [ testCaseAsync
+        "Go-to-definition from a usage in the implementation file goes to the signature"
+        (async {
+          let! server, _signaturePath, implementationPath, _usagePath = server
+          // `add` in `let addTwice x = add x x`
+          do! expectGotoDefinition server implementationPath (10u, 18u) "Signature.fsi" addInSignature
+        })
+
+      testCaseAsync
+        "Go-to-definition on the implementation itself goes to the signature"
+        (async {
+          let! server, _signaturePath, implementationPath, _usagePath = server
+          // `add` in `let add x y = helper x + y`
+          do! expectGotoDefinition server implementationPath (8u, 5u) "Signature.fsi" addInSignature
+        })
+
+      testCaseAsync
+        "Go-to-definition from a usage in another file goes to the signature"
+        (async {
+          let! server, _signaturePath, _implementationPath, usagePath = server
+          // `add` in `let usage = add 1 2`
+          do! expectGotoDefinition server usagePath (4u, 13u) "Signature.fsi" addInSignature
+        })
+
+      testCaseAsync
+        "Go-to-definition on a signature declaration goes to the implementation"
+        (async {
+          let! server, signaturePath, _implementationPath, _usagePath = server
+          // `add` in `val add: x: int -> y: int -> int`
+          do!
+            expectGotoDefinition
+              server
+              signaturePath
+              (6u, 5u)
+              "Signature.fs"
+              { Start = { Line = 8u; Character = 4u }
+                End = { Line = 8u; Character = 7u } }
+        })
+
+      testCaseAsync
+        "Go-to-definition on a type in a signature file goes to the implementation"
+        (async {
+          let! server, signaturePath, _implementationPath, _usagePath = server
+          // `Color` in `type Color =`
+          do!
+            expectGotoDefinition
+              server
+              signaturePath
+              (2u, 7u)
+              "Signature.fs"
+              { Start = { Line = 2u; Character = 5u }
+                End = { Line = 2u; Character = 10u } }
+        })
+
+      testCaseAsync
+        "Go-to-definition on a symbol that is not in the signature stays in the implementation"
+        (async {
+          let! server, _signaturePath, implementationPath, _usagePath = server
+          // `helper` in `let add x y = helper x + y`, declared `let private helper x = x + 1`
+          do!
+            expectGotoDefinition
+              server
+              implementationPath
+              (8u, 16u)
+              "Signature.fs"
+              { Start = { Line = 6u; Character = 12u }
+                End = { Line = 6u; Character = 18u } }
+        }) ]
+
 let tests createServer =
   testSequenced
   <| testList
     "Go to definition tests"
     [ gotoTest createServer
+      signatureGotoTests createServer
       scriptGotoTests createServer
       untitledGotoTests createServer ]

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/GoToTests.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/GoToTests.fsproj
@@ -6,6 +6,9 @@
     <Compile Include="Definition.fs" />
     <Compile Include="Library.fs" />
     <Compile Include="External.fs" />
+    <Compile Include="Signature.fsi" />
+    <Compile Include="Signature.fs" />
+    <Compile Include="SignatureUsage.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Giraffe" Version="4.0.1" />

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/Signature.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/Signature.fs
@@ -1,0 +1,11 @@
+module SignatureTests
+
+type Color =
+  | Red
+  | Green
+
+let private helper x = x + 1
+
+let add x y = helper x + y
+
+let addTwice x = add x x

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/Signature.fsi
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/Signature.fsi
@@ -1,0 +1,7 @@
+module SignatureTests
+
+type Color =
+  | Red
+  | Green
+
+val add: x: int -> y: int -> int

--- a/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/SignatureUsage.fs
+++ b/test/FsAutoComplete.Tests.Lsp/TestCases/GoToTests/SignatureUsage.fs
@@ -1,0 +1,6 @@
+module SignatureUsage
+
+open SignatureTests
+
+let usage = add 1 2
+let color = Red


### PR DESCRIPTION

<img width="896" height="410" alt="Kapture 2026-08-28 at 15 30 01" src="https://github.com/user-attachments/assets/f7b4ddc8-16c8-4d1a-9485-f243aa631f25" />


Go to definition now resolves to the declaration in the signature file when a symbol has one, because the signature is the public access point of the symbol. When the cursor is already on that signature declaration, it resolves to the matching definition in the implementation file instead, so repeated invocations move between the two files.

Usages outside the implementation file already resolved to the signature, so only usages within the implementation file change behaviour. That side is a matter of asking FCS for the signature range rather than the implementation range.

The other direction cannot be answered from the signature file's own check results: the signature is checked before the implementation, so at that point the implementation does not exist yet as far as the compiler is concerned. Instead the paired implementation file is checked and its definitions are matched on the SignatureLocation they point back to. Matching on the range rather than on the name means overloads and shadowed names resolve to exactly the definition the compiler paired them with.

Symbols that exist in only one of the two files are unaffected, and the call hierarchy and the make-declaration-mutable code fix keep resolving to the implementation, as they operate on the implementation file itself.