### PR TITLE
Improve background progress reporting

### DIFF
--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -246,6 +246,12 @@ module Async =
 
     Async.Parallel(computations, int maxConcurrency)
 
+  let parallel25 computations =
+    let maxConcurrency =
+      Math.Max(1.0, Math.Floor((float System.Environment.ProcessorCount) * 0.25))
+
+    Async.Parallel(computations, int maxConcurrency)
+
   [<RequireQualifiedAccess>]
   module Array =
     /// Async implementation of Array.map.

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -238,19 +238,16 @@ module Async =
       // Start the workflow using a provided cancellation token
       Async.StartWithContinuations(work, cont, econt, ccont, cancellationToken = cancellationToken))
 
-  /// <summary>Creates an asynchronous computation that executes all the given asynchronous computations, using 75% of the Environment.ProcessorCount</summary>
-  /// <param name="computations">A sequence of distinct computations to be parallelized.</param>
-  let parallel75 computations =
+
+  let private parallelOfPercentage percentage computations =
     let maxConcurrency =
-      Math.Max(1.0, Math.Floor((float System.Environment.ProcessorCount) * 0.75))
+      Math.Max(1.0, Math.Floor((float System.Environment.ProcessorCount) * percentage))
 
     Async.Parallel(computations, int maxConcurrency)
 
-  let parallel25 computations =
-    let maxConcurrency =
-      Math.Max(1.0, Math.Floor((float System.Environment.ProcessorCount) * 0.25))
-
-    Async.Parallel(computations, int maxConcurrency)
+  let parallel75 computations = parallelOfPercentage 0.75 computations
+  let parallel50 computations = parallelOfPercentage 0.50 computations
+  let parallel25 computations = parallelOfPercentage 0.25 computations
 
   [<RequireQualifiedAccess>]
   module Array =

--- a/src/FsAutoComplete.Core/Utils.fsi
+++ b/src/FsAutoComplete.Core/Utils.fsi
@@ -111,6 +111,9 @@ module Async =
   /// <param name="computations">A sequence of distinct computations to be parallelized.</param>
   val parallel75: computations: seq<Async<'a>> -> Async<'a array>
 
+  /// <summary>Creates an asynchronous computation that executes all the given asynchronous computations, using 50% of the Environment.ProcessorCount</summary>
+  /// <param name="computations">A sequence of distinct computations to be parallelized.</param>
+  val parallel50: computations: seq<Async<'a>> -> Async<'a array>
 
   /// <summary>Creates an asynchronous computation that executes all the given asynchronous computations, using 25% of the Environment.ProcessorCount</summary>
   /// <param name="computations">A sequence of distinct computations to be parallelized.</param>

--- a/src/FsAutoComplete.Core/Utils.fsi
+++ b/src/FsAutoComplete.Core/Utils.fsi
@@ -111,6 +111,11 @@ module Async =
   /// <param name="computations">A sequence of distinct computations to be parallelized.</param>
   val parallel75: computations: seq<Async<'a>> -> Async<'a array>
 
+
+  /// <summary>Creates an asynchronous computation that executes all the given asynchronous computations, using 25% of the Environment.ProcessorCount</summary>
+  /// <param name="computations">A sequence of distinct computations to be parallelized.</param>
+  val parallel25: computations: seq<Async<'a>> -> Async<'a array>
+
   [<RequireQualifiedAccess>]
   module Array =
     /// Async implementation of Array.map.

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -1820,7 +1820,7 @@ type AdaptiveState
             opts,
             shouldCache = shouldCache
           )
-          |> Async.withCancellation progressCt
+        |> Async.withCancellation progressCt
 
 
       let! ct = Async.CancellationToken

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -206,7 +206,11 @@ type AdaptiveState
   do disposables.Add analyzerProgressReporter
 
   let projectLoadingProgressReporter =
-    new SharedTypecheckProgressReporter("Loading Projects", fun () -> progressLookup.CreateProgressReport(lspClient))
+    new SharedTypecheckProgressReporter(
+      "Loading Projects",
+      (fun () -> progressLookup.CreateProgressReport(lspClient)),
+      isEnabled = (fun () -> (AVal.force config).Notifications.BackgroundServiceProgress)
+    )
 
   do disposables.Add projectLoadingProgressReporter
 
@@ -563,10 +567,13 @@ type AdaptiveState
           let! ct = Async.CancellationToken
           use! _l = analyzersLocker.LockAsync(ct)
           use! _progress = analyzerProgressReporter.Begin($"Unnecessary parens - {fileName}")
+          let! progressCt = analyzerProgressReporter.GetCancellationToken()
 
           let unnecessaryParentheses =
             (System.Collections.Generic.HashSet(comparer = Range.comparer), tyRes.GetAST)
             ||> ParsedInput.fold (fun ranges path node ->
+              progressCt.ThrowIfCancellationRequested()
+
               match node with
               | SyntaxNode.SynExpr(SynExpr.Paren(expr = inner; rightParenRange = Some _; range = range)) when
                 not (SynExpr.shouldBeParenthesizedInContext getSourceLine path inner)
@@ -581,6 +588,8 @@ type AdaptiveState
                 ranges
 
               | _ -> ranges)
+
+          progressCt.ThrowIfCancellationRequested()
 
           do!
             triggerNotificationAndWait
@@ -1811,18 +1820,18 @@ type AdaptiveState
       let! progressCt = typecheckProgressReporter.GetCancellationToken()
 
       let! result =
-        match compilerOptions with
-        | CompilerProjectOption.TransparentCompiler snap ->
-          checker.ParseAndCheckFileInProject(file.Source.FileName, snap, shouldCache = shouldCache)
-        | CompilerProjectOption.BackgroundCompiler opts ->
-          checker.ParseAndCheckFileInProject(
-            file.Source.FileName,
-            file.Version,
-            file.Source,
-            opts,
-            shouldCache = shouldCache
-          )
-          |> Async.withCancellation progressCt
+        (match compilerOptions with
+         | CompilerProjectOption.TransparentCompiler snap ->
+           checker.ParseAndCheckFileInProject(file.Source.FileName, snap, shouldCache = shouldCache)
+         | CompilerProjectOption.BackgroundCompiler opts ->
+           checker.ParseAndCheckFileInProject(
+             file.Source.FileName,
+             file.Version,
+             file.Source,
+             opts,
+             shouldCache = shouldCache
+           ))
+        |> Async.withCancellation progressCt
 
 
       let! ct = Async.CancellationToken
@@ -2541,7 +2550,6 @@ type AdaptiveState
 
       let batchFileList = innerChecks |> Array.map (fun (_, file) -> UMX.untag file)
 
-      // Start batch first so the report (and its CancellationToken) exists before per-file work begins
       use! _batchProgress = typecheckProgressReporter.BeginBatch(batchFileList)
       let! progressCt = typecheckProgressReporter.GetCancellationToken()
 
@@ -2551,19 +2559,15 @@ type AdaptiveState
         innerChecks
         |> Array.map (fun (proj, file) ->
           asyncEx {
+            let fileToken =
+              if file = sourceFilePath then
+                CancellationToken.None
+              else
+                resetCancellationToken file None
 
             use joinedToken =
-              if file = sourceFilePath then
-                // dont reset the token for the incoming file as it would cancel the whole operation
-                CancellationTokenSource.CreateLinkedTokenSource(rootToken, progressCt)
-              else
-                // only cancel other files
-                // If we have multiple saves from separate root files we want only one to be running
-                let fileToken = resetCancellationToken file None
-                // and join with the root token as well since we want to cancel the whole operation if the root files changes
-                CancellationTokenSource.CreateLinkedTokenSource(rootToken, fileToken, progressCt)
+              CancellationTokenSource.CreateLinkedTokenSource(rootToken, fileToken, progressCt)
 
-            // Track per-file progress so the shared reporter updates message and batch counter
             use! _fileProgress = typecheckProgressReporter.Begin(UMX.untag file)
 
             try
@@ -2572,8 +2576,10 @@ type AdaptiveState
                 |> Async.withCancellation joinedToken.Token
 
               ()
-            with :? OperationCanceledException ->
-              // if a file shows up multiple times in the list such as Microsoft.NET.Test.Sdk.Program.fs we may cancel it but we don't want to stop the whole operation for it
+            with :? OperationCanceledException when
+                fileToken.IsCancellationRequested
+                && not rootToken.IsCancellationRequested
+                && not progressCt.IsCancellationRequested ->
               ()
           })
 

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -185,6 +185,14 @@ type AdaptiveState
   let progressLookup = new ServerProgressLookup()
   do disposables.Add progressLookup
 
+  let typecheckProgressReporter =
+    new SharedTypecheckProgressReporter(
+      "Typechecking",
+      fun () -> progressLookup.CreateProgressReport(lspClient, cancellable = true)
+    )
+
+  do disposables.Add typecheckProgressReporter
+
   let serilogLoggerFactory = new SerilogLoggerFactory(Serilog.Log.Logger)
   do disposables.Add serilogLoggerFactory
 
@@ -1793,11 +1801,8 @@ type AdaptiveState
       )
 
 
-      use progressReport =
-        progressLookup.CreateProgressReport(lspClient, cancellable = true)
-
-      let simpleName = Path.GetFileName(UMX.untag file.Source.FileName)
-      do! progressReport.Begin($"Typechecking {simpleName}", message = $"{file.Source.FileName}")
+      let fileNameStr = UMX.untag file.Source.FileName
+      use! _fileProgress = typecheckProgressReporter.Begin(fileNameStr)
 
       let! result =
         match compilerOptions with
@@ -2519,29 +2524,23 @@ type AdaptiveState
         |> List.collect (fun (proj, snap) -> snap.SourceFilesTagged |> List.map (fun sourceFile -> proj, sourceFile))
         |> List.toArray
 
