### PR TITLE
perf(ci): shard the test suite across processes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
       run: dotnet build -c Release
 
     - name: Run and report tests
-      run: dotnet fsi build.fsx -- -p 'test:${{ matrix.test_tfm }}'
+      run: dotnet fsi build.fsx -- -p 'test-ci:${{ matrix.test_tfm }}'
       env:
         USE_TRANSPARENT_COMPILER: ${{ matrix.use-transparent-compiler }}
         USE_WORKSPACE_LOADER: ${{ matrix.workspace-loader }}

--- a/build.fsx
+++ b/build.fsx
@@ -445,11 +445,63 @@ let lspTestsPath = (__SOURCE_DIRECTORY__ </> "test" </> "FsAutoComplete.Tests.Ls
 let createGlobalJson sdkVersion =
   $"dotnet new globaljson --force --sdk-version %s{sdkVersion} --roll-forward LatestMinor"
 
+let coverageAssemblyExcludeFilter =
+  @"^(?!FsAutoComplete\.Core$)(?!FsAutoComplete\.Logging$)(?!fsautocomplete$).*"
+
 let testCommand targetFramework =
-  $"""dotnet test -c Release -f %s{targetFramework} --no-restore --no-build --logger "console;verbosity=normal" --logger GitHubActions /p:AltCover=true /p:AltCoverAssemblyExcludeFilter="System.Reactive|FSharp.Compiler.Service|Ionide.ProjInfo|FSharp.Analyzers|Analyzer|Humanizer|FSharp.Core|FSharp.DependencyManager" -- Expecto.fail-on-focused-tests=true --blame-hang --blame-hang-timeout 1m"""
+  $"""dotnet test -c Release -f %s{targetFramework} --no-restore --no-build --logger "console;verbosity=normal" --logger GitHubActions /p:AltCover=true /p:AltCoverAssemblyExcludeFilter="%s{coverageAssemblyExcludeFilter}" -- Expecto.fail-on-focused-tests=true --blame-hang --blame-hang-timeout 1m"""
+
+let coverageDirectory targetFramework = lspTestsPath </> "coverage" </> targetFramework
+
+let shardCoverageBaseReport targetFramework shard = coverageDirectory targetFramework </> $"shard-%i{shard}.xml"
+
+let shardCoverageReport targetFramework shard =
+  let baseReport = shardCoverageBaseReport targetFramework shard
+  let fileName = System.IO.Path.GetFileNameWithoutExtension baseReport
+
+  System.IO.Path.GetDirectoryName baseReport
+  </> $"%s{fileName}.%s{targetFramework}.xml"
+
+let mergedCoverageReport targetFramework = lspTestsPath </> $"coverage.%s{targetFramework}.xml"
+
+let altCoverToolkitPath () =
+  let versionPattern =
+    System.Text.RegularExpressions.Regex(@"^\s+AltCover \(([^)]+)\)$")
+
+  let version =
+    System.IO.File.ReadLines(__SOURCE_DIRECTORY__ </> "paket.lock")
+    |> Seq.tryPick (fun line ->
+      let matchResult = versionPattern.Match line
+
+      if matchResult.Success then
+        Some matchResult.Groups[1].Value
+      else
+        None)
+    |> Option.defaultWith (fun () -> failwith "paket.lock does not contain an AltCover version")
+
+  let packagesRoot =
+    match System.Environment.GetEnvironmentVariable "NUGET_PACKAGES" with
+    | value when not (System.String.IsNullOrWhiteSpace value) -> value
+    | _ ->
+      System.Environment.GetFolderPath System.Environment.SpecialFolder.UserProfile
+      </> ".nuget"
+      </> "packages"
+
+  packagesRoot
+  </> "altcover"
+  </> version
+  </> "tools"
+  </> "net8.0"
+  </> "AltCover.Toolkit.dll"
 
 let startTestShard targetFramework shard =
   let startInfo = System.Diagnostics.ProcessStartInfo("dotnet")
+  let coverageOutputRoot = coverageDirectory targetFramework </> $"shard-%i{shard}"
+  let coverageReport = shardCoverageBaseReport targetFramework shard
+
+  System.IO.Directory.CreateDirectory coverageOutputRoot |> ignore
+  System.IO.File.Delete(shardCoverageReport targetFramework shard)
+
   startInfo.WorkingDirectory <- lspTestsPath
   startInfo.UseShellExecute <- false
   startInfo.Environment["FSAC_TEST_SHARD"] <- string shard
@@ -468,6 +520,11 @@ let startTestShard targetFramework shard =
     "console;verbosity=normal"
     "--logger"
     "GitHubActions"
+    "/p:AltCover=true"
+    $"/p:AltCoverAssemblyExcludeFilter=%s{coverageAssemblyExcludeFilter}"
+    $"/p:AltCoverOutputRoot=%s{coverageOutputRoot}"
+    $"/p:AltCoverReport=%s{coverageReport}"
+    "/p:AltCoverForce=true"
     "--"
     "Expecto.fail-on-focused-tests=true"
     "--blame-hang"
@@ -481,7 +538,37 @@ let startTestShard targetFramework shard =
     return shard, childProcess.ExitCode
   }
 
+let mergeCoverageReports targetFramework =
+  let reports = [| for shard in 1..4 -> shardCoverageReport targetFramework shard |]
+  let missingReports = reports |> Array.filter (System.IO.File.Exists >> not)
+
+  if missingReports.Length > 0 then
+    missingReports
+    |> String.concat ", "
+    |> failwithf "CI test shards did not produce coverage reports: %s"
+
+  let finalReport = mergedCoverageReport targetFramework
+  System.IO.File.Delete finalReport
+
+  let toolkitPath = altCoverToolkitPath ()
+
+  if not (System.IO.File.Exists toolkitPath) then
+    failwithf "AltCover toolkit was not restored at %s" toolkitPath
+
+  let toolkit = System.Reflection.Assembly.LoadFrom toolkitPath
+  let openCover = toolkit.GetType("AltCover.OpenCover", true)
+
+  let merge =
+    openCover.GetMethod("Merge", [| typeof<System.Collections.Generic.IEnumerable<System.Xml.Linq.XDocument>> |])
+
+  let documents = reports |> Array.map System.Xml.Linq.XDocument.Load
+  let merged = merge.Invoke(null, [| box documents |]) :?> System.Xml.Linq.XDocument
+  merged.Save finalReport
+
 let runTestShards targetFramework =
+  System.IO.Directory.CreateDirectory(coverageDirectory targetFramework) |> ignore
+  System.IO.File.Delete(mergedCoverageReport targetFramework)
+
   let tasks = [| for shard in 1..4 -> startTestShard targetFramework shard |]
   let results = System.Threading.Tasks.Task.WhenAll(tasks).GetAwaiter().GetResult()
 
@@ -492,6 +579,8 @@ let runTestShards targetFramework =
     |> Array.map (fun (shard, exitCode) -> $"shard %i{shard}: exit code %i{exitCode}")
     |> String.concat ", "
     |> failwithf "CI test shards failed: %s"
+
+  mergeCoverageReports targetFramework
 
 let ciTests targetFramework sdkVersion =
   stage $"test-ci:%s{targetFramework}" {

--- a/build.fsx
+++ b/build.fsx
@@ -448,6 +448,63 @@ let createGlobalJson sdkVersion =
 let testCommand targetFramework =
   $"""dotnet test -c Release -f %s{targetFramework} --no-restore --no-build --logger "console;verbosity=normal" --logger GitHubActions /p:AltCover=true /p:AltCoverAssemblyExcludeFilter="System.Reactive|FSharp.Compiler.Service|Ionide.ProjInfo|FSharp.Analyzers|Analyzer|Humanizer|FSharp.Core|FSharp.DependencyManager" -- Expecto.fail-on-focused-tests=true --blame-hang --blame-hang-timeout 1m"""
 
+let startTestShard targetFramework shard =
+  let startInfo = System.Diagnostics.ProcessStartInfo("dotnet")
+  startInfo.WorkingDirectory <- lspTestsPath
+  startInfo.UseShellExecute <- false
+  startInfo.Environment["FSAC_TEST_SHARD"] <- string shard
+  startInfo.Environment["DOTNET_CLI_USE_MSBUILD_SERVER"] <- "0"
+  startInfo.Environment["MSBUILDDISABLENODEREUSE"] <- "1"
+  startInfo.Environment["UseSharedCompilation"] <- "false"
+
+  [ "test"
+    "-c"
+    "Release"
+    "-f"
+    targetFramework
+    "--no-restore"
+    "--no-build"
+    "--logger"
+    "console;verbosity=normal"
+    "--logger"
+    "GitHubActions"
+    "--"
+    "Expecto.fail-on-focused-tests=true"
+    "--blame-hang"
+    "--blame-hang-timeout"
+    "1m" ]
+  |> List.iter (fun argument -> startInfo.ArgumentList.Add argument)
+
+  task {
+    use childProcess = System.Diagnostics.Process.Start startInfo
+    do! childProcess.WaitForExitAsync()
+    return shard, childProcess.ExitCode
+  }
+
+let runTestShards targetFramework =
+  let tasks = [| for shard in 1..4 -> startTestShard targetFramework shard |]
+  let results = System.Threading.Tasks.Task.WhenAll(tasks).GetAwaiter().GetResult()
+
+  let failures = results |> Array.filter (fun (_, exitCode) -> exitCode <> 0)
+
+  if failures.Length > 0 then
+    failures
+    |> Array.map (fun (shard, exitCode) -> $"shard %i{shard}: exit code %i{exitCode}")
+    |> String.concat ", "
+    |> failwithf "CI test shards failed: %s"
+
+let ciTests targetFramework sdkVersion =
+  stage $"test-ci:%s{targetFramework}" {
+    workingDir lspTestsPath
+    run (createGlobalJson sdkVersion)
+
+    run (fun _ ->
+      try
+        runTestShards targetFramework
+      finally
+        System.IO.File.Delete(lspTestsPath </> "global.json"))
+  }
+
 // Every stage restores with the .NET 10 SDK because older SDKs cannot restore Paket 10.
 // It then builds and tests with the SDK that matches the test target framework.
 let net80Tests =
@@ -485,6 +542,10 @@ let net100Tests =
     run (fun _ -> System.IO.File.Delete(lspTestsPath </> "global.json"))
   }
 
