### PR TITLE
Analyzer code actions show the replacement, not just the code

### DIFF
--- a/src/FsAutoComplete/CodeFixes/ExternalSystemDiagnostics.fs
+++ b/src/FsAutoComplete/CodeFixes/ExternalSystemDiagnostics.fs
@@ -22,12 +22,43 @@ let private mapExternalDiagnostic diagnosticType =
       match fixes with
       | Payload(fixes: list<TextEdit>) ->
         let title =
-          diagnostic.Code
-          |> Option.map (function
-            | U2.C1 n -> n.ToString()
-            | U2.C2 s -> s)
-          |> Option.map (sprintf "Fix %s")
-          |> Option.defaultValue "Fix Issue"
+          let code =
+            diagnostic.Code
+            |> Option.map (function
+              | U2.C1 n -> n.ToString()
+              | U2.C2 s -> s)
+            |> Option.map (sprintf "Fix %s")
+            |> Option.defaultValue "Fix Issue"
+
+          // an analyzer can offer SEVERAL actions for one span (a primary
+          // fix and alternatives); the code alone renders them as
+          // identical menu entries. The replacement text is the clearest
+          // possible label — show what the code will BECOME
+          let firstLineOf (text: string) =
+            let i = text.IndexOfAny([| '\n'; '\r' |])
+            let line = if i >= 0 then text.Substring(0, i) else text
+
+            if line.Length > 50 then
+              line.Substring(0, 47) + "..."
+            else
+              line
+
+          let editPreview =
+            fixes
+            |> List.tryPick (fun edit ->
+              match edit.NewText.Trim() with
+              | "" -> None
+              | text -> Some(firstLineOf text))
+
+          match editPreview with
+          | Some preview -> $"{code} → {preview}"
+          | None ->
+            // a pure deletion has nothing to preview; fall back to the
+            // diagnostic message so distinct actions still read distinct
+            match diagnostic.Message with
+            | null
+            | "" -> code
+            | message -> $"{code}: {firstLineOf message}"
 
         AsyncResult.retn
           [ { SourceDiagnostic = Some diagnostic


### PR DESCRIPTION
Fix for #1548 

An analyzer can attach several actions to one span - a primary fix and alternatives - and titling each "Fix FR0136" renders them as identical menu entries, leaving the user to guess. The replacement text is the clearest possible label, so the title becomes "Fix FR0136 -> Guid.NewGuid()" (first line, capped at 50 chars); pure deletions fall back to the diagnostic message's first line, and only an empty message leaves the bare code.