-      let mutable checksCompleted = 0
+      let innerChecks =
+        Array.concat [| dependentFiles; dependentProjectsAndSourceFiles |]
+        |> Array.filter (fun (_, file) ->
+          let file = UMX.untag file
 
-      use progressReporter =
-        progressLookup.CreateProgressReport(lspClient, cancellable = true)
+          file.Contains "AssemblyInfo.fs" |> not
+          && file.Contains "AssemblyAttributes.fs" |> not)
 
-      let percentage numerator denominator =
-        if denominator = 0 then
-          0u
-        else
-          ((float numerator) / (float denominator)) * 100.0 |> uint32
+      let batchFileList = innerChecks |> Array.map (fun (_, file) -> UMX.untag file)
+
+      // Start batch first so the report (and its CancellationToken) exists before per-file work begins
+      use! _batchProgress = typecheckProgressReporter.BeginBatch(batchFileList)
+      let! progressCt = typecheckProgressReporter.GetCancellationToken()
+
+      let rootToken = sourceFilePath |> getOpenFileTokenOrDefault
 
       let checksToPerform =
-        let innerChecks =
-          Array.concat [| dependentFiles; dependentProjectsAndSourceFiles |]
-          |> Array.filter (fun (_, file) ->
-            let file = UMX.untag file
-
-            file.Contains "AssemblyInfo.fs" |> not
-            && file.Contains "AssemblyAttributes.fs" |> not)
-
-        let checksToPerformLength = innerChecks.Length
-        let rootToken = sourceFilePath |> getOpenFileTokenOrDefault
-
         innerChecks
         |> Array.map (fun (proj, file) ->
           async {
@@ -2549,45 +2548,32 @@ type AdaptiveState
             use joinedToken =
               if file = sourceFilePath then
                 // dont reset the token for the incoming file as it would cancel the whole operation
-                CancellationTokenSource.CreateLinkedTokenSource(rootToken, progressReporter.CancellationToken)
+                CancellationTokenSource.CreateLinkedTokenSource(rootToken, progressCt)
               else
                 // only cancel other files
                 // If we have multiple saves from separate root files we want only one to be running
                 let fileToken = resetCancellationToken file None
                 // and join with the root token as well since we want to cancel the whole operation if the root files changes
-                CancellationTokenSource.CreateLinkedTokenSource(
-                  rootToken,
-                  fileToken,
-                  progressReporter.CancellationToken
-                )
+                CancellationTokenSource.CreateLinkedTokenSource(rootToken, fileToken, progressCt)
+
+            // Track per-file progress so the shared reporter updates message and batch counter
+            let! fileProgress =
+              typecheckProgressReporter.Begin (UMX.untag file) CancellationToken.None
+              |> Async.AwaitTask
 
             try
-              let! _ =
-                bypassAdaptiveTypeCheck (file) (proj) (AVal.force proj.FSharpProjectCompilerOptions)
-                |> Async.withCancellation joinedToken.Token
+              try
+                let! _ =
+                  bypassAdaptiveTypeCheck (file) (proj) (AVal.force proj.FSharpProjectCompilerOptions)
+                  |> Async.withCancellation joinedToken.Token
 
-              ()
-            with :? OperationCanceledException ->
-              // if a file shows up multiple times in the list such as Microsoft.NET.Test.Sdk.Program.fs we may cancel it but we don't want to stop the whole operation for it
-              ()
-
-            let checksCompleted = Interlocked.Increment(&checksCompleted)
-
-            do!
-              progressReporter.Report(
-                message = $"{checksCompleted}/{checksToPerformLength} remaining",
-                percentage = percentage checksCompleted checksToPerformLength
-              )
+                ()
+              with :? OperationCanceledException ->
+                // if a file shows up multiple times in the list such as Microsoft.NET.Test.Sdk.Program.fs we may cancel it but we don't want to stop the whole operation for it
+                ()
+            finally
+              fileProgress.DisposeAsync().AsTask().GetAwaiter().GetResult()
           })
-
-
-
-      do!
-        progressReporter.Begin(
-          "Typechecking Dependent F# files",
-          message = $"0/{checksToPerform.Length} remaining",
-          percentage = percentage 0 checksToPerform.Length
-        )
 
       do! checksToPerform |> Async.parallel75 |> Async.Ignore<unit array>
 

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -185,13 +185,25 @@ type AdaptiveState
   let progressLookup = new ServerProgressLookup()
   do disposables.Add progressLookup
 
+  let config = cval<FSharpConfig> FSharpConfig.Default
+
   let typecheckProgressReporter =
     new SharedTypecheckProgressReporter(
       "Typechecking",
-      fun () -> progressLookup.CreateProgressReport(lspClient, cancellable = true)
+      (fun () -> progressLookup.CreateProgressReport(lspClient, cancellable = true)),
+      isEnabled = (fun () -> (AVal.force config).Notifications.BackgroundServiceProgress)
     )
 
   do disposables.Add typecheckProgressReporter
+
+  let analyzerProgressReporter =
+    new SharedTypecheckProgressReporter(
+      "Analyzing",
+      (fun () -> progressLookup.CreateProgressReport(lspClient, cancellable = true)),
+      isEnabled = (fun () -> (AVal.force config).Notifications.BackgroundServiceProgress)
+    )
+
+  do disposables.Add analyzerProgressReporter
 
   let serilogLoggerFactory = new SerilogLoggerFactory(Serilog.Log.Logger)
   do disposables.Add serilogLoggerFactory
@@ -199,8 +211,6 @@ type AdaptiveState
   let projectSelector = cval<IFindProject> (FindFirstProject())
 
   let rootPath = cval<string option> None
-
-  let config = cval<FSharpConfig> FSharpConfig.Default
 
   let checker =
     config
@@ -488,14 +498,12 @@ type AdaptiveState
         try
           let! ct = Async.CancellationToken
           use! _l = analyzersLocker.LockAsync(ct)
-          use progress = progressLookup.CreateProgressReport(lspClient, cancellable = true)
-
-          if config.Notifications.BackgroundServiceProgress then
-            do! progress.Begin($"Checking unused opens {fileName}...", message = filePathUntag)
+          use! _progress = analyzerProgressReporter.Begin($"Unused opens - {fileName}")
+          let! progressCt = analyzerProgressReporter.GetCancellationToken()
 
           let! unused =
             UnusedOpens.getUnusedOpens (tyRes.GetCheckResults, getSourceLine)
-            |> Async.withCancellation progress.CancellationToken
+            |> Async.withCancellation progressCt
 
           do!
             triggerNotificationAndWait
@@ -510,16 +518,14 @@ type AdaptiveState
         try
           let! ct = Async.CancellationToken
           use! _l = analyzersLocker.LockAsync(ct)
-          use progress = progressLookup.CreateProgressReport(lspClient, cancellable = true)
-
-          if config.Notifications.BackgroundServiceProgress then
-            do! progress.Begin($"Checking unused declarations {fileName}...", message = filePathUntag)
+          use! _progress = analyzerProgressReporter.Begin($"Unused declarations - {fileName}")
+          let! progressCt = analyzerProgressReporter.GetCancellationToken()
 
           let isScript = Utils.isAScript (filePathUntag)
 
           let! unused =
             UnusedDeclarations.getUnusedDeclarations (tyRes.GetCheckResults, isScript)
-            |> Async.withCancellation progress.CancellationToken
+            |> Async.withCancellation progressCt
 
           let unused = unused |> Seq.toArray
 
@@ -533,14 +539,12 @@ type AdaptiveState
         try
           let! ct = Async.CancellationToken
           use! _l = analyzersLocker.LockAsync(ct)
-          use progress = progressLookup.CreateProgressReport(lspClient, cancellable = true)
-
-          if config.Notifications.BackgroundServiceProgress then
-            do! progress.Begin($"Checking simplifying of names {fileName}...", message = filePathUntag)
+          use! _progress = analyzerProgressReporter.Begin($"Simplify names - {fileName}")
+          let! progressCt = analyzerProgressReporter.GetCancellationToken()
 
           let! simplified =
             SimplifyNames.getSimplifiableNames (tyRes.GetCheckResults, getSourceLine)
-            |> Async.withCancellation progress.CancellationToken
+            |> Async.withCancellation progressCt
 
           let simplified = Array.ofSeq simplified
           do! triggerNotificationAndWait (NotificationEvent.SimplifyNames(filePath, simplified, file.Version)) ct
@@ -553,10 +557,7 @@ type AdaptiveState
         try
           let! ct = Async.CancellationToken
           use! _l = analyzersLocker.LockAsync(ct)
-          use progress = progressLookup.CreateProgressReport(lspClient)
-
-          if config.Notifications.BackgroundServiceProgress then
-            do! progress.Begin($"Checking for unnecessary parentheses {fileName}...", message = filePathUntag)
+          use! _progress = analyzerProgressReporter.Begin($"Unnecessary parens - {fileName}")
 
           let unnecessaryParentheses =
             (System.Collections.Generic.HashSet(comparer = Range.comparer), tyRes.GetAST)
@@ -629,10 +630,8 @@ type AdaptiveState
         let file = volatileFile.FileName
 
         try