+let ciNet80Tests = ciTests "net8.0" "8.0.100"
+let ciNet90Tests = ciTests "net9.0" "9.0.100"
+let ciNet100Tests = ciTests "net10.0" "10.0.100"
+
 pipeline "test:net8.0" {
   description "Run net8.0 tests"
   net80Tests
@@ -500,6 +561,24 @@ pipeline "test:net9.0" {
 pipeline "test:net10.0" {
   description "Run net10.0 tests"
   net100Tests
+  runIfOnlySpecified true
+}
+
+pipeline "test-ci:net8.0" {
+  description "Run net8.0 CI test shards"
+  ciNet80Tests
+  runIfOnlySpecified true
+}
+
+pipeline "test-ci:net9.0" {
+  description "Run net9.0 CI test shards"
+  ciNet90Tests
+  runIfOnlySpecified true
+}
+
+pipeline "test-ci:net10.0" {
+  description "Run net10.0 CI test shards"
+  ciNet100Tests
   runIfOnlySpecified true
 }
 

--- a/src/FsAutoComplete.Core/Utils.fs
+++ b/src/FsAutoComplete.Core/Utils.fs
@@ -668,6 +668,7 @@ type Path with
   static member FileUriToLocalPath(uriString: string) =
 
     let uriStringSpan = uriString.AsSpan()
+    let isUntitled = uriStringSpan.StartsWith("untitled:")
     let mutable initialLocalPath = Uri(uriString).LocalPath.AsSpan()
     let mutable builder = ValueStringBuilder()
 
@@ -681,10 +682,15 @@ type Path with
       else
         builder.Append initialLocalPath
 
-      if uriStringSpan.StartsWith("untitled:") then
+      if isUntitled then
         builder.Append(".fsx")
 
-      StringPool.Shared.GetOrAdd(builder.AsSpan())
+      let localPath = StringPool.Shared.GetOrAdd(builder.AsSpan())
+
+      if isUntitled then
+        Path.Combine(AppContext.BaseDirectory, localPath)
+      else
+        localPath
     finally
       builder.Dispose()
 

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -376,11 +376,23 @@ type AdaptiveState
 
   let diagnosticCollections = new DiagnosticCollection(sendDiagnostics)
 
-  let notifications = Event<NotificationEvent * CancellationToken>()
+  let notifications =
+    Event<NotificationEvent * CancellationToken * TaskCompletionSource<unit> option>()
+
+  let triggerNotification notification ct = notifications.Trigger(notification, ct, None)
+
+  let triggerNotificationAndWait notification ct =
+    async {
+      let completion =
+        TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+      notifications.Trigger(notification, ct, Some completion)
+      do! completion.Task |> Async.AwaitTask
+    }
 
   do
     workspaceLoader.Notifications.Subscribe(fun n ->
-      let inline trigger n = notifications.Trigger(n, CancellationToken.None)
+      let inline trigger n = triggerNotification n CancellationToken.None
 
       match n with
       | Ionide.ProjInfo.Types.WorkspaceProjectState.Loading(p) -> ProjectResponse.ProjectLoading(p)
@@ -441,7 +453,7 @@ type AdaptiveState
 
       logger.info (Log.setMessageI $"Test Detection of {parseResults.FileName:file} - {res:res}")
 
-      notifications.Trigger(NotificationEvent.TestDetected(fn, res |> List.toArray), ct)
+      triggerNotification (NotificationEvent.TestDetected(fn, res |> List.toArray)) ct
     with e ->
       logger.info (
         Log.setMessageI $"Test Detection of {parseResults.FileName:file} failed"
@@ -464,7 +476,6 @@ type AdaptiveState
     let filePath = file.FileName
     let filePathUntag = UMX.untag filePath
     let source = file.Source
-    let version = file.Version
     let fileName = Path.GetFileName filePathUntag
 
 
@@ -484,7 +495,10 @@ type AdaptiveState
             UnusedOpens.getUnusedOpens (tyRes.GetCheckResults, getSourceLine)
             |> Async.withCancellation progress.CancellationToken
 
-          notifications.Trigger(NotificationEvent.UnusedOpens(filePath, (unused |> List.toArray), file.Version), ct)
+          do!
+            triggerNotificationAndWait
+              (NotificationEvent.UnusedOpens(filePath, (unused |> List.toArray), file.Version))
+              ct
         with e ->
           logger.error (Log.setMessage "checkUnusedOpens failed" >> Log.addExn e)
       }
@@ -507,7 +521,7 @@ type AdaptiveState
 
           let unused = unused |> Seq.toArray
 
-          notifications.Trigger(NotificationEvent.UnusedDeclarations(filePath, unused, file.Version), ct)
+          do! triggerNotificationAndWait (NotificationEvent.UnusedDeclarations(filePath, unused, file.Version)) ct
         with e ->
           logger.error (Log.setMessage "checkUnusedDeclarations failed" >> Log.addExn e)
       }
@@ -527,7 +541,7 @@ type AdaptiveState
             |> Async.withCancellation progress.CancellationToken
 
           let simplified = Array.ofSeq simplified
-          notifications.Trigger(NotificationEvent.SimplifyNames(filePath, simplified, file.Version), ct)
+          do! triggerNotificationAndWait (NotificationEvent.SimplifyNames(filePath, simplified, file.Version)) ct
         with e ->
           logger.error (Log.setMessage "checkSimplifiedNames failed" >> Log.addExn e)
       }
@@ -560,10 +574,10 @@ type AdaptiveState
 
               | _ -> ranges)
 
-          notifications.Trigger(
-            NotificationEvent.UnnecessaryParentheses(filePath, Array.ofSeq unnecessaryParentheses, file.Version),
-            ct
-          )
+          do!
+            triggerNotificationAndWait
+              (NotificationEvent.UnnecessaryParentheses(filePath, Array.ofSeq unnecessaryParentheses, file.Version))
+              ct
         with e ->
           logger.error (Log.setMessage "checkUnnecessaryParentheses failed" >> Log.addExn e)
       }
@@ -593,15 +607,7 @@ type AdaptiveState
         then
           checkUnnecessaryParentheses ]
 
-    async {
-      do! analyzers |> Async.parallel75 |> Async.Ignore<unit[]>
-
-      do!
-        lspClient.NotifyDocumentAnalyzed
-          { TextDocument =
-              { Uri = filePath |> Path.LocalPathToUri
-                Version = version } }
-    }
+    async { do! analyzers |> Async.parallel75 |> Async.Ignore<unit[]> }
 
   let tryUriCreate (s: string) =
     match Uri.TryCreate(s, UriKind.Absolute) with
@@ -676,7 +682,7 @@ type AdaptiveState
               )
 
             let! ct = Async.CancellationToken
-            notifications.Trigger(NotificationEvent.AnalyzerMessage(res, file, volatileFile.Version), ct)
+            do! triggerNotificationAndWait (NotificationEvent.AnalyzerMessage(res, file, volatileFile.Version)) ct
 
             Loggers.analyzers.info (Log.setMessageI $"end analysis of {file:file}")
 
@@ -690,7 +696,7 @@ type AdaptiveState
 
 
 
-  let handleCommandEvents (n: NotificationEvent, ct: CancellationToken) =
+  let handleCommandEvents (n: NotificationEvent, ct: CancellationToken, completion: TaskCompletionSource<unit> option) =
     try
       async {
 
@@ -719,7 +725,7 @@ type AdaptiveState
           | NotificationEvent.ParseError(errors, file, version) ->
             let uri = Path.LocalPathToUri file
             let diags = errors |> Array.map fcsErrorToDiagnostic
-            diagnosticCollections.SetFor(uri, "F# Compiler", version, diags)
+            do! diagnosticCollections.SetForAndWait(uri, "F# Compiler", version, diags)
 
           | NotificationEvent.UnusedOpens(file, opens, version) ->
             let uri = Path.LocalPathToUri file
@@ -737,7 +743,7 @@ type AdaptiveState
                   Data = None
                   CodeDescription = None })
 
-            diagnosticCollections.SetFor(uri, "F# Unused opens", version, diags)
+            do! diagnosticCollections.SetForAndWait(uri, "F# Unused opens", version, diags)
 
           | NotificationEvent.UnusedDeclarations(file, decls, version) ->
             let uri = Path.LocalPathToUri file
@@ -755,7 +761,7 @@ type AdaptiveState
                   Data = None
                   CodeDescription = None })
 
-            diagnosticCollections.SetFor(uri, "F# Unused declarations", version, diags)
+            do! diagnosticCollections.SetForAndWait(uri, "F# Unused declarations", version, diags)
 
           | NotificationEvent.SimplifyNames(file, decls, version) ->
             let uri = Path.LocalPathToUri file
@@ -777,7 +783,7 @@ type AdaptiveState
                     Data = None
                     CodeDescription = None })
 
-            diagnosticCollections.SetFor(uri, "F# simplify names", version, diags)
+            do! diagnosticCollections.SetForAndWait(uri, "F# simplify names", version, diags)
 
           | NotificationEvent.UnnecessaryParentheses(file, ranges, version) ->
             let uri = Path.LocalPathToUri file
@@ -795,7 +801,7 @@ type AdaptiveState
                   Data = None
                   CodeDescription = None })
 
-            diagnosticCollections.SetFor(uri, "F# unnecessary parentheses", version, diags)
+            do! diagnosticCollections.SetForAndWait(uri, "F# unnecessary parentheses", version, diags)
 
           // | NotificationEvent.Lint (file, warnings) ->
           //     let uri = Path.LocalPathToUri file
@@ -844,7 +850,7 @@ type AdaptiveState
             let uri = Path.LocalPathToUri file
 
             match messages with
-            | [||] -> diagnosticCollections.SetFor(uri, "F# Analyzers", version, [||])
+            | [||] -> do! diagnosticCollections.SetForAndWait(uri, "F# Analyzers", version, [||])
             | messages ->
               let diags =
                 messages
@@ -879,7 +885,7 @@ type AdaptiveState
                     CodeDescription = None
                     Data = fixes })
 
-              diagnosticCollections.SetFor(uri, "F# Analyzers", version, diags)
+              do! diagnosticCollections.SetForAndWait(uri, "F# Analyzers", version, diags)
           | NotificationEvent.TestDetected(file, tests) ->
             let rec map
               (r: TestAdapter.TestAdapterEntry<FSharp.Compiler.Text.range>)
@@ -904,7 +910,7 @@ type AdaptiveState
             >> Log.addContext "ex" ex.Message
           )
 
-        ()
+        completion |> Option.iter (fun value -> value.TrySetResult() |> ignore)
       }
       |> fun work -> Async.StartImmediate(work, ct)
     with :? OperationCanceledException ->
@@ -1030,7 +1036,7 @@ type AdaptiveState
         let not =
           UMX.untag proj |> ProjectResponse.ProjectLoading |> NotificationEvent.Workspace
 
-        notifications.Trigger(not, CancellationToken.None))
+        triggerNotification not CancellationToken.None)
 
       use progressReport = new ServerProgressReport(lspClient)
 
@@ -1056,7 +1062,7 @@ type AdaptiveState
 
       let not = ProjectResponse.WorkspaceLoad true |> NotificationEvent.Workspace
 
-      notifications.Trigger(not, CancellationToken.None)
+      triggerNotification not CancellationToken.None
 
       // Collect other files that should trigger a reload of a project
       let additionalDependencies (p: Types.ProjectOptions) =
@@ -1304,10 +1310,8 @@ type AdaptiveState
   do
     disposables.Add
     <| fileChecked.Publish.Subscribe(fun (checkedFile) ->
-      if checkedFile.VolatileFile.Source.Length = 0 then
-        () // Don't analyze and error on an empty file
-      else
-        async {
+      async {
+        if checkedFile.VolatileFile.Source.Length > 0 then
           let config = config |> AVal.force
           let analyzerPaths = analyzerPaths |> AVal.force
           do! builtInCompilerAnalyzers config checkedFile.VolatileFile checkedFile.ParseAndCheckResults
@@ -1321,8 +1325,13 @@ type AdaptiveState
               checkedFile.Options
               checkedFile.CompilerOptions
 
-        }
-        |> Async.StartWithCT checkedFile.CancellationToken)
+        do!
+          lspClient.NotifyDocumentAnalyzed
+            { TextDocument =
+                { Uri = checkedFile.VolatileFile.FileName |> Path.LocalPathToUri
+                  Version = checkedFile.VolatileFile.Version } }
+      }
+      |> Async.StartWithCT checkedFile.CancellationToken)
 
 
 
@@ -1812,7 +1821,7 @@ type AdaptiveState
 
       let! ct = Async.CancellationToken
 
-      notifications.Trigger(NotificationEvent.FileParsed(file.Source.FileName), ct)
+      triggerNotification (NotificationEvent.FileParsed(file.Source.FileName)) ct
 
       match result with
       | Error e ->
@@ -1832,14 +1841,6 @@ type AdaptiveState
 
         fileParsed.Trigger(parseAndCheck.GetParseResults, compilerOptions, ct)
 
-        fileChecked.Trigger(
-          { Options = options
-            CompilerOptions = compilerOptions
-            ParseAndCheckResults = parseAndCheck
-            VolatileFile = file
-            CancellationToken = ct }
-        )
-
         let checkErrors = parseAndCheck.GetParseResults.Diagnostics
         let parseErrors = parseAndCheck.GetCheckResults.Diagnostics
 
@@ -1848,7 +1849,15 @@ type AdaptiveState
           |> Array.distinctBy (fun e ->
             e.Severity, e.ErrorNumber, e.StartLine, e.StartColumn, e.EndLine, e.EndColumn, e.Message)
 
-        notifications.Trigger(NotificationEvent.ParseError(errors, file.Source.FileName, file.Version), ct)
+        do! triggerNotificationAndWait (NotificationEvent.ParseError(errors, file.Source.FileName, file.Version)) ct
+
+        fileChecked.Trigger(
+          { Options = options
+            CompilerOptions = compilerOptions
+            ParseAndCheckResults = parseAndCheck
+            VolatileFile = file
+            CancellationToken = ct }
+        )
 
 
         return Ok parseAndCheck

--- a/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
+++ b/src/FsAutoComplete/LspServers/AdaptiveServerState.fs
@@ -381,14 +381,8 @@ type AdaptiveState
 
   let triggerNotification notification ct = notifications.Trigger(notification, ct, None)
 