-          use progress = new ServerProgressReport(lspClient)
-
-          if config.Notifications.BackgroundServiceProgress then
-            do! progress.Begin("Running analyzers...", message = UMX.untag file)
+          let fileName = Path.GetFileName(UMX.untag file)
+          use! _progress = analyzerProgressReporter.Begin($"External analyzers - {fileName}")
 
           Loggers.analyzers.info (
             Log.setMessage "begin analysis of {file}"
@@ -2543,7 +2542,7 @@ type AdaptiveState
       let checksToPerform =
         innerChecks
         |> Array.map (fun (proj, file) ->
-          async {
+          asyncEx {
 
             use joinedToken =
               if file = sourceFilePath then
@@ -2557,25 +2556,20 @@ type AdaptiveState
                 CancellationTokenSource.CreateLinkedTokenSource(rootToken, fileToken, progressCt)
 
             // Track per-file progress so the shared reporter updates message and batch counter
-            let! fileProgress =
-              typecheckProgressReporter.Begin (UMX.untag file) CancellationToken.None
-              |> Async.AwaitTask
+            use! _fileProgress = typecheckProgressReporter.Begin(UMX.untag file)
 
             try
-              try
-                let! _ =
-                  bypassAdaptiveTypeCheck (file) (proj) (AVal.force proj.FSharpProjectCompilerOptions)
-                  |> Async.withCancellation joinedToken.Token
+              let! _ =
+                bypassAdaptiveTypeCheck (file) (proj) (AVal.force proj.FSharpProjectCompilerOptions)
+                |> Async.withCancellation joinedToken.Token
 
-                ()
-              with :? OperationCanceledException ->
-                // if a file shows up multiple times in the list such as Microsoft.NET.Test.Sdk.Program.fs we may cancel it but we don't want to stop the whole operation for it
-                ()
-            finally
-              fileProgress.DisposeAsync().AsTask().GetAwaiter().GetResult()
+              ()
+            with :? OperationCanceledException ->
+              // if a file shows up multiple times in the list such as Microsoft.NET.Test.Sdk.Program.fs we may cancel it but we don't want to stop the whole operation for it
+              ()
           })
 
-      do! checksToPerform |> Async.parallel75 |> Async.Ignore<unit array>
+      do! checksToPerform |> Async.parallel25 |> Async.Ignore<unit array>
 
     }
 

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -205,6 +205,11 @@ type AdaptiveState
 
   do disposables.Add analyzerProgressReporter
 
+  let projectLoadingProgressReporter =
+    new SharedTypecheckProgressReporter("Loading Projects", fun () -> progressLookup.CreateProgressReport(lspClient))
+
+  do disposables.Add projectLoadingProgressReporter
+
   let serilogLoggerFactory = new SerilogLoggerFactory(Serilog.Log.Logger)
   do disposables.Add serilogLoggerFactory
 
@@ -1039,13 +1044,12 @@ type AdaptiveState
 
         triggerNotification not CancellationToken.None)
 
-      use progressReport = new ServerProgressReport(lspClient)
+      let projectFiles = projects |> Seq.map (fst >> UMX.untag) |> Seq.toArray
 
-      progressReport.Begin ($"Loading {projects.Count} Projects") (CancellationToken.None)
-      |> ignore<Task<unit>>
+      use _progressReport = projectLoadingProgressReporter.BeginBatchSync(projectFiles)
 
       let projectOptions =
-        loader.LoadProjects(projects |> Seq.map (fst >> UMX.untag) |> Seq.toList, [], binlogConfig)
+        loader.LoadProjects(projectFiles |> Array.toList, [], binlogConfig)
         |> Seq.toList
 
       for p in projectOptions do
@@ -1802,6 +1806,7 @@ type AdaptiveState
 
       let fileNameStr = UMX.untag file.Source.FileName
       use! _fileProgress = typecheckProgressReporter.Begin(fileNameStr)
+      let! progressCt = typecheckProgressReporter.GetCancellationToken()
 
       let! result =
         match compilerOptions with
@@ -1815,6 +1820,7 @@ type AdaptiveState
             opts,
             shouldCache = shouldCache
           )
+          |> Async.withCancellation progressCt
 
 
       let! ct = Async.CancellationToken

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -637,6 +637,7 @@ type AdaptiveState
         try
           let fileName = Path.GetFileName(UMX.untag file)
           use! _progress = analyzerProgressReporter.Begin($"External analyzers - {fileName}")
+          let! progressCt = analyzerProgressReporter.GetCancellationToken()
 
           Loggers.analyzers.info (
             Log.setMessage "begin analysis of {file}"
@@ -686,6 +687,7 @@ type AdaptiveState
                 analyzerOptions,
                 analyzerPredicate
               )
+              |> Async.withCancellation progressCt
 
             let! ct = Async.CancellationToken
             do! triggerNotificationAndWait (NotificationEvent.AnalyzerMessage(res, file, volatileFile.Version)) ct
@@ -1820,7 +1822,7 @@ type AdaptiveState
             opts,
             shouldCache = shouldCache
           )
-        |> Async.withCancellation progressCt
+          |> Async.withCancellation progressCt
 
 
       let! ct = Async.CancellationToken

--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fs
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fs
@@ -180,6 +180,168 @@ type ServerProgressReport(lspClient: FSharpLspClient, ?token: ProgressToken, ?ca
     member x.Dispose() = (x :> IAsyncDisposable).DisposeAsync() |> ignore
 
 
+/// <summary>
+/// A shared progress reporter that consolidates multiple concurrent typecheck operations
+/// into a single LSP progress notification. Instead of creating a new Begin/End cycle per file,
+/// this maintains one notification that updates its message with the current file being checked.
+/// </summary>
+type SharedTypecheckProgressReporter
+  (title: string, createReport: unit -> ServerProgressReport) =
+
+  let locker = new SemaphoreSlim(1, 1)
+  /// Display-only set of short file names currently being checked
+  let mutable activeFiles = Set.empty<string>
+  let mutable progressReport: ServerProgressReport option = None
+  let mutable batchTotal = 0
+  let mutable batchCompleted = 0
+  /// Tracks which files belong to active batches (by full normalized path) for accurate counting
+  let mutable batchFiles = Set.empty<string>
+  /// Number of currently active batch scopes (supports overlapping batches)
+  let mutable activeBatchScopes = 0
+
+  let normalizePath (path: string) = IO.Path.GetFullPath(path)
+
+  let buildMessage () =
+    let filesPart =
+      match Set.count activeFiles with
+      | 0 -> None
+      | 1 -> activeFiles |> Set.toList |> List.head |> Some
+      | n ->
+        let fileList = activeFiles |> Set.toList |> List.truncate 3 |> String.concat ", "
+
+        (if n > 3 then $"{fileList} (+{n - 3} more)" else fileList) |> Some
+
+    let batchPart =
+      if batchTotal > 0 then
+        Some $"{batchCompleted}/{batchTotal} completed"
+      else
+        None
+
+    match filesPart, batchPart with
+    | Some files, Some batch -> Some $"{files} ({batch})"
+    | Some files, None -> Some files
+    | None, Some batch -> Some batch
+    | None, None -> None
+
+  let calcPercentage () =
+    if batchTotal > 0 then
+      ((float batchCompleted) / (float batchTotal)) * 100.0 |> uint32 |> Some
+    else
+      None
+
+  member private x.StartFile(fileName: string) =
+    cancellableTask {
+      use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
+      let simpleName = IO.Path.GetFileName fileName
+      activeFiles <- Set.add simpleName activeFiles
+
+      match progressReport with
+      | None ->
+        let report = createReport ()
+        progressReport <- Some report
+        let message = buildMessage ()
+        do! report.Begin(title, ?message = message, ?percentage = calcPercentage ())
+      | Some report ->
+        let message = buildMessage ()
+        do! report.Report(?message = message, ?percentage = calcPercentage ())
+    }
+
+  member private x.EndFile(fileName: string) =
+    cancellableTask {
+      use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
+      let simpleName = IO.Path.GetFileName fileName
+      activeFiles <- Set.remove simpleName activeFiles
+
+      let normalizedName = normalizePath fileName
+
+      if batchTotal > 0 && Set.contains normalizedName batchFiles then
+        batchCompleted <- min (batchCompleted + 1) batchTotal
+        batchFiles <- Set.remove normalizedName batchFiles
+
+      match progressReport with
+      | Some report when Set.isEmpty activeFiles && activeBatchScopes <= 0 ->
+        do! report.End()
+        progressReport <- None
+      | Some report ->
+        let message = buildMessage ()
+        do! report.Report(?message = message, ?percentage = calcPercentage ())
+      | None -> ()
+    }
+
+  /// <summary>Begin tracking a file being typechecked. Returns an IAsyncDisposable that ends tracking on dispose.</summary>
+  member x.Begin(fileName: string) : CancellableTask<IAsyncDisposable> =
+    cancellableTask {
+      do! x.StartFile(fileName)
+
+      return
+        { new IAsyncDisposable with
+            member _.DisposeAsync() = x.EndFile (fileName) CancellationToken.None |> ValueTask }
+    }
+
+  member private x.StartBatch(files: string array) =
+    cancellableTask {
+      use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
+      activeBatchScopes <- activeBatchScopes + 1
+      let normalizedFiles = files |> Array.map normalizePath |> Array.distinct
+      batchTotal <- batchTotal + normalizedFiles.Length
+      batchFiles <- Set.union batchFiles (normalizedFiles |> Set.ofArray)
+
+      // Eagerly create the report so the CancellationToken is available for linking
+      match progressReport with
+      | None ->
+        let report = createReport ()
+        progressReport <- Some report
+        do! report.Begin(title, ?percentage = calcPercentage ())
+      | Some report -> do! report.Report(?percentage = calcPercentage ())
+    }
+
+  member private x.EndBatch() =
+    cancellableTask {
+      use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
+      activeBatchScopes <- activeBatchScopes - 1
+
+      if activeBatchScopes <= 0 then
+        activeBatchScopes <- 0
+        batchTotal <- 0
+        batchCompleted <- 0
+        batchFiles <- Set.empty
+
+      // End the report if nothing else is active
+      if Set.isEmpty activeFiles && activeBatchScopes <= 0 then
+        match progressReport with
+        | Some report ->
+          do! report.End()
+          progressReport <- None
+        | None -> ()
+    }
+
+  /// <summary>Set up a batch of files to be typechecked. Returns an IAsyncDisposable that clears the batch on dispose.</summary>
+  member x.BeginBatch(files: string array) : CancellableTask<IAsyncDisposable> =
+    cancellableTask {
+      do! x.StartBatch(files)
+
+      return
+        { new IAsyncDisposable with
+            member _.DisposeAsync() = x.EndBatch () CancellationToken.None |> ValueTask }
+    }
+
+  /// <summary>Gets the cancellation token from the current progress report, or CancellationToken.None if no report is active.</summary>
+  member x.GetCancellationToken() : Task<CancellationToken> =
+    task {
+      use! __ = locker.LockAsync()
+
+      return
+        match progressReport with
+        | Some report -> report.CancellationToken
+        | None -> CancellationToken.None
+    }
+
+  interface IDisposable with
+    member x.Dispose() =
+      progressReport |> Option.iter (fun r -> (r :> IDisposable).Dispose())
+      locker.Dispose()
+
+
 open System.Diagnostics.Tracing
 open System.Collections.Concurrent
 open System.Diagnostics

--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fs
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fs
@@ -186,9 +186,11 @@ type ServerProgressReport(lspClient: FSharpLspClient, ?token: ProgressToken, ?ca
 /// this maintains one notification that updates its message with the current file being checked.
 /// </summary>
 type SharedTypecheckProgressReporter
-  (title: string, createReport: unit -> ServerProgressReport) =
+  (title: string, createReport: unit -> ServerProgressReport, ?isEnabled: unit -> bool)
+  =
 
   let locker = new SemaphoreSlim(1, 1)
+  let isEnabled = defaultArg isEnabled (fun () -> true)
   /// Display-only set of short file names currently being checked
   let mutable activeFiles = Set.empty<string>
   let mutable progressReport: ServerProgressReport option = None
@@ -231,19 +233,24 @@ type SharedTypecheckProgressReporter
 
   member private x.StartFile(fileName: string) =
     cancellableTask {
-      use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
-      let simpleName = IO.Path.GetFileName fileName
-      activeFiles <- Set.add simpleName activeFiles
+      if isEnabled () then
+        use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
+        let simpleName = IO.Path.GetFileName fileName
+        activeFiles <- Set.add simpleName activeFiles
 
-      match progressReport with
-      | None ->
-        let report = createReport ()
-        progressReport <- Some report
-        let message = buildMessage ()
-        do! report.Begin(title, ?message = message, ?percentage = calcPercentage ())
-      | Some report ->
-        let message = buildMessage ()
-        do! report.Report(?message = message, ?percentage = calcPercentage ())
+        match progressReport with
+        | None ->
+          let report = createReport ()
+          progressReport <- Some report
+          let message = buildMessage ()
+          do! report.Begin(title, ?message = message, ?percentage = calcPercentage ())
+        | Some report ->
+          let message = buildMessage ()
+          do! report.Report(?message = message, ?percentage = calcPercentage ())
+
+        return true
+      else
+        return false
     }
 
   member private x.EndFile(fileName: string) =
@@ -271,28 +278,37 @@ type SharedTypecheckProgressReporter
   /// <summary>Begin tracking a file being typechecked. Returns an IAsyncDisposable that ends tracking on dispose.</summary>
   member x.Begin(fileName: string) : CancellableTask<IAsyncDisposable> =
     cancellableTask {
-      do! x.StartFile(fileName)
+      let! started = x.StartFile(fileName)
 
       return
         { new IAsyncDisposable with
-            member _.DisposeAsync() = x.EndFile (fileName) CancellationToken.None |> ValueTask }
+            member _.DisposeAsync() =
+              if started then
+                x.EndFile (fileName) CancellationToken.None |> ValueTask
+              else
+                ValueTask() }
     }
 
   member private x.StartBatch(files: string array) =
     cancellableTask {
-      use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
-      activeBatchScopes <- activeBatchScopes + 1
-      let normalizedFiles = files |> Array.map normalizePath |> Array.distinct
-      batchTotal <- batchTotal + normalizedFiles.Length
-      batchFiles <- Set.union batchFiles (normalizedFiles |> Set.ofArray)
+      if isEnabled () then
+        use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
+        activeBatchScopes <- activeBatchScopes + 1
+        let normalizedFiles = files |> Array.map normalizePath |> Array.distinct
+        batchTotal <- batchTotal + normalizedFiles.Length
+        batchFiles <- Set.union batchFiles (normalizedFiles |> Set.ofArray)
 
-      // Eagerly create the report so the CancellationToken is available for linking
-      match progressReport with
-      | None ->
-        let report = createReport ()
-        progressReport <- Some report
-        do! report.Begin(title, ?percentage = calcPercentage ())
-      | Some report -> do! report.Report(?percentage = calcPercentage ())
+        // Eagerly create the report so the CancellationToken is available for linking
+        match progressReport with
+        | None ->
+          let report = createReport ()
+          progressReport <- Some report
+          do! report.Begin(title, ?percentage = calcPercentage ())
+        | Some report -> do! report.Report(?percentage = calcPercentage ())
+
+        return true
+      else
+        return false
     }
 
   member private x.EndBatch() =
@@ -318,11 +334,15 @@ type SharedTypecheckProgressReporter
   /// <summary>Set up a batch of files to be typechecked. Returns an IAsyncDisposable that clears the batch on dispose.</summary>
   member x.BeginBatch(files: string array) : CancellableTask<IAsyncDisposable> =
     cancellableTask {
-      do! x.StartBatch(files)
+      let! started = x.StartBatch(files)
 
       return
         { new IAsyncDisposable with
-            member _.DisposeAsync() = x.EndBatch () CancellationToken.None |> ValueTask }
+            member _.DisposeAsync() =
+              if started then
+                x.EndBatch () CancellationToken.None |> ValueTask
+              else
+                ValueTask() }
     }
 
   /// <summary>Gets the cancellation token from the current progress report, or CancellationToken.None if no report is active.</summary>

--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fs
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fs
@@ -190,25 +190,39 @@ type SharedTypecheckProgressReporter
 
   let locker = new SemaphoreSlim(1, 1)
   let isEnabled = defaultArg isEnabled (fun () -> true)
-  /// Display-only set of short file names currently being checked
-  let mutable activeFiles = Set.empty<string>
+  let mutable activeFiles = Map.empty<string, int>
   let mutable progressReport: ServerProgressReport option = None
   let mutable batchTotal = 0
   let mutable batchCompleted = 0
-  /// Tracks which files belong to active batches (by full normalized path) for accurate counting
-  let mutable batchFiles = Set.empty<string>
-  /// Number of currently active batch scopes (supports overlapping batches)
+  let mutable batchFiles = Map.empty<string, int>
   let mutable activeBatchScopes = 0
 
   let normalizePath (path: string) = IO.Path.GetFullPath(path)
 
+  let incrementCount key counts =
+    counts
+    |> Map.change key (function
+      | Some count -> Some(count + 1)
+      | None -> Some 1)
+
+  let decrementCount key counts =
+    counts
+    |> Map.change key (function
+      | Some count when count > 1 -> Some(count - 1)
+      | Some _ -> None
+      | None -> None)
+
   let buildMessage () =
+    let activeFileNames =
+      activeFiles |> Map.toList |> List.map (fst >> IO.Path.GetFileName)
+
     let filesPart =
-      match Set.count activeFiles with
-      | 0 -> None
-      | 1 -> activeFiles |> Set.toList |> List.head |> Some
-      | n ->
-        let fileList = activeFiles |> Set.toList |> List.truncate 3 |> String.concat ", "
+      match activeFileNames with
+      | [] -> None
+      | [ file ] -> Some file
+      | files ->
+        let n = List.length files
+        let fileList = files |> List.truncate 3 |> String.concat ", "
 
         (if n > 3 then $"{fileList} (+{n - 3} more)" else fileList) |> Some
 