-  let triggerNotificationAndWait notification ct =
-    async {
-      let completion =
-        TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
-
-      notifications.Trigger(notification, ct, Some completion)
-      do! completion.Task |> Async.AwaitTask
-    }
+  let triggerNotificationAndWait =
+    AcknowledgedNotification.triggerAndWait notifications
 
   do
     workspaceLoader.Notifications.Subscribe(fun n ->

--- a/src/FsAutoComplete/LspServers/Common.fs
+++ b/src/FsAutoComplete/LspServers/Common.fs
@@ -53,6 +53,7 @@ module AsyncResult =
 type DiagnosticMessage =
   | Add of source: string * Version * diags: Diagnostic[]
   | Clear of source: string
+  | Flush of AsyncReplyChannel<unit>
 
 /// a type that handles bookkeeping for sending file diagnostics.  It will debounce calls and handle sending diagnostics via the configured function when safe
 type DiagnosticCollection(sendDiagnostics: DocumentUri -> int option -> Diagnostic[] -> Async<unit>) =
@@ -102,6 +103,9 @@ type DiagnosticCollection(sendDiagnostics: DocumentUri -> int option -> Diagnost
                 let newState = state |> Map.remove source
                 do! send uri newState
                 return! loop newState
+              | Flush reply ->
+                reply.Reply()
+                return! loop state
             }
 
           loop Map.empty),
@@ -138,6 +142,14 @@ type DiagnosticCollection(sendDiagnostics: DocumentUri -> int option -> Diagnost
       match values with
       | [||] -> mailbox.Post(Clear kind)
       | values -> mailbox.Post(Add(kind, version, values))
+
+  member x.SetForAndWait(fileUri: DocumentUri, kind: string, version: Version, values: Diagnostic[]) =
+    async {
+      if x.ClientSupportsDiagnostics then
+        x.SetFor(fileUri, kind, version, values)
+        let mailbox = getOrAddAgent fileUri
+        do! mailbox.PostAndAsyncReply Flush
+    }
 
   member x.ClearFor(fileUri: DocumentUri) =
     if x.ClientSupportsDiagnostics then

--- a/src/FsAutoComplete/LspServers/Common.fs
+++ b/src/FsAutoComplete/LspServers/Common.fs
@@ -194,10 +194,7 @@ type DiagnosticCollection(sendDiagnostics: DocumentUri -> int option -> Diagnost
   member x.SetFor(fileUri: DocumentUri, kind: string, version: Version, values: Diagnostic[]) =
     if x.ClientSupportsDiagnostics then
       let mailbox, _ = getOrAddAgent fileUri
-
-      match values with
-      | [||] -> mailbox.Post(Clear(kind, None))
-      | values -> mailbox.Post(Add(kind, version, values, None))
+      mailbox.Post(Add(kind, version, values, None))
 
   member x.SetForAndWait(fileUri: DocumentUri, kind: string, version: Version, values: Diagnostic[]) =
     async {
@@ -210,9 +207,7 @@ type DiagnosticCollection(sendDiagnostics: DocumentUri -> int option -> Diagnost
         use _registration =
           cts.Token.Register(fun () -> completion.TrySetCanceled(cts.Token) |> ignore)
 
-        match values with
-        | [||] -> mailbox.Post(Clear(kind, Some completion))
-        | values -> mailbox.Post(Add(kind, version, values, Some completion))
+        mailbox.Post(Add(kind, version, values, Some completion))
 
         try
           do! completion.Task |> Async.AwaitTask

--- a/src/FsAutoComplete/LspServers/Common.fs
+++ b/src/FsAutoComplete/LspServers/Common.fs
@@ -4,6 +4,7 @@ namespace FsAutoComplete.Lsp
 open System
 open System.IO
 open System.Threading
+open System.Threading.Tasks
 open FsAutoComplete
 open FsAutoComplete.LspHelpers
 open FsAutoComplete.Logging
@@ -49,11 +50,50 @@ module AsyncResult =
   let ofStringErr (ar: Async<Result<'a, string>>) = ar |> AsyncResult.mapError (fun s -> JsonRpc.Error.InternalError s)
 
 
+module AcknowledgedNotification =
+  let private canceled (ct: CancellationToken) =
+    Async.FromContinuations(fun (_, _, cancellation) -> cancellation (OperationCanceledException ct))
+
+  let triggerAndWait
+    (notifications: Event<'notification * CancellationToken * TaskCompletionSource<unit> option>)
+    (notification: 'notification)
+    (ct: CancellationToken)
+    =
+    async {
+      let completion =
+        TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+      let gate = obj ()
+      let mutable cancellationRequested = false
+
+      use _registration =
+        ct.Register(fun () ->
+          lock gate (fun () ->
+            cancellationRequested <- true
+            completion.TrySetCanceled(ct) |> ignore))
+
+      let triggered =
+        lock gate (fun () ->
+          if cancellationRequested then
+            false
+          else
+            notifications.Trigger(notification, ct, Some completion)
+            true)
+
+      if not triggered then
+        return! canceled ct
+      else
+        try
+          do! completion.Task |> Async.AwaitTask
+        with :? OperationCanceledException ->
+          return! canceled ct
+    }
+
+
 
 type DiagnosticMessage =
-  | Add of source: string * Version * diags: Diagnostic[]
-  | Clear of source: string
-  | Flush of AsyncReplyChannel<unit>
+  | Add of source: string * Version * diags: Diagnostic[] * completion: TaskCompletionSource<unit> option
+  | Clear of source: string * completion: TaskCompletionSource<unit> option
 
 /// a type that handles bookkeeping for sending file diagnostics.  It will debounce calls and handle sending diagnostics via the configured function when safe
 type DiagnosticCollection(sendDiagnostics: DocumentUri -> int option -> Diagnostic[] -> Async<unit>) =
@@ -74,16 +114,7 @@ type DiagnosticCollection(sendDiagnostics: DocumentUri -> int option -> Diagnost
       MailboxProcessor<DiagnosticMessage> * CancellationTokenSource
      >()
 
-  let rec restartAgent (fileUri: DocumentUri) =
-    removeAgent fileUri
-    getOrAddAgent fileUri |> ignore
-
-  and removeAgent (fileUri: DocumentUri) =
-    match agents.TryRemove(fileUri) with
-    | false, _ -> ()
-    | true, (_, ctok) -> ctok.Cancel()
-
-  and agentFor (uri: DocumentUri) cTok =
+  let rec agentFor (uri: DocumentUri) (cts: CancellationTokenSource) =
     let logger = LogProvider.getLoggerByName $"Diagnostics/{uri}"
 
     let mailbox =
@@ -91,64 +122,102 @@ type DiagnosticCollection(sendDiagnostics: DocumentUri -> int option -> Diagnost
         (fun inbox ->
           let rec loop (state: Map<string, Version * Diagnostic[]>) =
             async {
-              match! inbox.Receive() with
-              | Add(source, version, diags) ->
-                match Map.tryFind source state with
-                | Some(oldVersion, _) when oldVersion > version -> return! loop state
-                | _ ->
-                  let newState = state |> Map.add source (version, diags)
-                  do! send uri newState
-                  return! loop newState
-              | Clear source ->
-                let newState = state |> Map.remove source
-                do! send uri newState
+              let! message = inbox.Receive()
+
+              let completion =
+                match message with
+                | Add(_, _, _, completion)
+                | Clear(_, completion) -> completion
+
+              try
+                let! newState =
+                  async {
+                    match message with
+                    | Add(source, version, diags, _) ->
+                      match Map.tryFind source state with
+                      | Some(oldVersion, _) when oldVersion > version -> return state
+                      | _ ->
+                        let newState = state |> Map.add source (version, diags)
+                        do! send uri newState
+                        return newState
+                    | Clear(source, _) ->
+                      let newState = state |> Map.remove source
+                      do! send uri newState
+                      return newState
+                  }
+
+                completion |> Option.iter (fun value -> value.TrySetResult() |> ignore)
                 return! loop newState
-              | Flush reply ->
-                reply.Reply()
-                return! loop state
+              with ex ->
+                replaceAgent uri (inbox, cts)
+                completion |> Option.iter (fun value -> value.TrySetException ex |> ignore)
+
+                logger.error (
+                  Log.setMessage "Error while sending diagnostics: {message}"
+                  >> Log.addExn ex
+                  >> Log.addContext "message" ex.Message
+                )
+
+                cts.Cancel()
             }
 
           loop Map.empty),
-        cTok
+        cts.Token
       )
 
-    mailbox.Error.Add(fun exn ->
-      logger.error (
-        Log.setMessage "Error while sending diagnostics: {message}"
-        >> Log.addExn exn
-        >> Log.addContext "message" exn.Message
-      ))
-
-    mailbox.Error.Add(fun _exn -> restartAgent uri)
     mailbox
 
-  and getOrAddAgent fileUri =
+  and replaceAgent fileUri failedAgent =
+    let replacementCts = new CancellationTokenSource()
+    let replacementAgent = agentFor fileUri replacementCts, replacementCts
+
+    if not (agents.TryUpdate(fileUri, replacementAgent, failedAgent)) then
+      replacementCts.Cancel()
+
+  let getOrAddAgent fileUri =
     agents.GetOrAdd(
       fileUri,
       fun fileUri ->
         let cts = new CancellationTokenSource()
-        let mailbox = agentFor fileUri cts.Token
+        let mailbox = agentFor fileUri cts
         (mailbox, cts)
     )
-    |> fst
+
+  let removeAgent (fileUri: DocumentUri) =
+    match agents.TryRemove(fileUri) with
+    | false, _ -> ()
+    | true, (_, ctok) -> ctok.Cancel()
 
   /// If false, no diagnostics will be collected or sent to the client
   member val ClientSupportsDiagnostics = true with get, set
 
   member x.SetFor(fileUri: DocumentUri, kind: string, version: Version, values: Diagnostic[]) =
     if x.ClientSupportsDiagnostics then
-      let mailbox = getOrAddAgent fileUri
+      let mailbox, _ = getOrAddAgent fileUri
 
       match values with
-      | [||] -> mailbox.Post(Clear kind)
-      | values -> mailbox.Post(Add(kind, version, values))
+      | [||] -> mailbox.Post(Clear(kind, None))
+      | values -> mailbox.Post(Add(kind, version, values, None))
 
   member x.SetForAndWait(fileUri: DocumentUri, kind: string, version: Version, values: Diagnostic[]) =
     async {
       if x.ClientSupportsDiagnostics then
-        x.SetFor(fileUri, kind, version, values)
-        let mailbox = getOrAddAgent fileUri
-        do! mailbox.PostAndAsyncReply Flush
+        let completion =
+          TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+        let mailbox, cts = getOrAddAgent fileUri
+
+        use _registration =
+          cts.Token.Register(fun () -> completion.TrySetCanceled(cts.Token) |> ignore)
+
+        match values with
+        | [||] -> mailbox.Post(Clear(kind, Some completion))
+        | values -> mailbox.Post(Add(kind, version, values, Some completion))
+
+        try
+          do! completion.Task |> Async.AwaitTask
+        with :? AggregateException as aggregate when aggregate.InnerExceptions.Count = 1 ->
+          return raise aggregate.InnerException
     }
 
   member x.ClearFor(fileUri: DocumentUri) =
@@ -158,8 +227,8 @@ type DiagnosticCollection(sendDiagnostics: DocumentUri -> int option -> Diagnost
 
   member x.ClearFor(fileUri: DocumentUri, kind: string) =
     if x.ClientSupportsDiagnostics then
-      let mailbox = getOrAddAgent fileUri
-      mailbox.Post(Clear kind)
+      let mailbox, _ = getOrAddAgent fileUri
+      mailbox.Post(Clear(kind, None))
 
   interface IDisposable with
     member x.Dispose() =

--- a/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CompletionTests.fs
@@ -13,10 +13,10 @@ open Utils.Server
 open FsAutoComplete.LspHelpers
 
 
-let documentChanges path range text : DidChangeTextDocumentParams =
+let documentChanges path version range text : DidChangeTextDocumentParams =
   { TextDocument =
       { Uri = Path.FilePathToUri path
-        Version = 1 }
+        Version = version }
 
     ContentChanges =
       [| U2.C1
@@ -115,7 +115,7 @@ let tests state =
           let character = uint32 lineUnderTest.Length
 
           let textChange: DidChangeTextDocumentParams =
-            documentChanges path (posRange line character) "."
+            documentChanges path 1 (posRange line character) "."
 
           let! c = server.TextDocumentDidChange textChange |> Async.StartChild
 
@@ -183,7 +183,7 @@ let tests state =
           let character = uint32 lineUnderTest.Length
 
           let textChange: DidChangeTextDocumentParams =
-            documentChanges path (posRange line character) "."
+            documentChanges path 2 (posRange line character) "."
 
           let! c = server.TextDocumentDidChange textChange |> Async.StartChild
 
@@ -251,7 +251,7 @@ let tests state =
           let character = uint32 lineUnderTest.Length
 
           let textChange: DidChangeTextDocumentParams =
-            documentChanges path (posRange line character) "."
+            documentChanges path 3 (posRange line character) "."
 
           let! c = server.TextDocumentDidChange textChange |> Async.StartChild
 

--- a/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreTests.fs
@@ -33,23 +33,29 @@ let initTests createServer =
       let tempDir =
         Path.Combine(Path.GetTempPath(), "FsAutoComplete.Tests", Guid.NewGuid().ToString())
 
+      Directory.CreateDirectory(tempDir) |> ignore
+
+      use _tempDir =
+        { new IDisposable with
+            member _.Dispose() = Directory.Delete(tempDir, true) }
+
       let (server: IFSharpLspServer, _event) = createServer ()
+      use _server = server :> IDisposable
+
+      let tempUri = Path.FilePathToUri tempDir
 
       let p: InitializeParams =
         { ProcessId = Some 1
-          RootPath = Some __SOURCE_DIRECTORY__
+          RootPath = Some tempDir
           Locale = None
-          RootUri = None
+          RootUri = Some tempUri
           InitializationOptions = Some(Server.serialize defaultConfigDto)
           Capabilities = clientCaps
           ClientInfo =
             Some
               { Name = "FSAC Tests"
                 Version = Some "0.0.0" }
-          WorkspaceFolders =
-            Some
-              [| { Uri = Path.FilePathToUri tempDir
-                   Name = "Test Folder" } |]
+          WorkspaceFolders = Some [| { Uri = tempUri; Name = "Test Folder" } |]
           Trace = None
           WorkDoneToken = None }
 

--- a/test/FsAutoComplete.Tests.Lsp/CoreUtilsTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/CoreUtilsTests.fs
@@ -124,7 +124,16 @@ module UtilsTests =
             <| fun _ ->
               let result = "/usr/local" </> "/bin/tool"
               let expected = Path.Combine("/usr/local", "bin/tool")
-              Expect.equal result expected "Should handle complex paths" ] ]
+              Expect.equal result expected "Should handle complex paths" ]
+
+        testList
+          "normalizePath"
+          [ testCase "resolves ordinary Untitled-prefixed files from the current directory"
+            <| fun _ ->
+              for relativePath in [ "Untitled-notes.fsx"; "Untitled-7.fs"; "Untitled-7.fsx" ] do
+                let expected = relativePath |> Path.GetFullPath |> normalizePath
+                let actual = normalizePath relativePath
+                Expect.equal actual expected $"Should resolve {relativePath} from the current directory" ] ]
 
   /// Tests for string manipulation functions
   let stringTests =

--- a/test/FsAutoComplete.Tests.Lsp/DependentFileCheckingTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/DependentFileCheckingTests.fs
@@ -29,7 +29,7 @@ let tests state =
     testList "SameProject" [
       // Separate server for each test
       // Otherwise share diag stream -> second test must skip diags of first tests. But only when first test runs (-> running all tests vs. running test alone)
-      serverTestList "single" state defaultConfigDto (Some sameProjectRoot) (fun server -> [
+      serverTestListForPreparedProjects "single" state defaultConfigDto (Some sameProjectRoot) (fun server -> [
         testCaseAsync "When A is modified B is re-checked" (async {
           // open the files as they are on-disk and verify things are good
           let! (aDoc, aDiags) = Server.openDocument aFile server
@@ -54,7 +54,7 @@ let tests state =
           Expect.isNonEmpty bDiags $"Should have some compilation errors for {bFile} after erroneous change to {aFile}"
         })
       ])
-      serverTestList "multi" state defaultConfigDto (Some sameProjectRoot) (fun server -> [
+      serverTestListForPreparedProjects "multi" state defaultConfigDto (Some sameProjectRoot) (fun server -> [
         testCaseAsync "When A is modified repeatedly, B is re-checked after each modification" (async {
           // open the files as they are on-disk and verify things are good
           let! (aDoc, aDiags) = Server.openDocument aFile server
@@ -86,7 +86,7 @@ let tests state =
       let crossProject = crossProjectRoot tfm
       let aFile, bFile = Path.Join("Library1" </> "A.fs"), ("App" </> "B.fs")
       testList $"CrossProject-{tfm}" [
-        serverTestList "single" state defaultConfigDto (Some crossProject) (fun server -> [
+        serverTestListForPreparedProjects "single" state defaultConfigDto (Some crossProject) (fun server -> [
           testCaseAsync "When A is modified B is re-checked" (async {
             // open the files as they are on-disk and verify things are good
             let! (aDoc, aDiags) = Server.openDocument aFile server

--- a/test/FsAutoComplete.Tests.Lsp/DetectUnitTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/DetectUnitTests.fs
@@ -8,16 +8,17 @@ open FsAutoComplete.LspHelpers
 open Helpers
 open FsToolkit.ErrorHandling
 open Helpers.Expecto.ShadowedTimeouts
+open Utils.Server
 
 let tests state =
   let getTestNotification projectFolder fileName =
     async {
       let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", projectFolder)
-      let! server, events = serverInitialize path defaultConfigDto state
-      do! waitForWorkspaceFinishedParsing events
+      let! server = Server.createForPreparedProjects (Some path) defaultConfigDto state
+      let events = server.Events
       let path = Path.Combine(path, fileName)
       let tdop: DidOpenTextDocumentParams = { TextDocument = loadDocument path }
-      let! child = Async.StartChild(server.TextDocumentDidOpen tdop)
+      let! child = Async.StartChild(server.Server.TextDocumentDidOpen tdop)
       let! _diagnostics = waitForParseResultsForFile fileName events
       do! child
       return! waitForTestDetected fileName events

--- a/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/ExtensionsTests.fs
@@ -85,6 +85,18 @@ let uriTests =
         Expect.equal uri "file:///home/user/c%C3%B3digo/Program.fs" "ó (U+00F3) must encode as %C3%B3 (UTF-8), not %F3"
       } ]
 
+  let untitledTests =
+    [ test "FileUriToLocalPath gives untitled URIs a stable absolute path" {
+        let localPath = Path.FileUriToLocalPath "untitled:Untitled-7"
+        let expected = Path.Combine(AppContext.BaseDirectory, "Untitled-7.fsx")
+        Expect.equal localPath expected "Untitled paths should not depend on the current directory"
+
+        Expect.equal
+          (Path.FilePathToUri localPath)
+          "untitled:Untitled-7"
+          "The stable path should preserve the untitled URI"
+      } ]
+
   testList
     "Uri tests"
     [ testList "roundtrip tests" (samples |> List.map (fun (uriForm, filePath) -> verifyUri uriForm filePath))
@@ -92,7 +104,8 @@ let uriTests =
         "fileName to uri tests"
         (samples
          |> List.map (fun (uriForm, filePath) -> convertRawPathToUri filePath uriForm))
-      testList "unicode encoding tests" unicodeEncodingTests ]
+      testList "unicode encoding tests" unicodeEncodingTests
+      testList "untitled tests" untitledTests ]
 
 /// Tests for linter
 let linterTests state =
@@ -314,6 +327,7 @@ let formattingTests state =
           | Result.Error e -> failwithf "Error while formatting %s: %A" sourceFile e
         | Core.Result.Error errors -> failwithf "Errors while parsing script %s: %A" sourceFile errors
       })
+
   testList
     "fantomas integration"
     [ testList

--- a/test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
@@ -26,6 +26,9 @@
     <ProjectReference Include="..\OptionAnalyzer\OptionAnalyzer.fsproj" />
     <ProjectReference Include="..\FsAutoComplete.DependencyManager.Dummy\FsAutoComplete.DependencyManager.Dummy.fsproj" />
     <ProjectReference Include="TestCases\GoToCSharp\GoToCSharp.csproj" ReferenceOutputAssembly="false" />
+    <DependentFileCheckingProject Include="TestCases\DependentFileChecking\SameProject\SameProject.fsproj" />
+    <DependentFileCheckingProject Include="TestCases\DependentFileChecking\CrossProject-net8.0\App\App.fsproj" />
+    <DependentFileCheckingProject Include="TestCases\DependentFileChecking\CrossProject-net9.0\App\App.fsproj" Condition="'$(TargetFramework)' != 'net8.0'" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DotnetCli.fs" />
@@ -55,6 +58,9 @@
     <Compile Include="CodeFixTests/Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
+  <Target Name="RestoreDependentFileCheckingProjects" BeforeTargets="Build">
+    <MSBuild Projects="@(DependentFileCheckingProject)" Targets="Restore" BuildInParallel="true" />
+  </Target>
   <!-- This is a workaround for the test framework using Microsoft.Build dependencies and our
   project uses it's own set of Microsoft.Build dependencies which causes loading conflicts -->
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
@@ -25,6 +25,7 @@
     </ProjectReference>
     <ProjectReference Include="..\OptionAnalyzer\OptionAnalyzer.fsproj" />
     <ProjectReference Include="..\FsAutoComplete.DependencyManager.Dummy\FsAutoComplete.DependencyManager.Dummy.fsproj" />
+    <ProjectReference Include="TestCases\GoToCSharp\GoToCSharp.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DotnetCli.fs" />

--- a/test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
+++ b/test/FsAutoComplete.Tests.Lsp/FsAutoComplete.Tests.Lsp.fsproj
@@ -26,9 +26,12 @@
     <ProjectReference Include="..\OptionAnalyzer\OptionAnalyzer.fsproj" />
     <ProjectReference Include="..\FsAutoComplete.DependencyManager.Dummy\FsAutoComplete.DependencyManager.Dummy.fsproj" />
     <ProjectReference Include="TestCases\GoToCSharp\GoToCSharp.csproj" ReferenceOutputAssembly="false" />
-    <DependentFileCheckingProject Include="TestCases\DependentFileChecking\SameProject\SameProject.fsproj" />
-    <DependentFileCheckingProject Include="TestCases\DependentFileChecking\CrossProject-net8.0\App\App.fsproj" />
-    <DependentFileCheckingProject Include="TestCases\DependentFileChecking\CrossProject-net9.0\App\App.fsproj" Condition="'$(TargetFramework)' != 'net8.0'" />
+    <PreparedTestProject Include="TestCases\DependentFileChecking\SameProject\SameProject.fsproj" />
+    <PreparedTestProject Include="TestCases\DependentFileChecking\CrossProject-net8.0\App\App.fsproj" />
+    <PreparedTestProject Include="TestCases\DependentFileChecking\CrossProject-net9.0\App\App.fsproj" Condition="'$(TargetFramework)' != 'net8.0'" />
+    <PreparedTestProject Include="TestCases\NUnitTests\NUnitTests.fsproj" />
+    <PreparedTestProject Include="TestCases\XUnitTests\XUnitTests.fsproj" />
+    <PreparedTestProject Include="TestCases\ExpectoTests\ExpectoTests.fsproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DotnetCli.fs" />
@@ -58,8 +61,8 @@
     <Compile Include="CodeFixTests/Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
-  <Target Name="RestoreDependentFileCheckingProjects" BeforeTargets="Build">
-    <MSBuild Projects="@(DependentFileCheckingProject)" Targets="Restore" BuildInParallel="true" />
+  <Target Name="RestorePreparedTestProjects" BeforeTargets="Build">
+    <MSBuild Projects="@(PreparedTestProject)" Targets="Restore" RemoveProperties="TargetFramework" BuildInParallel="true" />
   </Target>
   <!-- This is a workaround for the test framework using Microsoft.Build dependencies and our
   project uses it's own set of Microsoft.Build dependencies which causes loading conflicts -->

--- a/test/FsAutoComplete.Tests.Lsp/GoToTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/GoToTests.fs
@@ -723,6 +723,56 @@ let private untitledGotoTests state =
           Expect.stringEnds r.Uri doc.Uri "should navigate to source file"
           Expect.equal r.Range declRange "should point to the range of function declaration"
         | Ok(_resultValue) -> failwith "Not Implemented"
+      }
+      testCaseAsync "can go to an untitled declaration after the current directory changes"
+      <| async {
+        let (usagePos, declRange, text) =
+          """
+        let $0myFun$0 a b = a + b
+        let _ = ()
+        let a = my$0Fun 1 1
+        """
+          |> Text.trimTripleQuotation
+          |> Cursor.assertExtractRange
+          |> fun (decl, text) ->
+              let (pos, text) = text |> Cursor.assertExtractPosition
+              (pos, decl, text)
+
+        let previousCurrentDirectory = Environment.CurrentDirectory
+        let didOpenDirectory = __SOURCE_DIRECTORY__
+        let requestDirectory = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "GoToCSharp")
+
+        try
+          Environment.CurrentDirectory <- didOpenDirectory
+          let! (doc, _diags) = server |> Server.createUntitledDocument text
+
+          let p: DefinitionParams =
+            { TextDocument = doc.TextDocumentIdentifier
+              Position = usagePos
+              WorkDoneToken = None
+              PartialResultToken = None }
+
+          let! res =
+            async {
+              use doc = doc
+
+              try
+                Environment.CurrentDirectory <- requestDirectory
+                return! doc.Server.Server.TextDocumentDefinition p
+              finally
+                Environment.CurrentDirectory <- didOpenDirectory
+            }
+
+          match res with
+          | Error e -> failtestf "Request failed: %A" e
+          | Ok None -> failtest "Request none"
+          | Ok(Some(U2.C2 _)) -> failtest "Should only get one location"
+          | Ok(Some(U2.C1(U2.C1 r))) ->
+            Expect.stringEnds r.Uri doc.Uri "should navigate to source file"
+            Expect.equal r.Range declRange "should point to the range of function declaration"
+          | Ok(_resultValue) -> failwith "Not Implemented"
+        finally
+          Environment.CurrentDirectory <- previousCurrentDirectory
       } ])
 
 /// GoTo tests between a signature file and its implementation file

--- a/test/FsAutoComplete.Tests.Lsp/GoToTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/GoToTests.fs
@@ -20,9 +20,6 @@ let private gotoTest state =
     async {
       let path = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "GoToTests")
 
-      let csharpPath = Path.Combine(__SOURCE_DIRECTORY__, "TestCases", "GoToCSharp")
-      let _buildInfo = DotnetCli.build csharpPath
-
       let! (server, event) = serverInitialize path defaultConfigDto state
       do! waitForWorkspaceFinishedParsing event
 

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -77,6 +77,19 @@ let compilers =
   | Some(EqIC "BackgroundCompiler") -> [ "BackgroundCompiler", false ]
   | _ -> [ "BackgroundCompiler", false; "TransparentCompiler", true ]
 
+let testShard =
+  match getEnvVarAsStr "FSAC_TEST_SHARD" with
+  | None -> None
+  | Some("1" | "2" | "3" | "4" as shard) -> Some(int shard)
+  | Some shard -> invalidArg "FSAC_TEST_SHARD" $"FSAC_TEST_SHARD must be 1, 2, 3, or 4. Actual value: %s{shard}"
+
+let selectTestGroups groups =
+  match testShard with
+  | None -> groups |> List.map snd
+  | Some selectedShard ->
+    groups
+    |> List.choose (fun (shard, test) -> if shard = selectedShard then Some test else None)
+
 let lspTests =
   testSequenced
   <| testList
@@ -86,62 +99,63 @@ let lspTests =
         testList
           $"{loaderName}"
           [ for (compilerName, useTransparentCompiler) in compilers do
-              testList
-                $"{compilerName}"
-                [ Templates.tests ()
-                  let createServer () =
-                    adaptiveLspServerFactory toolsPath workspaceLoaderFactory sourceTextFactory useTransparentCompiler
+              let createServer () =
+                adaptiveLspServerFactory toolsPath workspaceLoaderFactory sourceTextFactory useTransparentCompiler
 
-                  initTests createServer
-                  closeTests createServer
+              let compilerTests =
+                [ 4, Templates.tests ()
+                  4, initTests createServer
+                  4, closeTests createServer
 
-                  Utils.Tests.Server.tests createServer
-                  Utils.Tests.CursorbasedTests.tests createServer
+                  1, Utils.Tests.Server.tests createServer
+                  4, Utils.Tests.CursorbasedTests.tests createServer
 
-                  CodeLens.tests createServer
-                  documentSymbolTest createServer
-                  workspaceSymbolTest createServer
-                  Completion.autocompleteTest createServer
-                  Completion.autoOpenTests createServer
-                  Completion.fullNameExternalAutocompleteTest createServer
-                  foldingTests createServer
-                  tooltipTests createServer
-                  Highlighting.tests createServer
-                  scriptPreviewTests createServer
-                  scriptEvictionTests createServer
-                  scriptProjectOptionsCacheTests createServer
-                  dependencyManagerTests createServer
-                  interactiveDirectivesUnitTests
+                  4, CodeLens.tests createServer
+                  4, documentSymbolTest createServer
+                  4, workspaceSymbolTest createServer
+                  4, Completion.autocompleteTest createServer
+                  2, Completion.autoOpenTests createServer
+                  3, Completion.fullNameExternalAutocompleteTest createServer
+                  4, foldingTests createServer
+                  4, tooltipTests createServer
+                  4, Highlighting.tests createServer
+                  4, scriptPreviewTests createServer
+                  4, scriptEvictionTests createServer
+                  4, scriptProjectOptionsCacheTests createServer
+                  4, dependencyManagerTests createServer
+                  4, interactiveDirectivesUnitTests
 
                   // commented out because FSDN is down
                   //fsdnTest createServer
 
                   //linterTests createServer
-                  uriTests
-                  formattingTests createServer
-                  analyzerTests createServer
-                  signatureTests createServer
-                  SignatureHelp.tests createServer
-                  InlineHints.tests createServer
-                  CodeFixTests.Tests.tests sourceTextFactory createServer
-                  Completion.tests createServer
-                  GoTo.tests createServer
+                  4, uriTests
+                  4, formattingTests createServer
+                  4, analyzerTests createServer
+                  4, signatureTests createServer
+                  4, SignatureHelp.tests createServer
+                  4, InlineHints.tests createServer
+                  2, CodeFixTests.Tests.tests sourceTextFactory createServer
+                  4, Completion.tests createServer
+                  3, GoTo.tests createServer
 
-                  FindReferences.tests createServer
-                  Rename.tests createServer
+                  4, FindReferences.tests createServer
+                  3, Rename.tests createServer
 
-                  InfoPanelTests.docFormattingTest createServer
-                  DetectUnitTests.tests createServer
-                  XmlDocumentationGeneration.tests createServer
-                  InlayHintTests.tests createServer
-                  DependentFileChecking.tests createServer
-                  UnusedDeclarationsTests.tests createServer
-                  EmptyFileTests.tests createServer
-                  CallHierarchy.tests createServer
-                  diagnosticsTest createServer
-                  InheritDocTooltipTests.tests createServer
+                  4, InfoPanelTests.docFormattingTest createServer
+                  4, DetectUnitTests.tests createServer
+                  4, XmlDocumentationGeneration.tests createServer
+                  4, InlayHintTests.tests createServer
+                  3, DependentFileChecking.tests createServer
+                  2, UnusedDeclarationsTests.tests createServer
+                  4, EmptyFileTests.tests createServer
+                  3, CallHierarchy.tests createServer
+                  4, diagnosticsTest createServer
+                  4, InheritDocTooltipTests.tests createServer
 
-                  TestExplorer.tests createServer ] ] ]
+                  3, TestExplorer.tests createServer ]
+
+              testList $"{compilerName}" (selectTestGroups compilerTests) ] ]
 
 let expectedRuntimeMajor =
   System.Reflection.CustomAttributeExtensions
@@ -170,7 +184,11 @@ let generalTests =
 
 [<Tests>]
 let tests =
-  testList "FSAC" [ generalTests; lspTests; SnapshotTests.snapshotTests loaders toolsPath ]
+  match testShard with
+  | None -> testList "FSAC" [ generalTests; lspTests; SnapshotTests.snapshotTests loaders toolsPath ]
+  | Some 1 -> testList "FSAC" [ generalTests; lspTests ]
+  | Some 4 -> testList "FSAC" [ lspTests; SnapshotTests.snapshotTests loaders toolsPath ]
+  | Some _ -> testList "FSAC" [ lspTests ]
 
 open OpenTelemetry
 open OpenTelemetry.Resources

--- a/test/FsAutoComplete.Tests.Lsp/Program.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Program.fs
@@ -102,6 +102,7 @@ let lspTests =
               let createServer () =
                 adaptiveLspServerFactory toolsPath workspaceLoaderFactory sourceTextFactory useTransparentCompiler
 
+              // Shard 1 carries general tests and shard 4 carries snapshots; keep shared fixtures together and add isolated groups to the fastest measured shard.
               let compilerTests =
                 [ 4, Templates.tests ()
                   4, initTests createServer

--- a/test/FsAutoComplete.Tests.Lsp/Utils/CursorbasedTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/CursorbasedTests.fs
@@ -8,16 +8,11 @@ open Utils.Server
 open Utils.TextEdit
 open Ionide.ProjInfo.Logging
 
-/// Checks for CodeFixes, CodeActions
-open System.Runtime.ExceptionServices
-
 ///
 /// Prefixes:
 /// * `check`: Check to use inside a `testCaseAsync`. Not a Test itself!
 /// * `test`: Returns Expecto Test. Usually combines multiple tests (like: test all positions).
 module CodeFix =
-  let private _logger = LogProvider.getLoggerByName "CursorbasedTests.CodeFix"
-
   let private diagnosticsIn (range: Range) (diags: Diagnostic[]) =
     diags |> Array.filter (fun diag -> range |> Range.overlapsStrictly diag.Range)
 
@@ -118,39 +113,20 @@ module CodeFix =
     (expected: unit -> ExpectedResult)
     =
     async {
-      let mutable attempts = 5
+      let (range, text) =
+        beforeWithCursor |> Text.trimTripleQuotation |> Cursor.assertExtractRange
 
-      while attempts > 0 do
-        try
-          let (range, text) =
-            beforeWithCursor |> Text.trimTripleQuotation |> Cursor.assertExtractRange
-          // load text file
-          let! (doc, diags) = server |> Server.createUntitledDocument text
-          use doc = doc // ensure doc gets closed (disposed) after test
+      let! (doc, diags) = server |> Server.createUntitledDocument text
+      use doc = doc
 
-          do!
-            checkFixAt
-              (doc, diags)
-              doc.VersionedTextDocumentIdentifier
-              (text, range)
-              validateDiagnostics
-              chooseFix
-              (expected ())
-
-          attempts <- 0
-        with ex ->
-          attempts <- attempts - 1
-
-          if attempts = 0 then
-            ExceptionDispatchInfo.Capture(ex).Throw()
-            return failwith "Unreachable"
-          else
-            _logger.warn (
-              Log.setMessage "Retrying test after failure"
-              >> Log.addContext "attempts" (5 - attempts)
-            )
-
-            do! Async.Sleep 15
+      do!
+        checkFixAt
+          (doc, diags)
+          doc.VersionedTextDocumentIdentifier
+          (text, range)
+          validateDiagnostics
+          chooseFix
+          (expected ())
 
     }
 

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.Tests.fs
@@ -222,6 +222,17 @@ let tests state =
                 None
                 (fun server ->
                   [ testCaseAsync
+                      "shard one starts in a separate untitled document range"
+                      (async {
+                        let! actualServer = server
+
+                        match System.Environment.GetEnvironmentVariable "FSAC_TEST_SHARD" with
+                        | null -> Expect.equal actualServer.UntitledCounter 0 "Unsharded tests should start at zero"
+                        | "1" ->
+                          Expect.equal actualServer.UntitledCounter 1_000_000 "Shard one should use its own range"
+                        | shard -> failtestf "Unexpected shard for Server tests: %s" shard
+                      })
+                    testCaseAsync
                       "creating document increases untitled counter"
                       (async {
                         let! actualServer = server
@@ -606,11 +617,13 @@ let tests state =
                       |> Array.countBy id
                       |> Map.ofArray
 
+                    let count message = groups |> Map.tryFind message |> Option.defaultValue 0
+
                     let actual =
-                      {| UnusedOpens = groups.["Unused open statement"]
-                         UnusedDecls = groups.["This value is unused"]
-                         SimplifyNames = groups.["This qualifier is redundant"]
-                         CompilerErrors = groups.["The value or constructor is not defined"] |}
+                      {| UnusedOpens = count "Unused open statement"
+                         UnusedDecls = count "This value is unused"
+                         SimplifyNames = count "This qualifier is redundant"
+                         CompilerErrors = count "The value or constructor is not defined" |}
 
                     // exact count isn't actually that important because each analyzers sends all its diags together.
                     // important part is just: has arrived -> `waitForLatestDiagnostics` waited long enough for all diags
@@ -793,6 +806,22 @@ f2 "bar" |> ignore
                 let! (doc, _) = server |> Server.openDocument absolutePath
                 use _doc = doc
                 ()
+              }
+
+              testCaseAsync "reopened document uses a new version"
+              <| async {
+                let relativePath = "../TestCases/ServerTests/JustScript/Script.fsx"
+
+                let absolutePath =
+                  System.IO.Path.GetFullPath(System.IO.Path.Combine(__SOURCE_DIRECTORY__, relativePath))
+
+                let! (firstDocument, _) = server |> Server.openDocument absolutePath
+                let firstVersion = firstDocument.Version
+                do! firstDocument |> Document.close
+
+                let! (secondDocument, _) = server |> Server.openDocument absolutePath
+                use _secondDocument = secondDocument
+                Expect.isGreaterThan secondDocument.Version firstVersion "A reopened document must use a new version"
               }
 
               let mutable docState =

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.Tests.fs
@@ -1,6 +1,8 @@
 module Utils.Tests.Server
 
 open System
+open System.Threading
+open System.Threading.Tasks
 open Expecto
 open Helpers
 open FsAutoComplete
@@ -14,11 +16,128 @@ open Utils.Utils
 open FsToolkit.ErrorHandling
 open FSharpx.Control
 open FsAutoComplete.LspHelpers
+open FSharp.UMX
+
+let private startWithOutcome (work: Async<'result>) =
+  let completion =
+    TaskCompletionSource<Choice<'result, exn, OperationCanceledException>>(
+      TaskCreationOptions.RunContinuationsAsynchronously
+    )
+
+  Async.StartWithContinuations(
+    work,
+    (fun result -> completion.TrySetResult(Choice1Of3 result) |> ignore),
+    (fun ex -> completion.TrySetResult(Choice2Of3 ex) |> ignore),
+    (fun ex -> completion.TrySetResult(Choice3Of3 ex) |> ignore)
+  )
+
+  completion.Task
+
+let private completesWithin (timeout: TimeSpan) (work: Task) =
+  async {
+    let! completed = Task.WhenAny([| work; Task.Delay timeout |]) |> Async.AwaitTask
+    return Object.ReferenceEquals(completed, work)
+  }
+
+let private acknowledgedWaitTimeout = TimeSpan.FromSeconds 1.
 
 let tests state =
   testList
     (nameof (Server))
-    [ testList
+    [ testCaseAsync
+        "pre-canceled acknowledged notification completes as canceled"
+        (async {
+          let notifications =
+            Event<int * CancellationToken * TaskCompletionSource<unit> option>()
+
+          let mutable handlerInvoked = false
+          use _subscription = notifications.Publish.Subscribe(fun _ -> handlerInvoked <- true)
+          use cts = new CancellationTokenSource()
+          cts.Cancel()
+
+          let completion =
+            AcknowledgedNotification.triggerAndWait notifications 1 cts.Token
+            |> startWithOutcome
+
+          let! completed = completion |> completesWithin acknowledgedWaitTimeout
+          Expect.isTrue completed "The acknowledged notification wait must observe cancellation"
+
+          match completion.Result with
+          | Choice3Of3 _ -> ()
+          | Choice2Of3 ex -> failtestf "Expected cancellation, but got %s" ex.Message
+          | Choice1Of3() -> failtest "Expected cancellation"
+
+          Expect.isFalse handlerInvoked "A pre-canceled notification must not invoke its handler"
+        })
+      testCaseAsync
+        "in-flight acknowledged notification completes as canceled"
+        (async {
+          let notifications =
+            Event<int * CancellationToken * TaskCompletionSource<unit> option>()
+
+          let handlerStarted =
+            TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+          use _subscription =
+            notifications.Publish.Subscribe(fun _ -> handlerStarted.TrySetResult() |> ignore)
+
+          use cts = new CancellationTokenSource()
+
+          let completion =
+            AcknowledgedNotification.triggerAndWait notifications 1 cts.Token
+            |> startWithOutcome
+
+          let! started = handlerStarted.Task |> completesWithin acknowledgedWaitTimeout
+          Expect.isTrue started "The notification handler must start before cancellation"
+          cts.Cancel()
+
+          let! completed = completion |> completesWithin acknowledgedWaitTimeout
+          Expect.isTrue completed "The in-flight notification wait must observe cancellation"
+
+          match completion.Result with
+          | Choice3Of3 _ -> ()
+          | Choice2Of3 ex -> failtestf "Expected cancellation, but got %s" ex.Message
+          | Choice1Of3() -> failtest "Expected cancellation"
+        })
+      testCaseAsync
+        "acknowledged diagnostic update returns the send failure"
+        (async {
+          let failure = InvalidOperationException "diagnostic send failed"
+          let mutable sendCount = 0
+
+          let send _ _ _ =
+            async {
+              if Interlocked.Increment(&sendCount) = 1 then
+                return raise failure
+            }
+
+          use diagnostics = new DiagnosticCollection(send)
+          let uri: DocumentUri = UMX.tag "file:///diagnostic-failure.fs"
+
+          let firstCompletion =
+            diagnostics.SetForAndWait(uri, "test", 1, [||]) |> startWithOutcome
+
+          let! firstCompleted = firstCompletion |> completesWithin acknowledgedWaitTimeout
+          Expect.isTrue firstCompleted "The acknowledged update must return the send failure"
+
+          match firstCompletion.Result with
+          | Choice2Of3 ex -> Expect.isTrue (Object.ReferenceEquals(ex, failure)) "The original send failure must return"
+          | Choice3Of3 ex -> failtestf "Expected the send failure, but got cancellation: %s" ex.Message
+          | Choice1Of3() -> failtest "Expected the send failure"
+
+          let secondCompletion =
+            diagnostics.SetForAndWait(uri, "test", 2, [||]) |> startWithOutcome
+
+          let! secondCompleted = secondCompletion |> completesWithin acknowledgedWaitTimeout
+
+          Expect.isTrue secondCompleted "The replacement diagnostics agent must process the next update"
+
+          match secondCompletion.Result with
+          | Choice1Of3() -> ()
+          | Choice2Of3 ex -> failtestf "Expected the next update to succeed, but got %s" ex.Message
+          | Choice3Of3 ex -> failtestf "Expected the next update to succeed, but got cancellation: %s" ex.Message
+        })
+      testList
         "no root path"
         [ testList
             "can get diagnostics"

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.Tests.fs
@@ -244,6 +244,23 @@ let tests state =
                         Expect.isGreaterThan postCounter preCounter "Untitled Counter should increase"
                       })
                     testCaseAsync
+                      "separate servers allocate separate untitled document URIs"
+                      (async {
+                        let firstServer = Server.create None defaultConfigDto state
+                        let secondServer = Server.create None defaultConfigDto state
+                        let! (firstDocument, _) = firstServer |> Server.createUntitledDocument ""
+                        let! (secondDocument, _) = secondServer |> Server.createUntitledDocument ""
+                        let firstUri = firstDocument.Uri
+                        let secondUri = secondDocument.Uri
+
+                        do! firstDocument |> Document.close
+                        do! secondDocument |> Document.close
+                        do! firstServer |> Server.shutdown
+                        do! secondServer |> Server.shutdown
+
+                        Expect.notEqual firstUri secondUri "Separate servers must not reuse an untitled document URI"
+                      })
+                    testCaseAsync
                       "creating multiple documents increases untitled counter"
                       (async {
                         let getCounter server = server |> Async.map (fun s -> s.UntitledCounter)

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.Tests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.Tests.fs
@@ -137,6 +137,35 @@ let tests state =
           | Choice2Of3 ex -> failtestf "Expected the next update to succeed, but got %s" ex.Message
           | Choice3Of3 ex -> failtestf "Expected the next update to succeed, but got cancellation: %s" ex.Message
         })
+      testCaseAsync
+        "versioned empty updates preserve diagnostic version ordering"
+        (async {
+          let verify submitEmpty uri =
+            async {
+              let sent = ResizeArray<int option * Diagnostic[]>()
+              let send _ version diagnostics = async { sent.Add(version, diagnostics) }
+              use collection = new DiagnosticCollection(send)
+              let diagnostic = Unchecked.defaultof<Diagnostic>
+
+              do! collection.SetForAndWait(uri, "test", 3, [| diagnostic |])
+              do! submitEmpty collection uri
+              do! collection.SetForAndWait(uri, "test", 1, [| diagnostic |])
+
+              Expect.hasLength sent 1 "Stale updates must not publish diagnostics"
+              Expect.equal (fst sent[0]) (Some 3) "The newest diagnostic version must remain"
+              Expect.hasLength (snd sent[0]) 1 "The newest diagnostics must remain"
+            }
+
+          do!
+            verify
+              (fun collection uri -> async { collection.SetFor(uri, "test", 2, [||]) })
+              (UMX.tag "file:///diagnostic-post-version.fs")
+
+          do!
+            verify
+              (fun collection uri -> collection.SetForAndWait(uri, "test", 2, [||]))
+              (UMX.tag "file:///diagnostic-wait-version.fs")
+        })
       testList
         "no root path"
         [ testList

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
@@ -21,7 +21,9 @@ type Server =
   { RootPath: string option
     Server: IFSharpLspServer
     Events: ClientEvents
-    mutable UntitledCounter: int }
+    mutable UntitledCounter: int
+    mutable DocumentVersionCounter: int
+    OpenDocumentVersions: System.Collections.Concurrent.ConcurrentDictionary<DocumentUri, int> }
 
 /// `Server` cached with `Async.Cache`
 type CachedServer = Async<Server>
@@ -46,6 +48,15 @@ type Document =
     override doc.Dispose() : unit = doc |> Document.close |> Async.RunSynchronously
 
 module Server =
+  let private initialUntitledCounter () =
+    match Environment.GetEnvironmentVariable "FSAC_TEST_SHARD" with
+    | null -> 0
+    | "1" -> 1_000_000
+    | "2" -> 2_000_000
+    | "3" -> 3_000_000
+    | "4" -> 4_000_000
+    | shard -> invalidArg "FSAC_TEST_SHARD" $"FSAC_TEST_SHARD must be 1, 2, 3, or 4. Actual value: %s{shard}"
+
   let private initialize path (config: FSharpConfigDto) createServer =
     async {
       logger.trace (
@@ -91,7 +102,9 @@ module Server =
           { RootPath = path
             Server = server
             Events = events
-            UntitledCounter = 0 }
+            UntitledCounter = initialUntitledCounter ()
+            DocumentVersionCounter = 0
+            OpenDocumentVersions = System.Collections.Concurrent.ConcurrentDictionary() }
       | Result.Error error -> return failwith $"Initialization failed: %A{error}"
     }
 
@@ -113,10 +126,16 @@ module Server =
     }
 
   let private createDocument fullPath uri server =
+    let version =
+      server.OpenDocumentVersions.GetOrAdd(
+        uri,
+        fun _ -> System.Threading.Interlocked.Increment(&server.DocumentVersionCounter)
+      )
+
     { Server = server
       Uri = uri
       FilePath = fullPath
-      Version = 0 }
+      Version = version }
 
   let private untitledDocUrif = sprintf "untitled:Untitled-%i"
 
@@ -198,7 +217,6 @@ module Server =
 
 module Document =
   open System.Reactive.Linq
-  open System.Threading.Tasks
 
   let private typedEvents<'t> typ : _ -> System.IObservable<'t> =
     Observable.choose (fun (typ', _o) -> if typ' = typ then Some(unbox _o) else None)
@@ -220,28 +238,10 @@ module Document =
     |> Observable.filter (fun n -> n.TextDocument.Uri = doc.Uri)
 
 
-  /// in ms
-  let private waitForLateDiagnosticsDelay =
-    let envVar = "FSAC_WaitForLateDiagnosticsDelay"
-
-    System.Environment.GetEnvironmentVariable envVar
-    |> Option.ofObj
-    |> Option.map (fun d ->
-      match System.Int32.TryParse d with
-      | (true, d) -> d
-      | (false, _) -> failwith $"Environment Variable '%s{envVar}' exists, but is not a correct int number ('%s{d}')")
-    |> Option.orElseWith (fun _ ->
-      // set in Github Actions: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-      match System.Environment.GetEnvironmentVariable "CI" with
-      | null -> None
-      | _ -> Some 25)
-    |> Option.defaultValue 7 // testing locally
-
   /// Waits (if necessary) and gets latest diagnostics.
   ///
   /// To detect newest diags:
   /// * Waits for `fsharp/documentAnalyzed` for passed `doc` and its `doc.Version`.
-  /// * Then waits a but more for potential late diags.
   /// * Then returns latest diagnostics.
   ///
   ///
@@ -259,13 +259,6 @@ module Document =
   /// -> `fsharp/documentAnalyzed` was introduced. Notification when a doc was completely analyzed
   /// -> wait for `documentAnalyzed`
   ///
-  /// But issue: last `publishDiagnostics` might be received AFTER `documentAnalyzed` (because of async notifications & sending)
-  /// -> after receiving `documentAnalyzed` wait a bit for late `publishDiagnostics`
-  ///
-  /// But issue: Wait for how long? Too long: extends test execution time. Too short: Might miss diags.
-  /// -> unresolved. Current wait based on testing on modern_ish PC. Seems to work on CI too.
-  ///
-  ///
   /// *Inconvenience*: Only newest diags can be retrieved this way. Diags for older file versions cannot be extracted reliably:
   /// `doc.Server.Events` is a `ReplaySubject` -> returns ALL previous events on new subscription
   /// -> All past `documentAnalyzed` events and their diags are all received at once
@@ -279,34 +272,33 @@ module Document =
         >> Log.addContext "version" doc.Version
       )
 
-      let tcs = TaskCompletionSource<_>()
+      let mutable latest = [||]
 
       use _ =
         doc
         |> diagnosticsStream
-        |> Observable.takeUntilOther (
-          doc
-          // `fsharp/documentAnalyzed` signals all checks & analyzers done
-          |> analyzedStream
-          |> Observable.filter (fun n -> n.TextDocument.Version = doc.Version)
-          // wait for late diagnostics
-          |> Observable.delay waitForLateDiagnosticsDelay
-        )
-        |> Observable.bufferSpan (timeout)
-        // |> Observable.timeoutSpan timeout
-        |> Observable.subscribe (fun x -> tcs.SetResult x)
+        |> Observable.subscribe (fun diagnostics -> latest <- diagnostics)
 
-      let! result = tcs.Task |> Async.AwaitTask
+      do!
+        doc
+        |> analyzedStream
+        |> Observable.filter (fun n -> n.TextDocument.Version = doc.Version)
+        |> Observable.timeoutSpan timeout
+        |> Async.AwaitObservable
+        |> Async.Ignore
 
-      // The buffer can close empty under load (e.g. the `documentAnalyzed` signal arrives
-      // before any `publishDiagnostics` batch), so `Seq.last` would throw "input sequence
-      // was empty". No batch published in the window == no diagnostics -> return empty.
-      return result |> Seq.tryLast |> Option.defaultValue [||]
+      return latest
     }
 
 
   /// Note: Mutates passed `doc`
-  let private incrVersion (doc: Document) = System.Threading.Interlocked.Increment(&doc.Version)
+  let private incrVersion (doc: Document) =
+    let version =
+      System.Threading.Interlocked.Increment(&doc.Server.DocumentVersionCounter)
+
+    doc.Server.OpenDocumentVersions.[doc.Uri] <- version
+    System.Threading.Interlocked.Exchange(&doc.Version, version) |> ignore
+    version
 
   /// Note: Mutates passed `doc`
   let private incrVersionedTextDocumentIdentifier (doc: Document) : VersionedTextDocumentIdentifier =
@@ -334,6 +326,7 @@ module Document =
     async {
       let p: DidCloseTextDocumentParams = { TextDocument = doc.TextDocumentIdentifier }
       do! doc.Server.Server.TextDocumentDidClose p
+      doc.Server.OpenDocumentVersions.TryRemove(doc.Uri) |> ignore
     }
 
   ///<summary>

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
@@ -59,20 +59,20 @@ module Server =
 
   let private processUntitledCounter = [| initialUntitledCounter () |]
 
-  let private initialize path (config: FSharpConfigDto) createServer =
+  let private initialize prepareProjects path (config: FSharpConfigDto) createServer =
     async {
       logger.trace (
         Log.setMessage "Initialize Server in {path}"
         >> Log.addContextDestructured "path" path
       )
 
-      match path with
-      | None -> ()
-      | Some path ->
+      match path, prepareProjects with
+      | Some path, true ->
         dotnetCleanup path
 
         for file in System.IO.Directory.EnumerateFiles(path, "*.fsproj", SearchOption.AllDirectories) do
           do! file |> Path.GetDirectoryName |> dotnetRestore
+      | _ -> ()
 
       let (server: IFSharpLspServer, events: IObservable<_>) = createServer ()
       events |> Observable.add logEvent
@@ -110,9 +110,9 @@ module Server =
       | Result.Error error -> return failwith $"Initialization failed: %A{error}"
     }
 
-  let create path config createServer : CachedServer =
+  let private create' prepareProjects path config createServer : CachedServer =
     async {
-      let! server = initialize path config createServer
+      let! server = initialize prepareProjects path config createServer
 
       if path |> Option.isSome then
         do! waitForWorkspaceFinishedParsing server.Events
@@ -120,6 +120,10 @@ module Server =
       return server
     }
     |> Async.Cache
+
+  let create path config createServer = create' true path config createServer
+
+  let createForPreparedProjects path config createServer = create' false path config createServer
 
   let shutdown (server: CachedServer) =
     async {

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
@@ -57,6 +57,8 @@ module Server =
     | "4" -> 4_000_000
     | shard -> invalidArg "FSAC_TEST_SHARD" $"FSAC_TEST_SHARD must be 1, 2, 3, or 4. Actual value: %s{shard}"
 
+  let private processUntitledCounter = [| initialUntitledCounter () |]
+
   let private initialize path (config: FSharpConfigDto) createServer =
     async {
       logger.trace (
@@ -141,7 +143,8 @@ module Server =
 
   /// Note: mutates passed `server`: increments `server.UntitledCounter`
   let private nextUntitledDocUri (server: Server) =
-    let next = System.Threading.Interlocked.Increment(&server.UntitledCounter)
+    let next = System.Threading.Interlocked.Increment(&processUntitledCounter[0])
+    System.Threading.Interlocked.Exchange(&server.UntitledCounter, next) |> ignore
     untitledDocUrif (next - 1)
 
   let createUntitledDocument initialText (server: CachedServer) =

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.fs
@@ -320,7 +320,7 @@ module Document =
       do! doc.Server.Server.TextDocumentDidOpen p
 
       try
-        return! doc |> waitForLatestDiagnostics (TimeSpan.FromSeconds(2.))
+        return! doc |> waitForLatestDiagnostics Helpers.defaultTimeout
       with :? TimeoutException ->
         return failwith $"Timeout waiting for latest diagnostics for {doc.Uri}"
     }

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.fsi
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.fsi
@@ -16,111 +16,103 @@ open Utils
 open Ionide.ProjInfo.Logging
 
 type Server =
-    { RootPath: string option
-      Server: IFSharpLspServer
-      Events: ClientEvents
-      mutable UntitledCounter: int }
+  { RootPath: string option
+    Server: IFSharpLspServer
+    Events: ClientEvents
+    mutable UntitledCounter: int
+    mutable DocumentVersionCounter: int
+    OpenDocumentVersions: System.Collections.Concurrent.ConcurrentDictionary<DocumentUri, int> }
 
 /// `Server` cached with `Async.Cache`
 type CachedServer = Async<Server>
 
 type Document =
-    { Server: Server
-      FilePath: string
-      Uri: DocumentUri
-      mutable Version: int }
+  { Server: Server
+    FilePath: string
+    Uri: DocumentUri
+    mutable Version: int }
 
-    member TextDocumentIdentifier: TextDocumentIdentifier
-    member VersionedTextDocumentIdentifier: VersionedTextDocumentIdentifier
-    member Diagnostics: IObservable<Diagnostic array>
-    member CompilerDiagnostics: IObservable<Diagnostic array>
-    interface IDisposable
+  member TextDocumentIdentifier: TextDocumentIdentifier
+  member VersionedTextDocumentIdentifier: VersionedTextDocumentIdentifier
+  member Diagnostics: IObservable<Diagnostic array>
+  member CompilerDiagnostics: IObservable<Diagnostic array>
+  interface IDisposable
 
 module Server =
-    val create:
-        path: string option ->
-        config: FSharpConfigDto ->
-        createServer: (unit -> IFSharpLspServer * IObservable<string * obj>) ->
-            CachedServer
+  val create:
+    path: string option ->
+    config: FSharpConfigDto ->
+    createServer: (unit -> IFSharpLspServer * IObservable<string * obj>) ->
+      CachedServer
 
-    val shutdown: server: CachedServer -> Async<unit>
-    val createUntitledDocument: initialText: string -> server: CachedServer -> Async<Document * Diagnostic array>
-    /// `path` can be absolute or relative.
-    /// For relative path `server.RootPath` must be specified!
-    ///
-    /// Note: When `path` is relative: relative to `server.RootPath`!
-    val openDocument: path: string -> server: CachedServer -> Async<Document * Diagnostic array>
+  val shutdown: server: CachedServer -> Async<unit>
+  val createUntitledDocument: initialText: string -> server: CachedServer -> Async<Document * Diagnostic array>
+  /// `path` can be absolute or relative.
+  /// For relative path `server.RootPath` must be specified!
+  ///
+  /// Note: When `path` is relative: relative to `server.RootPath`!
+  val openDocument: path: string -> server: CachedServer -> Async<Document * Diagnostic array>
 
-    /// Like `Server.openDocument`, but instead of reading source text from `path`,
-    /// this here instead uses `initialText` (which can be different from content of `path`!).
-    ///
-    /// This way an existing file with different text can be faked.
-    /// Logically equal to `Server.openDocument`, and later changing its text via `Document.changeTextTo`.
-    /// But this here doesn't have to parse and check everything twice (once for open, once for changed)
-    /// and is WAY faster than `Server.openDocument` followed by `Document.changeTextTo` when involving multiple documents.
-    /// (For example with CodeFix tests using `fsi` file and corresponding `fs` file)
-    val openDocumentWithText:
-        path: string -> initialText: string -> server: CachedServer -> Async<Document * Diagnostic array>
+  /// Like `Server.openDocument`, but instead of reading source text from `path`,
+  /// this here instead uses `initialText` (which can be different from content of `path`!).
+  ///
+  /// This way an existing file with different text can be faked.
+  /// Logically equal to `Server.openDocument`, and later changing its text via `Document.changeTextTo`.
+  /// But this here doesn't have to parse and check everything twice (once for open, once for changed)
+  /// and is WAY faster than `Server.openDocument` followed by `Document.changeTextTo` when involving multiple documents.
+  /// (For example with CodeFix tests using `fsi` file and corresponding `fs` file)
+  val openDocumentWithText:
+    path: string -> initialText: string -> server: CachedServer -> Async<Document * Diagnostic array>
 
 module Document =
-    open System.Reactive.Linq
-    open System.Threading.Tasks
+  open System.Reactive.Linq
 
-    /// `textDocument/publishDiagnostics`
-    ///
-    /// Note: for each analyzing round there are might be multiple `publishDiagnostics` events (F# compiler, for each built-in Analyzer, for Custom Analyzers)
-    ///
-    /// Note: Because source `doc.Server.Events` is `ReplaySubject`, subscribing to Stream returns ALL past diagnostics too!
-    val diagnosticsStream: doc: Document -> IObservable<Diagnostic array>
-    /// `fsharp/documentAnalyzed`
-    val analyzedStream: doc: Document -> IObservable<DocumentAnalyzedNotification>
-    /// in ms
-    /// Waits (if necessary) and gets latest diagnostics.
-    ///
-    /// To detect newest diags:
-    /// * Waits for `fsharp/documentAnalyzed` for passed `doc` and its `doc.Version`.
-    /// * Then waits a but more for potential late diags.
-    /// * Then returns latest diagnostics.
-    ///
-    ///
-    /// ### Explanation: Get latest & correct diagnostics
-    /// Diagnostics aren't collected and then sent once, but instead sent after each parsing/analyzing step.
-    /// -> There are multiple `textDocument/publishDiagnostics` sent for each parsing/analyzing round:
-    /// * one when file parsed by F# compiler
-    /// * one for each built-in (enabled) Analyzers (in `src\FsAutoComplete\FsAutoComplete.Lsp.fs` > `FsAutoComplete.Lsp.FSharpLspServer.analyzeFile`),
-    /// * for linter (currently disabled)
-    /// * for custom analyzers
-    ///
-    /// -> To receive ALL diagnostics: use Diagnostics of last `textDocument/publishDiagnostics` event.
-    ///
-    /// Issue: What is the last `publishDiagnostics`? Might already be here or arrive in future.
-    /// -> `fsharp/documentAnalyzed` was introduced. Notification when a doc was completely analyzed
-    /// -> wait for `documentAnalyzed`
-    ///
-    /// But issue: last `publishDiagnostics` might be received AFTER `documentAnalyzed` (because of async notifications & sending)
-    /// -> after receiving `documentAnalyzed` wait a bit for late `publishDiagnostics`
-    ///
-    /// But issue: Wait for how long? Too long: extends test execution time. Too short: Might miss diags.
-    /// -> unresolved. Current wait based on testing on modern_ish PC. Seems to work on CI too.
-    ///
-    ///
-    /// *Inconvenience*: Only newest diags can be retrieved this way. Diags for older file versions cannot be extracted reliably:
-    /// `doc.Server.Events` is a `ReplaySubject` -> returns ALL previous events on new subscription
-    /// -> All past `documentAnalyzed` events and their diags are all received at once
-    /// -> waiting a bit after a version-specific `documentAnalyzed` always returns latest diags.
-    val waitForLatestDiagnostics: timeout: TimeSpan -> doc: Document -> Async<Diagnostic array>
-    val openWith: initialText: string -> doc: Document -> Async<Diagnostic array>
-    val close: doc: Document -> Async<unit>
-    ///<summary>
-    /// Fire a <code>textDocument/didChange</code> request for the specified document with the given text
-    /// as the entire new text of the document, then wait for diagnostics for the document.
-    /// </summary>
-    val changeTextTo: text: string -> doc: Document -> Async<Diagnostic array>
-    val saveText: text: string -> doc: Document -> Async<Diagnostic array>
+  /// `textDocument/publishDiagnostics`
+  ///
+  /// Note: for each analyzing round there are might be multiple `publishDiagnostics` events (F# compiler, for each built-in Analyzer, for Custom Analyzers)
+  ///
+  /// Note: Because source `doc.Server.Events` is `ReplaySubject`, subscribing to Stream returns ALL past diagnostics too!
+  val diagnosticsStream: doc: Document -> IObservable<Diagnostic array>
+  /// `fsharp/documentAnalyzed`
+  val analyzedStream: doc: Document -> IObservable<DocumentAnalyzedNotification>
+  /// Waits (if necessary) and gets latest diagnostics.
+  ///
+  /// To detect newest diags:
+  /// * Waits for `fsharp/documentAnalyzed` for passed `doc` and its `doc.Version`.
+  /// * Then returns latest diagnostics.
+  ///
+  ///
+  /// ### Explanation: Get latest & correct diagnostics
+  /// Diagnostics aren't collected and then sent once, but instead sent after each parsing/analyzing step.
+  /// -> There are multiple `textDocument/publishDiagnostics` sent for each parsing/analyzing round:
+  /// * one when file parsed by F# compiler
+  /// * one for each built-in (enabled) Analyzers (in `src\FsAutoComplete\FsAutoComplete.Lsp.fs` > `FsAutoComplete.Lsp.FSharpLspServer.analyzeFile`),
+  /// * for linter (currently disabled)
+  /// * for custom analyzers
+  ///
+  /// -> To receive ALL diagnostics: use Diagnostics of last `textDocument/publishDiagnostics` event.
+  ///
+  /// Issue: What is the last `publishDiagnostics`? Might already be here or arrive in future.
+  /// -> `fsharp/documentAnalyzed` was introduced. Notification when a doc was completely analyzed
+  /// -> wait for `documentAnalyzed`
+  ///
+  /// *Inconvenience*: Only newest diags can be retrieved this way. Diags for older file versions cannot be extracted reliably:
+  /// `doc.Server.Events` is a `ReplaySubject` -> returns ALL previous events on new subscription
+  /// -> All past `documentAnalyzed` events and their diags are all received at once
+  /// -> waiting a bit after a version-specific `documentAnalyzed` always returns latest diags.
+  val waitForLatestDiagnostics: timeout: TimeSpan -> doc: Document -> Async<Diagnostic array>
+  val openWith: initialText: string -> doc: Document -> Async<Diagnostic array>
+  val close: doc: Document -> Async<unit>
+  ///<summary>
+  /// Fire a <code>textDocument/didChange</code> request for the specified document with the given text
+  /// as the entire new text of the document, then wait for diagnostics for the document.
+  /// </summary>
+  val changeTextTo: text: string -> doc: Document -> Async<Diagnostic array>
+  val saveText: text: string -> doc: Document -> Async<Diagnostic array>
 
-    /// Note: diagnostics aren't filtered to match passed range in here
-    val codeActionAt:
-        diagnostics: Diagnostic[] -> range: Range -> doc: Document -> Async<TextDocumentCodeActionResult option>
+  /// Note: diagnostics aren't filtered to match passed range in here
+  val codeActionAt:
+    diagnostics: Diagnostic[] -> range: Range -> doc: Document -> Async<TextDocumentCodeActionResult option>
 
-    val inlayHintsAt: range: Range -> doc: Document -> Async<InlayHint array>
-    val resolveInlayHint: inlayHint: InlayHint -> doc: Document -> Async<InlayHint>
+  val inlayHintsAt: range: Range -> doc: Document -> Async<InlayHint array>
+  val resolveInlayHint: inlayHint: InlayHint -> doc: Document -> Async<InlayHint>

--- a/test/FsAutoComplete.Tests.Lsp/Utils/Server.fsi
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/Server.fsi
@@ -45,6 +45,12 @@ module Server =
     createServer: (unit -> IFSharpLspServer * IObservable<string * obj>) ->
       CachedServer
 
+  val createForPreparedProjects:
+    path: string option ->
+    config: FSharpConfigDto ->
+    createServer: (unit -> IFSharpLspServer * IObservable<string * obj>) ->
+      CachedServer
+
   val shutdown: server: CachedServer -> Async<unit>
   val createUntitledDocument: initialText: string -> server: CachedServer -> Async<Document * Diagnostic array>
   /// `path` can be absolute or relative.

--- a/test/FsAutoComplete.Tests.Lsp/Utils/ServerTests.fs
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/ServerTests.fs
@@ -39,6 +39,7 @@ let cleanableTestList
 
 let private serverTestList'
   runner
+  createCachedServer
   name
   createServer
   config
@@ -48,7 +49,7 @@ let private serverTestList'
   // path must be "absolutely normalized". `..` (parent) isn't valid -> Uri in FSAC and uri in doc are otherwise different, which leads to infinte waiting or timeouts.
   let path = path |> Option.map (System.IO.Path.GetFullPath)
 
-  let init = Server.create path config createServer
+  let init = createCachedServer path config createServer
   let cleanup = Server.shutdown
 
   cleanableTestList
@@ -70,9 +71,10 @@ let private serverTestList'
 ///   }
 /// ])
 /// ```
-let serverTestList = serverTestList' testList
-let fserverTestList = serverTestList' ftestList
-let pserverTestList = serverTestList' ptestList
+let serverTestList = serverTestList' testList Server.create
+let fserverTestList = serverTestList' ftestList Server.create
+let pserverTestList = serverTestList' ptestList Server.create
+let serverTestListForPreparedProjects = serverTestList' testList Server.createForPreparedProjects
 
 let private documentTestList'
   runner

--- a/test/FsAutoComplete.Tests.Lsp/Utils/ServerTests.fsi
+++ b/test/FsAutoComplete.Tests.Lsp/Utils/ServerTests.fsi
@@ -38,6 +38,7 @@ val cleanableTestList:
 val serverTestList: (string -> (unit -> FsAutoComplete.Lsp.IFSharpLspServer * System.IObservable<string * obj>) -> FsAutoComplete.LspHelpers.FSharpConfigDto -> option<string> -> (Async<Server> -> list<Test>) -> Test)
 val fserverTestList: (string -> (unit -> FsAutoComplete.Lsp.IFSharpLspServer * System.IObservable<string * obj>) -> FsAutoComplete.LspHelpers.FSharpConfigDto -> option<string> -> (Async<Server> -> list<Test>) -> Test)
 val pserverTestList: (string -> (unit -> FsAutoComplete.Lsp.IFSharpLspServer * System.IObservable<string * obj>) -> FsAutoComplete.LspHelpers.FSharpConfigDto -> option<string> -> (Async<Server> -> list<Test>) -> Test)
+val serverTestListForPreparedProjects: (string -> (unit -> FsAutoComplete.Lsp.IFSharpLspServer * System.IObservable<string * obj>) -> FsAutoComplete.LspHelpers.FSharpConfigDto -> option<string> -> (Async<Server> -> list<Test>) -> Test)
 
 
 /// Note: Not intended for changing document: always same (initial) diags

--- a/test/FsAutoComplete.Tests.Lsp/paket.references
+++ b/test/FsAutoComplete.Tests.Lsp/paket.references
@@ -5,7 +5,7 @@ FSharpx.Async
 Expecto.Diff
 Microsoft.NET.Test.Sdk
 YoloDev.Expecto.TestSdk
-# AltCover
+AltCover
 GitHubActionsTestLogger
 CliWrap
 FSharp.Data.Adaptive


### PR DESCRIPTION
## Summary

- run four balanced test shards as separate test hosts in every CI matrix job
- reuse the Release build and preserve existing `testSequenced` behavior inside each shard
- document shard placement by measured duration, shared fixtures, and process-wide state
- replace diagnostic delays and CodeFix retries with completion-based synchronization
- make acknowledged diagnostic notifications complete or fail on cancellation and diagnostic send errors
- isolate test-server workspaces and assign unique document URIs and increasing document versions
- prepare GoTo, dependent-file, NUnit, xUnit, and Expecto fixtures before timed tests start
- keep untitled URI paths stable when tests change the process current directory
- preserve all 18 operating-system, runtime, and compiler-mode combinations

## Shard model

Each matrix job builds once, then starts four `dotnet test` processes against the same Release output.

Process isolation prevents test hosts from sharing compiler, server, environment, and current-directory state. Existing sequenced groups remain sequential inside their assigned process.

Shard assignments use measured group duration and shared-fixture ownership. The comment in `Program.fs` tells contributors where to add future tests.

## GitHub Actions proof

The comparison uses the successful `main` run at this branch's merge base and attempt 5 at the final PR head.

- [`main` run 33236962569](https://github.com/ionide/FsAutoComplete/actions/runs/33236962569) at `d863bf64`
- [PR run 33339789199, attempt 5](https://github.com/ionide/FsAutoComplete/actions/runs/33339789199/attempts/5) at `d9aa9330`
- both runs passed the same 18 matrix combinations

| Metric | `main` | PR | Change |
| --- | ---: | ---: | ---: |
| Matrix elapsed time | 33m 29s | 16m 26s | **50.9% shorter** |
| Total matrix runner time | 259m 22s | 151m 16s | **41.7% lower** |
| Median matrix job | 14m 05.5s | 9m 05s | **35.5% shorter** |
| Total `Run and report tests` time | 193m 28s | 72m 57s | **62.3% lower** |
| Median `Run and report tests` step | 9m 23.5s | 3m 34s | **62.0% shorter** |
| Median `Run Build` step | 2m 15.5s | 2m 35s | 14.4% longer |

The final head moves fixture builds and restores out of timed tests. This adds 19.5 seconds to the median build step.

The full matrix still finishes 50.9% sooner and uses 41.7% less runner time. Test-step runner time is 62.3% lower.

## Determinism and coverage

- the unsharded and combined sharded manifests each contain 3,239 tests
- the manifest comparison found no missing, extra, or duplicate assignments
- the current-directory regression passed 50 fresh processes in each compiler mode
- local net8.0 and net10.0 shard regression runs passed with no failures
- focused delay toggles reproduced the GoTo, dependent-file, and unit-test fixture timeouts before their fixes
- completion tests keep concurrent change handling while using increasing LSP document versions
- acknowledged diagnostic waits now terminate on cancellation and propagate diagnostic send failures
- final run attempts 2, 3, 4, and 5 each passed all 19 jobs at `d9aa9330`
- those four complete attempts produced 76 successful jobs and no test failures

Attempt 1 ended before tests when `dotnet paket restore` exited 137 on one macOS runner. The unchanged SHA then passed four complete attempts.