@@ -233,8 +247,8 @@ type SharedTypecheckProgressReporter
   member private x.StartFile(fileName: string) =
     cancellableTask {
       use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
-      let simpleName = IO.Path.GetFileName fileName
-      activeFiles <- Set.add simpleName activeFiles
+      let normalizedName = normalizePath fileName
+      activeFiles <- incrementCount normalizedName activeFiles
 
       match progressReport with
       | None ->
@@ -250,17 +264,15 @@ type SharedTypecheckProgressReporter
   member private x.EndFile(fileName: string) =
     cancellableTask {
       use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
-      let simpleName = IO.Path.GetFileName fileName
-      activeFiles <- Set.remove simpleName activeFiles
-
       let normalizedName = normalizePath fileName
+      activeFiles <- decrementCount normalizedName activeFiles
 
-      if batchTotal > 0 && Set.contains normalizedName batchFiles then
+      if batchTotal > 0 && Map.containsKey normalizedName batchFiles then
         batchCompleted <- min (batchCompleted + 1) batchTotal
-        batchFiles <- Set.remove normalizedName batchFiles
+        batchFiles <- decrementCount normalizedName batchFiles
 
       match progressReport with
-      | Some report when Set.isEmpty activeFiles && activeBatchScopes <= 0 ->
+      | Some report when Map.isEmpty activeFiles && activeBatchScopes <= 0 ->
         do! report.End()
         progressReport <- None
       | Some report ->
@@ -290,9 +302,12 @@ type SharedTypecheckProgressReporter
     cancellableTask {
       use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
       activeBatchScopes <- activeBatchScopes + 1
-      let normalizedFiles = files |> Array.map normalizePath |> Array.distinct
+      let normalizedFiles = files |> Array.map normalizePath
       batchTotal <- batchTotal + normalizedFiles.Length
-      batchFiles <- Set.union batchFiles (normalizedFiles |> Set.ofArray)
+
+      batchFiles <-
+        (batchFiles, normalizedFiles)
+        ||> Array.fold (fun counts file -> incrementCount file counts)
 
       // Eagerly create the report so the CancellationToken is available for linking
       match progressReport with
@@ -312,10 +327,10 @@ type SharedTypecheckProgressReporter
         activeBatchScopes <- 0
         batchTotal <- 0
         batchCompleted <- 0
-        batchFiles <- Set.empty
+        batchFiles <- Map.empty
 
       // End the report if nothing else is active
-      if Set.isEmpty activeFiles && activeBatchScopes <= 0 then
+      if Map.isEmpty activeFiles && activeBatchScopes <= 0 then
         match progressReport with
         | Some report ->
           do! report.End()

--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fs
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fs
@@ -356,6 +356,22 @@ type SharedTypecheckProgressReporter
         | None -> CancellationToken.None
     }
 
+  /// <summary>Set up a batch of files synchronously (for contexts where CancellableTask is not available).
+  /// Sets up batch tracking and adds all files to activeFiles so their names appear in the message.
+  /// Returns an IDisposable that ends all file tracking and the batch on dispose.</summary>
+  member x.BeginBatchSync(files: string array) : IDisposable =
+    x.StartBatch (files) CancellationToken.None |> ignore<Task<unit>>
+
+    for file in files do
+      x.StartFile (file) CancellationToken.None |> ignore<Task<unit>>
+
+    { new IDisposable with
+        member _.Dispose() =
+          for file in files do
+            x.EndFile (file) CancellationToken.None |> ignore<Task<unit>>
+
+          x.EndBatch () CancellationToken.None |> ignore<Task<unit>> }
+
   interface IDisposable with
     member x.Dispose() =
       progressReport |> Option.iter (fun r -> (r :> IDisposable).Dispose())

--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fs
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fs
@@ -186,8 +186,7 @@ type ServerProgressReport(lspClient: FSharpLspClient, ?token: ProgressToken, ?ca
 /// this maintains one notification that updates its message with the current file being checked.
 /// </summary>
 type SharedTypecheckProgressReporter
-  (title: string, createReport: unit -> ServerProgressReport, ?isEnabled: unit -> bool)
-  =
+  (title: string, createReport: unit -> ServerProgressReport, ?isEnabled: unit -> bool) =
 
   let locker = new SemaphoreSlim(1, 1)
   let isEnabled = defaultArg isEnabled (fun () -> true)
@@ -233,24 +232,19 @@ type SharedTypecheckProgressReporter
 
   member private x.StartFile(fileName: string) =
     cancellableTask {
-      if isEnabled () then
-        use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
-        let simpleName = IO.Path.GetFileName fileName
-        activeFiles <- Set.add simpleName activeFiles
+      use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
+      let simpleName = IO.Path.GetFileName fileName
+      activeFiles <- Set.add simpleName activeFiles
 
-        match progressReport with
-        | None ->
-          let report = createReport ()
-          progressReport <- Some report
-          let message = buildMessage ()
-          do! report.Begin(title, ?message = message, ?percentage = calcPercentage ())
-        | Some report ->
-          let message = buildMessage ()
-          do! report.Report(?message = message, ?percentage = calcPercentage ())
-
-        return true
-      else
-        return false
+      match progressReport with
+      | None ->
+        let report = createReport ()
+        progressReport <- Some report
+        let message = buildMessage ()
+        do! report.Begin(title, ?message = message, ?percentage = calcPercentage ())
+      | Some report ->
+        let message = buildMessage ()
+        do! report.Report(?message = message, ?percentage = calcPercentage ())
     }
 
   member private x.EndFile(fileName: string) =
@@ -278,7 +272,10 @@ type SharedTypecheckProgressReporter
   /// <summary>Begin tracking a file being typechecked. Returns an IAsyncDisposable that ends tracking on dispose.</summary>
   member x.Begin(fileName: string) : CancellableTask<IAsyncDisposable> =
     cancellableTask {
-      let! started = x.StartFile(fileName)
+      let started = isEnabled ()
+
+      if started then
+        do! x.StartFile(fileName)
 
       return
         { new IAsyncDisposable with
@@ -291,24 +288,19 @@ type SharedTypecheckProgressReporter
 
   member private x.StartBatch(files: string array) =
     cancellableTask {
-      if isEnabled () then
-        use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
-        activeBatchScopes <- activeBatchScopes + 1
-        let normalizedFiles = files |> Array.map normalizePath |> Array.distinct
-        batchTotal <- batchTotal + normalizedFiles.Length
-        batchFiles <- Set.union batchFiles (normalizedFiles |> Set.ofArray)
+      use! __ = fun (ct: CancellationToken) -> locker.LockAsync(ct)
+      activeBatchScopes <- activeBatchScopes + 1
+      let normalizedFiles = files |> Array.map normalizePath |> Array.distinct
+      batchTotal <- batchTotal + normalizedFiles.Length
+      batchFiles <- Set.union batchFiles (normalizedFiles |> Set.ofArray)
 
-        // Eagerly create the report so the CancellationToken is available for linking
-        match progressReport with
-        | None ->
-          let report = createReport ()
-          progressReport <- Some report
-          do! report.Begin(title, ?percentage = calcPercentage ())
-        | Some report -> do! report.Report(?percentage = calcPercentage ())
-
-        return true
-      else
-        return false
+      // Eagerly create the report so the CancellationToken is available for linking
+      match progressReport with
+      | None ->
+        let report = createReport ()
+        progressReport <- Some report
+        do! report.Begin(title, ?percentage = calcPercentage ())
+      | Some report -> do! report.Report(?percentage = calcPercentage ())
     }
 
   member private x.EndBatch() =
@@ -334,7 +326,10 @@ type SharedTypecheckProgressReporter
   /// <summary>Set up a batch of files to be typechecked. Returns an IAsyncDisposable that clears the batch on dispose.</summary>
   member x.BeginBatch(files: string array) : CancellableTask<IAsyncDisposable> =
     cancellableTask {
-      let! started = x.StartBatch(files)
+      let started = isEnabled ()
+
+      if started then
+        do! x.StartBatch(files)
 
       return
         { new IAsyncDisposable with
@@ -360,17 +355,21 @@ type SharedTypecheckProgressReporter
   /// Sets up batch tracking and adds all files to activeFiles so their names appear in the message.
   /// Returns an IDisposable that ends all file tracking and the batch on dispose.</summary>
   member x.BeginBatchSync(files: string array) : IDisposable =
-    x.StartBatch (files) CancellationToken.None |> ignore<Task<unit>>
+    let started = isEnabled ()
 
-    for file in files do
-      x.StartFile (file) CancellationToken.None |> ignore<Task<unit>>
+    if started then
+      x.StartBatch (files) CancellationToken.None |> ignore<Task<unit>>
+
+      for file in files do
+        x.StartFile (file) CancellationToken.None |> ignore<Task<unit>>
 
     { new IDisposable with
         member _.Dispose() =
-          for file in files do
-            x.EndFile (file) CancellationToken.None |> ignore<Task<unit>>
+          if started then
+            for file in files do
+              x.EndFile (file) CancellationToken.None |> ignore<Task<unit>>
 
-          x.EndBatch () CancellationToken.None |> ignore<Task<unit>> }
+            x.EndBatch () CancellationToken.None |> ignore<Task<unit>> }
 
   interface IDisposable with
     member x.Dispose() =

--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fsi
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fsi
@@ -7,6 +7,7 @@ open Ionide.LanguageServerProtocol.JsonRpc
 open FsAutoComplete.LspHelpers
 open System
 open System.Threading
+open System.Threading.Tasks
 open IcedTasks
 
 type FSharpLspClient =
@@ -77,6 +78,24 @@ type ServerProgressReport =
   /// <returns></returns>
   member End: ?message: string -> CancellableTask<unit>
   interface IAsyncDisposable
+  interface IDisposable
+
+/// <summary>
+/// A shared progress reporter that consolidates multiple concurrent typecheck operations
+/// into a single LSP progress notification. Instead of creating a new Begin/End cycle per file,
+/// this maintains one notification that updates its message with the current file being checked.
+/// </summary>
+type SharedTypecheckProgressReporter =
+  new: title: string * createReport: (unit -> ServerProgressReport) -> SharedTypecheckProgressReporter
+
+  /// <summary>Begin tracking a file being typechecked. Returns an IAsyncDisposable that ends tracking on dispose.</summary>
+  member Begin: fileName: string -> CancellableTask<IAsyncDisposable>
+
+  /// <summary>Set up a batch of files to be typechecked. Returns an IAsyncDisposable that clears the batch on dispose.</summary>
+  member BeginBatch: files: string array -> CancellableTask<IAsyncDisposable>
+
+  /// <summary>Gets the cancellation token from the current progress report, or CancellationToken.None if no report is active.</summary>
+  member GetCancellationToken: unit -> Task<CancellationToken>
   interface IDisposable
 
 /// <summary>listener for the the events generated from the fsc ActivitySource</summary>

--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fsi
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fsi
@@ -100,6 +100,11 @@ type SharedTypecheckProgressReporter =
 
   /// <summary>Gets the cancellation token from the current progress report, or CancellationToken.None if no report is active.</summary>
   member GetCancellationToken: unit -> Task<CancellationToken>
+
+  /// <summary>Set up a batch of files synchronously (for contexts where CancellableTask is not available).
+  /// Sets up batch tracking and adds all files to activeFiles so their names appear in the message.
+  /// Returns an IDisposable that ends all file tracking and the batch on dispose.</summary>
+  member BeginBatchSync: files: string array -> IDisposable
   interface IDisposable
 
 /// <summary>listener for the the events generated from the fsc ActivitySource</summary>

--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fsi
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fsi
@@ -87,9 +87,7 @@ type ServerProgressReport =
 /// </summary>
 type SharedTypecheckProgressReporter =
   new:
-    title: string *
-    createReport: (unit -> ServerProgressReport) *
-    ?isEnabled: (unit -> bool) ->
+    title: string * createReport: (unit -> ServerProgressReport) * ?isEnabled: (unit -> bool) ->
       SharedTypecheckProgressReporter
 
   /// <summary>Begin tracking a file being typechecked. Returns an IAsyncDisposable that ends tracking on dispose.</summary>

--- a/src/FsAutoComplete/LspServers/FSharpLspClient.fsi
+++ b/src/FsAutoComplete/LspServers/FSharpLspClient.fsi
@@ -86,7 +86,11 @@ type ServerProgressReport =
 /// this maintains one notification that updates its message with the current file being checked.
 /// </summary>
 type SharedTypecheckProgressReporter =
-  new: title: string * createReport: (unit -> ServerProgressReport) -> SharedTypecheckProgressReporter
+  new:
+    title: string *
+    createReport: (unit -> ServerProgressReport) *
+    ?isEnabled: (unit -> bool) ->
+      SharedTypecheckProgressReporter
 
   /// <summary>Begin tracking a file being typechecked. Returns an IAsyncDisposable that ends tracking on dispose.</summary>
   member Begin: fileName: string -> CancellableTask<IAsyncDisposable>

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -13,6 +13,7 @@ open FsAutoComplete.Tests.ExtensionsTests
 open FsAutoComplete.Tests.InteractiveDirectivesTests
 open FsAutoComplete.Tests.Lsp.CoreUtilsTests
 open FsAutoComplete.Tests.Lsp.DecompilerTests
+open FsAutoComplete.Tests.SharedTypecheckProgressReporterTests
 open FsAutoComplete.Tests.CallHierarchy
 open Ionide.ProjInfo
 open System.Threading
@@ -174,6 +175,7 @@ let generalTests =
     [ testCase "test host uses target runtime" (fun _ ->
         Expect.equal Environment.Version.Major expectedRuntimeMajor "Test host runtime must match the target framework")
       testList (nameof (Utils)) [ Utils.Tests.Utils.tests; Utils.Tests.TextEdit.tests ]
+      SharedTypecheckProgressReporterTests.tests
       InlayHintTests.explicitTypeInfoTests sourceTextFactory
       FindReferences.tryFixupRangeTests sourceTextFactory
       UtilsTests.allTests

--- a/test/FsAutoComplete.Tests.Lsp/SharedTypecheckProgressReporterTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/SharedTypecheckProgressReporterTests.fs
@@ -1,0 +1,681 @@
+module FsAutoComplete.Tests.SharedTypecheckProgressReporterTests
+
+open Expecto
+open System
+open System.Threading
+open System.Threading.Tasks
+open System.Collections.Concurrent
+open FsAutoComplete.Lsp
+open Ionide.LanguageServerProtocol
+open Ionide.LanguageServerProtocol.Server
+open Ionide.LanguageServerProtocol.Types
+open Ionide.LanguageServerProtocol.JsonRpc
+
+/// Captured progress call from the mock client
+type ProgressCall =
+  | Begin of title: string * message: string option * percentage: uint32 option
+  | Report of message: string option * percentage: uint32 option
+  | End of message: string option
+
+/// Creates a mock FSharpLspClient that captures all progress notifications
+let private createMockClient () =
+  let progressCalls = ConcurrentQueue<ProgressCall>()
+
+  let notificationSender: ClientNotificationSender =
+    fun methodName payload ->
+      match methodName with
+      | "$/progress" ->
+        let p = payload :?> ProgressParams
+        // Parse the progress value to determine the call type
+        let json = p.Value.ToString()
+
+        if json.Contains("\"kind\":\"begin\"") || json.Contains("\"kind\": \"begin\"") then
+          // Extract title from JSON
+          let titleStart = json.IndexOf("\"title\"") + "\"title\"".Length
+          let colonAfterTitle = json.IndexOf(":", titleStart) + 1
+          let titleQuoteStart = json.IndexOf("\"", colonAfterTitle) + 1
+          let titleQuoteEnd = json.IndexOf("\"", titleQuoteStart)
+          let title = json.Substring(titleQuoteStart, titleQuoteEnd - titleQuoteStart)
+
+          let message =
+            if json.Contains("\"message\"") then
+              let msgStart = json.IndexOf("\"message\"") + "\"message\"".Length
+              let colonAfterMsg = json.IndexOf(":", msgStart) + 1
+              let msgQuoteStart = json.IndexOf("\"", colonAfterMsg) + 1
+              let msgQuoteEnd = json.IndexOf("\"", msgQuoteStart)
+              Some(json.Substring(msgQuoteStart, msgQuoteEnd - msgQuoteStart))
+            else
+              None
+
+          let percentage =
+            if json.Contains("\"percentage\"") then
+              let pctStart = json.IndexOf("\"percentage\"") + "\"percentage\"".Length
+              let colonAfterPct = json.IndexOf(":", pctStart) + 1
+              // Find the number value after the colon
+              let numStr =
+                json.Substring(colonAfterPct).TrimStart()
+                |> fun s ->
+                  let endIdx = s.IndexOfAny([| ','; '}'; ' ' |])
+
+                  if endIdx > 0 then s.Substring(0, endIdx) else s
+
+              match UInt32.TryParse(numStr) with
+              | true, v -> Some v
+              | _ -> None
+            else
+              None
+
+          progressCalls.Enqueue(Begin(title, message, percentage))
+        elif json.Contains("\"kind\":\"report\"") || json.Contains("\"kind\": \"report\"") then
+          let message =
+            if json.Contains("\"message\"") then
+              let msgStart = json.IndexOf("\"message\"") + "\"message\"".Length
+              let colonAfterMsg = json.IndexOf(":", msgStart) + 1
+              let msgQuoteStart = json.IndexOf("\"", colonAfterMsg) + 1
+              let msgQuoteEnd = json.IndexOf("\"", msgQuoteStart)
+              Some(json.Substring(msgQuoteStart, msgQuoteEnd - msgQuoteStart))
+            else
+              None
+
+          let percentage =
+            if json.Contains("\"percentage\"") then
+              let pctStart = json.IndexOf("\"percentage\"") + "\"percentage\"".Length
+              let colonAfterPct = json.IndexOf(":", pctStart) + 1
+
+              let numStr =
+                json.Substring(colonAfterPct).TrimStart()
+                |> fun s ->
+                  let endIdx = s.IndexOfAny([| ','; '}'; ' ' |])
+
+                  if endIdx > 0 then s.Substring(0, endIdx) else s
+
+              match UInt32.TryParse(numStr) with
+              | true, v -> Some v
+              | _ -> None
+            else
+              None
+
+          progressCalls.Enqueue(Report(message, percentage))
+        elif json.Contains("\"kind\":\"end\"") || json.Contains("\"kind\": \"end\"") then
+          let message =
+            if json.Contains("\"message\"") then
+              let msgStart = json.IndexOf("\"message\"") + "\"message\"".Length
+              let colonAfterMsg = json.IndexOf(":", msgStart) + 1
+              let msgQuoteStart = json.IndexOf("\"", colonAfterMsg) + 1
+              let msgQuoteEnd = json.IndexOf("\"", msgQuoteStart)
+              Some(json.Substring(msgQuoteStart, msgQuoteEnd - msgQuoteStart))
+            else
+              None
+
+          progressCalls.Enqueue(End message)
+      | _ -> ()
+
+      AsyncLspResult.success ()
+
+  let requestSender =
+    { new ClientRequestSender with
+        member _.Send _name _payload = AsyncLspResult.success Unchecked.defaultof<_> }
+
+  let client = new FSharpLspClient(notificationSender, requestSender)
+
+  client.ClientCapabilities <-
+    Some
+      { Workspace = None
+        TextDocument = None
+        Experimental = None
+        Window =
+          Some
+            { WorkDoneProgress = Some true
+              ShowMessage = None
+              ShowDocument = None }
+        General = None
+        NotebookDocument = None }
+
+  client, progressCalls
+
+/// Helper: create a reporter with a mock client, returning (reporter, capturedCalls, reportCount)
+let private createReporter (title: string) =
+  let client, calls = createMockClient ()
+  let reportCount = ref 0
+
+  let reporter =
+    new SharedTypecheckProgressReporter(
+      title,
+      fun () ->
+        Interlocked.Increment(reportCount) |> ignore
+        new ServerProgressReport(client)
+    )
+
+  reporter, calls, reportCount
+
+/// Wait briefly for fire-and-forget tasks to settle
+let private settle () = Task.Delay(50) |> Async.AwaitTask
+
+
+let singleFileTests =
+  testList
+    "Single File"
+    [ testCaseAsync "Begin creates report and End disposes it"
+      <| async {
+        let reporter, calls, reportCount = createReporter "Typechecking"
+
+        use reporter = reporter
+
+        let! disp = reporter.Begin ("C:/src/Foo.fs") CancellationToken.None |> Async.AwaitTask
+
+        do! settle ()
+
+        Expect.equal reportCount.Value 1 "Should create one report"
+        Expect.isGreaterThanOrEqual (calls.Count) 1 "Should have at least a Begin call"
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.isFalse (ct = CancellationToken.None) "CancellationToken should be active during file tracking"
+
+        do! disp.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.isTrue (ct = CancellationToken.None) "CancellationToken should be None after all files end"
+      }
+
+      testCaseAsync "Multiple sequential files reuse the same report cycle"
+      <| async {
+        let reporter, _calls, reportCount = createReporter "Typechecking"
+
+        use reporter = reporter
+
+        // File 1
+        let! disp1 = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+        do! settle ()
+        do! disp1.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        Expect.equal reportCount.Value 1 "First file creates one report"
+
+        // File 2 — new report cycle
+        let! disp2 = reporter.Begin ("C:/src/B.fs") CancellationToken.None |> Async.AwaitTask
+        do! settle ()
+        do! disp2.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        Expect.equal reportCount.Value 2 "Second file after first ended creates new report"
+      }
+
+      testCaseAsync "Concurrent files keep report alive until all end"
+      <| async {
+        let reporter, _calls, reportCount = createReporter "Typechecking"
+
+        use reporter = reporter
+
+        let! disp1 = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+        let! disp2 = reporter.Begin ("C:/src/B.fs") CancellationToken.None |> Async.AwaitTask
+        do! settle ()
+
+        Expect.equal reportCount.Value 1 "Concurrent files share one report"
+
+        // End first file — report should still be active
+        do! disp1.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.isFalse (ct = CancellationToken.None) "Report should still be active with one file remaining"
+
+        // End second file — report should end
+        do! disp2.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.isTrue (ct = CancellationToken.None) "Report should end after all files complete"
+      } ]
+
+
+let batchTests =
+  testList
+    "Batch"
+    [ testCaseAsync "BeginBatch creates report eagerly for CancellationToken access"
+      <| async {
+        let reporter, _calls, reportCount = createReporter "Typechecking"
+
+        use reporter = reporter
+
+        let! batchDisp =
+          reporter.BeginBatch ([| "C:/src/A.fs"; "C:/src/B.fs" |]) CancellationToken.None
+          |> Async.AwaitTask
+
+        do! settle ()
+
+        Expect.equal reportCount.Value 1 "BeginBatch should eagerly create a report"
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.isFalse (ct = CancellationToken.None) "CancellationToken should be available after BeginBatch"
+
+        do! batchDisp.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+      }
+
+      testCaseAsync "Batch tracks completion percentage for batch files only"
+      <| async {
+        let reporter, calls, _reportCount = createReporter "Typechecking"
+
+        use reporter = reporter
+
+        let! batchDisp =
+          reporter.BeginBatch ([| "C:/src/A.fs"; "C:/src/B.fs"; "C:/src/C.fs" |]) CancellationToken.None
+          |> Async.AwaitTask
+
+        do! settle ()
+
+        // Process batch file A
+        let! dispA = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+        do! settle ()
+        do! dispA.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        // After A completes: 1/3 = 33%
+        let lastReport =
+          calls.ToArray()
+          |> Array.tryFindBack (fun c ->
+            match c with
+            | Report(_, Some _) -> true
+            | _ -> false)
+
+        match lastReport with
+        | Some(Report(_, Some pct)) -> Expect.equal pct 33u "After 1/3 batch files complete, percentage should be 33%"
+        | _ -> failtest "Expected a Report call with percentage after first batch file completes"
+
+        // Process non-batch file — should NOT affect batch percentage
+        let! dispX = reporter.Begin ("C:/src/X.fs") CancellationToken.None |> Async.AwaitTask
+        do! settle ()
+        do! dispX.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        // Process batch file B
+        let! dispB = reporter.Begin ("C:/src/B.fs") CancellationToken.None |> Async.AwaitTask
+        do! settle ()
+        do! dispB.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        // After B completes: 2/3 = 66%
+        let lastReport2 =
+          calls.ToArray()
+          |> Array.tryFindBack (fun c ->
+            match c with
+            | Report(_, Some pct) when pct >= 60u -> true
+            | _ -> false)
+
+        match lastReport2 with
+        | Some(Report(_, Some pct)) -> Expect.equal pct 66u "After 2/3 batch files complete, percentage should be 66%"
+        | _ -> failtest "Expected a Report call with ~66% after second batch file completes"
+
+        do! batchDisp.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+      }
+
+      testCaseAsync "Batch with active file scopes keeps report alive"
+      <| async {
+        let reporter, _calls, _reportCount = createReporter "Typechecking"
+
+        use reporter = reporter
+
+        let! batchDisp =
+          reporter.BeginBatch ([| "C:/src/A.fs" |]) CancellationToken.None
+          |> Async.AwaitTask
+
+        let! fileDisp = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+
+        do! settle ()
+
+        // End batch scope but file is still active
+        do! batchDisp.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.isFalse (ct = CancellationToken.None) "Report should remain active while file scope is open"
+
+        // End file scope
+        do! fileDisp.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.isTrue (ct = CancellationToken.None) "Report should end after file and batch both complete"
+      }
+
+      testCaseAsync "EndBatch resets batch counters"
+      <| async {
+        let reporter, calls, _reportCount = createReporter "Typechecking"
+
+        use reporter = reporter
+
+        // First batch
+        let! batchDisp1 =
+          reporter.BeginBatch ([| "C:/src/A.fs"; "C:/src/B.fs" |]) CancellationToken.None
+          |> Async.AwaitTask
+
+        let! dispA = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+        do! settle ()
+        do! dispA.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+        do! batchDisp1.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        // Second batch — counters should have been reset
+        let! batchDisp2 =
+          reporter.BeginBatch ([| "C:/src/C.fs"; "C:/src/D.fs" |]) CancellationToken.None
+          |> Async.AwaitTask
+
+        do! settle ()
+
+        // The Begin for second batch should show 0% (0/2)
+        let callsArr = calls.ToArray()
+
+        let hasZeroPercentage =
+          callsArr
+          |> Array.exists (fun c ->
+            match c with
+            | Begin(_, _, Some 0u) -> true
+            | Report(_, Some 0u) -> true
+            | _ -> false)
+
+        Expect.isTrue hasZeroPercentage "Second batch should start at 0% after first batch ended"
+
+        do! batchDisp2.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+      } ]
+
+
+let batchSyncTests =
+  testList
+    "BeginBatchSync"
+    [ testCaseAsync "BeginBatchSync adds files to active tracking and sets up batch"
+      <| async {
+        let reporter, calls, reportCount = createReporter "Loading Projects"
+        use reporter = reporter
+
+        let disp =
+          reporter.BeginBatchSync([| "C:/src/Proj1.fsproj"; "C:/src/Proj2.fsproj"; "C:/src/Proj3.fsproj" |])
+
+        // Give fire-and-forget tasks time to complete
+        do! settle ()
+        do! settle ()
+
+        Expect.equal reportCount.Value 1 "Should create one report"
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.isFalse (ct = CancellationToken.None) "Report should be active after BeginBatchSync"
+
+        // Check that a Begin call was made with the title
+        let callsArr = calls.ToArray()
+
+        let hasBegin =
+          callsArr
+          |> Array.exists (fun c ->
+            match c with
+            | Begin("Loading Projects", _, _) -> true
+            | _ -> false)
+
+        Expect.isTrue hasBegin "Should have a Begin call with the title"
+
+        // Check that file names appear in report messages
+        let hasFileNames =
+          callsArr
+          |> Array.exists (fun c ->
+            match c with
+            | Report(Some msg, _) ->
+              msg.Contains("Proj1.fsproj")
+              || msg.Contains("Proj2.fsproj")
+              || msg.Contains("Proj3.fsproj")
+            | _ -> false)
+
+        Expect.isTrue hasFileNames "Report messages should contain project file names"
+
+        disp.Dispose()
+        do! settle ()
+        do! settle ()
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.isTrue (ct = CancellationToken.None) "Report should end after Dispose"
+      }
+
+      testCaseAsync "BeginBatchSync Dispose ends all file tracking and batch"
+      <| async {
+        let reporter, calls, _reportCount = createReporter "Loading Projects"
+        use reporter = reporter
+
+        let disp = reporter.BeginBatchSync([| "C:/src/A.fsproj"; "C:/src/B.fsproj" |])
+        do! settle ()
+        do! settle ()
+
+        disp.Dispose()
+        do! settle ()
+        do! settle ()
+
+        // After dispose, an End call should have been made
+        let callsArr = calls.ToArray()
+
+        let hasEnd =
+          callsArr
+          |> Array.exists (fun c ->
+            match c with
+            | End _ -> true
+            | _ -> false)
+
+        Expect.isTrue hasEnd "Should have an End call after Dispose"
+      } ]
+
+
+let messageFormattingTests =
+  testList
+    "Message Formatting"
+    [ testCaseAsync "Single file shows just the filename"
+      <| async {
+        let reporter, calls, _reportCount = createReporter "Typechecking"
+        use reporter = reporter
+
+        let! disp = reporter.Begin ("C:/src/Foo.fs") CancellationToken.None |> Async.AwaitTask
+
+        do! settle ()
+
+        let callsArr = calls.ToArray()
+
+        let beginMsg =
+          callsArr
+          |> Array.tryPick (fun c ->
+            match c with
+            | Begin(_, msg, _) -> msg
+            | _ -> None)
+
+        Expect.equal beginMsg (Some "Foo.fs") "Single file message should be just the filename"
+
+        do! disp.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+      }
+
+      testCaseAsync "Two concurrent files shows both filenames"
+      <| async {
+        let reporter, calls, _reportCount = createReporter "Typechecking"
+        use reporter = reporter
+
+        let! disp1 = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+        do! settle ()
+        let! disp2 = reporter.Begin ("C:/src/B.fs") CancellationToken.None |> Async.AwaitTask
+        do! settle ()
+
+        let callsArr = calls.ToArray()
+
+        let hasMultipleFiles =
+          callsArr
+          |> Array.exists (fun c ->
+            match c with
+            | Report(Some msg, _) -> msg.Contains("A.fs") && msg.Contains("B.fs")
+            | _ -> false)
+
+        Expect.isTrue hasMultipleFiles "Message should contain both file names"
+
+        do! disp1.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! disp2.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+      }
+
+      testCaseAsync "More than 3 concurrent files truncates with (+N more)"
+      <| async {
+        let reporter, calls, _reportCount = createReporter "Typechecking"
+        use reporter = reporter
+
+        let! disp1 = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+        let! disp2 = reporter.Begin ("C:/src/B.fs") CancellationToken.None |> Async.AwaitTask
+        let! disp3 = reporter.Begin ("C:/src/C.fs") CancellationToken.None |> Async.AwaitTask
+        let! disp4 = reporter.Begin ("C:/src/D.fs") CancellationToken.None |> Async.AwaitTask
+        do! settle ()
+
+        let callsArr = calls.ToArray()
+
+        let hasTruncation =
+          callsArr
+          |> Array.exists (fun c ->
+            match c with
+            | Report(Some msg, _) -> msg.Contains("(+1 more)")
+            | _ -> false)
+
+        Expect.isTrue hasTruncation "4 files should show (+1 more) truncation"
+
+        do! disp1.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! disp2.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! disp3.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! disp4.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+      }
+
+      testCaseAsync "Batch file with active file shows combined message"
+      <| async {
+        let reporter, calls, _reportCount = createReporter "Typechecking"
+        use reporter = reporter
+
+        let! batchDisp =
+          reporter.BeginBatch ([| "C:/src/A.fs"; "C:/src/B.fs" |]) CancellationToken.None
+          |> Async.AwaitTask
+
+        let! fileDisp = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+
+        do! settle ()
+
+        let callsArr = calls.ToArray()
+
+        // Should have a message with both file name and batch progress
+        let hasCombined =
+          callsArr
+          |> Array.exists (fun c ->
+            match c with
+            | Report(Some msg, _) -> msg.Contains("A.fs") && msg.Contains("0/2 completed")
+            | _ -> false)
+
+        Expect.isTrue hasCombined "Message should contain filename and batch progress"
+
+        do! fileDisp.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! batchDisp.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+      } ]
+
+
+let cancellationTokenTests =
+  testList
+    "CancellationToken"
+    [ testCaseAsync "GetCancellationToken returns None when no report is active"
+      <| async {
+        let reporter, _calls, _reportCount = createReporter "Typechecking"
+        use reporter = reporter
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.isTrue (ct = CancellationToken.None) "Should return None when no report is active"
+      }
+
+      testCaseAsync "GetCancellationToken returns token from active report"
+      <| async {
+        let reporter, _calls, _reportCount = createReporter "Typechecking"
+        use reporter = reporter
+
+        let! disp = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+        do! settle ()
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.isFalse (ct = CancellationToken.None) "Should return active token"
+        Expect.isFalse ct.IsCancellationRequested "Token should not be cancelled"
+
+        do! disp.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+      }
+
+      testCaseAsync "GetCancellationToken returns token from batch-created report"
+      <| async {
+        let reporter, _calls, _reportCount = createReporter "Typechecking"
+        use reporter = reporter
+
+        let! batchDisp =
+          reporter.BeginBatch ([| "C:/src/A.fs" |]) CancellationToken.None
+          |> Async.AwaitTask
+
+        do! settle ()
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.isFalse (ct = CancellationToken.None) "BeginBatch should eagerly create report with token"
+
+        do! batchDisp.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+      } ]
+
+
+let disabledReporterTests =
+  testList
+    "Disabled reporter"
+    [ testCaseAsync "Does not create progress reports"
+      <| async {
+        let client, calls = createMockClient ()
+        let enabled = ref false
+        let reportCount = ref 0
+
+        use reporter =
+          new SharedTypecheckProgressReporter(
+            "Typechecking",
+            (fun () ->
+              Interlocked.Increment(reportCount) |> ignore
+              new ServerProgressReport(client)),
+            isEnabled = (fun () -> enabled.Value)
+          )
+
+        let! fileDisp = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+
+        let! batchDisp =
+          reporter.BeginBatch ([| "C:/src/A.fs" |]) CancellationToken.None
+          |> Async.AwaitTask
+
+        use _batchSyncDisp = reporter.BeginBatchSync([| "C:/src/A.fs" |])
+
+        do! fileDisp.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! batchDisp.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        Expect.equal reportCount.Value 0 "The disabled reporter must not create a report"
+        Expect.equal calls.Count 0 "The disabled reporter must not send progress"
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.equal ct CancellationToken.None "The disabled reporter must not create a cancellation token"
+
+        enabled.Value <- true
+
+        let! enabledDisp = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+        do! settle ()
+
+        Expect.equal reportCount.Value 1 "The enabled reporter must create a report"
+
+        do! enabledDisp.DisposeAsync().AsTask() |> Async.AwaitTask
+      } ]
+
+
+let tests =
+  testList
+    "SharedTypecheckProgressReporter"
+    [ singleFileTests
+      batchTests
+      batchSyncTests
+      messageFormattingTests
+      cancellationTokenTests
+      disabledReporterTests ]

--- a/test/FsAutoComplete.Tests.Lsp/SharedTypecheckProgressReporterTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/SharedTypecheckProgressReporterTests.fs
@@ -151,6 +151,13 @@ let private createReporter (title: string) =
 /// Wait briefly for fire-and-forget tasks to settle
 let private settle () = Task.Delay(50) |> Async.AwaitTask
 
+let private lastPercentage (calls: ConcurrentQueue<ProgressCall>) =
+  calls.ToArray()
+  |> Array.rev
+  |> Array.tryPick (function
+    | Report(_, Some percentage) -> Some percentage
+    | _ -> None)
+
 
 let singleFileTests =
   testList
@@ -178,7 +185,7 @@ let singleFileTests =
         Expect.isTrue (ct = CancellationToken.None) "CancellationToken should be None after all files end"
       }
 
-      testCaseAsync "Multiple sequential files reuse the same report cycle"
+      testCaseAsync "Sequential files create separate report cycles"
       <| async {
         let reporter, _calls, reportCount = createReporter "Typechecking"
 
@@ -226,6 +233,48 @@ let singleFileTests =
 
         let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
         Expect.isTrue (ct = CancellationToken.None) "Report should end after all files complete"
+      }
+
+      testCaseAsync "Concurrent scopes for the same path keep the report active"
+      <| async {
+        let reporter, _calls, _reportCount = createReporter "Typechecking"
+        use reporter = reporter
+
+        let! disp1 = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+        let! disp2 = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+
+        do! disp1.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.notEqual ct CancellationToken.None "The second scope must keep the report active"
+
+        do! disp2.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.equal ct CancellationToken.None "The report must end after both scopes end"
+      }
+
+      testCaseAsync "Files with the same basename keep independent scopes"
+      <| async {
+        let reporter, _calls, _reportCount = createReporter "Typechecking"
+        use reporter = reporter
+
+        let! disp1 = reporter.Begin ("C:/src/A/Foo.fs") CancellationToken.None |> Async.AwaitTask
+        let! disp2 = reporter.Begin ("C:/src/B/Foo.fs") CancellationToken.None |> Async.AwaitTask
+
+        do! disp1.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.notEqual ct CancellationToken.None "The second path must keep the report active"
+
+        do! disp2.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        let! ct = reporter.GetCancellationToken() |> Async.AwaitTask
+        Expect.equal ct CancellationToken.None "The report must end after both paths complete"
       } ]
 
 
@@ -311,6 +360,69 @@ let batchTests =
         do! settle ()
       }
 
+      testCaseAsync "Batch counts duplicate paths independently"
+      <| async {
+        let reporter, calls, _reportCount = createReporter "Typechecking"
+        use reporter = reporter
+
+        let! batchDisp =
+          reporter.BeginBatch ([| "C:/src/A.fs"; "C:/src/A.fs" |]) CancellationToken.None
+          |> Async.AwaitTask
+
+        let! disp1 = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+        let! disp2 = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+
+        do! disp1.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        let firstPercentage = lastPercentage calls
+
+        Expect.equal firstPercentage (Some 50u) "The first duplicate completion must report 50 percent"
+
+        do! disp2.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        let secondPercentage = lastPercentage calls
+
+        Expect.equal secondPercentage (Some 100u) "The second duplicate completion must report 100 percent"
+
+        do! batchDisp.DisposeAsync().AsTask() |> Async.AwaitTask
+      }
+
+      testCaseAsync "Overlapping batches count the same path independently"
+      <| async {
+        let reporter, calls, _reportCount = createReporter "Typechecking"
+        use reporter = reporter
+
+        let! batchDisp1 =
+          reporter.BeginBatch ([| "C:/src/A.fs" |]) CancellationToken.None
+          |> Async.AwaitTask
+
+        let! batchDisp2 =
+          reporter.BeginBatch ([| "C:/src/A.fs" |]) CancellationToken.None
+          |> Async.AwaitTask
+
+        let! disp1 = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+        let! disp2 = reporter.Begin ("C:/src/A.fs") CancellationToken.None |> Async.AwaitTask
+
+        do! disp1.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        let firstPercentage = lastPercentage calls
+
+        Expect.equal firstPercentage (Some 50u) "The first overlapping completion must report 50 percent"
+
+        do! disp2.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! settle ()
+
+        let secondPercentage = lastPercentage calls
+
+        Expect.equal secondPercentage (Some 100u) "The second overlapping completion must report 100 percent"
+
+        do! batchDisp2.DisposeAsync().AsTask() |> Async.AwaitTask
+        do! batchDisp1.DisposeAsync().AsTask() |> Async.AwaitTask
+      }
+
       testCaseAsync "Batch with active file scopes keeps report alive"
       <| async {
         let reporter, _calls, _reportCount = createReporter "Typechecking"
@@ -359,6 +471,8 @@ let batchTests =
         do! settle ()
 
         // Second batch — counters should have been reset
+        let callCountBeforeSecondBatch = calls.Count
+
         let! batchDisp2 =
           reporter.BeginBatch ([| "C:/src/C.fs"; "C:/src/D.fs" |]) CancellationToken.None
           |> Async.AwaitTask
@@ -366,7 +480,7 @@ let batchTests =
         do! settle ()
 
         // The Begin for second batch should show 0% (0/2)
-        let callsArr = calls.ToArray()
+        let callsArr = calls.ToArray() |> Array.skip callCountBeforeSecondBatch
 
         let hasZeroPercentage =
           callsArr


### PR DESCRIPTION
## Summary

- consolidate concurrent typecheck and analyzer work into shared LSP progress notifications
- report batch progress for project loading and dependent-file typechecking
- propagate progress cancellation and limit dependent-file typechecking concurrency
- honor `FSharp.notifications.backgroundServiceProgress` for all shared progress reporters

## Testing

- `dotnet fantomas --check build.fsx src`
- `dotnet build test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj -c Release -f net10.0 -p:ImportDirectoryPackagesProps=false --nologo`
- `dotnet run -c Release -f net10.0 --no-build --project test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj -- --filter-test-list "SharedTypecheckProgressReporter"` — 17 passed

The full solution build reached the changed projects, but nested TestExplorer sample builds imported a parent `Directory.Packages.props` and failed with `NU1008`. The focused LSP build completed with zero warnings and errors.
